### PR TITLE
개선: InteractiveAPITester UI DPI 스케일링

### DIFF
--- a/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
+++ b/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
@@ -118,5 +118,14 @@ mergeInto(LibraryManager.library, {
         };
 
         console.log('[E2E-TRIGGER] Trigger functions registered');
+    },
+
+    /**
+     * window.devicePixelRatio 반환
+     * Unity WebGL에서 Screen.dpi가 항상 0을 반환하므로 직접 브라우저 API 사용
+     * @returns {number} devicePixelRatio (보통 1.0 ~ 3.0)
+     */
+    E2E_GetDevicePixelRatio: function() {
+        return window.devicePixelRatio || 1.0;
     }
 });

--- a/Tests~/E2E/SharedScripts/Runtime/AdV2Tester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/AdV2Tester.cs
@@ -72,13 +72,13 @@ public class AdV2Tester : MonoBehaviour
         GUILayout.BeginHorizontal();
         if (GUILayout.Button(
             selectedAdType == "interstitial" ? "[Interstitial]" : "Interstitial",
-            buttonStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true)))
+            buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true)))
         {
             selectedAdType = "interstitial";
         }
         if (GUILayout.Button(
             selectedAdType == "rewarded" ? "[Rewarded]" : "Rewarded",
-            buttonStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true)))
+            buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true)))
         {
             selectedAdType = "rewarded";
         }
@@ -92,7 +92,7 @@ public class AdV2Tester : MonoBehaviour
 
         // Step 1: 광고 로드
         GUILayout.Label("Step 1: Load Ad", fieldLabelStyle);
-        if (GUILayout.Button("loadAppsInTossAdMob(...)", buttonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("loadAppsInTossAdMob(...)", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             ExecuteLoadAd();
         }
@@ -102,7 +102,7 @@ public class AdV2Tester : MonoBehaviour
         // Step 2: 광고 표시
         GUILayout.Label("Step 2: Show Ad", fieldLabelStyle);
         GUI.enabled = isAdLoaded;
-        if (GUILayout.Button("showAppsInTossAdMob(...)", buttonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("showAppsInTossAdMob(...)", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             ExecuteShowAd();
         }
@@ -118,7 +118,7 @@ public class AdV2Tester : MonoBehaviour
         // 로그 초기화
         if (adEventLog.Count > 0)
         {
-            if (GUILayout.Button("Clear Log", buttonStyle, GUILayout.Height(32)))
+            if (GUILayout.Button("Clear Log", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(32))))
             {
                 adEventLog.Clear();
                 adStatus = "";

--- a/Tests~/E2E/SharedScripts/Runtime/ContactsViralTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/ContactsViralTester.cs
@@ -66,11 +66,11 @@ public class ContactsViralTester : MonoBehaviour
 
         // moduleId 입력 (PASTE 버튼 포함)
         GUILayout.BeginHorizontal();
-        GUILayout.Label("Module ID:", fieldLabelStyle, GUILayout.Width(100));
-        moduleId = GUILayout.TextField(moduleId, textFieldStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true));
+        GUILayout.Label("Module ID:", fieldLabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(100)));
+        moduleId = GUILayout.TextField(moduleId, textFieldStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true));
 
         GUI.enabled = !isPasting;
-        if (GUILayout.Button(isPasting ? "..." : "PASTE", buttonStyle, GUILayout.Width(70), GUILayout.Height(36)))
+        if (GUILayout.Button(isPasting ? "..." : "PASTE", buttonStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(70)), GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36))))
         {
             PasteFromClipboard();
         }
@@ -82,7 +82,7 @@ public class ContactsViralTester : MonoBehaviour
         // ContactsViral 호출 버튼
         if (!isActive)
         {
-            if (GUILayout.Button("contactsViral(...) 호출", buttonStyle, GUILayout.Height(44)))
+            if (GUILayout.Button("contactsViral(...) 호출", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(44))))
             {
                 ExecuteContactsViral();
             }
@@ -90,7 +90,7 @@ public class ContactsViralTester : MonoBehaviour
         else
         {
             // 구독 해제 버튼
-            if (GUILayout.Button("구독 해제 (Unsubscribe)", buttonStyle, GUILayout.Height(44)))
+            if (GUILayout.Button("구독 해제 (Unsubscribe)", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(44))))
             {
                 Unsubscribe();
             }
@@ -101,7 +101,7 @@ public class ContactsViralTester : MonoBehaviour
         // 로그 초기화
         if (eventLog.Count > 0)
         {
-            if (GUILayout.Button("Clear Log", buttonStyle, GUILayout.Height(32)))
+            if (GUILayout.Button("Clear Log", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(32))))
             {
                 eventLog.Clear();
                 status = "";

--- a/Tests~/E2E/SharedScripts/Runtime/IAPv2Tester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/IAPv2Tester.cs
@@ -79,7 +79,7 @@ public class IAPv2Tester : MonoBehaviour
 
         // Step 1: 상품 목록 조회
         GUILayout.Label("Step 1: Get Product List", fieldLabelStyle);
-        if (GUILayout.Button("IAPGetProductItemList()", buttonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("IAPGetProductItemList()", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             ExecuteIAPGetProductList();
         }
@@ -101,8 +101,8 @@ public class IAPv2Tester : MonoBehaviour
         // Step 2: 구매 주문 생성
         GUILayout.Label("Step 2: Create Purchase Order", fieldLabelStyle);
         GUILayout.BeginHorizontal();
-        GUILayout.Label("SKU:", fieldLabelStyle, GUILayout.Width(50));
-        iapSku = GUILayout.TextField(iapSku, textFieldStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true));
+        GUILayout.Label("SKU:", fieldLabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(50)));
+        iapSku = GUILayout.TextField(iapSku, textFieldStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true));
         GUILayout.EndHorizontal();
 
         // 상품 목록에서 빠른 선택 버튼
