### PR TITLE
수정: SafeAreaInsetsGet API 반환 타입 void → SafeAreaInsetsGetResult

### DIFF
--- a/Runtime/SDK/AIT.Other.cs
+++ b/Runtime/SDK/AIT.Other.cs
@@ -309,21 +309,21 @@ namespace AppsInToss
 #endif
         /// <exception cref="AITException">Thrown when the API call fails</exception>
         [APICategory("Other")]
-        public static async Task SafeAreaInsetsGet()
+        public static async Task<SafeAreaInsetsGetResult> SafeAreaInsetsGet()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
-            string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+            var tcs = new TaskCompletionSource<SafeAreaInsetsGetResult>();
+            string callbackId = AITCore.Instance.RegisterCallback<SafeAreaInsetsGetResult>(
+                result => tcs.TrySetResult(result),
                 error => tcs.TrySetException(error)
             );
-            __SafeAreaInsetsGet_Internal(callbackId, "void");
-            await tcs.Task;
+            __SafeAreaInsetsGet_Internal(callbackId, "SafeAreaInsetsGetResult");
+            return await tcs.Task;
 #else
             // Unity Editor mock implementation
             UnityEngine.Debug.Log($"[AIT Mock] SafeAreaInsetsGet called");
             await Task.CompletedTask;
-            // void return - nothing to return
+            return default(SafeAreaInsetsGetResult);
 #endif
         }
 

