### PR TITLE
수정: 릴리즈 빌드 ref 경로를 refs/heads/로 변경

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,8 @@ jobs:
         id: commit
         run: |
           VERSION="${{ needs.release.outputs.version }}"
-          BUILD_REF="refs/builds/release-v${VERSION}"
+          # refs/heads/ 경로 사용 (refs/builds/는 GitHub GC에 의해 삭제될 수 있음)
+          BUILD_REF="refs/heads/_build/release-v${VERSION}"
 
           echo "=== Orphan Commit 생성 ==="
 


### PR DESCRIPTION
## Summary
- 릴리즈 워크플로우에서 임시 빌드 ref 경로를 `refs/builds/` → `refs/heads/_build/`로 변경

## 문제
- Release #109 실패: `couldn't find remote ref refs/builds/release-v1.5.2`
- `regenerate-sdk` job에서 push된 ref가 약 3.5시간 후 `create-release-tag` job 실행 시 사라짐
- GitHub의 garbage collection이 비표준 ref 경로(`refs/builds/*`)를 정리한 것으로 추정

## 해결
- `refs/heads/_build/release-v${VERSION}` 경로 사용
- `refs/heads/` 하위는 일반 브랜치로 취급되어 GC 대상에서 제외됨

## Test plan
- [ ] Release 워크플로우 수동 실행하여 테스트