### PR TITLE
기능: 커스텀 jslib 브릿지 자동 생성 기능

### DIFF
--- a/Editor/AITCustomBridgeGenerator.cs
+++ b/Editor/AITCustomBridgeGenerator.cs
@@ -1,0 +1,800 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 커스텀 브릿지 생성기
+    /// bridges/ 폴더의 TypeScript 파일에서 C# 바인딩과 jslib을 자동 생성합니다.
+    /// </summary>
+    public static class AITCustomBridgeGenerator
+    {
+        /// <summary>
+        /// 생성된 파일이 위치할 경로 (ait-build/generated/)
+        /// </summary>
+        private const string GENERATED_DIR = "generated";
+
+        /// <summary>
+        /// 커스텀 브릿지 C# 파일이 복사될 경로
+        /// </summary>
+        private const string CSHARP_OUTPUT_DIR = "Assets/AppsInToss/Runtime/CustomBridges";
+
+        /// <summary>
+        /// 커스텀 브릿지 jslib 파일이 복사될 경로
+        /// </summary>
+        private const string JSLIB_OUTPUT_DIR = "Assets/AppsInToss/Plugins";
+
+        /// <summary>
+        /// bridges 폴더에 TypeScript 파일이 있는지 확인
+        /// </summary>
+        public static bool HasBridgeFiles()
+        {
+            string bridgesPath = GetBridgesPath();
+            if (!Directory.Exists(bridgesPath))
+            {
+                return false;
+            }
+
+            // 재귀적으로 .ts 파일 검색 (index.ts, .d.ts 제외)
+            return HasTsFilesRecursive(bridgesPath);
+        }
+
+        private static bool HasTsFilesRecursive(string dir)
+        {
+            foreach (var file in Directory.GetFiles(dir, "*.ts"))
+            {
+                string fileName = Path.GetFileName(file);
+                if (!fileName.EndsWith(".d.ts") && fileName != "index.ts")
+                {
+                    return true;
+                }
+            }
+
+            foreach (var subDir in Directory.GetDirectories(dir))
+            {
+                if (HasTsFilesRecursive(subDir))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// bridges 폴더 경로 가져오기
+        /// 프로젝트의 WebGLTemplates/AITTemplate/BuildConfig~/bridges 또는
+        /// SDK 패키지의 WebGLTemplates/AITTemplate/BuildConfig~/bridges
+        /// </summary>
+        private static string GetBridgesPath()
+        {
+            // 1. 프로젝트 경로 확인
+            string projectBridgesPath = Path.Combine(Application.dataPath, "WebGLTemplates/AITTemplate/BuildConfig~/bridges");
+            if (Directory.Exists(projectBridgesPath))
+            {
+                return projectBridgesPath;
+            }
+
+            // 2. SDK 패키지 경로 확인
+            string[] possibleSdkPaths = new string[]
+            {
+                Path.GetFullPath("Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/BuildConfig~/bridges"),
+                Path.GetFullPath("Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/BuildConfig~/bridges"),
+            };
+
+            foreach (string path in possibleSdkPaths)
+            {
+                if (Directory.Exists(path))
+                {
+                    return path;
+                }
+            }
+
+            return projectBridgesPath; // 기본값 반환
+        }
+
+        /// <summary>
+        /// BuildConfig~ 경로 가져오기
+        /// </summary>
+        private static string GetBuildConfigPath()
+        {
+            // 1. 프로젝트 경로 확인
+            string projectPath = Path.Combine(Application.dataPath, "WebGLTemplates/AITTemplate/BuildConfig~");
+            if (Directory.Exists(projectPath))
+            {
+                return projectPath;
+            }
+
+            // 2. SDK 패키지 경로 확인
+            string[] possibleSdkPaths = new string[]
+            {
+                Path.GetFullPath("Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/BuildConfig~"),
+                Path.GetFullPath("Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/BuildConfig~"),
+            };
+
+            foreach (string path in possibleSdkPaths)
+            {
+                if (Directory.Exists(path))
+                {
+                    return path;
+                }
+            }
+
+            return projectPath;
+        }
+
+        /// <summary>
+        /// 커스텀 브릿지 생성 (Vite 플러그인 실행)
+        /// </summary>
+        /// <returns>성공 여부</returns>
+        public static bool GenerateBridges()
+        {
+            if (!HasBridgeFiles())
+            {
+                Debug.Log("[CustomBridge] bridges 폴더에 TypeScript 파일이 없습니다.");
+                return true; // 파일이 없으면 성공으로 처리
+            }
+
+            Debug.Log("[CustomBridge] 커스텀 브릿지 생성 시작...");
+
+            string buildConfigPath = GetBuildConfigPath();
+            if (!Directory.Exists(buildConfigPath))
+            {
+                Debug.LogError($"[CustomBridge] BuildConfig 폴더를 찾을 수 없습니다: {buildConfigPath}");
+                return false;
+            }
+
+            // pnpm 경로 찾기
+            string pnpmPath = AITNpmRunner.FindPnpmPath();
+            if (string.IsNullOrEmpty(pnpmPath))
+            {
+                Debug.LogError("[CustomBridge] pnpm을 찾을 수 없습니다.");
+                return false;
+            }
+
+            // node_modules가 없으면 먼저 설치
+            string nodeModulesPath = Path.Combine(buildConfigPath, "node_modules");
+            if (!Directory.Exists(nodeModulesPath))
+            {
+                Debug.Log("[CustomBridge] node_modules가 없습니다. pnpm install 실행 중...");
+
+                EditorUtility.DisplayProgressBar("커스텀 브릿지", "의존성 설치 중...", 0.2f);
+
+                string localCachePath = Path.Combine(buildConfigPath, ".npm-cache");
+                var installResult = AITNpmRunner.RunNpmCommandWithCache(buildConfigPath, pnpmPath, "install", localCachePath, "pnpm install...");
+                if (installResult != AITConvertCore.AITExportError.SUCCEED)
+                {
+                    EditorUtility.ClearProgressBar();
+                    Debug.LogError("[CustomBridge] pnpm install 실패");
+                    return false;
+                }
+            }
+
+            // Vite 플러그인을 통해 브릿지 생성 (pnpm run generate-bridges 또는 직접 실행)
+            // 현재는 빌드 시 자동으로 생성되므로, 여기서는 빌드를 트리거
+            EditorUtility.DisplayProgressBar("커스텀 브릿지", "브릿지 코드 생성 중...", 0.5f);
+
+            // tsx를 사용하여 생성 스크립트 직접 실행
+            var generateResult = RunBridgeGenerator(buildConfigPath, pnpmPath);
+
+            EditorUtility.ClearProgressBar();
+
+            if (!generateResult)
+            {
+                Debug.LogError("[CustomBridge] 브릿지 생성 실패");
+                return false;
+            }
+
+            // 생성된 파일을 Unity 프로젝트에 복사
+            if (!CopyGeneratedFiles(buildConfigPath))
+            {
+                Debug.LogError("[CustomBridge] 생성된 파일 복사 실패");
+                return false;
+            }
+
+            Debug.Log("[CustomBridge] ✓ 커스텀 브릿지 생성 완료");
+            AssetDatabase.Refresh();
+
+            return true;
+        }
+
+        /// <summary>
+        /// 브릿지 생성기 실행
+        /// </summary>
+        private static bool RunBridgeGenerator(string buildConfigPath, string pnpmPath)
+        {
+            // Vite 플러그인의 buildStart 훅을 직접 실행하기 위해
+            // tsx를 사용하여 생성 스크립트 실행
+            string generatorScript = Path.Combine(buildConfigPath, "generate-bridges.ts");
+
+            // generate-bridges.ts가 없으면 생성
+            if (!File.Exists(generatorScript))
+            {
+                CreateGeneratorScript(generatorScript);
+            }
+
+            // pnpm tsx generate-bridges.ts 실행
+            string pnpmDir = Path.GetDirectoryName(pnpmPath);
+            string command = $"\"{pnpmPath}\" tsx generate-bridges.ts";
+
+            var result = AITPlatformHelper.ExecuteCommand(command, buildConfigPath, new[] { pnpmDir }, verbose: true);
+
+            return result.Success;
+        }
+
+        /// <summary>
+        /// 브릿지 생성 스크립트 생성
+        /// </summary>
+        private static void CreateGeneratorScript(string scriptPath)
+        {
+            string scriptContent = @"/**
+ * generate-bridges.ts
+ *
+ * 커스텀 브릿지 생성 스크립트
+ * Vite 플러그인의 생성 로직을 직접 실행합니다.
+ */
+
+import { Project, SyntaxKind } from 'ts-morph';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const bridgesDir = './bridges';
+const outputDir = './generated';
+
+interface BridgeParam {
+  name: string;
+  type: string;
+  optional: boolean;
+}
+
+interface BridgeFunction {
+  name: string;
+  params: BridgeParam[];
+  returnType: string;
+  isAsync: boolean;
+  jsDoc?: string;
+}
+
+interface BridgeModule {
+  filePath: string;
+  namespace: string[];
+  functions: BridgeFunction[];
+}
+
+function toPascalCase(str: string): string {
+  return str
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function simplifyType(typeText: string): string {
+  return typeText.replace(/import\([^)]+\)\./g, '');
+}
+
+function mapToCSharpType(tsType: string): string {
+  const typeMap: Record<string, string> = {
+    'string': 'string',
+    'number': 'double',
+    'boolean': 'bool',
+    'void': 'void',
+  };
+
+  const promiseMatch = tsType.match(/^Promise<(.+)>$/);
+  if (promiseMatch) {
+    return mapToCSharpType(promiseMatch[1]);
+  }
+
+  const arrayMatch = tsType.match(/^(.+)\[\]$/);
+  if (arrayMatch) {
+    return `${mapToCSharpType(arrayMatch[1])}[]`;
+  }
+
+  const recordMatch = tsType.match(/^Record<string,\s*(.+)>$/);
+  if (recordMatch) {
+    return `Dictionary<string, ${mapToCSharpType(recordMatch[1])}>`;
+  }
+
+  const unionMatch = tsType.match(/^(.+)\s*\|\s*(undefined|null)$/);
+  if (unionMatch) {
+    return mapToCSharpType(unionMatch[1]);
+  }
+
+  return typeMap[tsType] || 'object';
+}
+
+function parseBridgesFolder(): BridgeModule[] {
+  const modules: BridgeModule[] = [];
+
+  if (!fs.existsSync(bridgesDir)) {
+    return modules;
+  }
+
+  const project = new Project({
+    compilerOptions: {
+      strict: true,
+      target: 99,
+      module: 99,
+    },
+  });
+
+  function scanDir(dir: string, namespace: string[] = []) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        const nsName = toPascalCase(entry.name);
+        scanDir(fullPath, [...namespace, nsName]);
+      } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+        const sourceFile = project.addSourceFileAtPath(fullPath);
+        const functions: BridgeFunction[] = [];
+
+        sourceFile.getFunctions().forEach((func) => {
+          if (!func.isExported()) return;
+
+          const name = func.getName();
+          if (!name) return;
+
+          const params: BridgeParam[] = func.getParameters().map((param) => {
+            const paramType = param.getType();
+            const typeText = simplifyType(paramType.getText());
+
+            return {
+              name: param.getName(),
+              type: typeText,
+              optional: param.isOptional() || param.hasQuestionToken(),
+            };
+          });
+
+          const returnType = func.getReturnType();
+          const returnTypeText = simplifyType(returnType.getText());
+          const isAsync = func.isAsync() || returnTypeText.startsWith('Promise<');
+
+          const jsDocNodes = func.getJsDocs();
+          const jsDoc = jsDocNodes.length > 0 ? jsDocNodes[0].getDescription() : undefined;
+
+          functions.push({ name, params, returnType: returnTypeText, isAsync, jsDoc });
+        });
+
+        if (functions.length > 0) {
+          const moduleName = toPascalCase(entry.name.replace(/\.ts$/, ''));
+
+          modules.push({
+            filePath: path.relative(bridgesDir, fullPath),
+            namespace: [...namespace, moduleName],
+            functions,
+          });
+        }
+      }
+    }
+  }
+
+  scanDir(bridgesDir);
+  return modules;
+}
+
+function generateCSharpCode(modules: BridgeModule[]): string {
+  const lines: string[] = [];
+
+  lines.push('// -----------------------------------------------------------------------');
+  lines.push('// <auto-generated>');
+  lines.push('//     This file is auto-generated by vite-plugin-unity-bridge.');
+  lines.push('//     Do not modify directly.');
+  lines.push('// </auto-generated>');
+  lines.push('// -----------------------------------------------------------------------');
+  lines.push('');
+  lines.push('using System;');
+  lines.push('using System.Collections.Generic;');
+  lines.push('using System.Threading.Tasks;');
+  lines.push('using Newtonsoft.Json;');
+  lines.push('using UnityEngine.Scripting;');
+  lines.push('');
+  lines.push('namespace AppsInToss.Bridges');
+  lines.push('{');
+
+  for (const module of modules) {
+    const className = module.namespace.join('_');
+
+    lines.push(`    /// <summary>`);
+    lines.push(`    /// Custom Bridge: ${module.namespace.join('.')}`);
+    lines.push(`    /// Source: ${module.filePath}`);
+    lines.push(`    /// </summary>`);
+    lines.push(`    [Preserve]`);
+    lines.push(`    public static class ${className}`);
+    lines.push(`    {`);
+
+    for (const func of module.functions) {
+      const methodName = toPascalCase(func.name);
+      const internalFuncName = `__CustomBridge_${className}_${func.name}_Internal`;
+
+      let returnType = mapToCSharpType(func.returnType);
+      const isVoid = returnType === 'void';
+      const taskReturnType = isVoid ? 'Task' : `Task<${returnType}>`;
+
+      if (func.jsDoc) {
+        lines.push(`        /// <summary>${func.jsDoc}</summary>`);
+      }
+
+      const paramStrings = func.params.map((p) => {
+        const csType = mapToCSharpType(p.type);
+        const needsNullable = p.optional && (csType === 'double' || csType === 'bool');
+        return `${csType}${needsNullable ? '?' : ''} ${p.name}${p.optional && !needsNullable ? ' = null' : ''}`;
+      });
+
+      lines.push(`        [Preserve]`);
+      lines.push(`        public static async ${taskReturnType} ${methodName}(${paramStrings.join(', ')})`);
+      lines.push(`        {`);
+      lines.push(`#if UNITY_WEBGL && !UNITY_EDITOR`);
+
+      if (isVoid) {
+        lines.push(`            var tcs = new TaskCompletionSource<object>();`);
+        lines.push(`            string callbackId = AITCore.Instance.RegisterCallback<object>(`);
+        lines.push(`                result => tcs.TrySetResult(null),`);
+      } else {
+        lines.push(`            var tcs = new TaskCompletionSource<${returnType}>();`);
+        lines.push(`            string callbackId = AITCore.Instance.RegisterCallback<${returnType}>(`);
+        lines.push(`                result => tcs.TrySetResult(result),`);
+      }
+      lines.push(`                error => tcs.TrySetException(error)`);
+      lines.push(`            );`);
+
+      const callArgs = func.params.map((p) => {
+        const csType = mapToCSharpType(p.type);
+        if (csType.startsWith('Dictionary') || csType.endsWith('[]') || csType === 'object') {
+          return `JsonConvert.SerializeObject(${p.name})`;
+        }
+        if (csType === 'bool') {
+          return p.optional ? `(${p.name} ?? false) ? 1 : 0` : `${p.name} ? 1 : 0`;
+        }
+        if (csType === 'double' && p.optional) {
+          return `${p.name} ?? 0`;
+        }
+        return p.name;
+      });
+
+      const typeName = isVoid ? 'void' : returnType;
+      lines.push(`            ${internalFuncName}(${[...callArgs, 'callbackId', `""${typeName}""`].join(', ')});`);
+
+      if (isVoid) {
+        lines.push(`            await tcs.Task;`);
+      } else {
+        lines.push(`            return await tcs.Task;`);
+      }
+
+      lines.push(`#else`);
+      lines.push(`            UnityEngine.Debug.Log($""[CustomBridge Mock] ${className}.${methodName} called"");`);
+      lines.push(`            await Task.CompletedTask;`);
+      if (!isVoid) {
+        lines.push(`            return default;`);
+      }
+      lines.push(`#endif`);
+      lines.push(`        }`);
+      lines.push('');
+
+      lines.push(`#if UNITY_WEBGL && !UNITY_EDITOR`);
+      const dllImportParams = func.params.map((p) => {
+        const csType = mapToCSharpType(p.type);
+        if (csType === 'string' || csType.startsWith('Dictionary') || csType.endsWith('[]') || csType === 'object') {
+          return `string ${p.name}`;
+        }
+        if (csType === 'bool') {
+          return `int ${p.name}`;
+        }
+        return `${csType} ${p.name}`;
+      });
+      lines.push(`        [System.Runtime.InteropServices.DllImport(""__Internal"")]`);
+      lines.push(`        private static extern void ${internalFuncName}(${[...dllImportParams, 'string callbackId', 'string typeName'].join(', ')});`);
+      lines.push(`#endif`);
+      lines.push('');
+    }
+
+    lines.push(`    }`);
+    lines.push('');
+  }
+
+  lines.push('}');
+
+  return lines.join('\n');
+}
+
+function generateJslibCode(modules: BridgeModule[]): string {
+  const lines: string[] = [];
+
+  lines.push('/**');
+  lines.push(' * CustomBridges.jslib');
+  lines.push(' *');
+  lines.push(' * This file is auto-generated by vite-plugin-unity-bridge.');
+  lines.push(' */');
+  lines.push('');
+  lines.push('mergeInto(LibraryManager.library, {');
+
+  const funcDefs: string[] = [];
+
+  for (const module of modules) {
+    const className = module.namespace.join('_');
+
+    for (const func of module.functions) {
+      const internalFuncName = `__CustomBridge_${className}_${func.name}_Internal`;
+      const funcLines: string[] = [];
+
+      const paramNames = [...func.params.map((p) => p.name), 'callbackId', 'typeName'];
+
+      funcLines.push(`    ${internalFuncName}: function(${paramNames.join(', ')}) {`);
+      funcLines.push(`        var callback = UTF8ToString(callbackId);`);
+      funcLines.push(`        var typeNameStr = UTF8ToString(typeName);`);
+      funcLines.push('');
+
+      for (const param of func.params) {
+        const baseType = param.type.replace(/\?$/, '').replace(/\s*\|\s*(undefined|null)$/, '');
+        let processing: string;
+        if (baseType === 'string') {
+          processing = `UTF8ToString(${param.name})`;
+        } else if (baseType === 'number') {
+          processing = param.name;
+        } else if (baseType === 'boolean') {
+          processing = `${param.name} !== 0`;
+        } else {
+          processing = `JSON.parse(UTF8ToString(${param.name}))`;
+        }
+        funcLines.push(`        var ${param.name}_val = ${processing};`);
+      }
+
+      const bridgePath = ['window', 'Bridges', ...module.namespace].join('.');
+      const funcCall = `${bridgePath}.${func.name}`;
+      const callArgs = func.params.map((p) => `${p.name}_val`).join(', ');
+
+      funcLines.push('');
+      funcLines.push('        try {');
+
+      if (func.isAsync) {
+        funcLines.push(`            var promiseResult = ${funcCall}(${callArgs});`);
+        funcLines.push('');
+        funcLines.push('            if (!promiseResult || typeof promiseResult.then !== ""function"") {');
+        funcLines.push('                var payload = JSON.stringify({');
+        funcLines.push('                    CallbackId: callback,');
+        funcLines.push('                    TypeName: typeNameStr,');
+        funcLines.push('                    Result: JSON.stringify({ success: true, data: JSON.stringify(promiseResult), error: """" })');
+        funcLines.push('                });');
+        funcLines.push('                SendMessage(""AITCore"", ""OnAITCallback"", payload);');
+        funcLines.push('                return;');
+        funcLines.push('            }');
+        funcLines.push('');
+        funcLines.push('            promiseResult');
+        funcLines.push('                .then(function(result) {');
+        funcLines.push('                    var payload = JSON.stringify({');
+        funcLines.push('                        CallbackId: callback,');
+        funcLines.push('                        TypeName: typeNameStr,');
+        funcLines.push('                        Result: JSON.stringify({ success: true, data: JSON.stringify(result), error: """" })');
+        funcLines.push('                    });');
+        funcLines.push('                    SendMessage(""AITCore"", ""OnAITCallback"", payload);');
+        funcLines.push('                })');
+        funcLines.push('                .catch(function(error) {');
+        funcLines.push('                    var payload = JSON.stringify({');
+        funcLines.push('                        CallbackId: callback,');
+        funcLines.push('                        TypeName: typeNameStr,');
+        funcLines.push('                        Result: JSON.stringify({ success: false, data: """", error: error.message || String(error) })');
+        funcLines.push('                    });');
+        funcLines.push('                    SendMessage(""AITCore"", ""OnAITCallback"", payload);');
+        funcLines.push('                });');
+      } else {
+        funcLines.push(`            var result = ${funcCall}(${callArgs});`);
+        funcLines.push('            var payload = JSON.stringify({');
+        funcLines.push('                CallbackId: callback,');
+        funcLines.push('                TypeName: typeNameStr,');
+        funcLines.push('                Result: JSON.stringify({ success: true, data: JSON.stringify(result), error: """" })');
+        funcLines.push('            });');
+        funcLines.push('            SendMessage(""AITCore"", ""OnAITCallback"", payload);');
+      }
+
+      funcLines.push('        } catch (error) {');
+      funcLines.push('            var payload = JSON.stringify({');
+      funcLines.push('                CallbackId: callback,');
+      funcLines.push('                TypeName: typeNameStr,');
+      funcLines.push('                Result: JSON.stringify({ success: false, data: """", error: error.message || String(error) })');
+      funcLines.push('            });');
+      funcLines.push('            SendMessage(""AITCore"", ""OnAITCallback"", payload);');
+      funcLines.push('        }');
+      funcLines.push('    }');
+
+      funcDefs.push(funcLines.join('\n'));
+    }
+  }
+
+  lines.push(funcDefs.join(',\n\n'));
+  lines.push('});');
+
+  return lines.join('\n');
+}
+
+function generateBridgesEntryCode(modules: BridgeModule[]): string {
+  const lines: string[] = [];
+
+  lines.push('/**');
+  lines.push(' * bridges-entry.ts');
+  lines.push(' *');
+  lines.push(' * Auto-generated entry point for custom bridges.');
+  lines.push(' */');
+  lines.push('');
+
+  for (const module of modules) {
+    const importName = module.namespace.join('_');
+    const importPath = './bridges/' + module.filePath.replace(/\.ts$/, '');
+    lines.push(`import * as ${importName} from '${importPath}';`);
+  }
+
+  lines.push('');
+  lines.push('declare global {');
+  lines.push('  interface Window {');
+  lines.push('    Bridges: Record<string, unknown>;');
+  lines.push('  }');
+  lines.push('}');
+  lines.push('');
+  lines.push('window.Bridges = window.Bridges || {};');
+  lines.push('');
+
+  for (const module of modules) {
+    const importName = module.namespace.join('_');
+    let currentPath = 'window.Bridges';
+
+    for (let i = 0; i < module.namespace.length - 1; i++) {
+      const ns = module.namespace[i];
+      currentPath += `.${ns}`;
+      lines.push(`${currentPath} = ${currentPath} || {};`);
+    }
+
+    const fullPath = ['window', 'Bridges', ...module.namespace].join('.');
+    lines.push(`${fullPath} = ${importName};`);
+  }
+
+  lines.push('');
+  lines.push('console.log(""[CustomBridges] Registered:"", Object.keys(window.Bridges));');
+
+  return lines.join('\n');
+}
+
+// Main
+const modules = parseBridgesFolder();
+
+if (modules.length === 0) {
+  console.log('[CustomBridge] No bridge modules found.');
+  process.exit(0);
+}
+
+console.log(`[CustomBridge] Found ${modules.length} bridge module(s):`);
+for (const mod of modules) {
+  console.log(`  - ${mod.namespace.join('.')} (${mod.functions.length} functions)`);
+}
+
+// Create output directory
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+
+// Generate manifest
+const manifest = {
+  version: '1.0.0',
+  generatedAt: new Date().toISOString(),
+  modules,
+};
+fs.writeFileSync(path.join(outputDir, 'bridge-manifest.json'), JSON.stringify(manifest, null, 2));
+
+// Generate C#
+const csharpCode = generateCSharpCode(modules);
+fs.writeFileSync(path.join(outputDir, 'CustomBridges.cs'), csharpCode);
+
+// Generate jslib
+const jslibCode = generateJslibCode(modules);
+fs.writeFileSync(path.join(outputDir, 'CustomBridges.jslib'), jslibCode);
+
+// Generate entry
+const entryCode = generateBridgesEntryCode(modules);
+fs.writeFileSync(path.join(outputDir, 'bridges-entry.ts'), entryCode);
+
+console.log('[CustomBridge] Generated files:');
+console.log(`  - ${outputDir}/bridge-manifest.json`);
+console.log(`  - ${outputDir}/CustomBridges.cs`);
+console.log(`  - ${outputDir}/CustomBridges.jslib`);
+console.log(`  - ${outputDir}/bridges-entry.ts`);
+";
+            File.WriteAllText(scriptPath, scriptContent, System.Text.Encoding.UTF8);
+            Debug.Log("[CustomBridge] generate-bridges.ts 생성됨");
+        }
+
+        /// <summary>
+        /// 생성된 파일을 Unity 프로젝트에 복사
+        /// </summary>
+        private static bool CopyGeneratedFiles(string buildConfigPath)
+        {
+            string generatedPath = Path.Combine(buildConfigPath, GENERATED_DIR);
+
+            if (!Directory.Exists(generatedPath))
+            {
+                Debug.LogWarning("[CustomBridge] 생성된 파일이 없습니다.");
+                return false;
+            }
+
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+
+            // C# 파일 복사
+            string csharpSrc = Path.Combine(generatedPath, "CustomBridges.cs");
+            if (File.Exists(csharpSrc))
+            {
+                string csharpDest = Path.Combine(projectRoot, CSHARP_OUTPUT_DIR);
+                if (!Directory.Exists(csharpDest))
+                {
+                    Directory.CreateDirectory(csharpDest);
+                }
+
+                string destFile = Path.Combine(csharpDest, "CustomBridges.cs");
+                File.Copy(csharpSrc, destFile, true);
+                Debug.Log($"[CustomBridge] ✓ CustomBridges.cs → {CSHARP_OUTPUT_DIR}");
+            }
+
+            // jslib 파일 복사
+            string jslibSrc = Path.Combine(generatedPath, "CustomBridges.jslib");
+            if (File.Exists(jslibSrc))
+            {
+                string jslibDest = Path.Combine(projectRoot, JSLIB_OUTPUT_DIR);
+                if (!Directory.Exists(jslibDest))
+                {
+                    Directory.CreateDirectory(jslibDest);
+                }
+
+                string destFile = Path.Combine(jslibDest, "CustomBridges.jslib");
+                File.Copy(jslibSrc, destFile, true);
+                Debug.Log($"[CustomBridge] ✓ CustomBridges.jslib → {JSLIB_OUTPUT_DIR}");
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 빌드 전 커스텀 브릿지 생성 체크
+        /// </summary>
+        public static bool CheckAndGenerateBridges()
+        {
+            if (!HasBridgeFiles())
+            {
+                return true; // 브릿지 파일이 없으면 스킵
+            }
+
+            Debug.Log("[CustomBridge] bridges 폴더에서 TypeScript 파일 감지됨. 브릿지 생성 중...");
+            return GenerateBridges();
+        }
+
+        #region Menu Items
+
+        [MenuItem("Apps in Toss/Custom Bridges/Generate Bridges", false, 300)]
+        public static void MenuGenerateBridges()
+        {
+            if (GenerateBridges())
+            {
+                EditorUtility.DisplayDialog("커스텀 브릿지", "브릿지 생성이 완료되었습니다.", "확인");
+            }
+            else
+            {
+                EditorUtility.DisplayDialog("커스텀 브릿지", "브릿지 생성에 실패했습니다.\nConsole 창을 확인해주세요.", "확인");
+            }
+        }
+
+        [MenuItem("Apps in Toss/Custom Bridges/Open Bridges Folder", false, 301)]
+        public static void MenuOpenBridgesFolder()
+        {
+            string bridgesPath = GetBridgesPath();
+
+            if (!Directory.Exists(bridgesPath))
+            {
+                Directory.CreateDirectory(bridgesPath);
+                Debug.Log($"[CustomBridge] bridges 폴더 생성됨: {bridgesPath}");
+            }
+
+            EditorUtility.RevealInFinder(bridgesPath);
+        }
+
+        #endregion
+    }
+}

