### PR TITLE
개선: Docs/*.meta를 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ tools.meta
 # AI Assistant files
 CLAUDE.md.meta
 
+# Docs meta files (문서는 GUID 안정성 불필요)
+Docs/*.meta
+
 # Unity License files (sensitive)
 *.alf
 *.ulf

--- a/Docs/LoadingScreenCustomization.md.meta
+++ b/Docs/LoadingScreenCustomization.md.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 50ecd547b266c4c809c6823111324b2c
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Docs/Metrics.md.meta
+++ b/Docs/Metrics.md.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 1723391265f349a193eb36198c291cc2
-TextScriptImporter:
-  externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:


### PR DESCRIPTION
## Summary
- 문서 파일(Docs/)의 `.meta` 파일을 `.gitignore`에 추가
- 문서는 어셈블리 참조나 에셋 레퍼런스에 사용되지 않아 GUID 안정성이 불필요
- 기존 추적되던 `LoadingScreenCustomization.md.meta`, `Metrics.md.meta` 제거

## Test plan
- [ ] Unity 에디터에서 프로젝트 열 때 Docs/ meta 관련 경고 없음 확인