### PR TITLE
수정: Unity Splash 로고 설정이 SDK 빌드 시 변경되지 않도록 개선

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -128,11 +128,7 @@ namespace AppsInToss.Editor
 #endif
 #endif
 
-            // ===== Unity 로고 표시 (사용자 지정 또는 자동, Unity Pro 라이선스 필요) =====
-            bool showUnityLogo = editorConfig.showUnityLogo >= 0
-                ? editorConfig.showUnityLogo == 1
-                : AITDefaultSettings.GetDefaultShowUnityLogo();
-            PlayerSettings.SplashScreen.showUnityLogo = showUnityLogo;
+            // ===== Unity 로고 표시: 사용자의 PlayerSettings 설정을 그대로 유지 =====
 
             // ===== 디버그 심볼 (빌드 프로필에서 설정 - ApplyBuildProfileSettings 참조) =====
             // 프로필 기반 설정은 DoExport()에서 ApplyBuildProfileSettings()를 통해 적용됨
@@ -154,7 +150,6 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - 예외 처리: {exceptionSupport}{(editorConfig.exceptionSupport < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Stripping Level: {strippingLevel}{(profile?.managedStrippingLevel < 0 || profile == null ? " (자동)" : " (프로필)")}");
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
-            Debug.Log($"[AIT]   - Unity 로고: {showUnityLogo}{(editorConfig.showUnityLogo < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
 #if UNITY_2023_3_OR_NEWER

--- a/Editor/AITPlayerSettingsBackup.cs
+++ b/Editor/AITPlayerSettingsBackup.cs
@@ -28,7 +28,6 @@ namespace AppsInToss.Editor
         public Vector2 cursorHotspot;
         public bool runInBackground;
         public bool stripEngineCode;
-        public bool showUnityLogo;
 
         // IL2CPP/Stripping 설정
         public ScriptingImplementation scriptingBackend;
@@ -69,7 +68,6 @@ namespace AppsInToss.Editor
                 cursorHotspot = PlayerSettings.cursorHotspot,
                 runInBackground = PlayerSettings.runInBackground,
                 stripEngineCode = PlayerSettings.stripEngineCode,
-                showUnityLogo = PlayerSettings.SplashScreen.showUnityLogo,
 
                 // IL2CPP/Stripping 설정
 #if UNITY_6000_0_OR_NEWER
@@ -118,7 +116,6 @@ namespace AppsInToss.Editor
             PlayerSettings.cursorHotspot = cursorHotspot;
             PlayerSettings.runInBackground = runInBackground;
             PlayerSettings.stripEngineCode = stripEngineCode;
-            PlayerSettings.SplashScreen.showUnityLogo = showUnityLogo;
 
             // IL2CPP/Stripping 설정
 #if UNITY_6000_0_OR_NEWER


### PR DESCRIPTION
## Summary
- 사용자가 Unity PlayerSettings에서 설정한 "Show Unity Logo" 값을 SDK가 덮어쓰지 않도록 수정
- SDK 빌드 시 Splash 로고 설정을 건드리지 않아 사용자 설정이 그대로 유지됨

## 변경 내용
- `AITBuildInitializer.cs`: showUnityLogo 설정 코드 제거
- `AITPlayerSettingsBackup.cs`: showUnityLogo 백업/복원 로직 제거

## Test plan
- [ ] Unity PlayerSettings에서 "Show Unity Logo" 해제 후 SDK 빌드 실행
- [ ] 빌드 후 "Show Unity Logo" 설정이 해제된 상태로 유지되는지 확인