### PR TITLE
수정: 일괄 릴리즈 아티팩트 이름 충돌 해결

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,7 @@ jobs:
       os: macos
       unity-version: ${{ matrix.unity-version }}
       web-framework-version: ${{ needs.release.outputs.version }}
+      sdk-version: ${{ needs.release.outputs.version }}
       run-build: true
       run-e2e-test: false
       run-benchmark: false
@@ -239,6 +240,7 @@ jobs:
       os: windows
       unity-version: ${{ matrix.unity-version }}
       web-framework-version: ${{ needs.release.outputs.version }}
+      sdk-version: ${{ needs.release.outputs.version }}
       run-build: true
       run-e2e-test: false
       run-benchmark: false

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -41,6 +41,11 @@ on:
         type: boolean
         required: false
         default: false
+      sdk-version:
+        description: 'SDK version for artifact naming (bulk release)'
+        type: string
+        required: false
+        default: ''
       clean-library:
         description: 'Clean Unity Library cache'
         type: boolean
@@ -532,7 +537,12 @@ jobs:
         id: artifact
         shell: bash
         run: |
-          echo "name=ait-build-${{ inputs.os }}-${{ inputs.unity-version }}" >> $GITHUB_OUTPUT
+          SDK_VERSION="${{ inputs.sdk-version }}"
+          if [ -n "$SDK_VERSION" ]; then
+            echo "name=ait-build-${{ inputs.os }}-${{ inputs.unity-version }}-v${SDK_VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "name=ait-build-${{ inputs.os }}-${{ inputs.unity-version }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload AIT Build
         if: inputs.run-build


### PR DESCRIPTION
## Summary
- unity-build.yml에 `sdk-version` 입력 파라미터 추가
- 아티팩트 이름에 SDK 버전 포함하도록 수정
  - 기존: `ait-build-macos-6000.0`
  - 변경: `ait-build-macos-6000.0-v1.5.2`
- release.yml에서 sdk-version 전달

## 문제
병렬 릴리즈 시 여러 SDK 버전이 동일한 Unity 버전으로 빌드될 때 아티팩트 이름 충돌(409 Conflict) 발생

## Test plan
- [ ] Bulk Release 워크플로우 재실행하여 아티팩트 충돌 해결 확인