### PR TITLE
개선: 로컬 서버 .unityweb 파일 Content-Encoding 헤더 설정

### DIFF
--- a/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
@@ -1,7 +1,92 @@
-import { defineConfig, mergeConfig } from 'vite';
+import { defineConfig, mergeConfig, type Plugin } from 'vite';
+import { openSync, readSync, closeSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Unity WebGL .unityweb 파일의 압축 방식을 헤더에서 감지
+ * @param filePath 파일 경로
+ * @returns 감지된 압축 방식 ('br' | 'gzip') 또는 null
+ */
+function detectUnityWebCompression(filePath: string): 'br' | 'gzip' | null {
+  try {
+    // 파일 헤더의 처음 64바이트만 읽음
+    const fd = openSync(filePath, 'r');
+    const buffer = Buffer.alloc(64);
+    readSync(fd, buffer, 0, 64, 0);
+    closeSync(fd);
+
+    const header = buffer.toString('ascii');
+
+    if (header.includes('(brotli)')) return 'br';
+    if (header.includes('(gzip)')) return 'gzip';
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Unity WebGL 압축 파일용 Content-Encoding 헤더 플러그인
+ *
+ * Unity 6부터 .unityweb 확장자로 압축 파일이 통합됨.
+ * 이 플러그인은 파일 헤더를 읽어 압축 방식을 감지하고,
+ * 적절한 Content-Encoding 헤더를 설정하여 브라우저가 직접 압축 해제하도록 함.
+ *
+ * 헤더가 없으면 Unity의 JavaScript 디컴프레서가 처리하지만,
+ * 헤더가 있으면 브라우저가 직접 처리하여 시작 시간이 단축됨.
+ */
+function unityWebContentEncodingPlugin(): Plugin {
+  const compressionCache = new Map<string, 'br' | 'gzip' | null>();
+
+  return {
+    name: 'unity-web-content-encoding',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url || '';
+
+        if (url.endsWith('.unityweb')) {
+          // public/ 폴더 기준으로 파일 경로 계산
+          const filePath = join(process.cwd(), 'public', url);
+
+          // 캐시 확인 또는 감지
+          let encoding = compressionCache.get(filePath);
+          if (encoding === undefined) {
+            encoding = detectUnityWebCompression(filePath);
+            compressionCache.set(filePath, encoding);
+          }
+
+          if (encoding) {
+            res.setHeader('Content-Encoding', encoding);
+          }
+
+          // Content-Type 설정
+          if (url.includes('.wasm.')) {
+            res.setHeader('Content-Type', 'application/wasm');
+          } else if (url.includes('.js.')) {
+            res.setHeader('Content-Type', 'application/javascript');
+          } else if (url.includes('.data.')) {
+            res.setHeader('Content-Type', 'application/octet-stream');
+          }
+        }
+        // 레거시 .br 파일 (Unity 2021/2022)
+        else if (url.endsWith('.br')) {
+          res.setHeader('Content-Encoding', 'br');
+        }
+        // 레거시 .gz 파일 (Unity 2021/2022)
+        else if (url.endsWith('.gz')) {
+          res.setHeader('Content-Encoding', 'gzip');
+        }
+
+        next();
+      });
+    },
+  };
+}
 
 //// SDK_GENERATED_START - DO NOT EDIT THIS SECTION ////
 const sdkConfig = defineConfig({
+  // Unity WebGL 압축 파일 헤더 처리 플러그인
+  plugins: [unityWebContentEncodingPlugin()],
   // Apps in Toss 플랫폼에서 서브 경로 호스팅을 위해 상대 경로 사용
   base: './',
   server: {


### PR DESCRIPTION
## Summary
- Vite 개발 서버에서 `.unityweb` 파일의 압축 방식을 파일 헤더에서 감지하여 적절한 `Content-Encoding` 헤더 설정
- Unity 6부터 `.unityweb` 확장자로 압축 파일이 통합됨에 따른 대응
- 브라우저가 직접 압축 해제하여 Unity WebGL 시작 시간 단축

## 변경 내용
- `unityWebContentEncodingPlugin()` Vite 플러그인 추가
- 파일 헤더에서 `(brotli)` 또는 `(gzip)` 문자열을 감지하여 `Content-Encoding` 헤더 설정
- 파일 확장자에 따라 적절한 `Content-Type` 헤더 설정 (`.wasm.unityweb`, `.js.unityweb`, `.data.unityweb`)
- 레거시 `.br`, `.gz` 파일도 지원 (Unity 2021/2022 호환)

## Test plan
- [x] Unity 6000.3 WebGL 빌드 후 로컬 서버 실행
- [x] 브라우저 Network 탭에서 `.unityweb` 파일의 Response Headers 확인
  - `Content-Encoding: br` 또는 `gzip`
  - 적절한 `Content-Type`
- [x] Unity WebGL 앱 정상 로드 확인
- [x] 콘솔에서 Content-Encoding 경고 메시지 사라짐 확인