### PR TITLE
기능: .ait protobuf 헤더에 Unity 빌드 메타데이터 포함

### DIFF
--- a/Editor/AITAsyncCommandRunner.cs
+++ b/Editor/AITAsyncCommandRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
@@ -75,7 +76,8 @@ namespace AppsInToss.Editor
             string[] additionalPaths,
             Action<AITPlatformHelper.CommandResult> onComplete,
             Action<string> onOutputReceived = null,
-            int timeoutMs = 300000)
+            int timeoutMs = 300000,
+            Dictionary<string, string> additionalEnvVars = null)
         {
             EnsureQueueProcessorRegistered();
 
@@ -86,7 +88,7 @@ namespace AppsInToss.Editor
             };
 
             // 백그라운드 스레드에서 명령 실행
-            ThreadPool.QueueUserWorkItem(_ => ExecuteCommandAsync(task, command, workingDirectory, additionalPaths, timeoutMs));
+            ThreadPool.QueueUserWorkItem(_ => ExecuteCommandAsync(task, command, workingDirectory, additionalPaths, timeoutMs, additionalEnvVars));
 
             return task;
         }
@@ -126,7 +128,8 @@ namespace AppsInToss.Editor
             string command,
             string workingDirectory,
             string[] additionalPaths,
-            int timeoutMs)
+            int timeoutMs,
+            Dictionary<string, string> additionalEnvVars = null)
         {
             task.State = CommandState.Running;
             var result = new AITPlatformHelper.CommandResult();
@@ -140,12 +143,30 @@ namespace AppsInToss.Editor
                 {
                     shell = "powershell.exe";
                     string escapedCommand = EscapeForPowerShell(command);
-                    shellArgs = $"-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $env:CI = 'true'; {escapedCommand}\"";
+                    string envSetup = "$env:CI = 'true';";
+                    if (additionalEnvVars != null)
+                    {
+                        foreach (var kvp in additionalEnvVars)
+                        {
+                            string escapedValue = kvp.Value.Replace("'", "''");
+                            envSetup += $" $env:{kvp.Key} = '{escapedValue}';";
+                        }
+                    }
+                    shellArgs = $"-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; {envSetup} {escapedCommand}\"";
                 }
                 else
                 {
                     shell = "/bin/bash";
-                    shellArgs = $"-l -c \"export CI=true && export PATH='{pathEnv}' && {command}\"";
+                    string envExports = "export CI=true";
+                    if (additionalEnvVars != null)
+                    {
+                        foreach (var kvp in additionalEnvVars)
+                        {
+                            string escapedValue = kvp.Value.Replace("'", "'\\''");
+                            envExports += $" && export {kvp.Key}='{escapedValue}'";
+                        }
+                    }
+                    shellArgs = $"-l -c \"{envExports} && export PATH='{pathEnv}' && {command}\"";
                 }
 
                 EnqueueMainThread(() => Debug.Log($"[AIT Async] 명령 시작: {command}"));
@@ -172,6 +193,15 @@ namespace AppsInToss.Editor
                     processInfo.EnvironmentVariables["PATH"] = pathEnv;
                 }
                 processInfo.EnvironmentVariables["CI"] = "true";
+
+                // 추가 환경변수 설정
+                if (additionalEnvVars != null)
+                {
+                    foreach (var kvp in additionalEnvVars)
+                    {
+                        processInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+                    }
+                }
 
                 using (var process = new Process { StartInfo = processInfo })
                 {

--- a/Editor/AITNpmRunner.cs
+++ b/Editor/AITNpmRunner.cs
@@ -182,7 +182,8 @@ namespace AppsInToss.Editor
             string npmPath,
             string arguments,
             string cachePath,
-            string progressTitle)
+            string progressTitle,
+            Dictionary<string, string> additionalEnvVars = null)
         {
             string pmName = Path.GetFileNameWithoutExtension(npmPath);
             string fullArguments = BuildFullArguments(arguments, cachePath);
@@ -208,7 +209,8 @@ namespace AppsInToss.Editor
                     workingDirectory,
                     additionalPaths.ToArray(),
                     timeoutMs: maxWaitSeconds * 1000,
-                    verbose: true
+                    verbose: true,
+                    additionalEnvVars: additionalEnvVars
                 );
 
                 EditorUtility.ClearProgressBar();
