### PR TITLE
개선: GitHub Actions concurrency 설정 개선

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: preview-${{ inputs.target_ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # =====================================================

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -38,7 +38,7 @@ on:
 
 concurrency:
   group: e2e-test-${{ github.ref }}-${{ inputs.target_ref || 'default' }}-${{ inputs.sdk_version_override || 'latest' }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # =====================================================

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -76,9 +76,6 @@ jobs:
     name: Build (${{ inputs.os }}, Unity ${{ inputs.unity-version }})
     runs-on: ${{ inputs.os == 'macos' && fromJSON('["self-hosted", "macOS", "ARM64"]') || fromJSON('["self-hosted", "Windows", "X64", "enabled"]') }}
     timeout-minutes: 60
-    concurrency:
-      group: unity-build-${{ inputs.os }}-${{ inputs.unity-version }}${{ inputs.sdk-version-override && format('-sdk{0}', inputs.sdk-version-override) || '' }}
-      cancel-in-progress: false
 
     outputs:
       artifact-name: ${{ steps.artifact.outputs.name }}
@@ -438,6 +435,93 @@ jobs:
           Write-Host "Ad IDs injected successfully"
 
       # =====================================================
+      # Unity 빌드 락 획득 (같은 Unity 버전 동시 빌드 방지)
+      # 같은 물리 머신에서 여러 Runner가 동일 Unity 버전을 빌드하면
+      # 라이선스 충돌이 발생하므로, 파일 락으로 직렬화합니다.
+      # =====================================================
+      - name: Acquire Unity Build Lock (macOS)
+        if: inputs.os == 'macos' && inputs.run-build
+        id: lock-macos
+        run: |
+          LOCK_DIR="/tmp/unity-build-lock-${{ inputs.unity-version }}"
+          echo "LOCK_DIR=${LOCK_DIR}" >> $GITHUB_OUTPUT
+
+          echo "Acquiring lock: ${LOCK_DIR}"
+          WAIT_SECONDS=0
+          MAX_WAIT=3600  # 최대 1시간 대기
+
+          while ! mkdir "${LOCK_DIR}" 2>/dev/null; do
+            if [ $WAIT_SECONDS -ge $MAX_WAIT ]; then
+              echo "::error::Lock acquisition timed out after ${MAX_WAIT}s"
+              exit 1
+            fi
+
+            # Stale lock 감지: 락 디렉토리가 2시간 이상 된 경우 강제 해제
+            if [ -d "${LOCK_DIR}" ]; then
+              LOCK_AGE=$(( $(date +%s) - $(stat -f %m "${LOCK_DIR}") ))
+              if [ $LOCK_AGE -gt 7200 ]; then
+                echo "::warning::Stale lock detected (age: ${LOCK_AGE}s), removing..."
+                rmdir "${LOCK_DIR}" 2>/dev/null || rm -rf "${LOCK_DIR}"
+                continue
+              fi
+            fi
+
+            if [ $((WAIT_SECONDS % 60)) -eq 0 ]; then
+              echo "Waiting for Unity ${{ inputs.unity-version }} lock... (${WAIT_SECONDS}s elapsed)"
+            fi
+            sleep 10
+            WAIT_SECONDS=$((WAIT_SECONDS + 10))
+          done
+
+          echo "Lock acquired after ${WAIT_SECONDS}s"
+
+      - name: Acquire Unity Build Lock (Windows)
+        if: inputs.os == 'windows' && inputs.run-build
+        id: lock-windows
+        shell: powershell
+        run: |
+          $lockFile = "C:\unity-build-lock-${{ inputs.unity-version }}.lock"
+          echo "LOCK_FILE=$lockFile" >> $env:GITHUB_OUTPUT
+
+          Write-Host "Acquiring lock: $lockFile"
+          $waitSeconds = 0
+          $maxWait = 3600  # 최대 1시간 대기
+
+          while ($true) {
+            try {
+              # Exclusive create: 파일이 이미 존재하면 예외 발생
+              $fs = [System.IO.File]::Open($lockFile, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write)
+              $fs.Close()
+              break
+            } catch [System.IO.IOException] {
+              # 파일이 이미 존재 = 다른 빌드가 진행 중
+            }
+
+            if ($waitSeconds -ge $maxWait) {
+              Write-Host "::error::Lock acquisition timed out after ${maxWait}s"
+              exit 1
+            }
+
+            # Stale lock 감지: 2시간 이상 된 락 강제 해제
+            if (Test-Path $lockFile) {
+              $lockAge = (New-TimeSpan -Start (Get-Item $lockFile).LastWriteTime -End (Get-Date)).TotalSeconds
+              if ($lockAge -gt 7200) {
+                Write-Host "::warning::Stale lock detected (age: $([int]$lockAge)s), removing..."
+                Remove-Item -Force $lockFile -ErrorAction SilentlyContinue
+                continue
+              }
+            }
+
+            if ($waitSeconds % 60 -eq 0) {
+              Write-Host "Waiting for Unity ${{ inputs.unity-version }} lock... (${waitSeconds}s elapsed)"
+            }
+            Start-Sleep -Seconds 10
+            $waitSeconds += 10
+          }
+
+          Write-Host "Lock acquired after ${waitSeconds}s"
+
+      # =====================================================
       # Unity WebGL 빌드
       # =====================================================
       - name: Build Unity WebGL (macOS)
@@ -522,6 +606,28 @@ jobs:
             }
 
             Write-Host "Unity build completed successfully (exit code: $exitCode)"
+
+      # =====================================================
+      # Unity 빌드 락 해제
+      # =====================================================
+      - name: Release Unity Build Lock (macOS)
+        if: always() && inputs.os == 'macos' && inputs.run-build && steps.lock-macos.outputs.LOCK_DIR
+        run: |
+          LOCK_DIR="${{ steps.lock-macos.outputs.LOCK_DIR }}"
+          if [ -d "${LOCK_DIR}" ]; then
+            rmdir "${LOCK_DIR}" 2>/dev/null || rm -rf "${LOCK_DIR}"
+            echo "Lock released: ${LOCK_DIR}"
+          fi
+
+      - name: Release Unity Build Lock (Windows)
+        if: always() && inputs.os == 'windows' && inputs.run-build && steps.lock-windows.outputs.LOCK_FILE
+        shell: powershell
+        run: |
+          $lockFile = "${{ steps.lock-windows.outputs.LOCK_FILE }}"
+          if (Test-Path $lockFile) {
+            Remove-Item -Force $lockFile -ErrorAction SilentlyContinue
+            Write-Host "Lock released: $lockFile"
+          }
 
       # =====================================================
       # 빌드 출력 검증


### PR DESCRIPTION
## Summary
- `test-e2e.yml`, `preview.yml`: `cancel-in-progress`를 `true`로 변경하여 같은 PR/ref 재트리거 시 이전 실행을 즉시 취소 (queue depth 1 문제 회피)
- `unity-build.yml`: concurrency 블록 제거, 파일 락 기반 직렬화로 대체 (같은 Unity 버전 라이선스 충돌 방지)

## 배경

GitHub Actions의 concurrency queue depth는 1로 제한됨. `cancel-in-progress: false`여도 pending job이 새 job에 의해 취소되는 문제가 있음.

## 2계층 전략

| 계층 | 적용 대상 | 동작 |
|------|----------|------|
| **Caller 워크플로우** | `test-e2e.yml`, `preview.yml` | 같은 PR/ref 재트리거 → 이전 실행 취소, 최신만 실행 |
| **unity-build.yml** | 빌드 job | 파일 락으로 같은 Unity 버전 동시 빌드 직렬화 |

## 동작 시나리오

| 시나리오 | 동작 |
|---------|------|
| 같은 PR E2E 재트리거 | 이전 실행 취소, 최신만 실행 |
| 다른 PR에서 같은 Unity 버전 빌드 | 파일 락으로 직렬화 (self-hosted) |
| 빌드 중 취소됨 | `if: always()`로 파일 락 해제 |
| GitHub-hosted runner | 파일 락 무해하게 통과 (별도 VM) |
| Release 중 E2E 실행 | 서로 다른 concurrency group, 간섭 없음 |

## Test plan
- [ ] 같은 PR에 E2E 테스트를 연속 2회 트리거하여 첫 번째 실행이 취소되는지 확인
- [ ] 서로 다른 PR에서 같은 Unity 버전 빌드 동시 트리거하여 파일 락 직렬화 확인
- [ ] Release 워크플로우가 영향받지 않는지 확인