@@ -111,14 +111,14 @@ public class IAPv2Tester : MonoBehaviour
             GUILayout.Label("Quick Select:", labelStyle);
             foreach (var product in iapProducts.Products)
             {
-                if (GUILayout.Button($"{product.DisplayName} ({product.Sku})", buttonStyle, GUILayout.Height(32)))
+                if (GUILayout.Button($"{product.DisplayName} ({product.Sku})", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(32))))
                 {
                     iapSku = product.Sku;
                 }
             }
         }
 
-        if (GUILayout.Button("IAPCreateOneTimePurchaseOrder(...)", buttonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("IAPCreateOneTimePurchaseOrder(...)", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             ExecuteIAPCreateOrder();
         }
@@ -127,7 +127,7 @@ public class IAPv2Tester : MonoBehaviour
 
         // Step 3: 대기 중인 주문 조회
         GUILayout.Label("Step 3: Get Pending Orders", fieldLabelStyle);
-        if (GUILayout.Button("IAPGetPendingOrders()", buttonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("IAPGetPendingOrders()", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             ExecuteIAPGetPendingOrders();
         }
@@ -142,7 +142,7 @@ public class IAPv2Tester : MonoBehaviour
             {
                 if (!string.IsNullOrEmpty(order.OrderId))
                 {
-                    if (GUILayout.Button($"→ {order.OrderId} ({order.Sku})", buttonStyle, GUILayout.Height(32)))
+                    if (GUILayout.Button($"→ {order.OrderId} ({order.Sku})", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(32))))
                     {
                         iapOrderId = order.OrderId;
                     }
@@ -160,7 +160,7 @@ public class IAPv2Tester : MonoBehaviour
 
         // Step 4: 완료/환불 주문 조회 (복구 플로우용)
         GUILayout.Label("Step 4: Get Completed/Refunded Orders (복구용)", fieldLabelStyle);
-        if (GUILayout.Button("IAPGetCompletedOrRefundedOrders()", buttonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("IAPGetCompletedOrRefundedOrders()", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             ExecuteIAPGetCompletedOrRefundedOrders();
         }
@@ -176,7 +176,7 @@ public class IAPv2Tester : MonoBehaviour
                 if (!string.IsNullOrEmpty(order.OrderId))
                 {
                     string status = order.Status == CompletedOrRefundedOrdersResultOrderStatus.REFUNDED ? "Refunded" : "Completed";
-                    if (GUILayout.Button($"→ {order.OrderId} ({order.Sku}, {status})", buttonStyle, GUILayout.Height(32)))
+                    if (GUILayout.Button($"→ {order.OrderId} ({order.Sku}, {status})", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(32))))
                     {
                         iapOrderId = order.OrderId;
                     }
@@ -195,10 +195,10 @@ public class IAPv2Tester : MonoBehaviour
         // Step 5: 상품 지급 완료 처리 (복구 플로우용 - 정상 플로우에서는 processProductGrant 콜백에서 자동 처리됨)
         GUILayout.Label("Step 5: Complete Product Grant (복구용)", fieldLabelStyle);
         GUILayout.BeginHorizontal();
-        GUILayout.Label("Order ID:", fieldLabelStyle, GUILayout.Width(80));
-        iapOrderId = GUILayout.TextField(iapOrderId, textFieldStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true));
+        GUILayout.Label("Order ID:", fieldLabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(80)));
+        iapOrderId = GUILayout.TextField(iapOrderId, textFieldStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true));
         GUILayout.EndHorizontal();
-        if (GUILayout.Button("IAPCompleteProductGrant(...)", buttonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("IAPCompleteProductGrant(...)", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             ExecuteIAPCompleteGrant();
         }

--- a/Tests~/E2E/SharedScripts/Runtime/InteractiveAPITester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/InteractiveAPITester.cs
@@ -237,6 +237,9 @@ public class InteractiveAPITester : MonoBehaviour
         GUILayout.BeginArea(safeRect);
         GUILayout.BeginVertical(InteractiveAPITesterStyles.BoxStyle);
 
+        // DPI 디버그 정보
+        GUILayout.Label($"Screen: {Screen.width}x{Screen.height} | dpi:{Screen.dpi} | dpiScale:{InteractiveAPITesterStyles.DpiScale:F2}", InteractiveAPITesterStyles.LabelStyle);
+
         switch (currentState)
         {
             case UIState.APIList:
@@ -358,10 +361,10 @@ public class InteractiveAPITester : MonoBehaviour
         GUILayout.BeginHorizontal();
 
         // 검색 아이콘/레이블
-        GUILayout.Label("🔍", InteractiveAPITesterStyles.LabelStyle, GUILayout.Width(24));
+        GUILayout.Label("🔍", InteractiveAPITesterStyles.LabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(24)));
 
         // 검색 입력 필드
-        string newQuery = GUILayout.TextField(searchQuery, InteractiveAPITesterStyles.TextFieldStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true));
+        string newQuery = GUILayout.TextField(searchQuery, InteractiveAPITesterStyles.TextFieldStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true));
 
         // 검색어가 변경되면 검색 수행
         if (newQuery != searchQuery)
@@ -373,7 +376,7 @@ public class InteractiveAPITester : MonoBehaviour
         // 검색어 지우기 버튼
         if (!string.IsNullOrEmpty(searchQuery))
         {
-            if (GUILayout.Button("✕", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Width(40), GUILayout.Height(36)))
+            if (GUILayout.Button("✕", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(40)), GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36))))
             {
                 searchQuery = "";
                 searchResults.Clear();
@@ -521,10 +524,10 @@ public class InteractiveAPITester : MonoBehaviour
         GUILayout.BeginHorizontal();
 
         // 카테고리 라벨
-        GUILayout.Label($"[{method.Category}]", InteractiveAPITesterStyles.LabelStyle, GUILayout.Width(100));
+        GUILayout.Label($"[{method.Category}]", InteractiveAPITesterStyles.LabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(100)));
 
         // API 버튼
-        if (ScrollAreaButton(method.Name, InteractiveAPITesterStyles.ApiButtonStyle, GUILayout.Height(44), GUILayout.ExpandWidth(true)))
+        if (ScrollAreaButton(method.Name, InteractiveAPITesterStyles.ApiButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(44)), GUILayout.ExpandWidth(true)))
         {
             SelectAPI(method);
         }
@@ -538,7 +541,7 @@ public class InteractiveAPITester : MonoBehaviour
         string icon = isExpanded ? "▼" : "▶";
         string label = $"{icon}  {categoryName} ({apiCount})";
 
-        if (ScrollAreaButton(label, InteractiveAPITesterStyles.GroupHeaderStyle, GUILayout.Height(44)))
+        if (ScrollAreaButton(label, InteractiveAPITesterStyles.GroupHeaderStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(44))))
         {
             groupFoldouts[categoryName] = !isExpanded;
         }
