### PR TITLE
수정: Fork PR에서 E2E 테스트 및 Preview 실행 가능하도록 개선

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,6 +23,7 @@ jobs:
 
     outputs:
       targets: ${{ steps.parse.outputs.targets }}
+      repository: ${{ steps.resolve.outputs.repository }}
       ref: ${{ steps.resolve.outputs.ref }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
 
@@ -39,8 +40,8 @@ jobs:
             PR_NUMBER="$TARGET_REF"
             echo "PR 번호로 감지: #${PR_NUMBER}"
 
-            # PR에서 브랜치 가져오기
-            PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{ref: .head.ref}' 2>/dev/null || echo "")
+            # PR에서 브랜치와 저장소 가져오기
+            PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{ref: .head.ref, repo: .head.repo.full_name}' 2>/dev/null || echo "")
 
             if [ -z "$PR_DATA" ]; then
               echo "::error::PR #${PR_NUMBER}을(를) 찾을 수 없습니다"
@@ -48,14 +49,17 @@ jobs:
             fi
 
             REF=$(echo "$PR_DATA" | jq -r '.ref')
+            REPO=$(echo "$PR_DATA" | jq -r '.repo')
             echo "ref=${REF}" >> $GITHUB_OUTPUT
+            echo "repository=${REPO}" >> $GITHUB_OUTPUT
             echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
-            echo "브랜치: ${REF}"
+            echo "브랜치: ${REF} (저장소: ${REPO})"
           else
             # 브랜치 이름으로 간주
             REF="$TARGET_REF"
             echo "브랜치 이름으로 감지: ${REF}"
             echo "ref=${REF}" >> $GITHUB_OUTPUT
+            echo "repository=${{ github.repository }}" >> $GITHUB_OUTPUT
 
             # 브랜치에서 열린 PR 찾기
             PR_NUMBER=$(gh pr list --head "${REF}" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
@@ -136,10 +140,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           REF="${{ needs.parse-targets.outputs.ref }}"
-          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/${REF}" --jq '.object.sha' 2>/dev/null || echo "")
+          REPO="${{ needs.parse-targets.outputs.repository }}"
+          SHA=$(gh api "repos/${REPO}/git/ref/heads/${REF}" --jq '.object.sha' 2>/dev/null || echo "")
 
           if [ -z "$SHA" ]; then
-            echo "::warning::Could not get SHA for ref ${REF}"
+            echo "::warning::Could not get SHA for ref ${REF} in ${REPO}"
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "sha=${SHA}" >> $GITHUB_OUTPUT
@@ -177,6 +182,7 @@ jobs:
 
     uses: ./.github/workflows/unity-build.yml
     with:
+      repository: ${{ needs.parse-targets.outputs.repository }}
       ref: ${{ needs.parse-targets.outputs.ref }}
       os: ${{ matrix.target.os }}
       unity-version: ${{ matrix.target.unity-version }}
@@ -435,10 +441,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           REF="${{ needs.parse-targets.outputs.ref }}"
-          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/${REF}" --jq '.object.sha' 2>/dev/null || echo "")
+          REPO="${{ needs.parse-targets.outputs.repository }}"
+          SHA=$(gh api "repos/${REPO}/git/ref/heads/${REF}" --jq '.object.sha' 2>/dev/null || echo "")
 
           if [ -z "$SHA" ]; then
-            echo "::warning::Could not get SHA for ref ${REF}"
+            echo "::warning::Could not get SHA for ref ${REF} in ${REPO}"
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "sha=${SHA}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,6 +35,7 @@ jobs:
 
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
+      repository: ${{ steps.ref.outputs.repository }}
       pr_number: ${{ steps.ref.outputs.pr_number }}
 
     steps:
@@ -54,7 +55,7 @@ jobs:
             PR_NUMBER="$TARGET_REF"
             echo "PR 번호로 감지: #${PR_NUMBER}"
 
-            PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{ref: .head.ref}' 2>/dev/null || echo "")
+            PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{ref: .head.ref, repo: .head.repo.full_name}' 2>/dev/null || echo "")
 
             if [ -z "$PR_DATA" ]; then
               echo "::error::PR #${PR_NUMBER}을(를) 찾을 수 없습니다"
@@ -62,9 +63,11 @@ jobs:
             fi
 
             REF=$(echo "$PR_DATA" | jq -r '.ref')
+            REPO=$(echo "$PR_DATA" | jq -r '.repo')
             echo "ref=${REF}" >> $GITHUB_OUTPUT
+            echo "repository=${REPO}" >> $GITHUB_OUTPUT
             echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
-            echo "브랜치: ${REF}"
+            echo "브랜치: ${REF} (저장소: ${REPO})"
             exit 0
           else
             # 브랜치 이름으로 간주
@@ -74,6 +77,7 @@ jobs:
 
           # 브랜치에서 열린 PR 찾기
           echo "ref=${REF}" >> $GITHUB_OUTPUT
+          echo "repository=${{ github.repository }}" >> $GITHUB_OUTPUT
           PR_NUMBER=$(gh pr list --head "${REF}" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
 
           if [ -n "$PR_NUMBER" ]; then
@@ -97,6 +101,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
+          repository: ${{ needs.setup.outputs.repository }}
           ref: ${{ needs.setup.outputs.ref }}
 
       - name: Setup Node.js
@@ -143,10 +148,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           REF="${{ needs.setup.outputs.ref }}"
-          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/${REF}" --jq '.object.sha' 2>/dev/null || echo "")
+          REPO="${{ needs.setup.outputs.repository }}"
+          SHA=$(gh api "repos/${REPO}/git/ref/heads/${REF}" --jq '.object.sha' 2>/dev/null || echo "")
 
           if [ -z "$SHA" ]; then
-            echo "::warning::Could not get SHA for ref ${REF}"
+            echo "::warning::Could not get SHA for ref ${REF} in ${REPO}"
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "sha=${SHA}" >> $GITHUB_OUTPUT
@@ -184,6 +190,7 @@ jobs:
 
     uses: ./.github/workflows/unity-build.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       os: macos
       unity-version: ${{ matrix.unity-version }}
@@ -206,6 +213,7 @@ jobs:
 
     uses: ./.github/workflows/unity-build.yml
     with:
+      repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       os: windows
       unity-version: ${{ matrix.unity-version }}
@@ -346,10 +354,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           REF="${{ needs.setup.outputs.ref }}"
-          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/${REF}" --jq '.object.sha' 2>/dev/null || echo "")
+          REPO="${{ needs.setup.outputs.repository }}"
+          SHA=$(gh api "repos/${REPO}/git/ref/heads/${REF}" --jq '.object.sha' 2>/dev/null || echo "")
 
           if [ -z "$SHA" ]; then
-            echo "::warning::Could not get SHA for ref ${REF}"
+            echo "::warning::Could not get SHA for ref ${REF} in ${REPO}"
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "sha=${SHA}" >> $GITHUB_OUTPUT

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -3,6 +3,11 @@ name: Unity Build
 on:
   workflow_call:
     inputs:
+      repository:
+        description: 'Repository to checkout (for fork PRs)'
+        type: string
+        required: false
+        default: ''
       ref:
         description: 'Git ref to checkout'
         type: string
@@ -98,6 +103,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
+          repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
 
       # =====================================================


### PR DESCRIPTION
## Summary
- Fork에서 온 PR에 대해서도 E2E 테스트와 Preview 워크플로우를 수동 실행할 수 있도록 개선

## Changes
- `test-e2e.yml`: PR의 `head.repo.full_name` 추출하여 `repository` output 추가
- `unity-build.yml`: `repository` input 추가, checkout 시 fork 저장소 지원
- `preview.yml`: 동일한 패턴으로 fork PR 지원 추가

## How it works
1. PR 번호 입력 시 PR API에서 `head.repo.full_name` 정보도 함께 조회
2. `repository` 정보를 하위 워크플로우에 전달
3. `actions/checkout`에서 fork 저장소를 직접 checkout

## Test plan
- [x] PR #75 (fork PR)에 대해 E2E Tests 워크플로우 수동 실행
- [x] 정상적으로 fork 코드가 checkout되고 테스트가 실행되는지 확인