### PR TITLE
수정: Windows에서 한글 로그 깨짐 문제 해결

### DIFF
--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -207,7 +207,8 @@ namespace AppsInToss.Editor
                 if (IsWindows)
                 {
                     shell = "cmd.exe";
-                    shellArgs = $"/c \"{command}\"";
+                    // chcp 65001: 코드 페이지를 UTF-8로 변경하여 한글 등 유니코드 문자가 깨지지 않도록 함
+                    shellArgs = $"/c \"chcp 65001 >nul && {command}\"";
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Windows cmd.exe 실행 시 `chcp 65001`로 코드 페이지를 UTF-8로 변경
- npm/pnpm 등 외부 프로세스 출력의 한글이 정상적으로 표시되도록 수정

## 문제 원인
- Windows cmd.exe의 기본 코드 페이지가 한국어 환경에서 CP949
- `StandardOutputEncoding = UTF8` 설정은 Process 클래스가 읽을 때의 인코딩
- cmd.exe 내에서 실행되는 npm/pnpm은 시스템 코드 페이지로 출력 → UTF-8로 읽으면 한글 깨짐

## 해결 방법
- 명령 실행 전 `chcp 65001 >nul &&`를 추가하여 코드 페이지를 UTF-8로 변경

## Test plan
- [ ] Windows 환경에서 빌드 실행
- [ ] npm install/pnpm install 시 한글 오류 메시지 정상 출력 확인