@@ -256,7 +258,8 @@ namespace AppsInToss.Editor
             string cachePath,
             Action<AITConvertCore.AITExportError> onComplete,
             Action<string> onOutputReceived = null,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            Dictionary<string, string> additionalEnvVars = null)
         {
             string pmName = Path.GetFileNameWithoutExtension(npmPath);
             string fullArguments = BuildFullArguments(arguments, cachePath);
@@ -297,7 +300,8 @@ namespace AppsInToss.Editor
                     }
                 },
                 onOutputReceived: onOutputReceived,
-                timeoutMs: 300000 // 5분
+                timeoutMs: 300000, // 5분
+                additionalEnvVars: additionalEnvVars
             );
 
             // 현재 작업 등록 (취소용)

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -192,7 +192,11 @@ namespace AppsInToss.Editor
             // granite build 실행 (web 폴더를 dist로 복사)
             Debug.Log("[AIT] granite build 실행 중...");
 
-            var buildResult = AITNpmRunner.RunNpmCommandWithCache(buildProjectPath, pnpmPath, "run build", localCachePath, "granite build 실행 중...");
+            // UNITY_METADATA 환경변수를 통해 빌드 메타데이터를 granite build에 전달
+            var unityMetadataEnv = AITUnityMetadata.BuildEnvironmentVariables();
+            Debug.Log($"[AIT] UNITY_METADATA: {unityMetadataEnv["UNITY_METADATA"]}");
+
+            var buildResult = AITNpmRunner.RunNpmCommandWithCache(buildProjectPath, pnpmPath, "run build", localCachePath, "granite build 실행 중...", additionalEnvVars: unityMetadataEnv);
 
             if (buildResult != AITConvertCore.AITExportError.SUCCEED)
             {
@@ -209,7 +213,7 @@ namespace AppsInToss.Editor
                 }
 
                 // build 재시도
-                buildResult = AITNpmRunner.RunNpmCommandWithCache(buildProjectPath, pnpmPath, "run build", localCachePath, "granite build (재시도)...");
+                buildResult = AITNpmRunner.RunNpmCommandWithCache(buildProjectPath, pnpmPath, "run build", localCachePath, "granite build (재시도)...", additionalEnvVars: unityMetadataEnv);
                 if (buildResult != AITConvertCore.AITExportError.SUCCEED)
                 {
                     Debug.LogError("[AIT] granite build 재시도도 실패");
@@ -1174,6 +1178,10 @@ namespace AppsInToss.Editor
                     onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.5f, "granite build 실행 중...");
                     Debug.Log("[AIT] granite build 실행 중...");
 
+                    // UNITY_METADATA 환경변수를 통해 빌드 메타데이터를 granite build에 전달
+                    var unityMetadataEnv = AITUnityMetadata.BuildEnvironmentVariables();
+                    Debug.Log($"[AIT] UNITY_METADATA: {unityMetadataEnv["UNITY_METADATA"]}");
+
                     AITNpmRunner.RunNpmCommandWithCacheAsync(
                         buildProjectPath,
                         pnpmPath,
@@ -1245,7 +1253,8 @@ namespace AppsInToss.Editor
                                         onOutputReceived: (line2) =>
                                         {
                                             onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.85f, line2);
-                                        }
+                                        },
+                                        additionalEnvVars: unityMetadataEnv
                                     );
                                 },
                                 onOutputReceived: (line2) =>
@@ -1257,7 +1266,8 @@ namespace AppsInToss.Editor
                         onOutputReceived: (line) =>
                         {
                             onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.75f, line);
-                        }
+                        },
+                        additionalEnvVars: unityMetadataEnv
                     );
                 }
             );

--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -279,7 +280,8 @@ namespace AppsInToss.Editor
             string workingDirectory = null,
             string[] additionalPaths = null,
             int timeoutMs = 300000,
