### PR TITLE
수정: WebGL 빌드 TaskCompletionSource 반환 타입 불일치 해결

### DIFF
--- a/Runtime/SDK/AIT.Advertising.cs
+++ b/Runtime/SDK/AIT.Advertising.cs
@@ -203,9 +203,9 @@ namespace AppsInToss
         public static async Task TossAdsInitialize(InitializeOptions options)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __TossAdsInitialize_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
@@ -228,9 +228,9 @@ namespace AppsInToss
         public static async Task TossAdsAttach(string adGroupId, string target, TossAdsAttachOptions options = null)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __TossAdsAttach_Internal(adGroupId, target, AITJsonSettings.Serialize(options), callbackId, "void");
@@ -253,9 +253,9 @@ namespace AppsInToss
         public static async Task TossAdsDestroy(string slotId)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __TossAdsDestroy_Internal(slotId, callbackId, "void");
@@ -278,9 +278,9 @@ namespace AppsInToss
         public static async Task TossAdsDestroyAll()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __TossAdsDestroyAll_Internal(callbackId, "void");

--- a/Runtime/SDK/AIT.Certificate.cs
+++ b/Runtime/SDK/AIT.Certificate.cs
@@ -24,9 +24,9 @@ namespace AppsInToss
         public static async Task AppsInTossSignTossCert(AppsInTossSignTossCertParams paramsParam)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __appsInTossSignTossCert_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");

--- a/Runtime/SDK/AIT.Clipboard.cs
+++ b/Runtime/SDK/AIT.Clipboard.cs
@@ -48,9 +48,9 @@ namespace AppsInToss
         public static async Task SetClipboardText(string text)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __setClipboardText_Internal(text, callbackId, "void");

--- a/Runtime/SDK/AIT.Device.cs
+++ b/Runtime/SDK/AIT.Device.cs
@@ -23,9 +23,9 @@ namespace AppsInToss
         public static async Task GenerateHapticFeedback(HapticFeedbackOptions options)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __generateHapticFeedback_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
@@ -50,9 +50,9 @@ namespace AppsInToss
         public static async Task SetDeviceOrientation(SetDeviceOrientationOptions options)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __setDeviceOrientation_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
@@ -76,9 +76,9 @@ namespace AppsInToss
         public static async Task SetIosSwipeGestureEnabled(SetIosSwipeGestureEnabledOptions options)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __setIosSwipeGestureEnabled_Internal(AITJsonSettings.Serialize(options), callbackId, "void");

--- a/Runtime/SDK/AIT.Environment.cs
+++ b/Runtime/SDK/AIT.Environment.cs
@@ -20,7 +20,7 @@ namespace AppsInToss
         /// <exception cref="AITException">Thrown when the API call fails</exception>
         [Preserve]
         [APICategory("Environment")]
-        public static async Task<string> envGetDeploymentId()
+        public static async Task<string> EnvGetDeploymentId()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
@@ -32,7 +32,7 @@ namespace AppsInToss
             return await tcs.Task;
 #else
             // Unity Editor mock implementation
-            UnityEngine.Debug.Log($"[AIT Mock] envGetDeploymentId called");
+            UnityEngine.Debug.Log($"[AIT Mock] EnvGetDeploymentId called");
             await Task.CompletedTask;
             return "";
 #endif

--- a/Runtime/SDK/AIT.Events.cs
+++ b/Runtime/SDK/AIT.Events.cs
@@ -25,9 +25,9 @@ namespace AppsInToss
         public static async Task EventLog(EventLogParams paramsParam)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __eventLog_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");

--- a/Runtime/SDK/AIT.GameCenter.cs
+++ b/Runtime/SDK/AIT.GameCenter.cs
@@ -102,9 +102,9 @@ namespace AppsInToss
         public static async Task OpenGameCenterLeaderboard()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __openGameCenterLeaderboard_Internal(callbackId, "void");

--- a/Runtime/SDK/AIT.Media.cs
+++ b/Runtime/SDK/AIT.Media.cs
@@ -74,9 +74,9 @@ namespace AppsInToss
         public static async Task SaveBase64Data(SaveBase64DataParams paramsParam)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __saveBase64Data_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");

--- a/Runtime/SDK/AIT.Navigation.cs
+++ b/Runtime/SDK/AIT.Navigation.cs
@@ -23,9 +23,9 @@ namespace AppsInToss
         public static async Task CloseView()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __closeView_Internal(callbackId, "void");
@@ -50,9 +50,9 @@ namespace AppsInToss
         public static async Task OpenURL(string url)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __openURL_Internal(url, callbackId, "void");

--- a/Runtime/SDK/AIT.Partner.cs
+++ b/Runtime/SDK/AIT.Partner.cs
@@ -23,19 +23,19 @@ namespace AppsInToss
         /// <exception cref="AITException">Thrown when the API call fails</exception>
         [Preserve]
         [APICategory("Partner")]