@@ -550,7 +553,7 @@ public class InteractiveAPITester : MonoBehaviour
         GUILayout.Space(20); // 들여쓰기
 
         // API 버튼 - 반응형으로 남은 공간 채우기
-        if (ScrollAreaButton(method.Name, InteractiveAPITesterStyles.ApiButtonStyle, GUILayout.Height(44), GUILayout.ExpandWidth(true)))
+        if (ScrollAreaButton(method.Name, InteractiveAPITesterStyles.ApiButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(44)), GUILayout.ExpandWidth(true)))
         {
             SelectAPI(method);
         }
@@ -590,14 +593,14 @@ public class InteractiveAPITester : MonoBehaviour
         GUILayout.Space(10);
         GUILayout.BeginHorizontal();
 
-        if (GUILayout.Button("← Back", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Height(48), GUILayout.Width(120)))
+        if (GUILayout.Button("← Back", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(48)), GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(120))))
         {
             BackToList();
         }
 
         GUILayout.FlexibleSpace();
 
-        if (GUILayout.Button("Execute →", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Height(48), GUILayout.Width(140)))
+        if (GUILayout.Button("Execute →", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(48)), GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(140))))
         {
             ExecuteAPI();
         }
@@ -622,14 +625,14 @@ public class InteractiveAPITester : MonoBehaviour
         if (lastResultSuccess && lastResultObject != null)
         {
             GUILayout.BeginHorizontal();
-            GUILayout.Label("표시 모드:", InteractiveAPITesterStyles.LabelStyle, GUILayout.Width(80));
+            GUILayout.Label("표시 모드:", InteractiveAPITesterStyles.LabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(80)));
 
             Color origBg = GUI.backgroundColor;
 
             GUI.backgroundColor = resultDisplayMode == ResultDisplayMode.Structured
                 ? new Color(0.3f, 0.6f, 0.3f)
                 : new Color(0.3f, 0.3f, 0.3f);
-            if (GUILayout.Button("구조화", InteractiveAPITesterStyles.ToggleButtonStyle, GUILayout.Height(32), GUILayout.Width(80)))
+            if (GUILayout.Button("구조화", InteractiveAPITesterStyles.ToggleButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(32)), GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(80))))
             {
                 resultDisplayMode = ResultDisplayMode.Structured;
             }
@@ -637,7 +640,7 @@ public class InteractiveAPITester : MonoBehaviour
             GUI.backgroundColor = resultDisplayMode == ResultDisplayMode.RawJson
                 ? new Color(0.3f, 0.6f, 0.3f)
                 : new Color(0.3f, 0.3f, 0.3f);
-            if (GUILayout.Button("JSON", InteractiveAPITesterStyles.ToggleButtonStyle, GUILayout.Height(32), GUILayout.Width(80)))
+            if (GUILayout.Button("JSON", InteractiveAPITesterStyles.ToggleButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(32)), GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(80))))
             {
                 resultDisplayMode = ResultDisplayMode.RawJson;
             }
@@ -672,14 +675,14 @@ public class InteractiveAPITester : MonoBehaviour
         GUILayout.Space(10);
         GUILayout.BeginHorizontal();
 
-        if (GUILayout.Button("← Back to List", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Height(48), GUILayout.Width(160)))
+        if (GUILayout.Button("← Back to List", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(48)), GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(160))))
         {
             BackToList();
         }
 
         GUILayout.FlexibleSpace();
 
-        if (GUILayout.Button("Retry", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Height(48), GUILayout.Width(120)))
+        if (GUILayout.Button("Retry", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(48)), GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(120))))
         {
             currentState = UIState.ParameterInput;
             _scrollHandler.ResetScroll();
@@ -729,8 +732,8 @@ public class InteractiveAPITester : MonoBehaviour
             for (int i = 0; i < array.Length; i++)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Space(indentLevel * 20);
-                GUILayout.Label($"[{i}]:", InteractiveAPITesterStyles.ResultKeyStyle, GUILayout.Width(60));
+                GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
+                GUILayout.Label($"[{i}]:", InteractiveAPITesterStyles.ResultKeyStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(60)));
                 GUILayout.EndHorizontal();
                 DrawStructuredResult(array.GetValue(i), indentLevel + 1);
             }
@@ -760,8 +763,8 @@ public class InteractiveAPITester : MonoBehaviour
             if (APIParameterInspector.IsSimpleType(fieldType) || fieldType.IsEnum)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Space(indentLevel * 20);
