### PR TITLE
개선: SDK Update에서 타입 검사 실패해도 PR 생성

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -108,6 +108,7 @@ jobs:
 
       - name: web-framework 버전 업데이트 및 SDK 재생성
         if: steps.check.outputs.skip != 'true'
+        id: generate
         working-directory: sdk-runtime-generator~
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -121,9 +122,14 @@ jobs:
           pnpm list @apps-in-toss/web-framework
 
           echo "SDK 코드 생성 중..."
-          pnpm generate
-
-          echo "SDK 코드 생성 완료"
+          # 타입 검사 실패해도 PR 생성을 위해 계속 진행
+          if pnpm generate; then
+            echo "generate_status=success" >> $GITHUB_OUTPUT
+            echo "SDK 코드 생성 완료"
+          else
+            echo "generate_status=failed" >> $GITHUB_OUTPUT
+            echo "::warning::SDK 코드 생성 실패 - PR 생성 후 수동 수정 필요"
+          fi
 
       - name: 루트 package.json 버전 업데이트
         if: steps.check.outputs.skip != 'true'
@@ -187,13 +193,25 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH_NAME="${{ steps.version.outputs.branch_name }}"
+          GENERATE_STATUS="${{ steps.generate.outputs.generate_status }}"
+
+          # SDK 생성 실패 시 경고 메시지
+          if [ "$GENERATE_STATUS" = "failed" ]; then
+            GENERATE_WARNING="> ⚠️ **SDK 코드 생성 중 타입 검사 실패** - 수동 수정이 필요합니다.
+
+          "
+            TITLE_PREFIX="[타입 오류] "
+          else
+            GENERATE_WARNING=""
+            TITLE_PREFIX=""
+          fi
 
           # PR 생성
           PR_RESULT=$(gh pr create \
-            --title "SDK 업데이트: v${VERSION}" \
+            --title "${TITLE_PREFIX}SDK 업데이트: v${VERSION}" \
             --body "## SDK 업데이트: v${VERSION}
 
-          \`@apps-in-toss/web-framework\` v${VERSION} 기반으로 SDK 코드를 재생성했습니다.
+          ${GENERATE_WARNING}\`@apps-in-toss/web-framework\` v${VERSION} 기반으로 SDK 코드를 재생성했습니다.
 
           ### 검토 사항
           - [ ] E2E 테스트 통과 확인 (이 워크플로우에서 자동 실행)


### PR DESCRIPTION
## 변경 사항

SDK Update 워크플로우에서 `pnpm generate` (타입 검사 포함) 실패 시에도 PR을 생성하도록 개선합니다.

### 이유
- 타입 검사 실패 시에도 PR이 생성되어야 해당 브랜치에서 수정 작업 진행 가능
- validate 워크플로우에서 실패 상태 확인 가능

### 변경 내용
- `pnpm generate` 실패해도 워크플로우 계속 진행
- 실패 시 PR 제목에 `[타입 오류]` 접두사 추가
- PR 본문에 경고 메시지 표시

### PR 예시 (타입 오류 시)
**제목**: `[타입 오류] SDK 업데이트: v1.6.0`

**본문**:
> ⚠️ **SDK 코드 생성 중 타입 검사 실패** - 수동 수정이 필요합니다.