-        public static async Task partnerAddAccessoryButton(AddAccessoryButtonOptions args_0)
+        public static async Task PartnerAddAccessoryButton(AddAccessoryButtonOptions args_0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __partnerAddAccessoryButton_Internal(AITJsonSettings.Serialize(args_0), callbackId, "void");
             await tcs.Task;
 #else
             // Unity Editor mock implementation
-            UnityEngine.Debug.Log($"[AIT Mock] partnerAddAccessoryButton called");
+            UnityEngine.Debug.Log($"[AIT Mock] PartnerAddAccessoryButton called");
             await Task.CompletedTask;
             // void return - nothing to return
 #endif
@@ -51,19 +51,19 @@ namespace AppsInToss
         /// <exception cref="AITException">Thrown when the API call fails</exception>
         [Preserve]
         [APICategory("Partner")]
-        public static async Task partnerRemoveAccessoryButton()
+        public static async Task PartnerRemoveAccessoryButton()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __partnerRemoveAccessoryButton_Internal(callbackId, "void");
             await tcs.Task;
 #else
             // Unity Editor mock implementation
-            UnityEngine.Debug.Log($"[AIT Mock] partnerRemoveAccessoryButton called");
+            UnityEngine.Debug.Log($"[AIT Mock] PartnerRemoveAccessoryButton called");
             await Task.CompletedTask;
             // void return - nothing to return
 #endif

--- a/Runtime/SDK/AIT.Share.cs
+++ b/Runtime/SDK/AIT.Share.cs
@@ -103,9 +103,9 @@ namespace AppsInToss
         public static async Task Share(ShareMessage message)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __share_Internal(AITJsonSettings.Serialize(message), callbackId, "void");

--- a/Runtime/SDK/AIT.Storage.cs
+++ b/Runtime/SDK/AIT.Storage.cs
@@ -55,9 +55,9 @@ namespace AppsInToss
         public static async Task StorageSetItem(string args_0, string args_1)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __StorageSetItem_Internal(args_0, args_1, callbackId, "void");
@@ -83,9 +83,9 @@ namespace AppsInToss
         public static async Task StorageRemoveItem(string args_0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __StorageRemoveItem_Internal(args_0, callbackId, "void");
@@ -111,9 +111,9 @@ namespace AppsInToss
         public static async Task StorageClearItems()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __StorageClearItems_Internal(callbackId, "void");

--- a/sdk-runtime-generator~/src/categories.ts
+++ b/sdk-runtime-generator~/src/categories.ts
@@ -76,8 +76,8 @@ export const API_CATEGORIES: Record<string, string[]> = {
     'SafeAreaInsetsSubscribe',
   ],
   Partner: [
-    'partnerAddAccessoryButton',
-    'partnerRemoveAccessoryButton',
+    'PartnerAddAccessoryButton',
+    'PartnerRemoveAccessoryButton',
   ],
   AppEvents: [
     'TdsEventSubscribeNavigationAccessoryEvent',
@@ -85,7 +85,7 @@ export const API_CATEGORIES: Record<string, string[]> = {
     'AppsInTossEventSubscribeEntryMessageExited',
   ],
   Environment: [
-    'envGetDeploymentId',
+    'EnvGetDeploymentId',
     'isMinVersionSupported',
     'getAppsInTossGlobals',
   ],

--- a/sdk-runtime-generator~/src/parser.ts
+++ b/sdk-runtime-generator~/src/parser.ts
@@ -1081,7 +1081,7 @@ export class TypeScriptParser {
 
       apis.push({
         name: fullName,
-        pascalName: fullName,
+        pascalName: this.toPascalCase(fullName),
         originalName: methodName,
         category,
         file: sourceFile.getFilePath(),

--- a/sdk-runtime-generator~/src/templates/csharp-category-partial.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-category-partial.hbs
@@ -240,9 +240,9 @@ namespace AppsInToss
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
 {{#if (eq this.callbackType "void")}}
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
@@ -293,9 +293,9 @@ namespace AppsInToss
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
 {{#if (eq this.callbackType "void")}}
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");

--- a/sdk-runtime-generator~/src/templates/csharp-partial-api.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-partial-api.hbs
@@ -34,9 +34,9 @@ namespace AppsInToss
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
 {{#if (eq callbackType "void")}}
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
-                result => tcs.TrySetResult(true),
+                result => tcs.TrySetResult(null),
                 error => tcs.TrySetException(error)
             );
             __{{{originalName}}}_Internal({{#each parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}UnityEngine.JsonUtility.ToJson({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{callbackType}}}");


### PR DESCRIPTION
## Summary

- WebGL 빌드에서 void 반환 API의 `TaskCompletionSource<bool>`와 `Task` 반환 타입 불일치로 인한 컴파일 에러 수정
- Partner 메서드의 C# 네이밍 컨벤션 위반 수정 (PascalCase 적용)

## Changes

### 1. TaskCompletionSource 타입 수정 (20개 void 반환 API)

**변경 전:**
```csharp
public static async Task CloseView()
{
    var tcs = new TaskCompletionSource<bool>();  // Task<bool>
    result => tcs.TrySetResult(true),
    await tcs.Task;
}
```

**변경 후:**
```csharp
public static async Task CloseView()
{
    var tcs = new TaskCompletionSource<object>();  // Task<object>
    result => tcs.TrySetResult(null),
    await tcs.Task;
}
```

### 2. Partner 메서드 네이밍 수정 (Breaking Change)

| 변경 전 | 변경 후 |
|--------|--------|
| `partnerAddAccessoryButton` | `PartnerAddAccessoryButton` |
| `partnerRemoveAccessoryButton` | `PartnerRemoveAccessoryButton` |

### 영향받는 API (20개)

- **Advertising**: TossAdsInitialize, TossAdsAttach, TossAdsDestroy, TossAdsDestroyAll
- **Certificate**: AppsInTossSignTossCert
- **Clipboard**: SetClipboardText
- **Device**: GenerateHapticFeedback, SetDeviceOrientation, SetIosSwipeGestureEnabled
- **Events**: EventLog
- **GameCenter**: OpenGameCenterLeaderboard
- **Media**: SaveBase64Data
- **Navigation**: CloseView, OpenURL
- **Partner**: PartnerAddAccessoryButton, PartnerRemoveAccessoryButton
- **Share**: Share
- **Storage**: StorageSetItem, StorageRemoveItem, StorageClearItems

## Test Plan

- [x] `pnpm run generate` - SDK 재생성 성공
- [x] `pnpm run validate` - 49/49 테스트 통과
- [x] E2E 테스트 (CI)
- [ ] WebGL 빌드 검증