### PR TITLE
개선: E2E 테스트에 SDK 버전 오버라이드 기능 추가

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -24,7 +24,7 @@ for dir in "${UNITY_DIRS[@]}"; do
             if [ ! -f "$meta_file" ]; then
                 missing_meta_files+=("$file")
             fi
-        done < <(find "$dir" -type d -name "node_modules" -prune -o -type f ! -name ".*" ! -name "*.meta" ! -name ".DS_Store" ! -name "*.swp" ! -name "*.tmp" -print0)
+        done < <(find "$dir" -type d -name "node_modules" -prune -o -type d -name "*~" -prune -o -type f ! -name ".*" ! -name "*.meta" ! -name ".DS_Store" ! -name "*.swp" ! -name "*.tmp" -print0)
     fi
 done
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,6 +12,11 @@ on:
         description: 'Clean Unity Library cache'
         type: boolean
         default: false
+      sdk_version_override:
+        description: 'SDK 버전 오버라이드 (호환성 테스트용, 예: 1.5.0)'
+        type: string
+        required: false
+        default: ''
 
   # update.yml에서 호출
   workflow_call:
@@ -24,6 +29,11 @@ on:
         description: 'Clean Unity Library cache'
         type: boolean
         default: false
+      sdk_version_override:
+        description: 'Override SDK version for compatibility testing'
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: e2e-test-${{ github.ref }}
@@ -202,6 +212,7 @@ jobs:
       run-e2e-test: true
       run-benchmark: true
       clean-library: ${{ inputs.clean_library || false }}
+      sdk-version-override: ${{ inputs.sdk_version_override || '' }}
 
   # =====================================================
   # E2E Tests - Windows (테스트 1-5만 실행)
@@ -225,6 +236,7 @@ jobs:
       run-e2e-test: true
       run-benchmark: false
       clean-library: ${{ inputs.clean_library || false }}
+      sdk-version-override: ${{ inputs.sdk_version_override || '' }}
 
   # =====================================================
   # Test Report Summary

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -46,6 +46,11 @@ on:
         type: string
         required: false
         default: ''
+      sdk-version-override:
+        description: 'Override SDK version in package.json (for compatibility testing)'
+        type: string
+        required: false
+        default: ''
       clean-library:
         description: 'Clean Unity Library cache'
         type: boolean
@@ -113,6 +118,31 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
+
+      # =====================================================
+      # SDK 버전 오버라이드 (호환성 테스트용)
+      # =====================================================
+      - name: Override SDK Version
+        if: inputs.sdk-version-override != ''
+        shell: bash
+        run: |
+          OVERRIDE_VERSION="${{ inputs.sdk-version-override }}"
+          PACKAGE_JSON="package.json"
+
+          echo "=== SDK Version Override ==="
+          echo "Original version: $(grep '"version"' $PACKAGE_JSON)"
+
+          # sed로 버전 변경 (macOS/Linux 호환)
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${OVERRIDE_VERSION}\"/" $PACKAGE_JSON
+          else
+            sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${OVERRIDE_VERSION}\"/" $PACKAGE_JSON
+          fi
+
+          echo "Overridden version: $(grep '"version"' $PACKAGE_JSON)"
+          echo ""
+          echo "This will affect Unity Version Defines:"
+          echo "  - AIT_SDK_1_7_OR_LATER will be $([ $(echo \"$OVERRIDE_VERSION\" | cut -d. -f1,2 | tr -d .) -ge 17 ] && echo 'DEFINED' || echo 'NOT defined')"
 
       # =====================================================
       # Windows Defender 제외 (Windows)


### PR DESCRIPTION
## Summary
- E2E 테스트 시 SDK 버전을 오버라이드할 수 있는 기능 추가
- 다양한 SDK 버전에 대한 호환성 테스트를 동일 커밋에서 수행 가능

## Changes
- `test-e2e.yml`: `sdk_version_override` 입력 추가 (workflow_dispatch, workflow_call 모두 지원)
- `unity-build.yml`: `sdk-version-override` 입력 및 package.json 버전 변경 로직 추가
- `.githooks/pre-commit`: `~` 접미사 폴더 제외 (Unity 무시 폴더)

## Usage
E2E Tests 워크플로우 수동 실행 시:
- SDK 1.5.0 호환성 테스트: `sdk_version_override: 1.5.0`
- SDK 1.7.0 호환성 테스트: `sdk_version_override: 1.7.0`

## Motivation
PR #119 (SDK v1.7.1 업데이트)의 테스트 코드가 이전 SDK 버전과도 호환되는지 검증하기 위함.

## Test plan
- [ ] 워크플로우가 올바르게 트리거되는지 확인
- [ ] SDK 버전 오버라이드가 정상 작동하는지 확인