-                GUILayout.Label($"{field.Name}:", InteractiveAPITesterStyles.ResultKeyStyle, GUILayout.Width(150));
+                GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
+                GUILayout.Label($"{field.Name}:", InteractiveAPITesterStyles.ResultKeyStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(150)));
                 string displayValue = value == null ? "null" :
                     (fieldType == typeof(string) ? $"\"{value}\"" : value.ToString());
                 GUILayout.Label(displayValue, InteractiveAPITesterStyles.ResultValueStyle, GUILayout.ExpandWidth(true));
@@ -772,7 +775,7 @@ public class InteractiveAPITester : MonoBehaviour
             {
                 // 중첩 객체
                 GUILayout.BeginHorizontal();
-                GUILayout.Space(indentLevel * 20);
+                GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
                 GUILayout.Label($"{field.Name}:", InteractiveAPITesterStyles.ResultKeyStyle);
                 GUILayout.EndHorizontal();
                 DrawStructuredResult(value, indentLevel + 1);
@@ -783,7 +786,7 @@ public class InteractiveAPITester : MonoBehaviour
     private void DrawResultValue(string value, int indentLevel)
     {
         GUILayout.BeginHorizontal();
-        GUILayout.Space(indentLevel * 20);
+        GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
         GUILayout.Label(value, InteractiveAPITesterStyles.ResultValueStyle);
         GUILayout.EndHorizontal();
     }

--- a/Tests~/E2E/SharedScripts/Runtime/InteractiveAPITesterStyles.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/InteractiveAPITesterStyles.cs
@@ -1,11 +1,20 @@
+using System.Runtime.InteropServices;
 using UnityEngine;
 
 /// <summary>
 /// InteractiveAPITester용 UI 스타일 및 유틸리티 클래스
 /// GUIStyle 초기화와 공통 GUI 헬퍼 메서드를 제공
+/// DPI 기반 스케일링으로 고DPI 디바이스에서도 적절한 UI 크기 유지
 /// </summary>
 public static class InteractiveAPITesterStyles
 {
+#if UNITY_WEBGL && !UNITY_EDITOR
+    [DllImport("__Internal")]
+    private static extern float E2E_GetDevicePixelRatio();
+#else
+    private static float E2E_GetDevicePixelRatio() => 1.0f;
+#endif
+
     // GUIStyle 필드 (18개)
     public static GUIStyle BoxStyle;
     public static GUIStyle ButtonStyle;
@@ -29,11 +38,23 @@ public static class InteractiveAPITesterStyles
     // 상태 필드
     private static bool _initialized = false;
     private static Font _koreanFont;
+    private static float _dpiScale = 1.0f;
 
     /// <summary>
     /// 스타일이 초기화되었는지 여부
     /// </summary>
     public static bool IsInitialized => _initialized;
+
+    /// <summary>
+    /// 현재 DPI 스케일 값 (디버그/외부 참조용)
+    /// </summary>
+    public static float DpiScale => _dpiScale;
+
+    /// <summary>
+    /// 기준 DPI 대비 스케일링된 정수 값을 반환합니다.
+    /// 외부에서 GUILayout.Height/Width 등에 사용할 수 있습니다.
+    /// </summary>
+    public static int ScaledInt(int baseValue) => Mathf.RoundToInt(baseValue * _dpiScale);
 
     /// <summary>
     /// 스타일을 초기화합니다. OnGUI 내에서 호출해야 합니다.
@@ -45,133 +66,138 @@ public static class InteractiveAPITesterStyles
 
         _koreanFont = koreanFont;
 
+        // DPI 스케일 계산
+        // Screen.height 기반: Screen.dpi는 플랫폼마다 부정확 (WebGL 0, Android 과소보고)
+        // 높이 1000px = 1.0x, 모바일은 보통 2000~2800px → 2.0~2.8x
+        _dpiScale = Mathf.Clamp(Screen.height / 1000f, 1.0f, 5.0f);
+
         BoxStyle = new GUIStyle(GUI.skin.box);
-        BoxStyle.padding = new RectOffset(10, 10, 10, 10);
+        BoxStyle.padding = new RectOffset(ScaledInt(10), ScaledInt(10), ScaledInt(10), ScaledInt(10));
         BoxStyle.normal.background = MakeTex(2, 2, new Color(0.1f, 0.1f, 0.1f, 0.95f));
 
         // 기본 버튼 스타일
         ButtonStyle = new GUIStyle(GUI.skin.button);
-        ButtonStyle.fontSize = 14;
-        ButtonStyle.padding = new RectOffset(10, 10, 8, 8);
-        ButtonStyle.margin = new RectOffset(4, 4, 4, 4);
+        ButtonStyle.fontSize = ScaledInt(14);
+        ButtonStyle.padding = new RectOffset(ScaledInt(10), ScaledInt(10), ScaledInt(8), ScaledInt(8));
+        ButtonStyle.margin = new RectOffset(ScaledInt(4), ScaledInt(4), ScaledInt(4), ScaledInt(4));
         if (_koreanFont != null) ButtonStyle.font = _koreanFont;
 
         // API 버튼 스타일 (너비 제한, 높이 증가)
         ApiButtonStyle = new GUIStyle(GUI.skin.button);
-        ApiButtonStyle.fontSize = 15;
+        ApiButtonStyle.fontSize = ScaledInt(15);
         ApiButtonStyle.fontStyle = FontStyle.Normal;
-        ApiButtonStyle.padding = new RectOffset(15, 15, 12, 12);
-        ApiButtonStyle.margin = new RectOffset(4, 4, 3, 3);
+        ApiButtonStyle.padding = new RectOffset(ScaledInt(15), ScaledInt(15), ScaledInt(12), ScaledInt(12));
+        ApiButtonStyle.margin = new RectOffset(ScaledInt(4), ScaledInt(4), ScaledInt(3), ScaledInt(3));
         ApiButtonStyle.alignment = TextAnchor.MiddleLeft;
         if (_koreanFont != null) ApiButtonStyle.font = _koreanFont;
 
         // 그룹 헤더 스타일
         GroupHeaderStyle = new GUIStyle(GUI.skin.button);
-        GroupHeaderStyle.fontSize = 16;
+        GroupHeaderStyle.fontSize = ScaledInt(16);
         GroupHeaderStyle.fontStyle = FontStyle.Bold;
-        GroupHeaderStyle.padding = new RectOffset(12, 12, 10, 10);
-        GroupHeaderStyle.margin = new RectOffset(0, 0, 8, 4);
+        GroupHeaderStyle.padding = new RectOffset(ScaledInt(12), ScaledInt(12), ScaledInt(10), ScaledInt(10));
+        GroupHeaderStyle.margin = new RectOffset(0, 0, ScaledInt(8), ScaledInt(4));
         GroupHeaderStyle.alignment = TextAnchor.MiddleLeft;
         GroupHeaderStyle.normal.textColor = new Color(0.4f, 0.8f, 1f);
         if (_koreanFont != null) GroupHeaderStyle.font = _koreanFont;
 
         LabelStyle = new GUIStyle(GUI.skin.label);
-        LabelStyle.fontSize = 12;
+        LabelStyle.fontSize = ScaledInt(12);
         LabelStyle.wordWrap = true;
         if (_koreanFont != null) LabelStyle.font = _koreanFont;
 
         TextAreaStyle = new GUIStyle(GUI.skin.textArea);
-        TextAreaStyle.fontSize = 12;
-        TextAreaStyle.padding = new RectOffset(5, 5, 5, 5);
+        TextAreaStyle.fontSize = ScaledInt(12);
+        TextAreaStyle.padding = new RectOffset(ScaledInt(5), ScaledInt(5), ScaledInt(5), ScaledInt(5));
         TextAreaStyle.wordWrap = true;
         if (_koreanFont != null) TextAreaStyle.font = _koreanFont;
 
         HeaderStyle = new GUIStyle(GUI.skin.label);
-        HeaderStyle.fontSize = 20;
+        HeaderStyle.fontSize = ScaledInt(20);
         HeaderStyle.fontStyle = FontStyle.Bold;
         HeaderStyle.alignment = TextAnchor.MiddleCenter;
-        HeaderStyle.margin = new RectOffset(0, 0, 10, 5);
+        HeaderStyle.margin = new RectOffset(0, 0, ScaledInt(10), ScaledInt(5));
         if (_koreanFont != null) HeaderStyle.font = _koreanFont;
 
         // 검색 입력 필드 스타일
         TextFieldStyle = new GUIStyle(GUI.skin.textField);
-        TextFieldStyle.fontSize = 16;
-        TextFieldStyle.padding = new RectOffset(12, 12, 10, 10);
-        TextFieldStyle.margin = new RectOffset(0, 0, 5, 10);
+        TextFieldStyle.fontSize = ScaledInt(16);
+        TextFieldStyle.padding = new RectOffset(ScaledInt(12), ScaledInt(12), ScaledInt(10), ScaledInt(10));
+        TextFieldStyle.margin = new RectOffset(0, 0, ScaledInt(5), ScaledInt(10));
         if (_koreanFont != null) TextFieldStyle.font = _koreanFont;
 
         // 검색 박스 배경 스타일
         SearchBoxStyle = new GUIStyle(GUI.skin.box);
-        SearchBoxStyle.padding = new RectOffset(10, 10, 8, 8);
-        SearchBoxStyle.margin = new RectOffset(0, 0, 0, 5);
+        SearchBoxStyle.padding = new RectOffset(ScaledInt(10), ScaledInt(10), ScaledInt(8), ScaledInt(8));
+        SearchBoxStyle.margin = new RectOffset(0, 0, 0, ScaledInt(5));
         SearchBoxStyle.normal.background = MakeTex(2, 2, new Color(0.15f, 0.15f, 0.2f, 0.95f));
 
         // 중첩 객체 헤더 스타일
         NestedHeaderStyle = new GUIStyle(GUI.skin.button);
-        NestedHeaderStyle.fontSize = 14;
+        NestedHeaderStyle.fontSize = ScaledInt(14);
         NestedHeaderStyle.fontStyle = FontStyle.Bold;
-        NestedHeaderStyle.padding = new RectOffset(10, 10, 8, 8);
-        NestedHeaderStyle.margin = new RectOffset(0, 0, 4, 4);
+        NestedHeaderStyle.padding = new RectOffset(ScaledInt(10), ScaledInt(10), ScaledInt(8), ScaledInt(8));
+        NestedHeaderStyle.margin = new RectOffset(0, 0, ScaledInt(4), ScaledInt(4));
         NestedHeaderStyle.alignment = TextAnchor.MiddleLeft;
         NestedHeaderStyle.normal.textColor = new Color(0.6f, 0.9f, 0.6f);
         if (_koreanFont != null) NestedHeaderStyle.font = _koreanFont;
 
         // Enum 버튼 스타일 (현재 선택값 표시)
         EnumButtonStyle = new GUIStyle(GUI.skin.button);
-        EnumButtonStyle.fontSize = 14;
-        EnumButtonStyle.padding = new RectOffset(12, 12, 8, 8);
+        EnumButtonStyle.fontSize = ScaledInt(14);
+        EnumButtonStyle.padding = new RectOffset(ScaledInt(12), ScaledInt(12), ScaledInt(8), ScaledInt(8));
         EnumButtonStyle.alignment = TextAnchor.MiddleLeft;
         EnumButtonStyle.normal.textColor = new Color(0.9f, 0.9f, 0.5f);
         if (_koreanFont != null) EnumButtonStyle.font = _koreanFont;
 
         // Enum 옵션 스타일
         EnumOptionStyle = new GUIStyle(GUI.skin.button);
-        EnumOptionStyle.fontSize = 13;
-        EnumOptionStyle.padding = new RectOffset(20, 10, 6, 6);
-        EnumOptionStyle.margin = new RectOffset(0, 0, 1, 1);
+        EnumOptionStyle.fontSize = ScaledInt(13);
+        EnumOptionStyle.padding = new RectOffset(ScaledInt(20), ScaledInt(10), ScaledInt(6), ScaledInt(6));
+        EnumOptionStyle.margin = new RectOffset(0, 0, ScaledInt(1), ScaledInt(1));
         EnumOptionStyle.alignment = TextAnchor.MiddleLeft;
         if (_koreanFont != null) EnumOptionStyle.font = _koreanFont;
 
         // 필드 라벨 스타일
         FieldLabelStyle = new GUIStyle(GUI.skin.label);
-        FieldLabelStyle.fontSize = 13;
+        FieldLabelStyle.fontSize = ScaledInt(13);
         FieldLabelStyle.fontStyle = FontStyle.Normal;
         FieldLabelStyle.normal.textColor = new Color(0.8f, 0.8f, 0.8f);
         if (_koreanFont != null) FieldLabelStyle.font = _koreanFont;
 
         // 결과 키 스타일
         ResultKeyStyle = new GUIStyle(GUI.skin.label);
-        ResultKeyStyle.fontSize = 13;
+        ResultKeyStyle.fontSize = ScaledInt(13);
         ResultKeyStyle.fontStyle = FontStyle.Bold;
         ResultKeyStyle.normal.textColor = new Color(0.7f, 0.85f, 1f);
         if (_koreanFont != null) ResultKeyStyle.font = _koreanFont;
 
         // 결과 값 스타일
         ResultValueStyle = new GUIStyle(GUI.skin.label);
-        ResultValueStyle.fontSize = 13;
+        ResultValueStyle.fontSize = ScaledInt(13);
         ResultValueStyle.wordWrap = true;
         ResultValueStyle.normal.textColor = new Color(0.9f, 0.9f, 0.9f);
         if (_koreanFont != null) ResultValueStyle.font = _koreanFont;
 
         // 콜백 필드 라벨 스타일
         CallbackLabelStyle = new GUIStyle(GUI.skin.label);
-        CallbackLabelStyle.fontSize = 12;
+        CallbackLabelStyle.fontSize = ScaledInt(12);
         CallbackLabelStyle.fontStyle = FontStyle.Italic;
         CallbackLabelStyle.normal.textColor = new Color(0.6f, 0.6f, 0.6f);
         if (_koreanFont != null) CallbackLabelStyle.font = _koreanFont;
 
         // 토글 버튼 스타일
         ToggleButtonStyle = new GUIStyle(GUI.skin.button);
-        ToggleButtonStyle.fontSize = 13;
-        ToggleButtonStyle.padding = new RectOffset(10, 10, 6, 6);
+        ToggleButtonStyle.fontSize = ScaledInt(13);
+        ToggleButtonStyle.padding = new RectOffset(ScaledInt(10), ScaledInt(10), ScaledInt(6), ScaledInt(6));
         if (_koreanFont != null) ToggleButtonStyle.font = _koreanFont;
 
         // 위험 버튼 스타일 (OOM 테스트용)
         DangerButtonStyle = new GUIStyle(GUI.skin.button);
-        DangerButtonStyle.fontSize = 14;
+        DangerButtonStyle.fontSize = ScaledInt(14);
         DangerButtonStyle.fontStyle = FontStyle.Bold;
-        DangerButtonStyle.padding = new RectOffset(15, 15, 12, 12);
-        DangerButtonStyle.margin = new RectOffset(4, 4, 8, 8);
+        DangerButtonStyle.padding = new RectOffset(ScaledInt(15), ScaledInt(15), ScaledInt(12), ScaledInt(12));
+        DangerButtonStyle.margin = new RectOffset(ScaledInt(4), ScaledInt(4), ScaledInt(8), ScaledInt(8));
         DangerButtonStyle.normal.textColor = Color.white;
         DangerButtonStyle.normal.background = MakeTex(2, 2, new Color(0.8f, 0.2f, 0.2f, 1f));
         DangerButtonStyle.hover.background = MakeTex(2, 2, new Color(0.9f, 0.3f, 0.3f, 1f));

--- a/Tests~/E2E/SharedScripts/Runtime/OOMTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/OOMTester.cs
@@ -114,15 +114,15 @@ public class OOMTester : MonoBehaviour
 
         // WASM 힙 할당 버튼들 (세로 배치)
         GUILayout.Label("WASM 힙 (C# byte[])", labelStyle);
-        if (GUILayout.Button("+50MB WASM", dangerButtonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("+50MB WASM", dangerButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             AllocateWasm(50);
         }
-        if (GUILayout.Button("+100MB WASM", dangerButtonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("+100MB WASM", dangerButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             AllocateWasm(100);
         }
-        if (GUILayout.Button("+500MB WASM", dangerButtonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("+500MB WASM", dangerButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             AllocateWasm(500);
         }
@@ -131,15 +131,15 @@ public class OOMTester : MonoBehaviour
 
         // WebView (JS) 할당 버튼들 (세로 배치)
         GUILayout.Label("WebView (JS ArrayBuffer)", labelStyle);
-        if (GUILayout.Button("+50MB WebView", dangerButtonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("+50MB WebView", dangerButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             AllocateWebView(50);
         }
-        if (GUILayout.Button("+100MB WebView", dangerButtonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("+100MB WebView", dangerButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             AllocateWebView(100);
         }
-        if (GUILayout.Button("+500MB WebView", dangerButtonStyle, GUILayout.Height(40)))
+        if (GUILayout.Button("+500MB WebView", dangerButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
         {
             AllocateWebView(500);
         }
@@ -156,7 +156,7 @@ public class OOMTester : MonoBehaviour
 
             if (hasWasmMemory)
             {
-                if (GUILayout.Button("WASM 해제", buttonStyle, GUILayout.Height(36)))
+                if (GUILayout.Button("WASM 해제", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36))))
                 {
                     ClearWasmAllocations();
                 }
@@ -164,7 +164,7 @@ public class OOMTester : MonoBehaviour
 
             if (hasJsMemory)
             {
-                if (GUILayout.Button("WebView 해제", buttonStyle, GUILayout.Height(36)))
+                if (GUILayout.Button("WebView 해제", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36))))
                 {
                     ClearJSAllocations();
                 }
@@ -172,7 +172,7 @@ public class OOMTester : MonoBehaviour
 
             if (hasWasmMemory && hasJsMemory)
             {
-                if (GUILayout.Button("전체 해제", buttonStyle, GUILayout.Height(36)))
+                if (GUILayout.Button("전체 해제", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36))))
                 {
                     ClearAllAllocations();
                 }

--- a/Tests~/E2E/SharedScripts/Runtime/ParameterInputRenderer.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/ParameterInputRenderer.cs
@@ -159,7 +159,7 @@ public class ParameterInputRenderer
 
         // 기타 타입 (폴백)
         GUILayout.BeginHorizontal();
-        GUILayout.Space(indentLevel * 20);
+        GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
         GUILayout.Label($"{displayName}: (지원하지 않는 타입: {type.Name})", InteractiveAPITesterStyles.CallbackLabelStyle);
         GUILayout.EndHorizontal();
     }
@@ -192,11 +192,11 @@ public class ParameterInputRenderer
         GUILayout.BeginVertical();
 
         GUILayout.BeginHorizontal();
-        GUILayout.Space(indentLevel * 20);
-        GUILayout.Label($"{displayName}:", InteractiveAPITesterStyles.FieldLabelStyle, GUILayout.Width(120));
+        GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
+        GUILayout.Label($"{displayName}:", InteractiveAPITesterStyles.FieldLabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(120)));
 
         string buttonLabel = isOpen ? $"▲ {enumNames[selectedIndex]}" : $"▼ {enumNames[selectedIndex]}";
-        if (GUILayout.Button(buttonLabel, InteractiveAPITesterStyles.EnumButtonStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true)))
+        if (GUILayout.Button(buttonLabel, InteractiveAPITesterStyles.EnumButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true)))
         {
             _enumDropdownOpen[fieldPath] = !isOpen;
         }
@@ -207,10 +207,10 @@ public class ParameterInputRenderer
             for (int i = 0; i < enumNames.Length; i++)
             {
                 GUILayout.BeginHorizontal();
-                GUILayout.Space(indentLevel * 20 + 120);
+                GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20) + InteractiveAPITesterStyles.ScaledInt(120));
 
                 string optionLabel = i == selectedIndex ? $"✓ {enumNames[i]}" : $"   {enumNames[i]}";
-                if (GUILayout.Button(optionLabel, InteractiveAPITesterStyles.EnumOptionStyle, GUILayout.Height(32)))
+                if (GUILayout.Button(optionLabel, InteractiveAPITesterStyles.EnumOptionStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(32))))
                 {
                     _enumSelectedIndices[fieldPath] = i;
                     _enumDropdownOpen[fieldPath] = false;
@@ -241,13 +241,13 @@ public class ParameterInputRenderer
         }
 
         GUILayout.BeginHorizontal();
-        GUILayout.Space(indentLevel * 20);
-        GUILayout.Label($"{displayName}:", InteractiveAPITesterStyles.FieldLabelStyle, GUILayout.Width(120));
-        _stringInputs[fieldPath] = GUILayout.TextField(value, InteractiveAPITesterStyles.TextFieldStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true));
+        GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
+        GUILayout.Label($"{displayName}:", InteractiveAPITesterStyles.FieldLabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(120)));
+        _stringInputs[fieldPath] = GUILayout.TextField(value, InteractiveAPITesterStyles.TextFieldStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true));
 
         // PASTE 버튼
         GUI.enabled = !isPasting;
-        if (GUILayout.Button(isPasting ? "..." : "PASTE", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Width(70), GUILayout.Height(36)))
+        if (GUILayout.Button(isPasting ? "..." : "PASTE", InteractiveAPITesterStyles.ButtonStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(70)), GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36))))
         {
             PasteFromClipboard(fieldPath);
         }
