### PR TITLE
수정: SDK 버전 override pnpm 충돌 문제 해결

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ${{ inputs.os == 'macos' && fromJSON('["self-hosted", "macOS", "ARM64"]') || fromJSON('["self-hosted", "Windows", "X64", "enabled"]') }}
     timeout-minutes: 60
     concurrency:
-      group: unity-build-${{ inputs.os }}-${{ inputs.unity-version }}
+      group: unity-build-${{ inputs.os }}-${{ inputs.unity-version }}${{ inputs.sdk-version-override && format('-sdk{0}', inputs.sdk-version-override) || '' }}
       cancel-in-progress: false
 
     outputs:
@@ -127,6 +127,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
+
+      - name: Clean pnpm home (for SDK override)
+        if: inputs.sdk-version-override != ''
+        shell: bash
+        run: |
+          # Clean up existing pnpm installation to avoid conflicts on self-hosted runners
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            PNPM_HOME="$USERPROFILE/setup-pnpm"
+          else
+            PNPM_HOME="$HOME/setup-pnpm"
+          fi
+          if [ -d "$PNPM_HOME" ]; then
+            echo "Cleaning existing pnpm directory: $PNPM_HOME"
+            rm -rf "$PNPM_HOME" 2>/dev/null || true
+          fi
+          echo "pnpm home cleaned"
 
       - name: Setup pnpm (for SDK override)
         if: inputs.sdk-version-override != ''
@@ -190,9 +206,14 @@ jobs:
 
           # 5. SDK 재생성 (해당 버전의 생성기 사용)
           echo ""
-          echo "=== Regenerating SDK with generator from ${TAG_NAME} ==="
+          echo "=== Regenerating SDK with generator from ${SDK_COMMIT} ==="
           cd sdk-runtime-generator~
-          pnpm install
+
+          # Use job-specific pnpm store to avoid conflicts between parallel jobs
+          export PNPM_STORE_DIR="${RUNNER_TEMP}/pnpm-store-${{ inputs.unity-version }}"
+          echo "Using pnpm store: ${PNPM_STORE_DIR}"
+
+          pnpm install --store-dir "$PNPM_STORE_DIR"
           pnpm generate
 
           echo ""


### PR DESCRIPTION
## Summary
- SDK 버전 override 테스트 시 병렬 빌드에서 pnpm 충돌 문제 해결

## Changes
1. **concurrency 그룹에 SDK 버전 포함**
   - 다른 SDK 버전 테스트가 서로 취소되지 않도록 concurrency 그룹 분리
   
2. **pnpm home 디렉토리 정리**
   - `pnpm/action-setup` 전에 기존 pnpm 디렉토리 삭제
   - self-hosted 러너에서 ENOTEMPTY/EPERM 에러 방지

3. **job별 독립적인 pnpm store**
   - `${RUNNER_TEMP}/pnpm-store-${unity-version}` 경로 사용
   - 병렬 빌드에서 store 충돌 방지

4. **변수명 오류 수정**
   - `${TAG_NAME}` → `${SDK_COMMIT}`

## Test plan
- [ ] SDK 버전 override 테스트 (예: SDK 1.6.2) 트리거
- [ ] 병렬 빌드에서 pnpm 에러 없이 완료 확인