### PR TITLE
개선: GitHub Actions 아티팩트 용량 최적화

### DIFF
--- a/.github/workflows/build-ait.yml
+++ b/.github/workflows/build-ait.yml
@@ -114,14 +114,19 @@ jobs:
           fi
 
       # ait deploy는 ait-build/ 디렉토리 내에서 실행되어야 함
-      # package.json, granite.config.ts 등 설정 파일이 필요하므로 전체 업로드
+      # 배포에 필요한 파일만 업로드 (node_modules, public 등 제외하여 용량 절감)
 
       - name: Upload AIT Package
         uses: actions/upload-artifact@v5
         with:
           name: ait-build-macos-${{ matrix.unity-version }}
-          path: Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/
+          path: |
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/dist/
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/package.json
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/pnpm-lock.yaml
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/granite.config.ts
           if-no-files-found: error
+          retention-days: 7
 
   # =====================================================
   # AIT Build - Windows
@@ -298,11 +303,16 @@ jobs:
           dir "%DIST_PATH%\web" 2>nul
 
       # ait deploy는 ait-build/ 디렉토리 내에서 실행되어야 함
-      # package.json, granite.config.ts 등 설정 파일이 필요하므로 전체 업로드
+      # 배포에 필요한 파일만 업로드 (node_modules, public 등 제외하여 용량 절감)
 
       - name: Upload AIT Package
         uses: actions/upload-artifact@v5
         with:
           name: ait-build-windows-${{ matrix.unity-version }}
-          path: Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/
+          path: |
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/dist/
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/package.json
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/pnpm-lock.yaml
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/granite.config.ts
           if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,13 +177,18 @@ jobs:
           fi
 
       # ait deploy는 ait-build/ 디렉토리 내에서 실행되어야 함
-      # package.json, granite.config.ts 등 설정 파일이 필요하므로 전체 업로드
+      # 배포에 필요한 파일만 업로드 (node_modules, public 등 제외하여 용량 절감)
       - name: Upload AIT Build
         uses: actions/upload-artifact@v5
         with:
           name: ait-build-macos-${{ matrix.unity-version }}
-          path: Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/
+          path: |
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/dist/
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/package.json
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/pnpm-lock.yaml
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/granite.config.ts
           if-no-files-found: error
+          retention-days: 7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -219,6 +224,8 @@ jobs:
           name: playwright-report-macos-${{ matrix.unity-version }}
           path: Tests~/E2E/tests/playwright-report/
           if-no-files-found: ignore
+          compression-level: 9
+          retention-days: 7
 
   # =====================================================
   # E2E Tests - Windows
@@ -449,13 +456,18 @@ jobs:
           )
 
       # ait deploy는 ait-build/ 디렉토리 내에서 실행되어야 함
-      # package.json, granite.config.ts 등 설정 파일이 필요하므로 전체 업로드
+      # 배포에 필요한 파일만 업로드 (node_modules, public 등 제외하여 용량 절감)
       - name: Upload AIT Build
         uses: actions/upload-artifact@v5
         with:
           name: ait-build-windows-${{ matrix.unity-version }}
-          path: Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/
+          path: |
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/dist/
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/package.json
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/pnpm-lock.yaml
+            Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build/granite.config.ts
           if-no-files-found: error
+          retention-days: 7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -495,6 +507,8 @@ jobs:
           name: playwright-report-windows-${{ matrix.unity-version }}
           path: Tests~/E2E/tests/playwright-report/
           if-no-files-found: ignore
+          compression-level: 9
+          retention-days: 7
 
   # =====================================================
   # Test Report Summary
@@ -565,12 +579,8 @@ jobs:
               console.log('Created new benchmark comment');
             }
 
-      - name: Upload Combined Report
-        uses: actions/upload-artifact@v5
-        with:
-          name: combined-test-report
-          path: artifacts/
-          if-no-files-found: ignore
+      # combined-test-report 제거됨: 모든 아티팩트를 중복 저장하여 용량 낭비
+      # 개별 아티팩트(ait-build-*, benchmark-results-*, playwright-report-*)는 여전히 다운로드 가능
 
       - name: Upload Benchmark Report
         uses: actions/upload-artifact@v5
@@ -578,6 +588,7 @@ jobs:
           name: benchmark-report
           path: benchmark-report.md
           if-no-files-found: warn
+          retention-days: 30
 
   # =====================================================
   # Commit Status 보고 (workflow_call로 호출된 경우)


### PR DESCRIPTION
## Summary
- ait-build 아티팩트 선택적 업로드 (dist/, 설정 파일만)
- node_modules, public 등 불필요한 파일 제외하여 용량 절감
- combined-test-report 제거 (모든 아티팩트 중복 저장 방지)
- retention-days 설정으로 자동 정리 (7일/30일)
- Playwright report 압축 최적화 (compression-level: 9)

## 예상 효과
| 항목 | 현재 | 개선 후 | 절감률 |
|------|------|--------|-------|
| ait-build × 10 (tests.yml) | ~500MB-1GB | ~100-200MB | **60-80%** |
| ait-build × 8 (build-ait.yml) | ~400MB-800MB | ~80-160MB | **60-80%** |
| combined-test-report | ~500MB-1GB | 제거됨 | **~100%** |
| **총 예상** | **1.5-3GB** | **200-400MB** | **~85%** |

## Test plan
- [ ] tests.yml 워크플로우 정상 실행 확인
- [ ] build-ait.yml 워크플로우 정상 실행 확인
- [ ] release.yml deploy-ait job에서 다운로드된 아티팩트로 배포 정상 동작 확인