-            bool verbose = true)
+            bool verbose = true,
+            Dictionary<string, string> additionalEnvVars = null)
         {
             var result = new CommandResult();
 
@@ -296,14 +298,22 @@ namespace AppsInToss.Editor
                     // -NoLogo: 시작 배너 숨김
                     // [Console]::OutputEncoding: UTF-8 출력 설정으로 한글 등 유니코드 지원
                     string escapedCommand = EscapeForPowerShell(command);
-                    shellArgs = $"-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $env:CI = 'true'; {escapedCommand}\"";
+                    // 환경변수는 ProcessStartInfo.EnvironmentVariables로 설정 (line 362~372)
+                    // PowerShell -Command "..." 안에서 $env: 할당 시 JSON 등의 큰따옴표가
+                    // 바깥 큰따옴표와 충돌하므로, 셸 명령에서는 CI만 설정
+                    string envSetup = "$env:CI = 'true';";
+                    shellArgs = $"-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; {envSetup} {escapedCommand}\"";
                 }
                 else
                 {
                     shell = "/bin/bash";
                     // -l 옵션으로 로그인 셸로 실행하여 .bashrc, .bash_profile 등을 로드
                     // CI=true: pnpm이 비-TTY 환경에서 확인 프롬프트 없이 실행되도록 설정
-                    shellArgs = $"-l -c \"export CI=true && export PATH='{pathEnv}' && {command}\"";
+                    // 환경변수는 ProcessStartInfo.EnvironmentVariables로 설정 (line 360~367)
+                    // bash -c "..." 안에서 export 할당 시 JSON 등의 큰따옴표가
+                    // 바깥 큰따옴표와 충돌하므로, 셸 명령에서는 CI만 설정
+                    string envExports = "export CI=true";
+                    shellArgs = $"-l -c \"{envExports} && export PATH='{pathEnv}' && {command}\"";
                 }
 
                 if (verbose)
@@ -341,6 +351,15 @@ namespace AppsInToss.Editor
 
                 // CI=true: pnpm이 비-TTY 환경에서 확인 프롬프트 없이 실행되도록 설정
                 processInfo.EnvironmentVariables["CI"] = "true";
+
+                // 추가 환경변수 설정
+                if (additionalEnvVars != null)
+                {
+                    foreach (var kvp in additionalEnvVars)
+                    {
+                        processInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+                    }
+                }
 
                 using (var process = new Process { StartInfo = processInfo })
                 {

--- a/Editor/AITUnityMetadata.cs
+++ b/Editor/AITUnityMetadata.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// Unity 빌드 메타데이터를 수집하여 UNITY_METADATA 환경변수용 JSON을 생성합니다.
+    /// granite build가 이 환경변수를 읽어 .ait 파일의 protobuf 헤더에 포함시킵니다.
+    /// </summary>
+    internal static class AITUnityMetadata
+    {
+        /// <summary>
+        /// Unity 빌드 메타데이터를 compact JSON 문자열로 반환합니다.
+        /// 환경변수로 전달되므로 줄바꿈 없는 single-line JSON이어야 합니다.
+        /// (MiniJson.Serialize는 pretty-print하여 PowerShell 이스케이프 문제 발생)
+        /// </summary>
+        internal static string BuildMetadataJson()
+        {
+            var pairs = new string[]
+            {
+                $"\"unityVersion\":{JsonEscape(Application.unityVersion)}",
+                $"\"bundleVersion\":{JsonEscape(PlayerSettings.bundleVersion)}",
+                $"\"sdkVersion\":{JsonEscape(AITVersion.Version)}",
+                $"\"sdkCommitHash\":{JsonEscape(AITVersion.CommitHash ?? "")}",
+                $"\"productName\":{JsonEscape(PlayerSettings.productName)}",
+                $"\"companyName\":{JsonEscape(PlayerSettings.companyName)}",
+                $"\"buildTimestamp\":{JsonEscape(DateTime.UtcNow.ToString("o"))}",
+            };
+            return "{" + string.Join(",", pairs) + "}";
+        }
+
+        private static string JsonEscape(string value)
+        {
+            return "\"" + value
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("\n", "\\n")
+                .Replace("\r", "\\r")
+                .Replace("\t", "\\t") + "\"";
+        }
+
+        /// <summary>
+        /// granite build에 전달할 환경변수 딕셔너리를 반환합니다.
+        /// </summary>
+        internal static Dictionary<string, string> BuildEnvironmentVariables()
+        {
+            return new Dictionary<string, string>
+            {
+                { "UNITY_METADATA", BuildMetadataJson() }
+            };
+        }
+    }
+}