@@ -293,11 +293,11 @@ public class ParameterInputRenderer
         }
 
         GUILayout.BeginHorizontal();
-        GUILayout.Space(indentLevel * 20);
-        GUILayout.Label($"{displayName}:", InteractiveAPITesterStyles.FieldLabelStyle, GUILayout.Width(120));
+        GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
+        GUILayout.Label($"{displayName}:", InteractiveAPITesterStyles.FieldLabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(120)));
 
         string strValue = value.ToString();
-        string newStrValue = GUILayout.TextField(strValue, InteractiveAPITesterStyles.TextFieldStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true));
+        string newStrValue = GUILayout.TextField(strValue, InteractiveAPITesterStyles.TextFieldStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true));
 
         if (newStrValue != strValue)
         {
@@ -327,14 +327,14 @@ public class ParameterInputRenderer
         }
 
         GUILayout.BeginHorizontal();
-        GUILayout.Space(indentLevel * 20);
-        GUILayout.Label($"{displayName}:", InteractiveAPITesterStyles.FieldLabelStyle, GUILayout.Width(120));
+        GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
+        GUILayout.Label($"{displayName}:", InteractiveAPITesterStyles.FieldLabelStyle, GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(120)));
 
         string btnLabel = value ? "✓ true" : "✗ false";
         Color originalColor = GUI.backgroundColor;
         GUI.backgroundColor = value ? new Color(0.4f, 0.7f, 0.4f) : new Color(0.5f, 0.5f, 0.5f);
 
