### PR TITLE
기능: SDK Update PR 머지 시 자동 릴리즈

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,13 @@ on:
         required: true
         type: string
 
+  # update/ 브랜치가 main에 머지되면 자동 릴리즈
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+
   # bulk-release.yml에서 호출용
   workflow_call:
     inputs:
@@ -39,13 +46,37 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag_name: ${{ steps.version.outputs.tag_name }}
+      skip: ${{ steps.version.outputs.skip }}
 
     steps:
+      - name: Checkout (push 이벤트용)
+        if: github.event_name == 'push'
+        uses: actions/checkout@v6
+
       - name: 버전 결정
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ inputs.version }}"
-          echo "입력된 버전: ${VERSION}"
+          # push 이벤트: package.json에서 버전 읽기
+          # workflow_dispatch/workflow_call: inputs에서 버전 받기
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION=$(cat package.json | jq -r '.version')
+            echo "package.json에서 버전 읽기: ${VERSION}"
+
+            # 이미 릴리즈 태그가 존재하면 스킵
+            TAG_NAME="release/v${VERSION}"
+            if git ls-remote --tags origin | grep -q "refs/tags/${TAG_NAME}$"; then
+              echo "이미 릴리즈 태그가 존재합니다: ${TAG_NAME}"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              echo "version=${VERSION}" >> $GITHUB_OUTPUT
+              echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          else
+            VERSION="${{ inputs.version }}"
+            echo "입력된 버전: ${VERSION}"
+          fi
 
           # Semver 형식 검증
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z][a-zA-Z0-9.]*)?$'; then
@@ -56,6 +87,7 @@ jobs:
           echo "버전 검증 통과: ${VERSION}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tag_name=release/v${VERSION}" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
 
   # =====================================================
   # SDK Runtime 재생성 (Orphan Commit)
@@ -65,6 +97,7 @@ jobs:
     name: SDK Runtime 재생성
     runs-on: ubuntu-latest
     needs: release
+    if: needs.release.outputs.skip != 'true'
 
     outputs:
       ref: ${{ steps.commit.outputs.ref }}
@@ -209,6 +242,7 @@ jobs:
   build-ait-macos:
     name: AIT 빌드 (macOS)
     needs: [release, regenerate-sdk]
+    if: needs.release.outputs.skip != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -234,6 +268,7 @@ jobs:
   build-ait-windows:
     name: AIT 빌드 (Windows)
     needs: [release, regenerate-sdk]
+    if: needs.release.outputs.skip != 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## 요약
- SDK Update PR이 main에 머지되면 자동으로 Release 워크플로우가 트리거됩니다

## 변경 내용
- release.yml에 push 이벤트 트리거 추가 (package.json 변경 시)
- push 이벤트에서 package.json의 버전을 읽어서 릴리즈
- 이미 릴리즈 태그가 존재하면 스킵

## 배경
기존에는 SDK Update 워크플로우가 PR을 생성하지만, 머지 후 릴리즈는 수동으로 트리거해야 했습니다.
이로 인해 v1.7.0, v1.7.1, v1.8.0 등의 버전이 누락되었습니다.

## 테스트 계획
- [ ] package.json 버전 변경 시 Release 워크플로우 트리거 확인
- [ ] 이미 릴리즈된 버전은 스킵되는지 확인