### PR TITLE
설정: dependabot에서 AIT SDK 패키지 무시

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,12 +17,17 @@ updates:
     directory: "/sdk-runtime-generator~"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@apps-in-toss/web-framework"
+      - dependency-name: "@apps-in-toss/framework"
 
   # WebGL 빌드 설정
   - package-ecosystem: "npm"
     directory: "/WebGLTemplates/AITTemplate/BuildConfig"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@apps-in-toss/web-framework"
 
   # E2E 테스트
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- `@apps-in-toss/web-framework`, `@apps-in-toss/framework` 패키지에 대한 dependabot PR 생성 비활성화
- AIT SDK 버전은 직접 관리하므로 자동 업데이트 불필요

## 관련 PR
- Closes #52
- Closes #54
- Closes #55

## Test plan
- [ ] dependabot이 해당 패키지에 대해 더 이상 PR을 생성하지 않는지 확인