### PR TITLE
수정: SDK 버전별 호환성 테스트를 위한 스크립팅 정의 직접 적용

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -128,6 +128,9 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 10
+          run_install: false
+          # standalone 모드로 pnpm store 충돌 방지 (self-hosted runner에서 병렬 실행 시)
+          standalone: true
 
       - name: Setup Node.js (for SDK regeneration)
         if: inputs.sdk-version-override != ''
@@ -209,9 +212,47 @@ jobs:
 
           echo ""
           echo "=== Version Defines Impact ==="
-          echo "Unity will define symbols based on package.json version: ${OVERRIDE_VERSION}"
-          echo "  - AIT_SDK_1_6_1_OR_LATER: $([ "$(printf '%s\n' "1.6.1" "${OVERRIDE_VERSION}" | sort -V | head -1)" = "1.6.1" ] && echo 'DEFINED' || echo 'NOT defined')"
-          echo "  - AIT_SDK_1_7_OR_LATER: $([ "$(printf '%s\n' "1.7.0" "${OVERRIDE_VERSION}" | sort -V | head -1)" = "1.7.0" ] && echo 'DEFINED' || echo 'NOT defined')"
+          echo "SDK version: ${OVERRIDE_VERSION}"
+
+          # SDK 버전에 따른 스크립팅 정의 심볼 설정
+          # Unity versionDefines가 batchmode에서 제대로 작동하지 않을 수 있어서
+          # 환경변수로 E2EBuildRunner에 전달하여 직접 적용
+          SDK_DEFINES=""
+
+          # 버전 비교: sort -V로 semver 정렬 후 비교
+          if [ "$(printf '%s\n' "1.6.1" "${OVERRIDE_VERSION}" | sort -V | head -1)" = "1.6.1" ]; then
+            SDK_DEFINES="AIT_SDK_1_6_1_OR_LATER"
+            echo "  - AIT_SDK_1_6_1_OR_LATER: DEFINED"
+          else
+            echo "  - AIT_SDK_1_6_1_OR_LATER: NOT defined"
+          fi
+
+          if [ "$(printf '%s\n' "1.7.0" "${OVERRIDE_VERSION}" | sort -V | head -1)" = "1.7.0" ]; then
+            if [ -n "$SDK_DEFINES" ]; then
+              SDK_DEFINES="${SDK_DEFINES};AIT_SDK_1_7_OR_LATER"
+            else
+              SDK_DEFINES="AIT_SDK_1_7_OR_LATER"
+            fi
+            echo "  - AIT_SDK_1_7_OR_LATER: DEFINED"
+          else
+            echo "  - AIT_SDK_1_7_OR_LATER: NOT defined"
+          fi
+
+          if [ "$(printf '%s\n' "1.7.1" "${OVERRIDE_VERSION}" | sort -V | head -1)" = "1.7.1" ]; then
+            if [ -n "$SDK_DEFINES" ]; then
+              SDK_DEFINES="${SDK_DEFINES};AIT_SDK_1_7_1_OR_LATER"
+            else
+              SDK_DEFINES="AIT_SDK_1_7_1_OR_LATER"
+            fi
+            echo "  - AIT_SDK_1_7_1_OR_LATER: DEFINED"
+          else
+            echo "  - AIT_SDK_1_7_1_OR_LATER: NOT defined"
+          fi
+
+          # 환경변수로 설정 (GitHub Actions의 $GITHUB_ENV로 다음 step에 전달)
+          echo "SDK_VERSION_DEFINES=${SDK_DEFINES}" >> $GITHUB_ENV
+          echo ""
+          echo "SDK_VERSION_DEFINES=${SDK_DEFINES}"
 
       # =====================================================
       # Windows Defender 제외 (Windows)


### PR DESCRIPTION
## Summary
- Unity versionDefines가 batchmode에서 제대로 작동하지 않는 문제 해결
- E2EBuildRunner에서 환경변수로 스크립팅 정의를 직접 적용
- pnpm 동시 실행 시 store 충돌 문제 해결

## 변경사항

### 1. E2EBuildRunner.cs
- `SDK_VERSION_DEFINES` 환경변수에서 스크립팅 정의 심볼 읽기
- PlayerSettings에 직접 적용하여 조건부 컴파일 작동 보장

### 2. unity-build.yml
- SDK 버전에 따른 환경변수 설정 로직 추가
  - `1.6.1` 이상: `AIT_SDK_1_6_1_OR_LATER`
  - `1.7.0` 이상: `AIT_SDK_1_7_OR_LATER`
  - `1.7.1` 이상: `AIT_SDK_1_7_1_OR_LATER`
- pnpm/action-setup에 `standalone: true` 추가 (동시 실행 충돌 방지)

## 배경
PR #124에서 SDK 버전별 호환성 테스트가 실패한 원인:
- package.json 버전은 정상적으로 변경됨
- 하지만 Unity batchmode에서 versionDefines가 적용되지 않음
- 결과적으로 조건부 컴파일이 작동하지 않아 최신 API 호출 시도 → 컴파일 에러

## Test plan
- [ ] SDK 1.6.0 버전 오버라이드 테스트
- [ ] SDK 1.5.0 버전 오버라이드 테스트
- [ ] 컴파일 성공 확인
- [ ] pnpm 동시 실행 충돌 없음 확인