### PR TITLE
수정: Dev 서버 시작 실패 버그 해결

### DIFF
--- a/Editor/AITNpmRunner.cs
+++ b/Editor/AITNpmRunner.cs
@@ -95,10 +95,12 @@ namespace AppsInToss.Editor
         {
             try
             {
+                // pnpmPath의 디렉토리를 additionalPaths로 전달 (workingDir이 아닌 실행파일 디렉토리)
+                string pnpmDir = Path.GetDirectoryName(pnpmPath);
                 var result = AITPlatformHelper.ExecuteCommand(
                     $"\"{pnpmPath}\" --version",
                     workingDir,
-                    new[] { workingDir },
+                    new[] { pnpmDir },
                     timeoutMs: 10000,
                     verbose: false
                 );
@@ -120,11 +122,13 @@ namespace AppsInToss.Editor
         /// </summary>
         internal static bool InstallPnpmWithNpm(string npmPath, string workingDir, string version)
         {
+            // npmPath의 디렉토리를 additionalPaths로 전달 (workingDir이 아닌 실행파일 디렉토리)
+            string npmDir = Path.GetDirectoryName(npmPath);
             string command = $"\"{npmPath}\" install -g pnpm@{version}";
             var result = AITPlatformHelper.ExecuteCommand(
                 command,
                 workingDir,
-                new[] { workingDir },
+                new[] { npmDir },
                 timeoutMs: 120000, // 2분
                 verbose: true
             );

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -866,7 +866,7 @@ namespace AppsInToss
                 };
 
                 // granite dev 명령어에 --host, --port 인자로 granite 서버 설정 전달
-                string graniteCommand = $"exec granite dev --host {graniteHost} --port {granitePort}";
+                string graniteCommand = "exec -- granite dev";
 
                 var processManager = new AITProcessTreeManager();
 
@@ -980,7 +980,7 @@ namespace AppsInToss
                 };
 
                 // granite dev 명령어에 --host, --port 인자로 granite 서버 설정 전달
-                string graniteCommand = $"exec granite dev --host {graniteHost} --port {granitePort}";
+                string graniteCommand = "exec -- granite dev";
 
                 var processManager = new AITProcessTreeManager();
 
@@ -1136,7 +1136,7 @@ namespace AppsInToss
                 };
 
                 // granite dev 명령어에 --host, --port 인자로 granite 서버 설정 전달
-                string graniteCommand = $"exec granite dev --host {graniteHost} --port {granitePort}";
+                string graniteCommand = "exec -- granite dev";
 
                 var processManager = new AITProcessTreeManager();
 
@@ -1250,7 +1250,7 @@ namespace AppsInToss
                 };
 
                 // granite dev 명령어에 --host, --port 인자로 granite 서버 설정 전달
-                string graniteCommand = $"exec granite dev --host {graniteHost} --port {granitePort}";
+                string graniteCommand = "exec -- granite dev";
 
                 var processManager = new AITProcessTreeManager();
 


### PR DESCRIPTION
## Summary
- npm exec 명령어에 `--` 구분자 추가하여 옵션 파싱 에러 해결
- additionalPaths에 workingDir 대신 실행파일 디렉토리 전달하여 pnpm 설치 실패(Exit Code 126) 해결
- E2E 테스트 추가: Granite Dev Server 명령어 검증 (버그 재발 방지)

## Changes
### Bug Fixes
- `Editor/AppsInTossMenu.cs`: `exec granite dev --host X --port Y` → `exec -- granite dev`
- `Editor/AITNpmRunner.cs`: `additionalPaths`에 workingDir 대신 실행파일 디렉토리 전달

### Tests
- `Tests~/E2E/tests/e2e-full-pipeline.test.js`:
  - `startGraniteDevServer()` 함수 추가
  - Test 1.5: Granite dev server command validation
  - npm 옵션 파싱 에러 감지로 버그 재발 방지

## Test plan
- [x] Unity에서 `Apps in Toss > Start Server` 실행
- [x] `npm warn Unknown cli config "--host"` 에러가 없는지 확인
- [x] `is a directory` 에러가 없는지 확인
- [x] Dev 서버가 정상 시작되는지 확인
- [ ] E2E 테스트 통과 확인