### PR TITLE
수정: release workflow에서 지정한 SDK 버전이 빌드에 반영되지 않는 문제

### DIFF
--- a/.github/workflows/build-ait.yml
+++ b/.github/workflows/build-ait.yml
@@ -76,16 +76,6 @@ jobs:
           echo "UNITY_PATH=${UNITY_PATH}" >> $GITHUB_OUTPUT
           echo "UNITY_VERSION=${DETECTED_VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - name: Update BuildConfig SDK Version
         run: |
           VERSION="${{ inputs.version }}"
@@ -105,7 +95,7 @@ jobs:
           rm -f "$LOCK_FILE"
           echo "Regenerating pnpm-lock.yaml..."
           cd "$BUILD_CONFIG_DIR"
-          pnpm install --lockfile-only
+          npx pnpm@9 install --lockfile-only
           echo "✓ pnpm-lock.yaml regenerated"
 
       - name: Build Unity WebGL
@@ -285,16 +275,6 @@ jobs:
           echo UNITY_PATH=%UNITY_PATH%>> %GITHUB_OUTPUT%
           echo UNITY_VERSION=%DETECTED_VERSION%>> %GITHUB_OUTPUT%
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - name: Update BuildConfig SDK Version
         shell: bash
         run: |
@@ -315,7 +295,7 @@ jobs:
           rm -f "$LOCK_FILE"
           echo "Regenerating pnpm-lock.yaml..."
           cd "$BUILD_CONFIG_DIR"
-          pnpm install --lockfile-only
+          npx pnpm@9 install --lockfile-only
           echo "✓ pnpm-lock.yaml regenerated"
 
       - name: Build Unity WebGL


### PR DESCRIPTION
## Summary
- release.yml에서 build-ait로 전달하는 `version` 입력이 실제 빌드에 반영되지 않던 버그 수정
- `@apps-in-toss/web-framework` 버전이 항상 main branch의 기본값(1.5.2)으로 고정되어 있었음

## Changes
`build-ait.yml`에 "Update BuildConfig SDK Version" step 추가:
1. `sed`로 `BuildConfig/package.json`의 web-framework 버전 업데이트
2. `npx pnpm@9 install --lockfile-only`로 lockfile 재생성
3. macOS와 Windows 빌드 모두에 적용

## Test plan
- [x] version=1.5.0으로 테스트 (main의 1.5.2와 다른 버전)
- [x] 10개 빌드 모두 성공 (macOS/Windows × 5 Unity versions)
- [x] artifact의 package.json에서 1.5.0 확인
- [x] artifact의 pnpm-lock.yaml에서 1.5.0 확인