### PR TITLE
수정: BuildConfig~/node_modules/ 명시적 무시 규칙 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ logs/
 !**/Plugins~/**
 !**/BuildConfig~
 !**/BuildConfig~/**
+**/BuildConfig~/node_modules/
 
 # Legacy folders (replaced with ~ suffix versions)
 BuildTemplate/


### PR DESCRIPTION
## Summary
- `.gitignore`에서 `!**/BuildConfig~/**` 규칙이 `node_modules/` 무시 규칙을 override하는 문제 수정
- `**/BuildConfig~/node_modules/` 명시적 무시 규칙 추가

## 문제 상황
SDK Update 워크플로우에서 `pnpm install` 실행 후 `BuildConfig~/node_modules/` 폴더가 커밋되는 문제 발생

## 원인
`.gitignore` 규칙 우선순위 문제:
1. `node_modules/` - 모든 node_modules 무시
2. `!**/BuildConfig~/**` - BuildConfig~ 하위 모든 것 추적 (node_modules 포함)

## 해결
`**/BuildConfig~/node_modules/` 규칙을 `!**/BuildConfig~/**` 이후에 추가하여 명시적으로 무시

## Test plan
- [ ] SDK Update 워크플로우에서 node_modules가 커밋되지 않는지 확인