### PR TITLE
수정: 프로젝트 경로에 공백이 있을 때 패키징 실패하는 버그 해결

### DIFF
--- a/Editor/AITAsyncCommandRunner.cs
+++ b/Editor/AITAsyncCommandRunner.cs
@@ -166,7 +166,9 @@ namespace AppsInToss.Editor
                             envExports += $" && export {kvp.Key}='{escapedValue}'";
                         }
                     }
-                    shellArgs = $"-l -c \"{envExports} && export PATH='{pathEnv}' && {command}\"";
+                    string escapedCommand = EscapeForBashDoubleQuotes(command);
+                    string escapedPathEnv = pathEnv.Replace("'", "'\\''");
+                    shellArgs = $"-l -c \"{envExports} && export PATH='{escapedPathEnv}' && {escapedCommand}\"";
                 }
 
                 EnqueueMainThread(() => Debug.Log($"[AIT Async] 명령 시작: {command}"));
@@ -330,6 +332,19 @@ namespace AppsInToss.Editor
             return command
                 .Replace("`", "``")
                 .Replace("$", "`$");
+        }
+
+        /// <summary>
+        /// Bash -c "..." 내부에서 사용할 문자열의 특수 문자 이스케이프
+        /// </summary>
+        private static string EscapeForBashDoubleQuotes(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+            return input
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("$", "\\$")
+                .Replace("`", "\\`");
         }
 
         /// <summary>

--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -313,7 +313,9 @@ namespace AppsInToss.Editor
                     // bash -c "..." 안에서 export 할당 시 JSON 등의 큰따옴표가
                     // 바깥 큰따옴표와 충돌하므로, 셸 명령에서는 CI만 설정
                     string envExports = "export CI=true";
-                    shellArgs = $"-l -c \"{envExports} && export PATH='{pathEnv}' && {command}\"";
+                    string escapedCommand = EscapeForBashDoubleQuotes(command);
+                    string escapedPathEnv = pathEnv.Replace("'", "'\\''");
+                    shellArgs = $"-l -c \"{envExports} && export PATH='{escapedPathEnv}' && {escapedCommand}\"";
                 }
 
                 if (verbose)
@@ -674,6 +676,19 @@ namespace AppsInToss.Editor
                 .Replace("`", "``")   // 백틱 먼저 이스케이프
                 .Replace("$", "`$");  // 변수 확장 방지만
             // 따옴표는 이스케이프하지 않음 - PowerShell 명령 구문의 일부
+        }
+
+        /// <summary>
+        /// Bash -c "..." 내부에서 사용할 문자열의 특수 문자 이스케이프
+        /// </summary>
+        private static string EscapeForBashDoubleQuotes(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+            return input
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("$", "\\$")
+                .Replace("`", "\\`");
         }
 
         /// <summary>

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -1987,7 +1987,7 @@ namespace AppsInToss
                 var exports = new List<string>();
                 foreach (var kv in envVars)
                 {
-                    exports.Add($"export {kv.Key}='{kv.Value}'");
+                    exports.Add($"export {kv.Key}='{kv.Value.Replace("'", "'\\''")}'");
                 }
                 envExports = string.Join(" && ", exports) + " && ";
             }
@@ -2024,7 +2024,7 @@ namespace AppsInToss
                 startInfo = new ProcessStartInfo
                 {
                     FileName = "/bin/bash",
-                    Arguments = $"-l -c \"{envExports}export PATH='{pathEnv}' && cd '{buildPath}' && '{npmPath}' {npmCommand}\"",
+                    Arguments = $"-l -c \"{envExports}export PATH='{pathEnv.Replace("'", "'\\''")}' && cd '{buildPath.Replace("'", "'\\''")}' && '{npmPath.Replace("'", "'\\''")}' {npmCommand}\"",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,


### PR DESCRIPTION
## Summary
- 프로젝트 경로에 공백이 포함되어 있을 때 (`unity.2d.pixelart-lighting-main 2/`) `pnpm run build` 단계에서 셸 인용 부호 오류가 발생하는 버그 수정
- `AITNpmRunner`에서 실행 파일 경로를 큰따옴표로 감싸는데, 이 command가 `bash -c "..."` 안에 삽입될 때 내부 `"`가 바깥 `"`를 종료시켜 셸 파싱이 깨지는 것이 근본 원인
- `EscapeForBashDoubleQuotes()` 헬퍼 메서드를 추가하여 bash 큰따옴표 내부 특수문자 이스케이프 적용
- 작은따옴표로 감싼 경로 값에도 `'\''` 이스케이프 적용

## 수정 파일
- `Editor/AITPlatformHelper.cs` - `EscapeForBashDoubleQuotes` 헬퍼 추가 + 셸 인수 이스케이프
- `Editor/AITAsyncCommandRunner.cs` - 동일한 헬퍼 추가 + 셸 인수 이스케이프
- `Editor/AppsInTossMenu.cs` - env var 값 및 경로 변수 작은따옴표 이스케이프

## Test plan
- [ ] 경로에 공백이 포함된 Unity 프로젝트에서 빌드 & 패키지 실행
- [ ] 경로에 공백이 없는 일반 프로젝트에서도 기존처럼 정상 작동 확인
- [ ] CI E2E 테스트 통과 확인