### PR TITLE
수정: AIT CLI 설치 시 npm latest 대신 고정 버전 사용

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -217,9 +217,20 @@ jobs:
         with:
           version: 9
 
+      - name: Checkout (버전 참조용)
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ needs.parse-targets.outputs.repository }}
+          ref: ${{ needs.parse-targets.outputs.ref }}
+          sparse-checkout: |
+            WebGLTemplates/AITTemplate/BuildConfig~/package.json
+          sparse-checkout-cone-mode: false
+
       - name: Install AIT CLI
         run: |
-          pnpm install -g @apps-in-toss/web-framework
+          WF_VERSION=$(node -p "require('./WebGLTemplates/AITTemplate/BuildConfig~/package.json').dependencies['@apps-in-toss/web-framework']")
+          echo "Installing @apps-in-toss/web-framework@${WF_VERSION}"
+          pnpm install -g "@apps-in-toss/web-framework@${WF_VERSION}"
           ait --version || echo "AIT CLI installed"
 
       - name: Download Build Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -535,9 +535,19 @@ jobs:
         with:
           version: 9
 
+      - name: Checkout (버전 참조용)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.create-release-tag.outputs.tag_name }}
+          sparse-checkout: |
+            WebGLTemplates/AITTemplate/BuildConfig~/package.json
+          sparse-checkout-cone-mode: false
+
       - name: Install AIT CLI
         run: |
-          pnpm install -g @apps-in-toss/web-framework
+          WF_VERSION=$(node -p "require('./WebGLTemplates/AITTemplate/BuildConfig~/package.json').dependencies['@apps-in-toss/web-framework']")
+          echo "Installing @apps-in-toss/web-framework@${WF_VERSION}"
+          pnpm install -g "@apps-in-toss/web-framework@${WF_VERSION}"
           ait --version || echo "AIT CLI installed"
 
       - name: AIT 빌드 결과물 다운로드


### PR DESCRIPTION
## Summary
- `preview.yml`과 `release.yml`의 Deploy 잡에서 `@apps-in-toss/web-framework`를 버전 지정 없이 설치하여 npm latest(현재 1.10.1)를 가져옴
- 1.10.1의 의존성 체인에 미게시 패키지(`@apps-in-toss/ait-format`)가 포함되어 404 오류 발생
- `BuildConfig~/package.json`에 명시된 버전(현재 1.9.4)을 sparse checkout으로 읽어서 설치하도록 수정

## 변경 파일
- `.github/workflows/preview.yml` — Deploy Preview 잡
- `.github/workflows/release.yml` — AIT 패키지 배포 잡

## Test plan
- [ ] Preview 워크플로우 트리거하여 Deploy 잡 성공 확인
- [ ] `unity-build.yml`, `test-e2e.yml`, `validate.yml`에는 동일 문제 없음 확인 완료