### PR TITLE
수정: 로컬 서버 Start/Stop 버튼 토글 문제 해결

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -1682,10 +1682,11 @@ namespace AppsInToss
                     }
 
                     // 서버 시작 성공 감지 (포트 감지)
-                    // localhost:PORT (Vite), 0.0.0.0:PORT (Granite), 127.0.0.1:PORT 모두 매칭
+                    // IPv4: localhost:PORT, 0.0.0.0:PORT, 127.0.0.1:PORT
+                    // IPv6: [::1]:PORT, [::]:PORT
                     if (!serverStarted && !serverFailed)
                     {
-                        var portMatch = Regex.Match(cleanOutput, @"(?:localhost|0\.0\.0\.0|127\.0\.0\.1):(\d+)");
+                        var portMatch = Regex.Match(cleanOutput, @"(?:localhost|0\.0\.0\.0|127\.0\.0\.1|\[::1?\]):(\d+)");
                         if (portMatch.Success)
                         {
                             int port = int.Parse(portMatch.Groups[1].Value);

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -242,8 +242,8 @@ async function startDevServer(aitBuildDir, defaultPort) {
       // ANSI 색상 코드 제거 후 포트 파싱
       const cleanOutput = output.replace(/\x1B\[[0-9;]*[mGKH]/g, '');
 
-      // 포트 파싱: localhost:PORT, 0.0.0.0:PORT, 127.0.0.1:PORT 모두 매칭
-      const portMatch = cleanOutput.match(/(?:localhost|0\.0\.0\.0|127\.0\.0\.1):(\d+)/);
+      // 포트 파싱: IPv4 (localhost, 0.0.0.0, 127.0.0.1), IPv6 ([::], [::1])
+      const portMatch = cleanOutput.match(/(?:localhost|0\.0\.0\.0|127\.0\.0\.1|\[::1?\]):(\d+)/);
       if (portMatch && !started) {
         actualPort = parseInt(portMatch[1], 10);
         console.log(`📍 Dev server running on port: ${actualPort}`);
@@ -325,8 +325,8 @@ async function startGraniteDevServer(aitBuildDir, viteHost, vitePort, graniteHos
       // ANSI 색상 코드 제거 후 포트 파싱
       const cleanOutput = output.replace(/\x1B\[[0-9;]*[mGKH]/g, '');
 
-      // 포트 파싱: localhost:PORT, 0.0.0.0:PORT, 127.0.0.1:PORT 모두 매칭
-      const portMatch = cleanOutput.match(/(?:localhost|0\.0\.0\.0|127\.0\.0\.1):(\d+)/);
+      // 포트 파싱: IPv4 (localhost, 0.0.0.0, 127.0.0.1), IPv6 ([::], [::1])
+      const portMatch = cleanOutput.match(/(?:localhost|0\.0\.0\.0|127\.0\.0\.1|\[::1?\]):(\d+)/);
       if (portMatch && !started) {
         actualPort = parseInt(portMatch[1], 10);
         console.log(`📍 Granite dev server running on port: ${actualPort}`);

--- a/Tests~/E2E/tests/test-interactive-mode.test.js
+++ b/Tests~/E2E/tests/test-interactive-mode.test.js
@@ -59,9 +59,9 @@ async function startServer(aitBuildDir, vitePort) {
       console.log('[vite dev]', output);
 
       // ANSI 색상 코드 제거 후 포트 파싱
-      // localhost:PORT, 0.0.0.0:PORT, 127.0.0.1:PORT 모두 매칭
+      // IPv4 (localhost, 0.0.0.0, 127.0.0.1), IPv6 ([::], [::1])
       const cleanOutput = output.replace(/\x1B\[[0-9;]*[mGKH]/g, '');
-      const portMatch = cleanOutput.match(/(?:localhost|0\.0\.0\.0|127\.0\.0\.1):(\d+)/);
+      const portMatch = cleanOutput.match(/(?:localhost|0\.0\.0\.0|127\.0\.0\.1|\[::1?\]):(\d+)/);
       if (portMatch && !started) {
         actualPort = parseInt(portMatch[1], 10);
         console.log(`📍 Server running on port: ${actualPort}`);


### PR DESCRIPTION
## Summary
- 로컬 서버 Start/Stop 버튼의 활성화/비활성화 상태가 실제 서버 상태와 일치하지 않는 문제 해결
- 서버 상태 관리 단순화 (Starting 상태 제거, 포트 기반 상태 판단)

## Changes

### AITServerStateManager.cs
- `Starting` 상태 제거 (NotRunning, Running 2단계로 단순화)
- 캐시 유효 시간 2초 → 0.1초로 단축
- 포트 기반 상태 판단으로 단순화 (포트가 열리면 Running, 아니면 NotRunning)
- `OnServerStarting()` → `SetExpectedPortAndProcess()`로 변경 (상태 즉시 변경 안함)

### AppsInTossMenu.cs
- 서버 시작 시 30초 타임아웃 추가
- 포트 충돌 시 자동으로 다른 포트 탐지 기능 활성화
- MenuItem 검증에서 Starting 상태 참조 제거
- **포트 감지 정규식 확장**: `localhost:PORT`, `0.0.0.0:PORT`, `127.0.0.1:PORT` 모두 지원

## Root Cause
Granite 서버는 `Listening on http://0.0.0.0:8081` 형식으로 포트를 출력하지만, 기존 정규식은 `localhost:(\d+)` 패턴만 매칭했음. 이로 인해 `onServerStarted` 콜백이 호출되지 않아 상태 전환이 실패했음.

## Test plan
- [x] `./run-local-tests.sh --validate` 통과
- [x] Dev Server 시작 → Start 비활성, Stop 활성
- [x] Dev Server 중지 → Start 활성, Stop 비활성
- [x] Production Server 동일하게 동작
- [x] 포트 충돌 시 자동 포트 탐지 동작
- [x] 30초 타임아웃 동작 확인