--- a/Editor/AITCustomBridgeGenerator.cs.meta
+++ b/Editor/AITCustomBridgeGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b4c2e9d0a3f6718c5d9e1b7a2c4f6d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/WebGLTemplates/AITTemplate/BuildConfig~/bridges/.gitkeep
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/bridges/.gitkeep
@@ -1,0 +1,2 @@
+# 커스텀 브릿지 함수를 이 폴더에 작성하세요.
+# 예시: analytics/firebase.ts → Bridges.Analytics.Firebase

--- a/WebGLTemplates/AITTemplate/BuildConfig~/bridges/example.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/bridges/example.ts
@@ -1,0 +1,75 @@
+/**
+ * example.ts
+ *
+ * 커스텀 브릿지 예제 파일
+ * 이 파일의 export 함수들은 Unity C# + jslib로 자동 변환됩니다.
+ *
+ * 사용 방법:
+ * 1. 이 폴더에 TypeScript 파일 작성
+ * 2. Unity 메뉴 > Apps in Toss > Custom Bridges > Generate Bridges 실행
+ * 3. Unity에서 AppsInToss.Bridges.Example 클래스로 호출
+ *
+ * Unity 사용 예:
+ * ```csharp
+ * using AppsInToss.Bridges;
+ *
+ * var result = await Example.Add(1, 2);
+ * Debug.Log($"Result: {result}"); // 3
+ *
+ * var greeting = await Example.Greet("Unity");
+ * Debug.Log(greeting); // "Hello, Unity!"
+ * ```
+ */
+
+/**
+ * 두 숫자를 더합니다.
+ * @param a 첫 번째 숫자
+ * @param b 두 번째 숫자
+ * @returns 합계
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+/**
+ * 인사 메시지를 생성합니다.
+ * @param name 이름
+ * @returns 인사 메시지
+ */
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+/**
+ * 비동기 작업 예제 (Promise 반환)
+ * @param ms 대기 시간 (밀리초)
+ * @returns 완료 메시지
+ */
+export async function delay(ms: number): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(`Waited ${ms}ms`);
+    }, ms);
+  });
+}
+
+/**
+ * 객체를 받아서 처리하는 예제
+ * @param data 키-값 데이터
+ * @returns 처리 결과
+ */
+export function processData(data: Record<string, string>): boolean {
+  console.log('[Example] Processing data:', data);
+  return Object.keys(data).length > 0;
+}
+
+/**
+ * 선택적 파라미터 예제
+ * @param message 메시지
+ * @param count 반복 횟수 (선택적, 기본값 1)
+ * @returns 반복된 메시지
+ */
+export function repeat(message: string, count?: number): string {
+  const times = count ?? 1;
+  return message.repeat(times);
+}

