### PR TITLE
수정: webViewType에서 external 옵션 제거

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -160,13 +160,12 @@ namespace AppsInToss.Editor
             GUILayout.Space(5);
 
             // webViewProps.type 드롭다운
-            string[] webViewTypeOptions = { "game (게임앱 - 투명배경)", "partner (일반앱 - 흰색배경)", "external (외부연동)" };
+            string[] webViewTypeOptions = { "game (게임앱 - 투명배경)", "partner (일반앱 - 흰색배경)" };
             config.webViewType = EditorGUILayout.Popup("WebView Type", config.webViewType, webViewTypeOptions);
 
             EditorGUILayout.HelpBox(
                 "게임앱은 'game' 타입으로 투명 배경 내비게이션이 적용됩니다.\n" +
-                "일반앱은 'partner' 타입으로 흰색 배경 내비게이션이 적용됩니다.\n" +
-                "외부 연동은 'external' 타입을 사용합니다.",
+                "일반앱은 'partner' 타입으로 흰색 배경 내비게이션이 적용됩니다.",
                 MessageType.Info
             );
 

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -120,8 +120,8 @@ namespace AppsInToss
         [Tooltip("브릿지 색상 모드. 게임앱은 'inverted' (다크모드), 일반앱은 'basic'")]
         public int bridgeColorMode = 0; // 0=inverted (게임 기본), 1=basic
 
-        [Tooltip("WebView 타입. 게임앱은 'game' (투명배경), 일반앱은 'partner' (흰색배경), 외부연동은 'external'")]
-        public int webViewType = 0; // 0=game, 1=partner, 2=external
+        [Tooltip("WebView 타입. 게임앱은 'game' (투명배경), 일반앱은 'partner' (흰색배경)")]
+        public int webViewType = 0; // 0=game, 1=partner
 
         [Header("서버 설정")]
         [Tooltip("Granite (Metro) 서버 호스트. 기본값: 0.0.0.0")]
@@ -272,7 +272,6 @@ namespace AppsInToss
             {
                 case 0: return "game";
                 case 1: return "partner";
-                case 2: return "external";
                 default: return "game";
             }
         }


### PR DESCRIPTION
## Summary
- webViewType에서 `external` 옵션을 제거하고 `partner`와 `game`만 유지
- 최신 레퍼런스 매뉴얼에 맞춰 유효한 webViewType 옵션만 남김

## Changes
- `Editor/AITEditorScriptObject.cs`: external 관련 주석 및 `GetWebViewTypeString()` 메서드 수정
- `Editor/AITConfigurationWindow.cs`: 드롭다운 옵션 및 HelpBox에서 external 관련 내용 제거

## Test plan
- [ ] Unity Editor에서 AIT Configuration 윈도우 열어서 WebView Type 드롭다운에 game, partner 두 옵션만 표시되는지 확인
- [ ] 빌드 시 webViewType이 정상적으로 적용되는지 확인