### PR TITLE
수정: Bulk Release 아티팩트 필터링 및 버전 중복 문제 해결

### DIFF
--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -158,10 +158,22 @@ jobs:
                   # 각 결과 줄에 버전 정보 추가
                   while IFS= read -r line; do
                     if [ -n "$line" ]; then
-                      # "macOS - 2021.3: URL" 형식을 "macOS - 2021.3-v1.5.0: URL" 형식으로 변환
+                      # 결과 라인이 해당 버전의 것인지 확인 (다른 버전 결과 필터링)
+                      # 형식: "macOS - 2021.3: URL" 또는 이미 버전이 포함된 경우 스킵
                       PLATFORM=$(echo "$line" | cut -d: -f1 | xargs)
                       STATUS=$(echo "$line" | cut -d: -f2- | xargs)
-                      ALL_RESULTS="${ALL_RESULTS}${PLATFORM}-v${FILE_VERSION}: ${STATUS}\n"
+
+                      # 이미 버전 정보가 포함되어 있는지 확인 (예: "macOS - 2021.3-v1.6.1")
+                      if echo "$PLATFORM" | grep -qE '\-v[0-9]+\.[0-9]+\.[0-9]+'; then
+                        # 이미 버전 정보 포함 - 해당 버전과 일치하는 경우만 추가
+                        if echo "$PLATFORM" | grep -q "\-v${FILE_VERSION}$"; then
+                          ALL_RESULTS="${ALL_RESULTS}${PLATFORM}: ${STATUS}\n"
+                        fi
+                        # 다른 버전의 결과는 무시
+                      else
+                        # 버전 정보 없음 - 버전 추가
+                        ALL_RESULTS="${ALL_RESULTS}${PLATFORM}-v${FILE_VERSION}: ${STATUS}\n"
+                      fi
                     fi
                   done <<< "$RESULTS"
                 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,7 +462,7 @@ jobs:
       - name: AIT 빌드 결과물 다운로드
         uses: actions/download-artifact@v7
         with:
-          pattern: ait-build-*
+          pattern: ait-build-*-v${{ needs.create-release-tag.outputs.version }}
           path: ait-builds/
 
       - name: 다운로드된 빌드 확인


### PR DESCRIPTION
## Summary
- Bulk Release 실행 시 다른 버전의 빌드 아티팩트가 함께 다운로드/배포되는 문제 해결
- 결과 수집 시 버전 중복 표시 문제 해결

## 변경 사항

### release.yml
- 아티팩트 다운로드 패턴 변경: `ait-build-*` → `ait-build-*-v{version}`
- 해당 버전의 빌드 아티팩트만 다운로드하도록 수정

### bulk-release.yml
- 결과 수집 시 버전 필터링 로직 추가
- 이미 버전 정보가 포함된 라인의 경우, 해당 버전과 일치하는 결과만 포함
- 다른 버전의 결과는 필터링하여 제외

## 수정 전/후

**수정 전:**
```
macOS - 2021.3-v1.6.1-v1.6.1: intoss-private://...  (버전 중복)
macOS - 2021.3-v1.6.2-v1.6.1: FAILED  (잘못된 버전 결과 포함)
```

**수정 후:**
```
macOS - 2021.3-v1.6.1: intoss-private://...
macOS - 2021.3-v1.6.2: intoss-private://...
```

## Test plan
- [ ] 2개 이상의 버전으로 bulk-release 실행
- [ ] 각 버전별로 올바른 아티팩트만 배포되는지 확인
- [ ] Slack 알림에 버전 중복 없이 표시되는지 확인