### PR TITLE
수정: Bulk Release Slack 알림 통합 전송

### DIFF
--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -106,6 +106,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ matrix.version }}
+      skip_notification: true
     secrets: inherit
 
   # =====================================================
@@ -118,6 +119,91 @@ jobs:
     if: always()
 
     steps:
+      - name: 배포 결과 아티팩트 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          pattern: deploy-results-*
+          path: all-deploy-results/
+        continue-on-error: true
+
+      - name: 통합 배포 알림 전송
+        env:
+          DEPLOY_WEBHOOK_URL: "https://ipd-public-gateway.core.toss-internal.com/api-public/v3/ipd-public-gateway/webhooks/ipd-corp-core-automation-webhook/8b6db539-6cb4-4b99-b2a8-8981c43b2592"
+        run: |
+          VERSIONS='${{ needs.prepare-versions.outputs.versions }}'
+
+          # 최신 버전 확인 (배열의 마지막 요소)
+          LATEST_VERSION=$(echo "$VERSIONS" | jq -r '.[-1]')
+          echo "최신 버전: ${LATEST_VERSION}"
+
+          # 모든 배포 결과 수집
+          ALL_RESULTS=""
+          HAS_ANY_RESULT=false
+
+          if [ -d "all-deploy-results" ]; then
+            echo "=== 배포 결과 수집 ==="
+            for dir in all-deploy-results/deploy-results-*/; do
+              if [ -d "$dir" ] && [ -f "${dir}deploy-results.txt" ]; then
+                echo "처리 중: $dir"
+                HAS_ANY_RESULT=true
+
+                # 파일에서 버전과 결과 추출
+                FILE_VERSION=$(grep "^version=" "${dir}deploy-results.txt" | cut -d= -f2)
+                echo "  버전: ${FILE_VERSION}"
+
+                # RESULTS 섹션 이후의 내용 추출
+                RESULTS=$(sed -n '/^---RESULTS---$/,$ p' "${dir}deploy-results.txt" | tail -n +2)
+
+                if [ -n "$RESULTS" ]; then
+                  # 각 결과 줄에 버전 정보 추가
+                  while IFS= read -r line; do
+                    if [ -n "$line" ]; then
+                      # "macOS - 2021.3: URL" 형식을 "macOS - 2021.3-v1.5.0: URL" 형식으로 변환
+                      PLATFORM=$(echo "$line" | cut -d: -f1 | xargs)
+                      STATUS=$(echo "$line" | cut -d: -f2- | xargs)
+                      ALL_RESULTS="${ALL_RESULTS}${PLATFORM}-v${FILE_VERSION}: ${STATUS}\n"
+                    fi
+                  done <<< "$RESULTS"
+                fi
+              fi
+            done
+          fi
+
+          if [ "$HAS_ANY_RESULT" = false ]; then
+            echo "::warning::수집된 배포 결과가 없습니다"
+            ALL_RESULTS="배포 결과 없음"
+          fi
+
+          echo ""
+          echo "=== 통합 배포 결과 ==="
+          echo -e "$ALL_RESULTS"
+          echo ""
+
+          echo "=== 배포 알림 전송 ==="
+          echo "버전: ${LATEST_VERSION}"
+
+          # jq로 안전한 JSON 생성
+          JSON_PAYLOAD=$(jq -n \
+            --arg version "$LATEST_VERSION" \
+            --arg urls "$(echo -e "$ALL_RESULTS")" \
+            '{version: $version, urlsForEdition: $urls}')
+
+          echo "전송할 JSON:"
+          echo "$JSON_PAYLOAD"
+
+          # HTTP 상태 코드 확인하여 실패 처리
+          HTTP_STATUS=$(curl -s -o /tmp/webhook_response.txt -w "%{http_code}" -X POST "$DEPLOY_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$JSON_PAYLOAD")
+
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            echo "✅ 통합 알림 전송 완료 (HTTP ${HTTP_STATUS})"
+          else
+            echo "::error::알림 전송 실패 (HTTP ${HTTP_STATUS})"
+            cat /tmp/webhook_response.txt
+            exit 1
+          fi
+
       - name: 결과 요약 생성
         run: |
           echo "## 일괄 릴리즈 결과" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         description: '릴리즈 버전'
         required: true
         type: string