--- a/Editor/AITUnityMetadata.cs.meta
+++ b/Editor/AITUnityMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7e2b4c8d1f6493e9c5d3a0b8e7f6c4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.Scripting;
+using Debug = UnityEngine.Debug;
 
 namespace AppsInToss
 {
@@ -10,20 +13,37 @@ namespace AppsInToss
     [Preserve]
     public static class AITVersion
     {
+        private static bool _loaded;
+        private static string _version = "unknown";
+        private static string _releaseDateTime;
+        private static string _commitHash;
+
         /// <summary>
         /// SDK 버전 (예: "1.8.0")
         /// </summary>
-        public static string Version { get; private set; } = "unknown";
+        public static string Version
+        {
+            get { EnsureLoaded(); return _version; }
+            private set { _version = value; }
+        }
 
         /// <summary>
         /// 릴리즈 일시 (예: "20260126_1803"), 없으면 null
         /// </summary>
-        public static string ReleaseDateTime { get; private set; } = null;
+        public static string ReleaseDateTime
+        {
+            get { EnsureLoaded(); return _releaseDateTime; }
+            private set { _releaseDateTime = value; }
+        }
 
         /// <summary>
         /// 릴리즈 커밋 해시 (예: "e89a387"), 없으면 null
         /// </summary>
-        public static string CommitHash { get; private set; } = null;
+        public static string CommitHash
+        {
+            get { EnsureLoaded(); return _commitHash; }
+            private set { _commitHash = value; }
+        }
 
         /// <summary>
         /// 전체 버전 문자열 (예: "1.8.0 (20260126_1803, e89a387)")
@@ -34,10 +54,17 @@ namespace AppsInToss
                 : $"{Version} ({ReleaseDateTime}" +
                   (string.IsNullOrEmpty(CommitHash) ? ")" : $", {CommitHash})");
 
+        private static void EnsureLoaded()
+        {
+            if (_loaded) return;
+            _loaded = true;
+            LoadVersionInfo();
+        }
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Initialize()
         {
-            LoadVersionInfo();
+            EnsureLoaded();
             Debug.Log($"[AIT] Apps in Toss Unity SDK v{FullVersion}");
         }
 
@@ -74,6 +101,40 @@ namespace AppsInToss
                 ReleaseDateTime = AITVersionConstants.ReleaseDateTime;
                 CommitHash = AITVersionConstants.CommitHash;
             }
+
+            // CommitHash가 비어있으면 git에서 직접 조회
+            if (string.IsNullOrEmpty(CommitHash))
+            {
+                CommitHash = GetGitCommitHash();
+            }
+        }
+
+        private static string GetGitCommitHash()
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = "rev-parse --short HEAD",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                };
+                using (var process = Process.Start(psi))
+                {
+                    var output = process.StandardOutput.ReadToEnd().Trim();
+                    process.WaitForExit(3000);
+                    if (process.ExitCode == 0 && output.Length > 0)
+                        return output;
+                }
+            }
+            catch (Exception)
+            {
+                // git이 없거나 실행 실패 시 무시
+            }
+            return null;
         }
 #endif
 


### PR DESCRIPTION
## Summary
- `UNITY_METADATA` 환경변수를 `granite build`에 전달하여 `.ait` 파일의 protobuf 헤더에 빌드 메타데이터 포함
- 포함되는 필드: `unityVersion`, `sdkVersion`, `sdkCommitHash`, `productName`, `companyName`, `buildTimestamp`
- `AITVersion`을 lazy 초기화로 변경하여 Editor 빌드 스크립트에서도 정확한 SDK 버전/커밋 해시 반환

## Changes
- `Editor/AITUnityMetadata.cs` (신규): Unity 빌드 메타데이터 수집 및 compact JSON 생성
- `Editor/AITPackageBuilder.cs`: granite build 실행 시 `UNITY_METADATA` 환경변수 전달
- `Editor/AITPlatformHelper.cs`: Windows/macOS에서 환경변수를 `ProcessStartInfo.EnvironmentVariables`로 전달 (셸 이스케이프 문제 방지)
- `Editor/AITAsyncCommandRunner.cs`, `Editor/AITNpmRunner.cs`: `additionalEnvVars` 파라미터 추가
- `Runtime/Helpers/AITVersion.cs`: lazy 초기화 + `CommitHash` 비어있을 때 `git rev-parse` 자동 조회

## Test plan
- [x] E2E 테스트 10/10 통과 (macOS + Windows × 5 Unity 버전)
- [x] 생성된 `.ait` 파일에서 `unityMetaData` 필드 정상 확인
  - `sdkVersion`: `1.11.2` (이전: `unknown`)
  - `sdkCommitHash`: 실제 커밋 해시 (이전: 빈 값)