### PR TITLE
수정: Package Only 시 AIT 빌드 결과물 검증 추가

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -32,6 +32,16 @@ namespace AppsInToss
         public string[] plugins;
     }
 
+    [System.Serializable]
+    internal class AITBuildInfo
+    {
+        public string sdkVersion;
+        public string buildTime;
+        public int compressionFormat;
+        public string profileName;
+        public string unityVersion;
+    }
+
     /// <summary>
     /// Apps in Toss 미니앱 변환 핵심 클래스 (파사드)
     /// 빌드 파이프라인의 진입점으로서 내부 헬퍼 클래스들을 조율합니다.
@@ -141,6 +151,7 @@ namespace AppsInToss
             CANCELLED = 5,
             FAIL_NPM_BUILD = 6,
             WEBGL_BUILD_INCOMPLETE = 7,
+            REQUIRES_FULL_BUILD = 8,
         }
 
         /// <summary>
@@ -202,10 +213,22 @@ namespace AppsInToss
                            "2. 'Clean Build' 옵션 활성화 후 재빌드\n" +
                            "3. AIT > Regenerate WebGL Templates 실행";
 
+                case AITExportError.REQUIRES_FULL_BUILD:
+                    return "현재 WebGL 빌드가 AIT SDK를 통해 생성되지 않았습니다.\n\n" +
+                           "AIT SDK의 빌드 설정(압축, 템플릿, 최적화 등)이 적용되지 않아\n" +
+                           "토스 앱에서 로딩 오류가 발생할 수 있습니다.\n\n" +
+                           "'Build & Package'를 사용하면 SDK 설정이 올바르게 적용됩니다.";
+
                 default:
                     return $"알 수 없는 오류가 발생했습니다. (코드: {error})";
             }
         }
+
+        #endregion
+
+        #region Build Marker
+
+        public const string BUILD_MARKER_FILENAME = ".ait-build-info.json";
 
         #endregion
 
@@ -590,6 +613,27 @@ namespace AppsInToss
             }
 
             Debug.Log("WebGL 빌드가 완료되었습니다.");
+
+            // AIT 빌드 마커 파일 생성 (Package Only 시 검증용)
+            try
+            {
+                var buildInfo = new AITBuildInfo
+                {
+                    sdkVersion = AITVersion.Version,
+                    buildTime = DateTime.UtcNow.ToString("o"),
+                    compressionFormat = (int)PlayerSettings.WebGL.compressionFormat,
+                    profileName = profile?.developmentBuild == true ? "Development" : "Production",
+                    unityVersion = Application.unityVersion
+                };
+                string markerPath = Path.Combine(outputPath, BUILD_MARKER_FILENAME);
+                File.WriteAllText(markerPath, JsonUtility.ToJson(buildInfo, true));
+                Debug.Log($"[AIT] 빌드 마커 생성: {markerPath}");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] 빌드 마커 생성 실패 (무시됨): {e.Message}");
+            }
+
             return AITExportError.SUCCEED;
         }
 

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -763,6 +763,13 @@ namespace AppsInToss.Editor
                 profile = AITBuildProfile.CreateProductionProfile();
             }
 
+            // AIT 빌드 마커 검증 (Package Only 시 AIT Build 결과물인지 확인)
+            var markerValidation = ValidateBuildMarker(webglPath, profile);
+            if (markerValidation != AITConvertCore.AITExportError.SUCCEED)
+            {
+                return markerValidation;
+            }
+
             var config = UnityUtil.GetEditorConf();
 
             // Unity WebGL 빌드를 Vite 프로젝트에 복사
@@ -1004,6 +1011,74 @@ namespace AppsInToss.Editor
             Debug.Log("[AIT] Unity WebGL 빌드 복사 완료");
             Debug.Log("[AIT]   - index.html → 프로젝트 루트");
             Debug.Log("[AIT]   - Build, TemplateData, Runtime → public/");