--- a/WebGLTemplates/AITTemplate/BuildConfig~/package.json
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/package.json
@@ -13,7 +13,8 @@
   },
   "devDependencies": {
     "vite": "^7.3.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "ts-morph": "^24.0.0"
   },
   "pnpm": {
     "overrides": {

--- a/WebGLTemplates/AITTemplate/BuildConfig~/vite-plugin-unity-bridge.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/vite-plugin-unity-bridge.ts
@@ -1,0 +1,650 @@
+/**
+ * vite-plugin-unity-bridge.ts
+ *
+ * Vite 플러그인: bridges/ 폴더의 TypeScript 함수를 Unity C# + jslib로 자동 변환
+ *
+ * 사용법:
+ * 1. bridges/ 폴더에 TypeScript 파일 작성
+ * 2. export 함수 정의 (async 함수도 지원)
+ * 3. 빌드 시 자동으로 C# 바인딩 + jslib 생성
+ *
+ * 네임스페이스:
+ * - bridges/analytics/firebase.ts → Bridges.Analytics.Firebase
+ * - bridges/utils.ts → Bridges.Utils
+ */
+
+import { Plugin } from 'vite';
+import { Project, SyntaxKind, FunctionDeclaration, SourceFile, Type } from 'ts-morph';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ============================================================================
+// 타입 정의
+// ============================================================================
+
+interface BridgeParam {
+  name: string;
+  type: string;
+  optional: boolean;
+}
+
+interface BridgeFunction {
+  name: string;
+  params: BridgeParam[];
+  returnType: string;
+  isAsync: boolean;
+  jsDoc?: string;
+}
+
+interface BridgeModule {
+  /** 원본 파일 경로 (상대 경로) */
+  filePath: string;
+  /** 네임스페이스 배열 (예: ['Analytics', 'Firebase']) */
+  namespace: string[];
+  /** 함수 목록 */
+  functions: BridgeFunction[];
+}
+
+interface BridgeManifest {
+  version: string;
+  generatedAt: string;
+  modules: BridgeModule[];
+}
+
+// ============================================================================
+// 타입 매핑
+// ============================================================================
+
+/** TypeScript → C# 타입 매핑 */
+function mapToCSharpType(tsType: string): string {
+  // 기본 타입
+  const typeMap: Record<string, string> = {
+    'string': 'string',
+    'number': 'double',
+    'boolean': 'bool',
+    'void': 'void',
+  };
+
+  // Promise<T> → T
+  const promiseMatch = tsType.match(/^Promise<(.+)>$/);
+  if (promiseMatch) {
+    return mapToCSharpType(promiseMatch[1]);
+  }
+
+  // T[] → T[]
+  const arrayMatch = tsType.match(/^(.+)\[\]$/);
+  if (arrayMatch) {
+    return `${mapToCSharpType(arrayMatch[1])}[]`;
+  }
+
+  // Record<string, T> → Dictionary<string, T>
+  const recordMatch = tsType.match(/^Record<string,\s*(.+)>$/);
+  if (recordMatch) {
+    return `Dictionary<string, ${mapToCSharpType(recordMatch[1])}>`;
+  }
+
+  // T | undefined, T | null → T (optional handled separately)
+  const unionMatch = tsType.match(/^(.+)\s*\|\s*(undefined|null)$/);
+  if (unionMatch) {
+    return mapToCSharpType(unionMatch[1]);
+  }
+
+  return typeMap[tsType] || 'object';
+}
+
+/** TypeScript → jslib 인수 처리 타입 */
+function getJsArgProcessing(param: BridgeParam): { argType: string; processing: string } {
+  const baseType = param.type.replace(/\?$/, '').replace(/\s*\|\s*(undefined|null)$/, '');
+
+  if (baseType === 'string') {
+    return { argType: 'ptr', processing: `UTF8ToString(${param.name})` };
+  }
+  if (baseType === 'number') {
+    return { argType: 'number', processing: param.name };
+  }
+  if (baseType === 'boolean') {
+    return { argType: 'number', processing: `${param.name} !== 0` };
+  }
+  // 복합 타입은 JSON 문자열로 전달
+  return { argType: 'ptr', processing: `JSON.parse(UTF8ToString(${param.name}))` };
+}
+
+// ============================================================================
+// TypeScript 파서
+// ============================================================================
+
+function parseBridgesFolder(bridgesDir: string): BridgeModule[] {
+  const modules: BridgeModule[] = [];
+
+  if (!fs.existsSync(bridgesDir)) {
+    return modules;
+  }
+
+  const project = new Project({
+    compilerOptions: {
+      strict: true,
+      target: 99, // ESNext
+      module: 99, // ESNext
+    },
+  });
+
+  // 재귀적으로 .ts 파일 탐색
+  function scanDir(dir: string, namespace: string[] = []) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        // 디렉토리 이름을 네임스페이스에 추가 (PascalCase 변환)
+        const nsName = toPascalCase(entry.name);
+        scanDir(fullPath, [...namespace, nsName]);
+      } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+        // TypeScript 파일 파싱
+        const sourceFile = project.addSourceFileAtPath(fullPath);
+        const functions = extractExportedFunctions(sourceFile);
+
+        if (functions.length > 0) {
+          // 파일 이름에서 모듈 이름 추출 (PascalCase 변환)
+          const moduleName = toPascalCase(entry.name.replace(/\.ts$/, ''));
+
+          modules.push({
+            filePath: path.relative(bridgesDir, fullPath),
+            namespace: [...namespace, moduleName],
+            functions,
+          });
+        }
+      }
+    }
+  }
+
+  scanDir(bridgesDir);
+  return modules;
+}
+
+function extractExportedFunctions(sourceFile: SourceFile): BridgeFunction[] {
+  const functions: BridgeFunction[] = [];
+
+  // export function 추출
+  sourceFile.getFunctions().forEach((func) => {
+    if (!func.isExported()) return;
+
+    const funcInfo = extractFunctionInfo(func);
+    if (funcInfo) {
+      functions.push(funcInfo);
+    }
+  });
+
+  // export default도 지원 (defineBridge 패턴 용)
+  // TODO: 필요시 구현
+
+  return functions;
+}
+
+function extractFunctionInfo(func: FunctionDeclaration): BridgeFunction | null {
+  const name = func.getName();
+  if (!name) return null;
+
+  // 파라미터 추출
+  const params: BridgeParam[] = func.getParameters().map((param) => {
+    const paramType = param.getType();
+    const typeText = simplifyType(paramType.getText());
+
+    return {
+      name: param.getName(),
+      type: typeText,
+      optional: param.isOptional() || param.hasQuestionToken(),
+    };
+  });
+
+  // 반환 타입 추출
+  const returnType = func.getReturnType();
+  const returnTypeText = simplifyType(returnType.getText());
+
+  // async 함수인지 또는 Promise를 반환하는지 확인
+  const isAsync = func.isAsync() || returnTypeText.startsWith('Promise<');
+
+  // JSDoc 추출
+  const jsDocNodes = func.getJsDocs();
+  const jsDoc = jsDocNodes.length > 0 ? jsDocNodes[0].getDescription() : undefined;
+
+  return {
+    name,
+    params,
+    returnType: returnTypeText,
+    isAsync,
+    jsDoc,
+  };
+}
+
+function simplifyType(typeText: string): string {
+  // import("...").SomeType → SomeType
+  return typeText.replace(/import\([^)]+\)\./g, '');
+}
+
+function toPascalCase(str: string): string {
+  return str
+    .split(/[-_]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+// ============================================================================
+// 코드 생성기
+// ============================================================================
+
+function generateManifest(modules: BridgeModule[]): BridgeManifest {
+  return {
+    version: '1.0.0',
+    generatedAt: new Date().toISOString(),
+    modules,
+  };
+}
+
+function generateCSharpCode(manifest: BridgeManifest): string {
+  const lines: string[] = [];
+
+  lines.push('// -----------------------------------------------------------------------');
+  lines.push('// <auto-generated>');
+  lines.push('//     This file is auto-generated by vite-plugin-unity-bridge.');
+  lines.push('//     Do not modify directly. 이 파일은 자동 생성되었습니다.');
+  lines.push('// </auto-generated>');
+  lines.push('// -----------------------------------------------------------------------');
+  lines.push('');
+  lines.push('using System;');
+  lines.push('using System.Collections.Generic;');
+  lines.push('using System.Threading.Tasks;');
+  lines.push('using Newtonsoft.Json;');
+  lines.push('using UnityEngine.Scripting;');
+  lines.push('');
+  lines.push('namespace AppsInToss.Bridges');
+  lines.push('{');
+
+  // 각 모듈에 대해 클래스 생성
+  for (const module of manifest.modules) {
+    const className = module.namespace.join('_');
+    const fullNamespace = module.namespace.join('.');
+
+    lines.push(`    /// <summary>`);
+    lines.push(`    /// Custom Bridge: ${fullNamespace}`);
+    lines.push(`    /// Source: ${module.filePath}`);
+    lines.push(`    /// </summary>`);
+    lines.push(`    [Preserve]`);
+    lines.push(`    public static class ${className}`);
+    lines.push(`    {`);
+
+    for (const func of module.functions) {
+      lines.push(...generateCSharpMethod(func, className));
+      lines.push('');
+    }
+
+    lines.push(`    }`);
+    lines.push('');
+  }
+
+  lines.push('}');
+
+  return lines.join('\n');
+}
+
+function generateCSharpMethod(func: BridgeFunction, className: string): string[] {
+  const lines: string[] = [];
+  const methodName = toPascalCase(func.name);
+  const internalFuncName = `__CustomBridge_${className}_${func.name}_Internal`;
+
+  // 반환 타입 결정
+  let returnType = mapToCSharpType(func.returnType);
+  const isVoid = returnType === 'void';
+
+  // async 함수는 Task로 래핑
+  const taskReturnType = isVoid ? 'Task' : `Task<${returnType}>`;
+
+  // JSDoc 주석
+  if (func.jsDoc) {
+    lines.push(`        /// <summary>${func.jsDoc}</summary>`);
+  }
+
+  // 파라미터 문자열 생성
+  const paramStrings = func.params.map((p) => {
+    const csType = mapToCSharpType(p.type);
+    const nullable = p.optional ? '?' : '';
+    // value type에만 nullable 적용
+    const needsNullable = p.optional && (csType === 'double' || csType === 'bool');
+    return `${csType}${needsNullable ? '?' : ''} ${p.name}${p.optional && !needsNullable ? ' = null' : ''}`;
+  });
+
+  lines.push(`        [Preserve]`);
+  lines.push(`        public static async ${taskReturnType} ${methodName}(${paramStrings.join(', ')})`);
+  lines.push(`        {`);
+  lines.push(`#if UNITY_WEBGL && !UNITY_EDITOR`);
+
+  // TaskCompletionSource 생성
+  if (isVoid) {
+    lines.push(`            var tcs = new TaskCompletionSource<object>();`);
+    lines.push(`            string callbackId = AITCore.Instance.RegisterCallback<object>(`);
+    lines.push(`                result => tcs.TrySetResult(null),`);
+  } else {
+    lines.push(`            var tcs = new TaskCompletionSource<${returnType}>();`);
+    lines.push(`            string callbackId = AITCore.Instance.RegisterCallback<${returnType}>(`);
+    lines.push(`                result => tcs.TrySetResult(result),`);
+  }
+  lines.push(`                error => tcs.TrySetException(error)`);
+  lines.push(`            );`);
+
+  // jslib 함수 호출
+  const callArgs = func.params.map((p) => {
+    const csType = mapToCSharpType(p.type);
+    // 복합 타입은 JSON 직렬화
+    if (csType.startsWith('Dictionary') || csType.endsWith('[]') || csType === 'object') {
+      return `JsonConvert.SerializeObject(${p.name})`;
+    }
+    if (csType === 'bool') {
+      return p.optional ? `(${p.name} ?? false) ? 1 : 0` : `${p.name} ? 1 : 0`;
+    }
+    if (csType === 'double' && p.optional) {
+      return `${p.name} ?? 0`;
+    }
+    return p.name;
+  });
+
+  // 타입 이름 결정 (콜백 라우팅용)
+  const typeName = isVoid ? 'void' : returnType;
+
+  lines.push(`            ${internalFuncName}(${[...callArgs, 'callbackId', `"${typeName}"`].join(', ')});`);
+
+  if (isVoid) {
+    lines.push(`            await tcs.Task;`);
+  } else {
+    lines.push(`            return await tcs.Task;`);
+  }
+
+  lines.push(`#else`);
+  lines.push(`            // Unity Editor mock implementation`);
+  lines.push(`            UnityEngine.Debug.Log($"[CustomBridge Mock] ${className}.${methodName} called");`);
+  lines.push(`            await Task.CompletedTask;`);
+  if (!isVoid) {
+    lines.push(`            return default;`);
+  }
+  lines.push(`#endif`);
+  lines.push(`        }`);
+  lines.push('');
+
+  // DllImport 선언
+  lines.push(`#if UNITY_WEBGL && !UNITY_EDITOR`);
+  const dllImportParams = func.params.map((p) => {
+    const csType = mapToCSharpType(p.type);
+    if (csType === 'string' || csType.startsWith('Dictionary') || csType.endsWith('[]') || csType === 'object') {
+      return `string ${p.name}`;
+    }
+    if (csType === 'bool') {
+      return `int ${p.name}`;
+    }
+    return `${csType} ${p.name}`;
+  });
+  lines.push(`        [System.Runtime.InteropServices.DllImport("__Internal")]`);
+  lines.push(`        private static extern void ${internalFuncName}(${[...dllImportParams, 'string callbackId', 'string typeName'].join(', ')});`);
+  lines.push(`#endif`);
+
+  return lines;
+}
+
+function generateJslibCode(manifest: BridgeManifest): string {
+  const lines: string[] = [];
+
+  lines.push('/**');
+  lines.push(' * CustomBridges.jslib');
+  lines.push(' *');
+  lines.push(' * This file is auto-generated by vite-plugin-unity-bridge.');
+  lines.push(' * Do not modify directly. 이 파일은 자동 생성되었습니다.');
+  lines.push(' */');
+  lines.push('');
+  lines.push('mergeInto(LibraryManager.library, {');
+
+  const funcDefs: string[] = [];
+
+  for (const module of manifest.modules) {
+    const className = module.namespace.join('_');
+
+    for (const func of module.functions) {
+      funcDefs.push(generateJslibFunction(func, className, module.namespace));
+    }
+  }
+
+  lines.push(funcDefs.join(',\n\n'));
+  lines.push('});');
+
+  return lines.join('\n');
+}
+
+function generateJslibFunction(func: BridgeFunction, className: string, namespace: string[]): string {
+  const internalFuncName = `__CustomBridge_${className}_${func.name}_Internal`;
+  const lines: string[] = [];
+
+  // 파라미터 목록 생성 (+ callbackId, typeName)
+  const paramNames = [...func.params.map((p) => p.name), 'callbackId', 'typeName'];
+
+  lines.push(`    ${internalFuncName}: function(${paramNames.join(', ')}) {`);
+  lines.push(`        var callback = UTF8ToString(callbackId);`);
+  lines.push(`        var typeNameStr = UTF8ToString(typeName);`);
+  lines.push('');
+
+  // 파라미터 처리
+  for (const param of func.params) {
+    const { processing } = getJsArgProcessing(param);
+    lines.push(`        var ${param.name}_val = ${processing};`);
+  }
+
+  // window.Bridges 경로 구성
+  const bridgePath = ['window', 'Bridges', ...namespace].join('.');
+  const funcCall = `${bridgePath}.${func.name}`;
+  const callArgs = func.params.map((p) => `${p.name}_val`).join(', ');
+
+  lines.push('');
+  lines.push('        try {');
+
+  if (func.isAsync) {
+    // 비동기 함수
+    lines.push(`            var promiseResult = ${funcCall}(${callArgs});`);
+    lines.push('');
+    lines.push('            if (!promiseResult || typeof promiseResult.then !== "function") {');
+    lines.push('                // Promise가 아닌 경우 즉시 응답');
+    lines.push('                var payload = JSON.stringify({');
+    lines.push('                    CallbackId: callback,');
+    lines.push('                    TypeName: typeNameStr,');
+    lines.push('                    Result: JSON.stringify({ success: true, data: JSON.stringify(promiseResult), error: "" })');
+    lines.push('                });');
+    lines.push('                SendMessage("AITCore", "OnAITCallback", payload);');
+    lines.push('                return;');
+    lines.push('            }');
+    lines.push('');
+    lines.push('            promiseResult');
+    lines.push('                .then(function(result) {');
+    lines.push('                    var payload = JSON.stringify({');
+    lines.push('                        CallbackId: callback,');
+    lines.push('                        TypeName: typeNameStr,');
+    lines.push('                        Result: JSON.stringify({ success: true, data: JSON.stringify(result), error: "" })');
+    lines.push('                    });');
+    lines.push('                    SendMessage("AITCore", "OnAITCallback", payload);');
+    lines.push('                })');
+    lines.push('                .catch(function(error) {');
+    lines.push('                    var payload = JSON.stringify({');
+    lines.push('                        CallbackId: callback,');
+    lines.push('                        TypeName: typeNameStr,');
+    lines.push('                        Result: JSON.stringify({ success: false, data: "", error: error.message || String(error) })');
+    lines.push('                    });');
+    lines.push('                    SendMessage("AITCore", "OnAITCallback", payload);');
+    lines.push('                });');
+  } else {
+    // 동기 함수
+    lines.push(`            var result = ${funcCall}(${callArgs});`);
+    lines.push('            var payload = JSON.stringify({');
+    lines.push('                CallbackId: callback,');
+    lines.push('                TypeName: typeNameStr,');
+    lines.push('                Result: JSON.stringify({ success: true, data: JSON.stringify(result), error: "" })');
+    lines.push('            });');
+    lines.push('            SendMessage("AITCore", "OnAITCallback", payload);');
+  }
+
+  lines.push('        } catch (error) {');
+  lines.push('            var payload = JSON.stringify({');
+  lines.push('                CallbackId: callback,');
+  lines.push('                TypeName: typeNameStr,');
+  lines.push('                Result: JSON.stringify({ success: false, data: "", error: error.message || String(error) })');
+  lines.push('            });');
+  lines.push('            SendMessage("AITCore", "OnAITCallback", payload);');
+  lines.push('        }');
+  lines.push('    }');
+
+  return lines.join('\n');
+}
+
+function generateBridgesEntryCode(manifest: BridgeManifest): string {
+  const lines: string[] = [];
+
+  lines.push('/**');
+  lines.push(' * bridges-entry.ts');
+  lines.push(' *');
+  lines.push(' * Auto-generated entry point for custom bridges.');
+  lines.push(' * Exposes all bridge functions to window.Bridges');
+  lines.push(' */');
+  lines.push('');
+
+  // 모든 브릿지 모듈 import
+  for (const module of manifest.modules) {
+    const importName = module.namespace.join('_');
+    const importPath = './' + module.filePath.replace(/\.ts$/, '');
+    lines.push(`import * as ${importName} from '${importPath}';`);
+  }
+
+  lines.push('');
+  lines.push('// window.Bridges 객체 구성');
+  lines.push('declare global {');
+  lines.push('  interface Window {');
+  lines.push('    Bridges: Record<string, unknown>;');
+  lines.push('  }');
+  lines.push('}');
+  lines.push('');
+  lines.push('window.Bridges = window.Bridges || {};');
+  lines.push('');
+
+  // 네임스페이스 구조 생성
+  for (const module of manifest.modules) {
+    const importName = module.namespace.join('_');
+    let currentPath = 'window.Bridges';
+
+    // 중첩 네임스페이스 생성
+    for (let i = 0; i < module.namespace.length - 1; i++) {
+      const ns = module.namespace[i];
+      currentPath += `.${ns}`;
+      lines.push(`${currentPath} = ${currentPath} || {};`);
+    }
+
+    // 최종 모듈 할당
+    const fullPath = ['window', 'Bridges', ...module.namespace].join('.');
+    lines.push(`${fullPath} = ${importName};`);
+  }
+
+  lines.push('');
+  lines.push('console.log("[CustomBridges] Registered:", Object.keys(window.Bridges));');
+
+  return lines.join('\n');
+}
+
+// ============================================================================
+// Vite 플러그인
+// ============================================================================
+
+export interface UnityBridgePluginOptions {
+  /** bridges 폴더 경로 (기본: ./bridges) */
+  bridgesDir?: string;
+  /** 출력 폴더 경로 (기본: ./generated) */
+  outputDir?: string;
+  /** C# 출력 경로 (Unity 프로젝트 기준, 빌드 시 복사됨) */
+  csharpOutputPath?: string;
+  /** jslib 출력 경로 (Unity 프로젝트 기준, 빌드 시 복사됨) */
+  jslibOutputPath?: string;
+}
+
+export function unityBridgePlugin(options: UnityBridgePluginOptions = {}): Plugin {
+  const bridgesDir = options.bridgesDir || './bridges';
+  const outputDir = options.outputDir || './generated';
+
+  let generatedEntryPath: string | null = null;
+
+  return {
+    name: 'vite-plugin-unity-bridge',
+
+    buildStart() {
+      // bridges 폴더가 없으면 스킵
+      if (!fs.existsSync(bridgesDir)) {
+        console.log('[unity-bridge] No bridges/ folder found, skipping...');
+        return;
+      }
+
+      console.log('[unity-bridge] Scanning bridges folder...');
+
+      // TypeScript 파싱
+      const modules = parseBridgesFolder(bridgesDir);
+
+      if (modules.length === 0) {
+        console.log('[unity-bridge] No bridge modules found.');
+        return;
+      }
+
+      console.log(`[unity-bridge] Found ${modules.length} bridge module(s):`);
+      for (const mod of modules) {
+        console.log(`  - ${mod.namespace.join('.')} (${mod.functions.length} functions)`);
+      }
+
+      // 출력 폴더 생성
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+
+      // Manifest 생성
+      const manifest = generateManifest(modules);
+      fs.writeFileSync(
+        path.join(outputDir, 'bridge-manifest.json'),
+        JSON.stringify(manifest, null, 2)
+      );
+
+      // C# 코드 생성
+      const csharpCode = generateCSharpCode(manifest);
+      fs.writeFileSync(path.join(outputDir, 'CustomBridges.cs'), csharpCode);
+
+      // jslib 코드 생성
+      const jslibCode = generateJslibCode(manifest);
+      fs.writeFileSync(path.join(outputDir, 'CustomBridges.jslib'), jslibCode);
+
+      // 브릿지 엔트리 코드 생성
+      const entryCode = generateBridgesEntryCode(manifest);
+      generatedEntryPath = path.join(outputDir, 'bridges-entry.ts');
+      fs.writeFileSync(generatedEntryPath, entryCode);
+
+      console.log('[unity-bridge] Generated files:');
+      console.log(`  - ${outputDir}/bridge-manifest.json`);
+      console.log(`  - ${outputDir}/CustomBridges.cs`);
+      console.log(`  - ${outputDir}/CustomBridges.jslib`);
+      console.log(`  - ${outputDir}/bridges-entry.ts`);
+    },
+
+    transform(code, id) {
+      // index.html 또는 main entry에 브릿지 엔트리 자동 주입
+      // 현재는 수동으로 import 해야 함
+      return null;
+    },
+
+    configureServer(server) {
+      // 개발 서버에서 bridges 폴더 변경 감지
+      server.watcher.add(bridgesDir);
+      server.watcher.on('change', (file) => {
+        if (file.includes(bridgesDir)) {
+          console.log('[unity-bridge] Bridge file changed, regenerating...');
+          // TODO: 핫 리로드 지원
+        }
+      });
+    },
+  };
+}
+
+export default unityBridgePlugin;

--- a/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from 'vite';
+import { unityBridgePlugin } from './vite-plugin-unity-bridge';
 
 //// SDK_GENERATED_START - DO NOT EDIT THIS SECTION ////
 const sdkConfig = defineConfig({
@@ -29,6 +30,13 @@ const sdkConfig = defineConfig({
 const userConfig = defineConfig({
   // 여기에 사용자 커스텀 설정을 추가하세요
   // 예: plugins: [vue()],
+  plugins: [
+    // 커스텀 브릿지 플러그인 (bridges/ 폴더에서 TypeScript → C# + jslib 자동 생성)
+    unityBridgePlugin({
+      bridgesDir: './bridges',
+      outputDir: './generated',
+    }),
+  ],
 });
 //// USER_CONFIG_END ////
 


### PR DESCRIPTION
## Summary

Vite 빌드 파이프라인에 통합된 커스텀 브릿지 생성 시스템을 추가합니다.

### 주요 기능
- `bridges/` 폴더의 TypeScript 함수를 Unity C# + jslib로 자동 변환
- ts-morph를 사용한 TypeScript AST 파싱
- 네임스페이스 지원 (폴더 구조 기반: `bridges/analytics/firebase.ts` → `Bridges.Analytics.Firebase`)
- npm 패키지 import 지원 (Vite 번들링으로 Firebase, AdMob 등 연동 가능)
- Unity Editor 메뉴 통합 (`Apps in Toss > Custom Bridges`)

### 사용 예시

```typescript
// bridges/analytics/firebase.ts
import { initializeApp } from 'firebase/app';
import { getAnalytics, logEvent } from 'firebase/analytics';

export async function trackEvent(name: string, params?: Record<string, string>): Promise<boolean> {
  logEvent(analytics, name, params);
  return true;
}
```

```csharp
// Unity에서 사용
using AppsInToss.Bridges;

await Analytics_Firebase.TrackEvent("level_complete", new Dictionary<string, string> {
    {"level", "5"}
});
```

### 변경된 파일
- `Editor/AITCustomBridgeGenerator.cs` - Unity Editor 통합
- `BuildConfig~/vite-plugin-unity-bridge.ts` - Vite 플러그인
- `BuildConfig~/bridges/example.ts` - 예제 브릿지 파일
- `BuildConfig~/package.json` - ts-morph 의존성 추가
- `BuildConfig~/vite.config.ts` - 플러그인 통합

## Test plan
- [ ] Unity 컴파일 테스트 (E2E CI)
- [ ] bridges 폴더에서 TypeScript 파싱 테스트
- [ ] C# 코드 생성 테스트
- [ ] jslib 코드 생성 테스트
- [ ] WebGL 빌드 및 실행 테스트