### PR TITLE
수정: GetUserKeyForGame API 역직렬화 오류 해결

### DIFF
--- a/Runtime/SDK/Plugins/AppsInToss-GetUserKeyForGame.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetUserKeyForGame.jslib
@@ -36,7 +36,7 @@ mergeInto(LibraryManager.library, {
                     if (typeof result === 'string') {
                         resultPayload = { _type: "error", _errorCode: result, _successJson: null };
                     } else {
-                        resultPayload = { _type: "success", _successJson: JSON.stringify(result), _errorCode: "" };
+                        resultPayload = { _type: "success", _successJson: result, _errorCode: "" };
                     }
                     var payload = JSON.stringify({
                         CallbackId: callback,

--- a/sdk-runtime-generator~/src/generators/jslib.ts
+++ b/sdk-runtime-generator~/src/generators/jslib.ts
@@ -576,7 +576,7 @@ ${onEventHandler}
                     if (typeof result === 'string') {
                         resultPayload = { _type: "error", _errorCode: result, _successJson: null };
                     } else {
-                        resultPayload = { _type: "success", _successJson: JSON.stringify(result), _errorCode: "" };
+                        resultPayload = { _type: "success", _successJson: result, _errorCode: "" };
                     }
                     var payload = JSON.stringify({
                         CallbackId: callback,


### PR DESCRIPTION
## Summary
- `GetUserKeyForGame` API 호출 시 발생하던 역직렬화 오류 수정
- discriminated union 응답 처리 시 `_successJson` 필드가 이중 직렬화되어 C#에서 파싱 실패하던 문제 해결

## 원인
jslib 생성기에서 discriminated union 성공 응답을 처리할 때 `JSON.stringify(result)`를 호출하여 객체를 문자열로 변환했으나, 이후 전체 payload를 다시 직렬화하면서 이중 직렬화 발생

```javascript
// Before (버그)
resultPayload = { _type: "success", _successJson: JSON.stringify(result), _errorCode: "" };

// After (수정)
resultPayload = { _type: "success", _successJson: result, _errorCode: "" };
```

## Test plan
- [x] SDK Generator Unit Tests 통과 (`./run-local-tests.sh --validate`)
- [ ] WebGL 빌드 후 GetUserKeyForGame API 호출 테스트