+
+            return AITConvertCore.AITExportError.SUCCEED;
+        }
+
+        /// <summary>
+        /// AIT 빌드 마커 파일을 검증합니다.
+        /// 마커가 없으면 AIT Build가 아닌 결과물이므로 사용자에게 선택지를 제공합니다.
+        /// </summary>
+        private static AITConvertCore.AITExportError ValidateBuildMarker(string webglPath, AITBuildProfile profile)
+        {
+            string markerPath = Path.Combine(webglPath, AITConvertCore.BUILD_MARKER_FILENAME);
+
+            if (!File.Exists(markerPath))
+            {
+                Debug.LogWarning("[AIT] AIT 빌드 마커 파일이 없습니다. AIT SDK를 통해 빌드되지 않은 결과물입니다.");
+
+                int choice = AITPlatformHelper.ShowComplexDialog(
+                    "AIT 빌드 결과물이 아닙니다",
+                    "현재 WebGL 빌드가 AIT SDK를 통해 생성되지 않았습니다.\n\n" +
+                    "AIT SDK의 빌드 설정(압축, 템플릿, 최적화 등)이 적용되지 않아\n" +
+                    "토스 앱에서 로딩 오류가 발생할 수 있습니다.\n\n" +
+                    "Build & Package로 실행하면 SDK 설정이 올바르게 적용됩니다.",
+                    "Build & Package로 실행",
+                    "취소",
+                    null,
+                    defaultChoice: 1
+                );
+
+                if (choice == 0)
+                {
+                    Debug.Log("[AIT] 사용자가 Build & Package 실행을 선택했습니다.");
+                    return AITConvertCore.AITExportError.REQUIRES_FULL_BUILD;
+                }
+                else
+                {
+                    Debug.Log("[AIT] 사용자가 패키징을 취소했습니다.");
+                    return AITConvertCore.AITExportError.CANCELLED;
+                }
+            }
+
+            // 마커가 있으면 압축 설정 불일치 검사
+            try
+            {
+                string markerJson = File.ReadAllText(markerPath);
+                var buildInfo = JsonUtility.FromJson<AITBuildInfo>(markerJson);
+
+                if (buildInfo != null)
+                {
+                    int currentCompression = profile.compressionFormat;
+                    // compressionFormat이 -1(자동)이면 AITDefaultSettings의 기본값 사용
+                    if (currentCompression == -1)
+                        currentCompression = (int)AITDefaultSettings.GetDefaultCompressionFormat();
+
+                    if (buildInfo.compressionFormat != currentCompression)
+                    {
+                        Debug.LogWarning($"[AIT] 빌드 시 압축 설정({buildInfo.compressionFormat})과 " +
+                                       $"현재 프로필 압축 설정({currentCompression})이 다릅니다. " +
+                                       "빌드 시점의 설정이 적용된 결과물입니다.");
+                    }
+
+                    Debug.Log($"[AIT] 빌드 마커 확인: SDK v{buildInfo.sdkVersion}, " +
+                             $"빌드 시각 {buildInfo.buildTime}, Unity {buildInfo.unityVersion}");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] 빌드 마커 읽기 실패 (무시됨): {e.Message}");
+            }
 
             return AITConvertCore.AITExportError.SUCCEED;
         }

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -880,6 +880,11 @@ namespace AppsInToss
                         Debug.Log($"AIT: 패키징 완료! (소요 시간: {buildStopwatch.Elapsed.TotalSeconds:F1}초)");
                         AITPlatformHelper.ShowInfoDialog("성공", $"패키징이 완료되었습니다!\n\n소요 시간: {buildStopwatch.Elapsed.TotalSeconds:F1}초", "확인");
                     }
+                    else if (result == AITConvertCore.AITExportError.REQUIRES_FULL_BUILD)
+                    {
+                        Debug.Log("AIT: Build & Package로 전환 실행합니다.");
+                        EditorApplication.delayCall += ExecuteBuildAndPackage;
+                    }
                     else if (result == AITConvertCore.AITExportError.CANCELLED)
                     {
                         Debug.Log("AIT: 패키징이 사용자에 의해 취소되었습니다.");


### PR DESCRIPTION
## Summary
- Package Only 실행 시 AIT SDK로 빌드되지 않은 WebGL 결과물을 감지하여 사용자에게 경고
- 비-AIT 빌드 패키징으로 인한 안드로이드 인트로 로딩 오류 방지

## Changes
- `BuildWebGL()` 성공 후 `.ait-build-info.json` 마커 파일 생성
- `CopyWebGLToPublic()`에서 마커 검증, 없으면 "Build & Package로 실행" / "취소" 다이얼로그 표시
- `REQUIRES_FULL_BUILD` 에러 코드 추가 및 `ExecutePackageOnly()`에서 자동 전환 처리

## Test plan
- [x] CI E2E Tests 통과 (10/10 매트릭스 전체 성공)
- [ ] Unity Editor에서 Package Only → 마커 없음 → 다이얼로그 표시 확인
- [ ] Unity Editor에서 Build & Package → 마커 생성 → Package Only 정상 진행 확인