### PR TITLE
수정: CI Playwright 버전 불일치 해결

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -630,8 +630,8 @@ jobs:
         run: |
           rm -rf node_modules package-lock.json pnpm-lock.yaml
           pnpm install
-          pnpx playwright install chromium --with-deps
-          pnpx playwright --version
+          pnpm exec playwright install chromium --with-deps
+          pnpm exec playwright --version
 
       - name: Install Playwright Dependencies (Windows)
         if: inputs.os == 'windows' && inputs.run-e2e-test
@@ -653,8 +653,8 @@ jobs:
           }
 
           pnpm install
-          pnpx playwright install chromium --with-deps
-          pnpx playwright --version
+          pnpm exec playwright install chromium --with-deps
+          pnpm exec playwright --version
 
       - name: Run E2E Tests (macOS - Full)
         if: inputs.os == 'macos' && inputs.run-e2e-test
@@ -672,7 +672,7 @@ jobs:
           UNITY_PROJECT_PATH: ${{ github.workspace }}\Tests~\E2E\SampleUnityProject-${{ inputs.unity-version }}
           # Use job-local Playwright cache to avoid race conditions between parallel runners
           PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}\.playwright-browsers
-        run: pnpx playwright test --grep "[1-5]\. "
+        run: pnpm exec playwright test --grep "[1-5]\. "
 
       # =====================================================
       # 벤치마크 결과 업로드 (선택적)

--- a/Tests~/E2E/tests/package.json
+++ b/Tests~/E2E/tests/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "UNLICENSED",
   "devDependencies": {
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "1.50.1",
     "serve": "^14.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- pnpx를 pnpm exec로 변경하여 프로젝트 로컬 Playwright 버전 사용
- Playwright 버전 1.50.1로 고정

## 문제
pnpx가 전역 캐시의 Playwright를 사용하여 프로젝트 버전과 불일치 발생

## Test plan
- [ ] E2E 테스트 통과 확인