+      skip_notification:
+        description: 'bulk-release에서 호출 시 개별 알림 스킵'
+        required: false
+        type: boolean
+        default: false
     secrets:
       AIT_DEPLOY_KEY:
         required: true
@@ -603,8 +608,31 @@ jobs:
             fi
           done
 
-      - name: 배포 알림 전송
+      - name: 배포 결과 아티팩트 저장
         if: always() && steps.check-packages.outputs.package_count > 0
+        run: |
+          VERSION="${{ needs.create-release-tag.outputs.version }}"
+          DEPLOY_RESULTS="${{ steps.deploy.outputs.deploy_results }}"
+          HAS_FAILURE="${{ steps.deploy.outputs.has_failure }}"
+
+          echo "version=${VERSION}" > deploy-results.txt
+          echo "has_failure=${HAS_FAILURE}" >> deploy-results.txt
+          echo "---RESULTS---" >> deploy-results.txt
+          echo -e "$DEPLOY_RESULTS" >> deploy-results.txt
+
+          echo "저장된 배포 결과:"
+          cat deploy-results.txt
+
+      - name: 배포 결과 아티팩트 업로드
+        if: always() && steps.check-packages.outputs.package_count > 0
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-results-${{ needs.create-release-tag.outputs.version }}
+          path: deploy-results.txt
+          retention-days: 1
+
+      - name: 배포 알림 전송
+        if: always() && steps.check-packages.outputs.package_count > 0 && inputs.skip_notification != true
         env:
           DEPLOY_WEBHOOK_URL: "https://ipd-public-gateway.core.toss-internal.com/api-public/v3/ipd-public-gateway/webhooks/ipd-corp-core-automation-webhook/8b6db539-6cb4-4b99-b2a8-8981c43b2592"
         run: |


### PR DESCRIPTION
## Summary
- Bulk Release 실행 시 Slack 알림에서 이전 버전들이 모두 FAILED로 표시되는 문제 수정
- 각 버전별 개별 알림 대신 모든 버전 배포 완료 후 통합 알림 전송하도록 변경
- 배포 결과를 아티팩트로 저장하고 summary job에서 수집하여 전송

## 변경 사항

### release.yml
- `skip_notification` 입력 파라미터 추가 (bulk-release에서 호출 시 개별 알림 스킵)
- 배포 결과를 `deploy-results.txt` 아티팩트로 저장하는 단계 추가
- 알림 전송 조건에 `inputs.skip_notification != true` 추가

### bulk-release.yml
- release.yml 호출 시 `skip_notification: true` 전달
- summary job에서 모든 `deploy-results-*` 아티팩트 다운로드
- 버전별 결과를 통합하여 웹훅으로 전송

## 수정 전/후 흐름

**수정 전 (문제):**
```
v1.5.0 → webhook 전송 → Slack?
v1.6.0 → webhook 전송 → Slack?
v1.6.1 → webhook 전송 → Slack?
v1.6.2 → webhook 전송 → Slack (마지막만 표시, 나머지 FAILED)
```

**수정 후:**
```
v1.5.0 → 아티팩트 저장 (알림 X)
v1.6.0 → 아티팩트 저장 (알림 X)
v1.6.1 → 아티팩트 저장 (알림 X)
v1.6.2 → 아티팩트 저장 (알림 X)
         ↓
summary job → 모든 아티팩트 수집 → 통합 webhook 전송 → Slack (모든 버전 표시)
```

## Test plan
- [ ] 2-3개 버전으로 bulk-release 워크플로우 실행
- [ ] 각 release.yml이 개별 알림을 전송하지 않는지 확인
- [ ] summary job에서 아티팩트 다운로드 성공 여부 확인
- [ ] 최종 Slack 알림에 모든 버전이 올바르게 표시되는지 확인