### PR TITLE
기능: WebGL 템플릿 사용자 커스터마이징 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,94 @@ AIT_DEBUG_CONSOLE=true /Applications/Unity/Hub/Editor/2022.3.62f1/Unity.app/Cont
 [AIT] ========================================
 ```
 
+## WebGL 템플릿 커스터마이징
+
+SDK는 사용자가 WebGL 빌드의 다양한 측면을 커스터마이징할 수 있도록 지원합니다. 커스터마이징은 SDK 업데이트 시에도 자동으로 보존됩니다.
+
+### 커스터마이징 가능한 파일
+
+| 파일 | 위치 | 커스터마이징 방법 |
+|------|------|------------------|
+| `index.html` | `Assets/WebGLTemplates/AITTemplate/` | 마커 영역에 스크립트/스타일 추가 |
+| `vite.config.ts` | `Assets/WebGLTemplates/AITTemplate/BuildConfig~/` | `USER_CONFIG` 섹션에 플러그인 추가 |
+| `granite.config.ts` | `Assets/WebGLTemplates/AITTemplate/BuildConfig~/` | `USER_CONFIG` 섹션에 설정 추가 |
+| `package.json` | `Assets/WebGLTemplates/AITTemplate/BuildConfig~/` | dependencies에 npm 패키지 추가 |
+
+### index.html 커스터마이징
+
+`index.html`에서 `USER_HEAD`와 `USER_BODY_END` 마커 영역에 커스텀 스크립트나 스타일을 추가할 수 있습니다:
+
+```html
+<!-- USER_HEAD_START - 이 영역에 사용자 커스텀 스크립트/스타일을 추가하세요 -->
+<script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-analytics-compat.js"></script>
+<link rel="stylesheet" href="custom-styles.css">
+<!-- USER_HEAD_END -->
+```
+
+```html
+<!-- USER_BODY_END_START - 이 영역에 사용자 커스텀 스크립트를 추가하세요 -->
+<script>
+    // Firebase 초기화
+    firebase.initializeApp({
+        apiKey: "your-api-key",
+        projectId: "your-project-id"
+    });
+    firebase.analytics();
+</script>
+<!-- USER_BODY_END_END -->
+```
+
+### npm 패키지 추가
+
+`BuildConfig~/package.json`의 `dependencies`에 필요한 패키지를 추가하세요:
+
+```json
+{
+  "dependencies": {
+    "@apps-in-toss/web-framework": "1.6.2",
+    "lodash-es": "^4.17.21",
+    "firebase": "^10.7.0"
+  }
+}
+```
+
+빌드 시 SDK 패키지와 사용자 패키지가 자동으로 머지됩니다.
+
+### Vite 플러그인 추가
+
+`BuildConfig~/vite.config.ts`의 `USER_CONFIG` 섹션에서 Vite 플러그인을 추가할 수 있습니다:
+
+```typescript
+//// USER_CONFIG_START ////
+const userConfig = defineConfig({
+  plugins: [
+    // 사용자 플러그인 추가
+  ],
+  define: {
+    __CUSTOM_FLAG__: JSON.stringify(true),
+  },
+});
+//// USER_CONFIG_END ////
+```
+
+### SDK 업데이트 시 동작
+
+SDK를 업데이트해도 사용자 커스터마이징은 자동으로 보존됩니다:
+
+| 상황 | 동작 |
+|------|------|
+| 마커가 있는 템플릿 | 사용자 영역 보존, SDK 영역만 업데이트 |
+| 마커가 없는 이전 템플릿 | 새 템플릿으로 교체 + 수동 마이그레이션 안내 |
+
+업데이트 시 콘솔에서 다음과 같은 로그를 확인할 수 있습니다:
+
+```
+[AIT] ✓ index.html 템플릿 업데이트 (사용자 커스텀 영역 보존)
+[AIT]   ✓ vite.config.ts (마커 기반 업데이트)
+[AIT]   ✓ granite.config.ts (마커 기반 업데이트)
+```
+
 ## 자주 묻는 질문
 
 ### Q1. 빌드 시 Node.js가 없다는 오류가 발생합니다

--- a/WebGLTemplates/AITTemplate/BuildConfig~/granite.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/granite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@apps-in-toss/web-framework/config';
 
-export default defineConfig({
+//// SDK_GENERATED_START - DO NOT EDIT THIS SECTION ////
+const sdkConfig = {
   appName: '%AIT_APP_NAME%',
   brand: {
     displayName: '%AIT_DISPLAY_NAME%',
@@ -22,4 +23,13 @@ export default defineConfig({
   },
   permissions: %AIT_PERMISSIONS%,
   outdir: '%AIT_OUTDIR%',
-});
+};
+//// SDK_GENERATED_END ////
+
+//// USER_CONFIG_START ////
+const userConfig = {
+  // 여기에 사용자 커스텀 설정을 추가하세요
+};
+//// USER_CONFIG_END ////
+
+export default defineConfig({ ...sdkConfig, ...userConfig });

--- a/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vite';
+import { defineConfig, mergeConfig } from 'vite';
 
-export default defineConfig({
+//// SDK_GENERATED_START - DO NOT EDIT THIS SECTION ////
+const sdkConfig = defineConfig({
   // Apps in Toss 플랫폼에서 서브 경로 호스팅을 위해 상대 경로 사용
   base: './',
   server: {
@@ -22,3 +23,13 @@ export default defineConfig({
     },
   },
 });
+//// SDK_GENERATED_END ////
+
+//// USER_CONFIG_START ////
+const userConfig = defineConfig({
+  // 여기에 사용자 커스텀 설정을 추가하세요
+  // 예: plugins: [vue()],
+});
+//// USER_CONFIG_END ////
+
+export default mergeConfig(sdkConfig, userConfig);

--- a/WebGLTemplates/AITTemplate/index.html
+++ b/WebGLTemplates/AITTemplate/index.html
@@ -256,6 +256,11 @@
             transition: width 0.3s ease;
         }
     </style>
+
+    <!-- USER_HEAD_START - 이 영역에 사용자 커스텀 스크립트/스타일을 추가하세요 -->
+    <!-- 예: <script src="https://cdn.example.com/library.js"></script> -->
+    <!-- 예: <link rel="stylesheet" href="custom.css"> -->
+    <!-- USER_HEAD_END -->
 </head>
 <body>
     <!-- Loading Screen -->
@@ -923,5 +928,10 @@
         });
         } // end of else block for createUnityInstance check
     </script>
+
+    <!-- USER_BODY_END_START - 이 영역에 사용자 커스텀 스크립트를 추가하세요 -->
+    <!-- 예: <script src="analytics.js"></script> -->
+    <!-- 예: <script>console.log('Custom initialization');</script> -->
+    <!-- USER_BODY_END_END -->
 </body>
 </html>


### PR DESCRIPTION
## Summary

사용자가 WebGL 빌드의 다양한 측면을 커스터마이징할 수 있도록 지원합니다. SDK 업데이트 시에도 사용자 커스터마이징이 자동으로 보존됩니다.

### 주요 변경사항

- **마커 기반 템플릿 시스템**: `index.html`, `vite.config.ts`, `granite.config.ts`에 사용자 커스텀 영역 마커 추가
- **package.json 머지**: 사용자가 추가한 npm 패키지가 SDK 패키지와 자동 머지
- **자동 템플릿 업데이트**: SDK 업데이트 시 사용자 영역은 보존하고 SDK 영역만 업데이트
- **이전 버전 마이그레이션**: 마커 없는 이전 템플릿은 새 템플릿으로 교체 + 경고 메시지

### 커스터마이징 가능 항목

| 파일 | 커스터마이징 방법 |
|------|------------------|
| `index.html` | `USER_HEAD`, `USER_BODY_END` 마커 영역 |
| `vite.config.ts` | `USER_CONFIG` 섹션에 플러그인 추가 |
| `granite.config.ts` | `USER_CONFIG` 섹션에 설정 추가 |
| `package.json` | dependencies에 npm 패키지 추가 |

### 사용 예시

```html
<!-- USER_HEAD_START -->
<script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-app-compat.js"></script>
<!-- USER_HEAD_END -->
```

```json
{
  "dependencies": {
    "lodash-es": "^4.17.21",
    "firebase": "^10.7.0"
  }
}
```

## Test plan

- [x] 이전 버전 템플릿(마커 없음) → 새 템플릿으로 자동 교체 확인
- [x] 마커 있는 템플릿 → SDK 업데이트 시 사용자 커스터마이징 보존 확인
- [x] package.json 머지 동작 확인
- [x] pnpm install 실패 시 재시도 로직 확인
- [x] E2E 테스트 통과 (8/8)
- [x] SDK Generator Unit Tests 통과 (23/23)