### PR TITLE
수정: 플레이스홀더 치환 실패 시 빌드 중단하도록 개선

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -102,6 +102,7 @@ namespace AppsInToss
             NETWORK_ERROR = 4,
             CANCELLED = 5,
             FAIL_NPM_BUILD = 6,
+            WEBGL_BUILD_INCOMPLETE = 7,
         }
 
         /// <summary>
@@ -153,6 +154,15 @@ namespace AppsInToss
                            "2. ait-build 폴더에서 직접 pnpm install 시도\n" +
                            "3. package.json 파일이 올바른지 확인\n" +
                            "4. Tools~/NodeJS 폴더를 삭제 후 다시 빌드 시도";
+
+                case AITExportError.WEBGL_BUILD_INCOMPLETE:
+                    return "WebGL 빌드 결과물이 불완전합니다.\n\n" +
+                           "필수 파일(loader.js, data, framework.js, wasm 등)이 누락되었거나\n" +
+                           "index.html의 플레이스홀더가 치환되지 않았습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. AIT > Clean 메뉴로 빌드 폴더 삭제\n" +
+                           "2. 'Clean Build' 옵션 활성화 후 재빌드\n" +
+                           "3. AIT > Regenerate WebGL Templates 실행";
 
                 default:
                     return $"알 수 없는 오류가 발생했습니다. (코드: {error})";


### PR DESCRIPTION
## Summary
- `index.html` 파일이 없으면 빌드 중단 및 명확한 에러 메시지 출력
- 필수 빌드 파일(`loader.js`, `data`, `framework.js`, `wasm`) 누락 시 빌드 중단
- 치명적 플레이스홀더(`%UNITY_WEBGL_*_URL%`) 미치환 시 빌드 중단
- 빈 경로 패턴(`Build/`) 발견 시 빌드 중단
- 새 에러 코드 `WEBGL_BUILD_INCOMPLETE` 추가

## 문제 상황
사용자가 "AIT > Dev Server > Start Server" 실행 시, `%UNITY_WEBGL_LOADER_URL%` 플레이스홀더가 치환되지 않은 채로 브라우저에 표시되어 JavaScript 에러 발생.

## 변경 파일
- `Editor/AITConvertCore.cs` - 새 에러 코드 추가
- `Editor/AITPackageBuilder.cs` - `CopyWebGLToPublic()` 에러 처리 강화
- `Editor/AITBuildValidator.cs` - `ValidatePlaceholderSubstitution()` 검증 강화

## Test plan
- [ ] Clean Build 후 정상 빌드 확인
- [ ] 증분 빌드 정상 동작 확인
- [ ] `index.html` 삭제 후 빌드 시 에러 메시지 확인
- [ ] `loader.js` 삭제 후 빌드 시 에러 메시지 확인