### PR TITLE
수정: Sample Project의 불필요한 safe area 여백 제거

### DIFF
--- a/Tests~/E2E/SampleUnityProject-2021.3/Assets/AppsInToss/Editor/AITConfig.asset
+++ b/Tests~/E2E/SampleUnityProject-2021.3/Assets/AppsInToss/Editor/AITConfig.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   primaryColor: '#1E88E5'
   iconUrl: https://via.placeholder.com/512
   bridgeColorMode: 0
-  webViewType: 1
+  webViewType: 0
   graniteHost: 0.0.0.0
   granitePort: 8081
   viteHost: localhost

--- a/Tests~/E2E/SampleUnityProject-2022.3/Assets/AppsInToss/Editor/AITConfig.asset
+++ b/Tests~/E2E/SampleUnityProject-2022.3/Assets/AppsInToss/Editor/AITConfig.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   primaryColor: '#1E88E5'
   iconUrl: https://via.placeholder.com/512
   bridgeColorMode: 0
-  webViewType: 1
+  webViewType: 0
   graniteHost: 0.0.0.0
   granitePort: 8082
   viteHost: localhost

--- a/Tests~/E2E/SampleUnityProject-6000.0/Assets/AppsInToss/Editor/AITConfig.asset
+++ b/Tests~/E2E/SampleUnityProject-6000.0/Assets/AppsInToss/Editor/AITConfig.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   primaryColor: '#1E88E5'
   iconUrl: https://via.placeholder.com/512
   bridgeColorMode: 0
-  webViewType: 1
+  webViewType: 0
   graniteHost: 0.0.0.0
   granitePort: 8083
   viteHost: localhost

--- a/Tests~/E2E/SampleUnityProject-6000.2/Assets/AppsInToss/Editor/AITConfig.asset
+++ b/Tests~/E2E/SampleUnityProject-6000.2/Assets/AppsInToss/Editor/AITConfig.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   primaryColor: '#1E88E5'
   iconUrl: https://via.placeholder.com/512
   bridgeColorMode: 0
-  webViewType: 1
+  webViewType: 0
   graniteHost: 0.0.0.0
   granitePort: 8084
   viteHost: localhost

--- a/Tests~/E2E/SampleUnityProject-6000.3/Assets/AppsInToss/Editor/AITConfig.asset
+++ b/Tests~/E2E/SampleUnityProject-6000.3/Assets/AppsInToss/Editor/AITConfig.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   primaryColor: '#1E88E5'
   iconUrl: https://via.placeholder.com/512
   bridgeColorMode: 0
-  webViewType: 1
+  webViewType: 0
   graniteHost: 0.0.0.0
   granitePort: 8085
   viteHost: localhost


### PR DESCRIPTION
## Summary
- Sample Project의 webViewType을 partner(1)에서 game(0)으로 변경
- partner 타입에서 발생하던 상단 safe area 여백 문제 해결
- 5개 Unity 버전의 Sample Project 설정 모두 적용

## Test plan
- [ ] 각 Unity 버전에서 빌드 후 safe area 여백이 제거되었는지 확인
- [ ] game 타입의 투명 배경 내비게이션이 정상 적용되는지 확인