### PR TITLE
개선: GitHub Actions CI/CD 최적화

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,22 +65,18 @@ jobs:
         with:
           version: 10
 
-      - name: web-framework 버전 고정 및 SDK 재생성
+      - name: web-framework 버전 업데이트 및 SDK 재생성
         working-directory: sdk-runtime-generator~
         run: |
           VERSION="${{ needs.release.outputs.version }}"
 
-          echo "=== web-framework 버전 고정: ${VERSION} ==="
+          echo "=== web-framework v${VERSION} 업데이트 ==="
 
-          # package.json에서 web-framework 버전 고정
-          jq --arg v "$VERSION" '.dependencies["@apps-in-toss/web-framework"] = $v' package.json > tmp.json
-          mv tmp.json package.json
+          # 기존 lockfile 유지하면서 web-framework와 transitive deps만 업데이트
+          pnpm update "@apps-in-toss/web-framework@${VERSION}" --registry https://registry.npmjs.org
 
-          # 내부 레지스트리 참조가 있는 lockfile 삭제 후 공개 레지스트리에서 새로 생성
-          rm -f pnpm-lock.yaml
-
-          echo "의존성 설치 중 (공개 npm 레지스트리 사용)..."
-          pnpm install --registry https://registry.npmjs.org
+          echo "설치된 web-framework 버전:"
+          pnpm list @apps-in-toss/web-framework
 
           echo "SDK 코드 생성 중..."
           pnpm generate

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -106,23 +106,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: web-framework 버전 고정 및 SDK 재생성
+      - name: web-framework 버전 업데이트 및 SDK 재생성
         if: steps.check.outputs.skip != 'true'
         working-directory: sdk-runtime-generator~
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          echo "=== web-framework 버전 고정: ${VERSION} ==="
+          echo "=== web-framework v${VERSION} 업데이트 ==="
 
-          # package.json에서 web-framework 버전 고정
-          jq --arg v "$VERSION" '.dependencies["@apps-in-toss/web-framework"] = $v' package.json > tmp.json
-          mv tmp.json package.json
+          # 기존 lockfile 유지하면서 web-framework와 transitive deps만 업데이트
+          pnpm update "@apps-in-toss/web-framework@${VERSION}" --registry https://registry.npmjs.org
 
-          # 내부 레지스트리 참조가 있는 lockfile 삭제 후 공개 레지스트리에서 새로 생성
-          rm -f pnpm-lock.yaml
-
-          echo "의존성 설치 중 (공개 npm 레지스트리 사용)..."
-          pnpm install --registry https://registry.npmjs.org
+          echo "설치된 web-framework 버전:"
+          pnpm list @apps-in-toss/web-framework
 
           echo "SDK 코드 생성 중..."
           pnpm generate


### PR DESCRIPTION
## 변경 사항

### CI/CD 최적화
- **push/PR에서 빠른 검증만 실행**: lint + SDK Generator 테스트 (~2분)
- **E2E 테스트 분리**: `/test-e2e` 슬래시 커맨드로 필요할 때만 실행

### 새로운 기능
- **Preview 배포 워크플로우**: `/preview` 코멘트로 PR 브랜치 테스트 앱 배포
- **통합 reusable workflow**: `unity-build.yml`로 빌드 로직 중복 제거
- **PR 코멘트 보고**: E2E 테스트 결과 및 Preview URL을 PR 코멘트로 자동 보고
- **Commit status 보고**: 테스트/배포 진행 상태를 commit status로 표시

### 버그 수정
- PR 코멘트 작성 시 `gh api` 사용 (git repo 의존성 제거)
- 단일 아티팩트 다운로드 시 디렉토리 구조 문제 해결
- `pnpm update` 사용으로 transitive dependency 안정화

### Release/Update 워크플로우 개선
- SDK Runtime 재생성 단계 추가 (web-framework 버전 동기화)
- lockfile 유지하면서 web-framework만 업데이트하여 의존성 안정화

## 워크플로우 변경 요약

| 워크플로우 | 트리거 | 실행 내용 |
|-----------|--------|----------|
| `lint.yml` | push, PR | Unity .meta 파일 검사 |
| `validate.yml` | push, PR | SDK Generator Tier 1/2 테스트 |
| `test-e2e.yml` | `/test-e2e`, workflow_call | E2E 테스트 (5 Unity × 2 OS) |
| `preview.yml` | `/preview` | 테스트 앱 배포 |
| `release.yml` | 태그, 수동 | SDK 재생성 + 정식 릴리스 |
| `update.yml` | 스케줄, 수동 | SDK 자동 업데이트 PR 생성 |

## 테스트 계획
- [ ] `validate.yml`이 PR에서 정상 실행되는지 확인
- [ ] `/test-e2e` 코멘트로 E2E 테스트 트리거 확인
- [ ] `/preview` 코멘트로 프리뷰 배포 확인