### PR TITLE
수정: 빌드 에러 방어적 대응 (node_modules 무결성 검증 + 재시도)

### DIFF
--- a/Editor/AITNodeJSDownloader.cs
+++ b/Editor/AITNodeJSDownloader.cs
@@ -15,16 +15,16 @@ namespace AppsInToss.Editor
     /// </summary>
     public static class AITNodeJSDownloader
     {
-        private const string NODE_VERSION = "24.11.1";
+        private const string NODE_VERSION = "24.13.0";
 
         // SHA256 체크섬 (Node.js 공식 SHASUMS256.txt에서 검증됨)
-        // 출처: https://nodejs.org/dist/v24.11.1/SHASUMS256.txt
+        // 출처: https://nodejs.org/dist/v24.13.0/SHASUMS256.txt
         private static readonly Dictionary<string, string> Checksums = new Dictionary<string, string>
         {
-            ["darwin-arm64"] = "b05aa3a66efe680023f930bd5af3fdbbd542794da5644ca2ad711d68cbd4dc35",
-            ["darwin-x64"] = "096081b6d6fcdd3f5ba0f5f1d44a47e83037ad2e78eada26671c252fe64dd111",
-            ["win-x64"] = "5355ae6d7c49eddcfde7d34ac3486820600a831bf81dc3bdca5c8db6a9bb0e76",
-            ["linux-x64"] = "58a5ff5cc8f2200e458bea22e329d5c1994aa1b111d499ca46ec2411d58239ca"
+            ["darwin-arm64"] = "d595961e563fcae057d4a0fb992f175a54d97fcc4a14dc2d474d92ddeea3b9f8",
+            ["darwin-x64"] = "6f03c1b48ddbe1b129a6f8038be08e0899f05f17185b4d3e4350180ab669a7f3",
+            ["win-x64"] = "ca2742695be8de44027d71b3f53a4bdb36009b95575fe1ae6f7f0b5ce091cb88",
+            ["linux-x64"] = "6223aad1a81f9d1e7b682c59d12e2de233f7b4c37475cd40d1c89c42b737ffa8"
         };
 
         // 예상 파일 크기 (bytes) - 불완전한 다운로드 감지용

--- a/Editor/AITPackageManagerHelper.cs
+++ b/Editor/AITPackageManagerHelper.cs
@@ -16,7 +16,7 @@ namespace AppsInToss.Editor
         /// pnpm 버전 (내장 Node.js에 설치할 버전)
         /// 최신 버전 강제 방지를 위해 고정
         /// </summary>
-        public const string PNPM_VERSION = "10.20.0";
+        public const string PNPM_VERSION = "10.28.0";
 
         /// <summary>
         /// 표준 실행 파일 경로 (플랫폼별)


### PR DESCRIPTION
## Summary
- 사용자(비공개 파일럿 프로젝트)의 `granite build`에서 `@apps-in-toss/plugins` MODULE_NOT_FOUND 에러 발생에 대한 방어적 수정
- 이전 빌드의 오염된 node_modules 또는 pnpm store 캐시 손상이 원인으로 추정

## Changes
- **Node.js v24.11.1 → v24.13.0** 업데이트 (ESM resolver 개선, 보안 릴리즈)
- **pnpm 10.20.0 → 10.28.0** 업데이트 (symlink 해결 및 store 관리 개선)
- **node_modules 무결성 검증**: 빌드 전 `@apps-in-toss/web-framework` 버전이 package.json과 node_modules 내 실제 설치 버전과 일치하는지 확인, 불일치 시 자동 정리
- **pnpm install 실패 시 재시도**: `--frozen-lockfile` → `--no-frozen-lockfile` → node_modules 정리 후 clean install (3단계 폴백)
- **granite build 실패 시 재시도**: MODULE_NOT_FOUND 등 런타임 에러 시 node_modules 정리 후 install→build 전체 재시도
- 동기/비동기 빌드 경로 모두 동일한 재시도 로직 적용

## Modified Files
1. `Editor/AITNodeJSDownloader.cs` — Node.js 버전 + SHA256 체크섬
2. `Editor/AITPackageManagerHelper.cs` — pnpm 버전
3. `Editor/AITPackageBuilder.cs` — node_modules 무결성 검증 + 실패 시 정리/재시도 로직

## Test plan
- [x] `./run-local-tests.sh --validate` 통과 (17 unit tests)
- [ ] CI E2E 테스트로 전체 빌드 파이프라인 검증
