### PR TITLE
개선: Claude Code 워크플로우 설정 추가

### DIFF
--- a/.claude/commands/generate.md
+++ b/.claude/commands/generate.md
@@ -1,0 +1,17 @@
+# SDK Generate Workflow
+
+SDK 런타임 코드를 재생성하고 검증합니다.
+
+## Steps
+
+1. `cd sdk-runtime-generator~`
+2. `pnpm generate` 실행하여 TypeScript → C# + jslib 브릿지 생성
+3. `pnpm validate` 실행하여 Mono mcs 컴파일 검사
+4. `pnpm test` 실행하여 유닛 테스트
+5. 생성된 파일 변경사항 요약: `git diff --stat Runtime/SDK/`
+6. 결과 보고
+
+## Arguments
+
+- `--format`: 생성 후 `pnpm format`도 실행 (CSharpier, dotnet 필요)
+- `$ARGUMENTS`가 있으면 추가 컨텍스트로 사용

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "preToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file_path=$(jq -r '.tool_input.file_path // \"\"'); case \"$file_path\" in */Runtime/SDK/*) echo '⚠️ BLOCKED: Runtime/SDK/ 파일은 자동 생성됩니다. sdk-runtime-generator~/를 수정하세요.' >&2; exit 2;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -120,8 +120,6 @@ tools/
 tools.meta
 
 # AI Assistant files
-.claude/
-CLAUDE.md
 CLAUDE.md.meta
 
 # Unity License files (sensitive)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,35 @@
   - IDE: `.idea/`, `.vscode/`, `*.swp`
 - 커밋하면 안 되는 추적되지 않은 파일 발견 시 적절한 `.gitignore` 파일에 추가
 
+## 자주 하는 실수 방지
+
+### SDK 생성기 관련
+- `Runtime/SDK/` 파일을 직접 수정하면 다음 `pnpm generate` 시 덮어씌워짐
+- SDK API 변경이 필요하면 반드시 `sdk-runtime-generator~/` 내 코드를 수정할 것
+- 생성기 수정 후 검증 순서: `pnpm generate` → `pnpm validate` → `pnpm test`
+
+### GitHub Actions 관련
+- `gh workflow run` 명령어 사용 불가 (GraphQL 차단) — REST API 사용 필수
+- 워크플로우 트리거 시 반드시 아래 워크플로우 ID 참조 테이블 확인
+- PR 번호 사용 시 `target_ref`에 숫자만 입력 (# 접두사 불필요)
+
+### 테스트 관련
+- E2E 테스트 전 빌드가 필요함: `./run-local-tests.sh --all` (빌드+테스트) vs `--e2e` (테스트만)
+- Playwright 테스트는 `Tests~/E2E/tests/` 디렉토리에서 실행
+- Level 0 테스트(EditMode)는 빌드 없이 ~10초만에 실행 가능
+
+## 빠른 참조: 주요 명령어
+
+| 작업 | 명령어 |
+|------|--------|
+| SDK 재생성 | `cd sdk-runtime-generator~ && pnpm generate` |
+| SDK 검증 | `cd sdk-runtime-generator~ && pnpm validate` |
+| SDK 테스트 | `cd sdk-runtime-generator~ && pnpm test` |
+| 전체 로컬 테스트 | `./run-local-tests.sh --all` |
+| 빠른 검증만 | `./run-local-tests.sh --validate` |
+| E2E만 | `./run-local-tests.sh --e2e` |
+| CI 트리거 (E2E) | 아래 GitHub Actions 섹션 참조 |
+
 ## 개요
 
 **Apps in Toss Unity SDK** - Unity/Tuanjie 엔진 게임 프로젝트를 Apps in Toss 플랫폼의 미니앱으로 변환하고 배포할 수 있게 해주는 Unity 패키지입니다. SDK 제공 기능:


### PR DESCRIPTION
## Summary
- CLAUDE.md에 "자주 하는 실수 방지" 섹션 및 "빠른 참조 명령어" 테이블 추가
- `.claude/settings.json`에 `Runtime/SDK/` 편집 차단 preToolUse hook 추가
- `.claude/commands/generate.md`에 `/generate` SDK 재생성 워크플로우 스킬 추가
- `.gitignore`에서 `.claude/`, `CLAUDE.md` 제외 규칙 제거 (팀 공유 가능하도록)

## Test plan
- [ ] 새 Claude Code 세션에서 `Runtime/SDK/AIT.cs` 편집 시도 → hook이 차단하는지 확인
- [ ] `/generate` 실행 → sdk-runtime-generator~/에서 생성 + 검증 완료되는지 확인