-        if (GUILayout.Button(btnLabel, InteractiveAPITesterStyles.ToggleButtonStyle, GUILayout.Height(36), GUILayout.Width(100)))
+        if (GUILayout.Button(btnLabel, InteractiveAPITesterStyles.ToggleButtonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.Width(InteractiveAPITesterStyles.ScaledInt(100))))
         {
             _boolInputs[fieldPath] = !value;
         }
@@ -357,7 +357,7 @@ public class ParameterInputRenderer
         if (!hasEditableFields)
         {
             GUILayout.BeginHorizontal();
-            GUILayout.Space(indentLevel * 20);
+            GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
             GUILayout.Label($"{displayName}: (콜백 전용 - 편집 불가)", InteractiveAPITesterStyles.CallbackLabelStyle);
             GUILayout.EndHorizontal();
             GUILayout.Space(4);
@@ -371,10 +371,10 @@ public class ParameterInputRenderer
         }
 
         GUILayout.BeginHorizontal();
-        GUILayout.Space(indentLevel * 20);
+        GUILayout.Space(indentLevel * InteractiveAPITesterStyles.ScaledInt(20));
 
         string icon = isExpanded ? "▼" : "▶";
-        if (GUILayout.Button($"{icon} {displayName} ({type.Name})", InteractiveAPITesterStyles.NestedHeaderStyle, GUILayout.Height(36), GUILayout.ExpandWidth(true)))
+        if (GUILayout.Button($"{icon} {displayName} ({type.Name})", InteractiveAPITesterStyles.NestedHeaderStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(36)), GUILayout.ExpandWidth(true)))
         {
             _nestedFoldouts[fieldPath] = !isExpanded;
         }
