### PR TITLE
수정: SDK 생성기 web-bridge 타입 정의 경로 호환성 개선

### DIFF
--- a/sdk-runtime-generator~/src/categories.ts
+++ b/sdk-runtime-generator~/src/categories.ts
@@ -58,6 +58,7 @@ export const API_CATEGORIES: Record<string, string[]> = {
   Advertising: [
     'GoogleAdMobLoadAppsInTossAdMob',
     'GoogleAdMobShowAppsInTossAdMob',
+    'GoogleAdMobIsAppsInTossAdMobLoaded', // v1.8.0+
     // TossAds (v1.6.0+)
     'TossAdsInitialize',
     'TossAdsAttach',
@@ -78,7 +79,7 @@ export const API_CATEGORIES: Record<string, string[]> = {
   AppEvents: [
     'TdsEventSubscribeNavigationAccessoryEvent',
     'GraniteEventSubscribeBackEvent',
-    'AppsInTossEventSubscribeEntryMessageExited',
+    // 'AppsInTossEventSubscribeEntryMessageExited', // v1.8.0에서 제거됨 (AppsInTossEvent = {})
   ],
   Environment: [
     'EnvGetDeploymentId',
@@ -153,6 +154,8 @@ export const EXCLUDED_APIS: string[] = [
   'GoogleAdMobShowAdMobInterstitialAd',
   'GoogleAdMobLoadAdMobRewardedAd',
   'GoogleAdMobShowAdMobRewardedAd',
+  // v1.8.0에서 제거된 API (AppsInTossEvent = {})
+  'AppsInTossEventSubscribeEntryMessageExited',
 ];
 
 /**

--- a/sdk-runtime-generator~/src/parser.ts
+++ b/sdk-runtime-generator~/src/parser.ts
@@ -99,14 +99,20 @@ export class TypeScriptParser {
     }
 
     // 2. web-bridge에서도 찾기 (TossAds 관련 타입 등)
+    // v1.8.0+: dist/, v1.5.0~v1.7.x: built/
     let webBridgePath: string | null = null;
     for (const dir of pnpmDirs) {
       if (dir.startsWith('@apps-in-toss+web-bridge')) {
-        const indexPath = path.join(pnpmPath, dir, 'node_modules', '@apps-in-toss', 'web-bridge', 'built', 'index.d.ts');
-        if (fs.existsSync(indexPath)) {
-          webBridgePath = indexPath;
-          break;
+        const basePath = path.join(pnpmPath, dir, 'node_modules', '@apps-in-toss', 'web-bridge');
+        // dist 우선, built 폴백
+        for (const subdir of ['dist', 'built']) {
+          const indexPath = path.join(basePath, subdir, 'index.d.ts');
+          if (fs.existsSync(indexPath)) {
+            webBridgePath = indexPath;
+            break;
+          }
         }
+        if (webBridgePath) break;
       }
     }
 

--- a/sdk-runtime-generator~/src/validators/types.ts
+++ b/sdk-runtime-generator~/src/validators/types.ts
@@ -80,6 +80,11 @@ export function isTypeSupported(type: ParsedType): boolean {
       if (type.isNullable && type.name && !type.name.includes('|')) {
         return true;
       }
+      // Named type이면서 valid한 식별자인 경우 허용 (외부 타입 참조)
+      // 예: IsAdMobLoadedOptions, LoadAdMobOptions 등
+      if (type.name && /^[A-Z][a-zA-Z0-9_]*$/.test(type.name)) {
+        return true;
+      }
       return false;
 
     default:

--- a/sdk-runtime-generator~/tests/unit/invariants.test.ts
+++ b/sdk-runtime-generator~/tests/unit/invariants.test.ts
@@ -160,7 +160,9 @@ const eventSubscriptionPatterns = [
   '__showFullScreenAd',    // 광고 표시 이벤트 (여러 이벤트 발생)
   '__IAPCreateOneTimePurchaseOrder', // 인앱결제 (중첩 콜백 패턴)
   '__AITRespondToNestedCallback', // 중첩 콜백 응답 함수
-  '__GoogleAdMob', // 네임스페이스 콜백 기반 광고 API (여러 이벤트 발생)
+  '__GoogleAdMobLoadAppsInTossAdMob', // 광고 로드 이벤트 (여러 이벤트 발생)
+  '__GoogleAdMobShowAppsInTossAdMob', // 광고 표시 이벤트 (여러 이벤트 발생)
+  // 참고: __GoogleAdMobIsAppsInTossAdMobLoaded_Internal은 일반 Promise API (단순 응답)
   '__contactsViral', // 연락처 바이럴 공유 (콜백 기반 API)
   '__onVisibilityChangedByTransparentServiceWeb', // 투명 서비스 웹 가시성 변경 구독
   '__startUpdateLocation', // 위치 업데이트 구독


### PR DESCRIPTION
## Summary
- `@apps-in-toss/web-bridge` 패키지의 빌드 출력 경로 변경에 대한 하위 호환성 지원
  - v1.5.0~v1.7.x: `built/` 디렉토리
  - v1.8.0+: `dist/` 디렉토리
- v1.8.0에서 제거된 `AppsInTossEventSubscribeEntryMessageExited` API 제외 처리
- v1.8.0 신규 `GoogleAdMobIsAppsInTossAdMobLoaded` API 카테고리 추가
- 외부 타입 참조(PascalCase named types) 검증 지원 개선

## Test plan
- [x] SDK v1.5.0 생성 테스트 통과
- [x] SDK v1.6.0 생성 테스트 통과
- [x] SDK v1.7.1 생성 테스트 통과
- [x] SDK v1.8.0 생성 테스트 통과
- [x] `pnpm test` 유닛 테스트 통과