### PR TITLE
수정: StreamingAssets 폴더 사용

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -1448,6 +1448,14 @@ namespace AppsInToss
                 UnityUtil.CopyDirectory(runtimeSrc, runtimeDest);
             }
 
+            // StreamingAssets 폴더 → public/StreamingAssets (있는 경우)
+            string streamingAssetsSrc = Path.Combine(webglPath, "StreamingAssets");
+            string streamingAssetsDest = Path.Combine(publicPath, "StreamingAssets");
+            if (Directory.Exists(streamingAssetsSrc))
+            {
+                UnityUtil.CopyDirectory(streamingAssetsSrc, streamingAssetsDest);
+            }
+
             // index.html → 프로젝트 루트 (Vite가 루트에서 index.html을 찾음)
             string indexSrc = Path.Combine(webglPath, "index.html");
             string indexDest = Path.Combine(buildProjectPath, "index.html");


### PR DESCRIPTION
### Summary
--------------
* StreamingAssets 폴더를 사용할 수 있도록 한다.
* https://docs.unity3d.com/kr/current/Manual/StreamingAssets.html

### 문제 원인
--------------
* 게임에서 사용되고 있는 StreamingAssets 폴더를 WebGL 폴더 이동시에 지원하지 못하는 문제 

### 수정내용
--------------
* CopyWebGLToPublic 함수 안에 StreamingAssets 폴더 복사 하도록 추가