@@ -388,7 +388,7 @@ public class ParameterInputRenderer
                 if (APIParameterInspector.IsCallbackField(field))
                 {
                     GUILayout.BeginHorizontal();
-                    GUILayout.Space((indentLevel + 1) * 20);
+                    GUILayout.Space((indentLevel + 1) * InteractiveAPITesterStyles.ScaledInt(20));
                     GUILayout.Label($"{field.Name}: (콜백 - 편집 불가)", InteractiveAPITesterStyles.CallbackLabelStyle);
                     GUILayout.EndHorizontal();
                     GUILayout.Space(2);

--- a/Tests~/E2E/SharedScripts/Runtime/VisibilityBGMTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/VisibilityBGMTester.cs
@@ -152,14 +152,14 @@ public class VisibilityBGMTester : MonoBehaviour
         // 컨트롤 버튼
         if (!isPlaying)
         {
-            if (GUILayout.Button("▶ BGM 재생", buttonStyle, GUILayout.Height(40)))
+            if (GUILayout.Button("▶ BGM 재생", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
             {
                 StartBGM();
             }
         }
         else
         {
-            if (GUILayout.Button("⏹ BGM 정지", buttonStyle, GUILayout.Height(40)))
+            if (GUILayout.Button("⏹ BGM 정지", buttonStyle, GUILayout.Height(InteractiveAPITesterStyles.ScaledInt(40))))
             {
                 StopBGM();
             }


### PR DESCRIPTION
## Summary
- 고DPI 모바일 디바이스에서 InteractiveAPITester UI 글씨/버튼이 너무 작은 문제 해결
- `Screen.height` 기반 스케일링 (1000px = 1.0x)
  - Screen.dpi는 WebGL에서 0 반환, Android에서 과소보고 → 신뢰 불가
  - jslib `window.devicePixelRatio`도 보조 수단으로 포함 (E2ETestBridge.jslib)
- 모든 fontSize, padding, margin, GUILayout.Height/Width에 `ScaledInt()` 적용
- 디버그 라인 상단 표시: `Screen: {w}x{h} | dpi:{dpi} | dpiScale:{scale}`

## 변경 파일 (9개)
- `InteractiveAPITesterStyles.cs` — `_dpiScale` 계산 + `ScaledInt()` public 헬퍼, 모든 스타일 적용
- `InteractiveAPITester.cs` — GUILayout.Height/Width, indent spacing 스케일링, 디버그 라인
- `E2ETestBridge.jslib` — `E2E_GetDevicePixelRatio()` 추가
- `OOMTester.cs`, `IAPv2Tester.cs`, `AdV2Tester.cs`, `ContactsViralTester.cs`, `VisibilityBGMTester.cs`, `ParameterInputRenderer.cs` — 동일 패턴 적용

## 검증 결과
- Galaxy Fold 7 (1080x2394): dpiScale 2.39x ✅
- iPhone 15 Pro (1179x2556): dpiScale 2.56x (예상)
- PC 브라우저 (~1000px): dpiScale 1.0x

## Test plan
- [x] Galaxy Fold 7 Preview 빌드 확인
- [ ] iPhone 15 Pro Preview 빌드 확인
- [ ] PC 브라우저에서 기존과 동일한 UI 크기 확인