### PR TITLE
수정: 프로젝트 경로에 싱글쿼트 포함 시 패키징 실패 해결

### DIFF
--- a/Editor/AITAsyncCommandRunner.cs
+++ b/Editor/AITAsyncCommandRunner.cs
@@ -162,13 +162,14 @@ namespace AppsInToss.Editor
                     {
                         foreach (var kvp in additionalEnvVars)
                         {
-                            string escapedValue = kvp.Value.Replace("'", "'\\''");
-                            envExports += $" && export {kvp.Key}='{escapedValue}'";
+                            string escapedKey = AITPlatformHelper.EscapeForBashDoubleQuotes(kvp.Key);
+                            string escapedValue = AITPlatformHelper.EscapeForBashDoubleQuotes(kvp.Value);
+                            envExports += $" && export {escapedKey}=\\\"{escapedValue}\\\"";
                         }
                     }
-                    string escapedCommand = EscapeForBashDoubleQuotes(command);
-                    string escapedPathEnv = pathEnv.Replace("'", "'\\''");
-                    shellArgs = $"-l -c \"{envExports} && export PATH='{escapedPathEnv}' && {escapedCommand}\"";
+                    string escapedCommand = AITPlatformHelper.EscapeForBashDoubleQuotes(command);
+                    string escapedPathEnv = AITPlatformHelper.EscapeForBashDoubleQuotes(pathEnv);
+                    shellArgs = $"-l -c \"{envExports} && export PATH=\\\"{escapedPathEnv}\\\" && {escapedCommand}\"";
                 }
 
                 EnqueueMainThread(() => Debug.Log($"[AIT Async] 명령 시작: {command}"));
@@ -332,19 +333,6 @@ namespace AppsInToss.Editor
             return command
                 .Replace("`", "``")
                 .Replace("$", "`$");
-        }
-
-        /// <summary>
-        /// Bash -c "..." 내부에서 사용할 문자열의 특수 문자 이스케이프
-        /// </summary>
-        private static string EscapeForBashDoubleQuotes(string input)
-        {
-            if (string.IsNullOrEmpty(input)) return input;
-            return input
-                .Replace("\\", "\\\\")
-                .Replace("\"", "\\\"")
-                .Replace("$", "\\$")
-                .Replace("`", "\\`");
         }
 
         /// <summary>

--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -314,8 +314,8 @@ namespace AppsInToss.Editor
                     // 바깥 큰따옴표와 충돌하므로, 셸 명령에서는 CI만 설정
                     string envExports = "export CI=true";
                     string escapedCommand = EscapeForBashDoubleQuotes(command);
-                    string escapedPathEnv = pathEnv.Replace("'", "'\\''");
-                    shellArgs = $"-l -c \"{envExports} && export PATH='{escapedPathEnv}' && {escapedCommand}\"";
+                    string escapedPathEnv = EscapeForBashDoubleQuotes(pathEnv);
+                    shellArgs = $"-l -c \"{envExports} && export PATH=\\\"{escapedPathEnv}\\\" && {escapedCommand}\"";
                 }
 
                 if (verbose)
@@ -680,8 +680,9 @@ namespace AppsInToss.Editor
 
         /// <summary>
         /// Bash -c "..." 내부에서 사용할 문자열의 특수 문자 이스케이프
+        /// AITAsyncCommandRunner, AppsInTossMenu에서도 공유하여 사용
         /// </summary>
-        private static string EscapeForBashDoubleQuotes(string input)
+        internal static string EscapeForBashDoubleQuotes(string input)
         {
             if (string.IsNullOrEmpty(input)) return input;
             return input

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -1987,7 +1987,9 @@ namespace AppsInToss
                 var exports = new List<string>();
                 foreach (var kv in envVars)
                 {
-                    exports.Add($"export {kv.Key}='{kv.Value.Replace("'", "'\\''")}'");
+                    string escapedKey = AITPlatformHelper.EscapeForBashDoubleQuotes(kv.Key);
+                    string escapedVal = AITPlatformHelper.EscapeForBashDoubleQuotes(kv.Value);
+                    exports.Add($"export {escapedKey}=\\\"{escapedVal}\\\"");
                 }
                 envExports = string.Join(" && ", exports) + " && ";
             }
@@ -2021,10 +2023,13 @@ namespace AppsInToss
             }
             else
             {
+                string escapedPathEnv = AITPlatformHelper.EscapeForBashDoubleQuotes(pathEnv);
+                string escapedBuildPath = AITPlatformHelper.EscapeForBashDoubleQuotes(buildPath);
+                string escapedNpmPath = AITPlatformHelper.EscapeForBashDoubleQuotes(npmPath);
                 startInfo = new ProcessStartInfo
                 {
                     FileName = "/bin/bash",
-                    Arguments = $"-l -c \"{envExports}export PATH='{pathEnv.Replace("'", "'\\''")}' && cd '{buildPath.Replace("'", "'\\''")}' && '{npmPath.Replace("'", "'\\''")}' {npmCommand}\"",
+                    Arguments = $"-l -c \"{envExports}export PATH=\\\"{escapedPathEnv}\\\" && cd \\\"{escapedBuildPath}\\\" && \\\"{escapedNpmPath}\\\" {npmCommand}\"",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,


### PR DESCRIPTION
## Summary
- 프로젝트 경로에 싱글쿼트(`'`)가 포함된 경우 패키징 시 `unexpected EOF while looking for matching '` 에러 발생하는 버그 수정
- 기존 PR #224에서 공백 경로 문제를 해결할 때 도입된 `'...'` + `'\''` 이스케이프 패턴이 `.NET ProcessStartInfo.Arguments` 토큰화 규칙과 충돌하는 것이 근본 원인
- 모든 bash 셸 쿼팅을 `\"...\"` (큰따옴표) + `EscapeForBashDoubleQuotes()`로 통일하여 해결

## Changes
- `AITPlatformHelper.cs`: `EscapeForBashDoubleQuotes`를 `internal`로 공개, PATH 쿼팅 방식 변경
- `AITAsyncCommandRunner.cs`: env var/PATH 쿼팅 변경, 중복 `EscapeForBashDoubleQuotes` 함수 제거
- `AppsInTossMenu.cs`: env var export 및 PATH/buildPath/npmPath 쿼팅 변경

## Test plan
- [x] `./run-local-tests.sh --validate` 통과 (17/17 unit tests)
- [ ] 경로에 싱글쿼트 포함된 프로젝트에서 패키징 테스트 (수동)
- [ ] 경로에 공백 포함된 프로젝트에서 패키징 테스트 (회귀 확인)