### PR TITLE
개선: Preview 워크플로우 run-name에 입력값 표시

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,5 @@
 name: Preview
+run-name: "Preview - ${{ inputs.target_ref }}${{ inputs.targets != 'macos-6000.2' && format(' ({0})', inputs.targets) || '' }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Preview 워크플로우 실행 시 run-name에 PR 번호/브랜치명이 표시되도록 개선
- 기본 타겟이 아닌 경우 타겟 정보도 함께 표시
- GitHub Actions API 제약으로 run-name은 input 기반으로만 설정 (PR 제목 동적 업데이트는 미지원)

## 결과 예시
| 입력 | run-name |
|------|----------|
| `target_ref=123` | `Preview - 123` |
| `target_ref=123`, `targets=macos-6000.3,macos-2021.3` | `Preview - 123 (macos-6000.3,macos-2021.3)` |
| `target_ref=feature/pay` | `Preview - feature/pay` |

## Changes
- `run-name` 필드 1줄 추가

## Test plan
- [x] PR 번호로 Preview 워크플로우 트리거 → run name `Preview - 219` 표시 확인
- [x] Parse Targets job 정상 통과 확인