--- a/sdk-runtime-generator~/src/generators/csharp.ts
+++ b/sdk-runtime-generator~/src/generators/csharp.ts
@@ -179,12 +179,20 @@ export class CSharpGenerator {
     }
     // 익명 객체 타입(__type, object)이면 더 구체적인 이름 생성
     else if (callbackType === '__type' || callbackType === 'object') {
-      const promiseType = api.returnType.promiseType;
-      if (promiseType && promiseType.kind === 'object' &&
-          promiseType.properties && promiseType.properties.length > 0) {
+      // 동기/비동기 함수 모두 처리: promiseType이 있으면 사용, 없으면 returnType 직접 사용
+      const targetType = api.returnType.kind === 'promise'
+        ? api.returnType.promiseType
+        : api.returnType;
+
+      if (targetType && targetType.kind === 'object' &&
+          targetType.properties && targetType.properties.length > 0) {
         callbackType = `${api.pascalName}Result`;
-      } else if (!promiseType || promiseType.name === 'void' || promiseType.name === 'undefined') {
+      } else if (!targetType || targetType.name === 'void' || targetType.name === 'undefined') {
         callbackType = 'void';
+      } else {
+        // 이름이 있는 타입이지만 properties가 빈 경우 (예: interface 참조)
+        // → Result 타입으로 처리
+        callbackType = `${api.pascalName}Result`;
       }
     }
 
@@ -299,12 +307,20 @@ export class CSharpGenerator {
         }
         // 익명 객체 타입(__type, object)이면 Result 클래스 사용
         else if (callbackType === '__type' || callbackType === 'object') {
-          const promiseType = api.returnType.promiseType;
-          if (promiseType && promiseType.kind === 'object' &&
-              promiseType.properties && promiseType.properties.length > 0) {
+          // 동기/비동기 함수 모두 처리: promiseType이 있으면 사용, 없으면 returnType 직접 사용
+          const targetType = api.returnType.kind === 'promise'
+            ? api.returnType.promiseType
+            : api.returnType;
+
+          if (targetType && targetType.kind === 'object' &&
+              targetType.properties && targetType.properties.length > 0) {
             callbackType = `${api.pascalName}Result`;
-          } else if (!promiseType || promiseType.name === 'void' || promiseType.name === 'undefined') {
+          } else if (!targetType || targetType.name === 'void' || targetType.name === 'undefined') {
             callbackType = 'void';
+          } else {
+            // 이름이 있는 타입이지만 properties가 빈 경우 (예: interface 참조)
+            // → Result 타입으로 처리
+            callbackType = `${api.pascalName}Result`;
           }
         }
 
@@ -397,12 +413,20 @@ export class CSharpGenerator {
     }
     // 익명 객체 타입(__type, object)이면 더 구체적인 이름 생성
     else if (callbackType === '__type' || callbackType === 'object') {
-      const promiseType = api.returnType.promiseType;
-      if (promiseType && promiseType.kind === 'object' &&
-          promiseType.properties && promiseType.properties.length > 0) {
+      // 동기/비동기 함수 모두 처리: promiseType이 있으면 사용, 없으면 returnType 직접 사용
+      const targetType = api.returnType.kind === 'promise'
+        ? api.returnType.promiseType
+        : api.returnType;
+
+      if (targetType && targetType.kind === 'object' &&
+          targetType.properties && targetType.properties.length > 0) {
         callbackType = `${api.pascalName}Result`;
-      } else if (!promiseType || promiseType.name === 'void' || promiseType.name === 'undefined') {
+      } else if (!targetType || targetType.name === 'void' || targetType.name === 'undefined') {
         callbackType = 'void';
+      } else {
+        // 이름이 있는 타입이지만 properties가 빈 경우 (예: interface 참조)
+        // → Result 타입으로 처리
+        callbackType = `${api.pascalName}Result`;
       }
     }
 
@@ -550,12 +574,20 @@ export class CSharpGenerator {
     }
     // 익명 객체 타입(__type, object)이면 더 구체적인 이름 생성
     else if (callbackType === '__type' || callbackType === 'object') {
-      const promiseType = api.returnType.promiseType;
-      if (promiseType && promiseType.kind === 'object' &&
-          promiseType.properties && promiseType.properties.length > 0) {
+      // 동기/비동기 함수 모두 처리: promiseType이 있으면 사용, 없으면 returnType 직접 사용
+      const targetType = api.returnType.kind === 'promise'
+        ? api.returnType.promiseType
+        : api.returnType;
+
+      if (targetType && targetType.kind === 'object' &&
+          targetType.properties && targetType.properties.length > 0) {
         callbackType = `${api.pascalName}Result`;
-      } else if (!promiseType || promiseType.name === 'void' || promiseType.name === 'undefined') {
+      } else if (!targetType || targetType.name === 'void' || targetType.name === 'undefined') {
         callbackType = 'void';
+      } else {
+        // 이름이 있는 타입이지만 properties가 빈 경우 (예: interface 참조)
+        // → Result 타입으로 처리
+        callbackType = `${api.pascalName}Result`;
       }
     }
 


### PR DESCRIPTION
## Summary
- 동기 함수(`SafeAreaInsets.get()`)의 반환 타입이 `void`로 잘못 생성되는 버그 수정
- SDK 생성기의 callbackType 결정 로직에서 동기/비동기 함수 모두 올바르게 처리하도록 개선

## 문제
`SafeAreaInsets.get()`은 TypeScript에서 동기 함수(`get(): SafeAreaInsetsGetResult`)로 정의되어 있으나, SDK 생성기가 `api.returnType.promiseType`을 참조하여 `undefined`를 반환하고, 이로 인해 `callbackType`이 `'void'`로 설정되었습니다.

## 수정 내용
`csharp.ts`의 4곳에서 동일한 패턴 수정:
```typescript
// 수정 전
const promiseType = api.returnType.promiseType;
if (promiseType && ...) { ... }
else if (!promiseType || ...) { callbackType = 'void'; }

// 수정 후  
const targetType = api.returnType.kind === 'promise'
  ? api.returnType.promiseType
  : api.returnType;
if (targetType && ...) { ... }
else if (!targetType || ...) { callbackType = 'void'; }
else { callbackType = `${api.pascalName}Result`; }
```

## Test plan
- [x] `pnpm generate` - SDK 재생성
- [x] `./run-local-tests.sh --all` - Unity 빌드 + E2E 테스트 (9/9 통과)
- [x] 기존 IAP 메서드 등 회귀 테스트 확인