### PR TITLE
Build 파일 선별 복사로 로딩 실패 방지

### DIFF
--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
@@ -243,6 +244,20 @@ namespace AppsInToss.Editor
             var files = Directory.GetFiles(buildPath, pattern);
             if (files.Length > 0)
             {
+                // 중복 파일 감지 시 경고 + 최신 파일 우선 선택
+                if (files.Length > 1)
+                {
+                    Debug.LogWarning($"[AIT] ⚠️ '{pattern}'에 {files.Length}개 파일이 일치합니다. 최신 파일을 사용합니다.");
+                    Array.Sort(files, (a, b) => File.GetLastWriteTime(b).CompareTo(File.GetLastWriteTime(a)));
+                    foreach (var file in files)
+                    {
+                        var time = File.GetLastWriteTime(file);
+                        var selected = file == files[0] ? " ← 선택됨" : "";
+                        Debug.LogWarning($"[AIT]    - {Path.GetFileName(file)} ({time:yyyy-MM-dd HH:mm:ss}){selected}");
+                    }
+                    Debug.LogWarning("[AIT]    이전 빌드 잔여물일 수 있습니다. 'Clean Build' 사용을 권장합니다.");
+                }
+
                 string fileName = Path.GetFileName(files[0]);
                 if (isRequired)
                 {

--- a/Editor/AITFileUtils.cs
+++ b/Editor/AITFileUtils.cs
@@ -74,7 +74,7 @@ namespace AppsInToss
         /// <summary>
         /// 파일에 읽기 권한 부여 (macOS/Linux에서 chmod 644 효과)
         /// </summary>
-        private static void EnsureFileReadable(string filePath)
+        internal static void EnsureFileReadable(string filePath)
         {
             try
             {

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -783,12 +783,94 @@ namespace AppsInToss.Editor
                 Directory.CreateDirectory(publicPath);
             }
 
-            // Build 폴더 → public/Build
+            // Build 폴더 → public/Build (필수 파일만 선별 복사)
             string buildSrc = Path.Combine(webglPath, "Build");
             string buildDest = Path.Combine(publicPath, "Build");
-            if (Directory.Exists(buildSrc))
+
+            if (!Directory.Exists(buildSrc))
             {
-                UnityUtil.CopyDirectory(buildSrc, buildDest);
+                Debug.LogError("[AIT] ========================================");
+                Debug.LogError("[AIT] ✗ 치명적: Build 폴더를 찾을 수 없습니다!");
+                Debug.LogError("[AIT] ========================================");
+                Debug.LogError($"[AIT] 검색 경로: {buildSrc}");
+                return AITConvertCore.AITExportError.WEBGL_BUILD_INCOMPLETE;
+            }
+
+            // Build 폴더에서 실제 파일 이름 찾기
+            // Unity 압축 설정에 따라 .unityweb, .gz, .br 확장자가 붙을 수 있음
+            Debug.Log("[AIT] WebGL 빌드 파일 검색 중...");
+
+            // 필수 파일들 (isRequired = true)
+            string loaderFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.loader.js", isRequired: true);
+            string dataFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.data*", isRequired: true);
+            string frameworkFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.framework.js*", isRequired: true);
+            string wasmFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.wasm*", isRequired: true);
+
+            // 선택적 파일 (isRequired = false)
+            string symbolsFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.symbols.json*", isRequired: false);
+
+            // 필수 파일 검증
+            var missingFiles = new List<string>();
+            if (string.IsNullOrEmpty(loaderFile)) missingFiles.Add("*.loader.js");
+            if (string.IsNullOrEmpty(dataFile)) missingFiles.Add("*.data");
+            if (string.IsNullOrEmpty(frameworkFile)) missingFiles.Add("*.framework.js");
+            if (string.IsNullOrEmpty(wasmFile)) missingFiles.Add("*.wasm");
+
+            if (missingFiles.Count > 0)
+            {
+                Debug.LogError("[AIT] ========================================");
+                Debug.LogError("[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락!");
+                Debug.LogError("[AIT] ========================================");
+                Debug.LogError($"[AIT] 누락된 필수 파일: {string.Join(", ", missingFiles)}");
+                Debug.LogError("[AIT] ");
+                Debug.LogError("[AIT] 가능한 원인:");
+                Debug.LogError("[AIT]   1. Unity WebGL 빌드가 완료되지 않았습니다.");
+                Debug.LogError("[AIT]   2. WebGL 빌드가 실패했지만 부분 결과물만 남아있습니다.");
+                Debug.LogError("[AIT]   3. 빌드 설정(압축 방식 등)이 예상과 다릅니다.");
+                Debug.LogError("[AIT] ");
+                Debug.LogError("[AIT] 해결 방법:");
+                Debug.LogError("[AIT]   1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.");
+                Debug.LogError("[AIT]   2. Unity Console에서 빌드 에러를 확인하세요.");
+                Debug.LogError("[AIT] ========================================");
+                return AITConvertCore.AITExportError.WEBGL_BUILD_INCOMPLETE;
+            }
+
+            // Build 대상 폴더 정리 후 재생성
+            if (Directory.Exists(buildDest))
+            {
+                AITFileUtils.DeleteDirectory(buildDest);
+            }
+            Directory.CreateDirectory(buildDest);
+
+            // 필수 파일만 선별 복사
+            var filesToCopy = new List<string> { loaderFile, dataFile, frameworkFile, wasmFile };
+            if (!string.IsNullOrEmpty(symbolsFile))
+            {
+                filesToCopy.Add(symbolsFile);
+            }
+
+            long totalBytes = 0;
+            foreach (var fileName in filesToCopy)
+            {
+                string src = Path.Combine(buildSrc, fileName);
+                string dest = Path.Combine(buildDest, fileName);
+                File.Copy(src, dest, true);
+                UnityUtil.EnsureFileReadable(dest);
+                totalBytes += new FileInfo(src).Length;
+            }
+
+            Debug.Log($"[AIT] ✓ Build 파일 {filesToCopy.Count}개 선별 복사 완료 ({totalBytes / 1024.0 / 1024.0:0.#}MB)");
+
+            // 안전장치: Build/ 폴더에 인식되지 않은 파일이 있으면 경고
+            var allBuildFiles = Directory.GetFiles(buildSrc);
+            var copiedFileNames = new HashSet<string>(filesToCopy);
+            foreach (var file in allBuildFiles)
+            {
+                string name = Path.GetFileName(file);
+                if (!copiedFileNames.Contains(name))
+                {
+                    Debug.LogWarning($"[AIT] ⚠️ Build 폴더에 복사되지 않은 파일: {name}");
+                }
             }
 
             // TemplateData 폴더 → public/TemplateData
@@ -858,150 +940,106 @@ namespace AppsInToss.Editor
                 return AITConvertCore.AITExportError.WEBGL_BUILD_INCOMPLETE;
             }
 
+            string indexContent = File.ReadAllText(indexSrc);
+
+            // 프로필 기반 설정값 (Mock 브릿지가 비활성화되면 프로덕션 모드로 간주)
+            string isProduction = profile.enableMockBridge ? "false" : "true";
+            string enableDebugConsole = profile.enableDebugConsole ? "true" : "false";
+
+            // 프로젝트의 index.html에서 사용자 커스텀 섹션 추출 (있는 경우)
+            string projectIndexPath = Path.Combine(Application.dataPath, "WebGLTemplates", "AITTemplate", "index.html");
+            if (File.Exists(projectIndexPath))
             {
-                string indexContent = File.ReadAllText(indexSrc);
+                string projectIndexContent = File.ReadAllText(projectIndexPath);
 
-                // Build 폴더에서 실제 파일 이름 찾기
-                // Unity 압축 설정에 따라 .unityweb, .gz, .br 확장자가 붙을 수 있음
-                Debug.Log("[AIT] WebGL 빌드 파일 검색 중...");
-
-                // 필수 파일들 (isRequired = true)
-                string loaderFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.loader.js", isRequired: true);
-                string dataFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.data*", isRequired: true);
-                string frameworkFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.framework.js*", isRequired: true);
-                string wasmFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.wasm*", isRequired: true);
-
-                // 선택적 파일 (isRequired = false)
-                string symbolsFile = AITBuildValidator.FindFileInBuild(buildSrc, "*.symbols.json*", isRequired: false);
-
-                // 필수 파일 검증 경고
-                var missingFiles = new List<string>();
-                if (string.IsNullOrEmpty(loaderFile)) missingFiles.Add("*.loader.js");
-                if (string.IsNullOrEmpty(dataFile)) missingFiles.Add("*.data");
-                if (string.IsNullOrEmpty(frameworkFile)) missingFiles.Add("*.framework.js");
-                if (string.IsNullOrEmpty(wasmFile)) missingFiles.Add("*.wasm");
-
-                if (missingFiles.Count > 0)
+                // USER_HEAD 섹션 추출 및 교체
+                string userHeadSection = AITTemplateManager.ExtractHtmlUserSection(projectIndexContent, AITTemplateManager.HTML_USER_HEAD_START, AITTemplateManager.HTML_USER_HEAD_END);
+                if (userHeadSection != null)
                 {
-                    Debug.LogError("[AIT] ========================================");
-                    Debug.LogError("[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락!");
-                    Debug.LogError("[AIT] ========================================");
-                    Debug.LogError($"[AIT] 누락된 필수 파일: {string.Join(", ", missingFiles)}");
-                    Debug.LogError("[AIT] ");
-                    Debug.LogError("[AIT] 가능한 원인:");
-                    Debug.LogError("[AIT]   1. Unity WebGL 빌드가 완료되지 않았습니다.");
-                    Debug.LogError("[AIT]   2. WebGL 빌드가 실패했지만 부분 결과물만 남아있습니다.");
-                    Debug.LogError("[AIT]   3. 빌드 설정(압축 방식 등)이 예상과 다릅니다.");
-                    Debug.LogError("[AIT] ");
-                    Debug.LogError("[AIT] 해결 방법:");
-                    Debug.LogError("[AIT]   1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.");
-                    Debug.LogError("[AIT]   2. Unity Console에서 빌드 에러를 확인하세요.");
-                    Debug.LogError("[AIT] ========================================");
-                    return AITConvertCore.AITExportError.WEBGL_BUILD_INCOMPLETE;
+                    indexContent = AITTemplateManager.ReplaceHtmlUserSection(indexContent, AITTemplateManager.HTML_USER_HEAD_START, AITTemplateManager.HTML_USER_HEAD_END, userHeadSection);
+                    Debug.Log("[AIT] index.html USER_HEAD 섹션 머지됨");
                 }
 
-                // 프로필 기반 설정값 (Mock 브릿지가 비활성화되면 프로덕션 모드로 간주)
-                string isProduction = profile.enableMockBridge ? "false" : "true";
-                string enableDebugConsole = profile.enableDebugConsole ? "true" : "false";
-
-                // 프로젝트의 index.html에서 사용자 커스텀 섹션 추출 (있는 경우)
-                string projectIndexPath = Path.Combine(Application.dataPath, "WebGLTemplates", "AITTemplate", "index.html");
-                if (File.Exists(projectIndexPath))
+                // USER_BODY_END 섹션 추출 및 교체
+                string userBodyEndSection = AITTemplateManager.ExtractHtmlUserSection(projectIndexContent, AITTemplateManager.HTML_USER_BODY_END_START, AITTemplateManager.HTML_USER_BODY_END_END);
+                if (userBodyEndSection != null)
                 {
-                    string projectIndexContent = File.ReadAllText(projectIndexPath);
-
-                    // USER_HEAD 섹션 추출 및 교체
-                    string userHeadSection = AITTemplateManager.ExtractHtmlUserSection(projectIndexContent, AITTemplateManager.HTML_USER_HEAD_START, AITTemplateManager.HTML_USER_HEAD_END);
-                    if (userHeadSection != null)
-                    {
-                        indexContent = AITTemplateManager.ReplaceHtmlUserSection(indexContent, AITTemplateManager.HTML_USER_HEAD_START, AITTemplateManager.HTML_USER_HEAD_END, userHeadSection);
-                        Debug.Log("[AIT] index.html USER_HEAD 섹션 머지됨");
-                    }
-
-                    // USER_BODY_END 섹션 추출 및 교체
-                    string userBodyEndSection = AITTemplateManager.ExtractHtmlUserSection(projectIndexContent, AITTemplateManager.HTML_USER_BODY_END_START, AITTemplateManager.HTML_USER_BODY_END_END);
-                    if (userBodyEndSection != null)
-                    {
-                        indexContent = AITTemplateManager.ReplaceHtmlUserSection(indexContent, AITTemplateManager.HTML_USER_BODY_END_START, AITTemplateManager.HTML_USER_BODY_END_END, userBodyEndSection);
-                        Debug.Log("[AIT] index.html USER_BODY_END 섹션 머지됨");
-                    }
+                    indexContent = AITTemplateManager.ReplaceHtmlUserSection(indexContent, AITTemplateManager.HTML_USER_BODY_END_START, AITTemplateManager.HTML_USER_BODY_END_END, userBodyEndSection);
+                    Debug.Log("[AIT] index.html USER_BODY_END 섹션 머지됨");
                 }
+            }
 
-                // Unity 플레이스홀더 치환
-                indexContent = indexContent
-                    .Replace("%UNITY_WEB_NAME%", PlayerSettings.productName)
-                    .Replace("%UNITY_WIDTH%", PlayerSettings.defaultWebScreenWidth.ToString())
-                    .Replace("%UNITY_HEIGHT%", PlayerSettings.defaultWebScreenHeight.ToString())
-                    .Replace("%UNITY_COMPANY_NAME%", PlayerSettings.companyName)
-                    .Replace("%UNITY_PRODUCT_NAME%", PlayerSettings.productName)
-                    .Replace("%UNITY_PRODUCT_VERSION%", PlayerSettings.bundleVersion)
-                    // Unity 표준 URL 형식 (Unity가 치환하지 않은 경우 SDK가 처리)
-                    .Replace("%UNITY_WEBGL_LOADER_URL%", $"Build/{loaderFile}")
-                    .Replace("%UNITY_WEBGL_DATA_URL%", $"Build/{dataFile}")
-                    .Replace("%UNITY_WEBGL_FRAMEWORK_URL%", $"Build/{frameworkFile}")
-                    .Replace("%UNITY_WEBGL_CODE_URL%", $"Build/{wasmFile}")
-                    .Replace("%UNITY_WEBGL_SYMBOLS_URL%", !string.IsNullOrEmpty(symbolsFile) ? $"Build/{symbolsFile}" : "")
-                    // 하위 호환성을 위한 FILENAME 형식 (레거시)
-                    .Replace("%UNITY_WEBGL_LOADER_FILENAME%", loaderFile)
-                    .Replace("%UNITY_WEBGL_DATA_FILENAME%", dataFile)
-                    .Replace("%UNITY_WEBGL_FRAMEWORK_FILENAME%", frameworkFile)
-                    .Replace("%UNITY_WEBGL_CODE_FILENAME%", wasmFile)
-                    .Replace("%UNITY_WEBGL_SYMBOLS_FILENAME%", symbolsFile)
-                    // AIT 커스텀 플레이스홀더
-                    .Replace("%AIT_IS_PRODUCTION%", isProduction)
-                    .Replace("%AIT_ENABLE_DEBUG_CONSOLE%", enableDebugConsole)
-                    .Replace("%AIT_DEVICE_PIXEL_RATIO%", config.devicePixelRatio.ToString())
-                    .Replace("%AIT_ICON_URL%", config.iconUrl ?? "")
-                    .Replace("%AIT_DISPLAY_NAME%", config.displayName ?? "")
-                    .Replace("%AIT_PRIMARY_COLOR%", config.primaryColor ?? "#3182f6")
-                    // HTML5 Preload 태그 (로딩 성능 개선)
-                    .Replace("%AIT_PRELOAD_TAGS%", GeneratePreloadTags(dataFile, wasmFile, frameworkFile));
+            // Unity 플레이스홀더 치환
+            indexContent = indexContent
+                .Replace("%UNITY_WEB_NAME%", PlayerSettings.productName)
+                .Replace("%UNITY_WIDTH%", PlayerSettings.defaultWebScreenWidth.ToString())
+                .Replace("%UNITY_HEIGHT%", PlayerSettings.defaultWebScreenHeight.ToString())
+                .Replace("%UNITY_COMPANY_NAME%", PlayerSettings.companyName)
+                .Replace("%UNITY_PRODUCT_NAME%", PlayerSettings.productName)
+                .Replace("%UNITY_PRODUCT_VERSION%", PlayerSettings.bundleVersion)
+                // Unity 표준 URL 형식 (Unity가 치환하지 않은 경우 SDK가 처리)
+                .Replace("%UNITY_WEBGL_LOADER_URL%", $"Build/{loaderFile}")
+                .Replace("%UNITY_WEBGL_DATA_URL%", $"Build/{dataFile}")
+                .Replace("%UNITY_WEBGL_FRAMEWORK_URL%", $"Build/{frameworkFile}")
+                .Replace("%UNITY_WEBGL_CODE_URL%", $"Build/{wasmFile}")
+                .Replace("%UNITY_WEBGL_SYMBOLS_URL%", !string.IsNullOrEmpty(symbolsFile) ? $"Build/{symbolsFile}" : "")
+                // 하위 호환성을 위한 FILENAME 형식 (레거시)
+                .Replace("%UNITY_WEBGL_LOADER_FILENAME%", loaderFile)
+                .Replace("%UNITY_WEBGL_DATA_FILENAME%", dataFile)
+                .Replace("%UNITY_WEBGL_FRAMEWORK_FILENAME%", frameworkFile)
+                .Replace("%UNITY_WEBGL_CODE_FILENAME%", wasmFile)
+                .Replace("%UNITY_WEBGL_SYMBOLS_FILENAME%", symbolsFile)
+                // AIT 커스텀 플레이스홀더
+                .Replace("%AIT_IS_PRODUCTION%", isProduction)
+                .Replace("%AIT_ENABLE_DEBUG_CONSOLE%", enableDebugConsole)
+                .Replace("%AIT_DEVICE_PIXEL_RATIO%", config.devicePixelRatio.ToString())
+                .Replace("%AIT_ICON_URL%", config.iconUrl ?? "")
+                .Replace("%AIT_DISPLAY_NAME%", config.displayName ?? "")
+                .Replace("%AIT_PRIMARY_COLOR%", config.primaryColor ?? "#3182f6")
+                // HTML5 Preload 태그 (로딩 성능 개선)
+                .Replace("%AIT_PRELOAD_TAGS%", GeneratePreloadTags(dataFile, wasmFile, frameworkFile));
 
-                // 로딩 화면 삽입 (%AIT_LOADING_SCREEN% 플레이스홀더)
-                string loadingContent = "";
-                string projectLoadingPath = AITPackageInitializer.GetProjectLoadingPath();
+            // 로딩 화면 삽입 (%AIT_LOADING_SCREEN% 플레이스홀더)
+            string loadingContent = "";
+            string projectLoadingPath = AITPackageInitializer.GetProjectLoadingPath();
 
-                // 프로젝트의 loading.html 사용 (SDK 초기화 시 자동 생성됨)
-                if (File.Exists(projectLoadingPath))
+            // 프로젝트의 loading.html 사용 (SDK 초기화 시 자동 생성됨)
+            if (File.Exists(projectLoadingPath))
+            {
+                loadingContent = File.ReadAllText(projectLoadingPath);
+                Debug.Log("[AIT] ✓ 로딩 화면 적용: " + projectLoadingPath);
+            }
+            else
+            {
+                // 폴백: SDK 기본 템플릿 직접 사용 (초기화가 실행되지 않은 경우)
+                string sdkTemplatePath = AITPackageInitializer.GetSDKLoadingTemplatePath();
+                if (sdkTemplatePath != null)
                 {
-                    loadingContent = File.ReadAllText(projectLoadingPath);
-                    Debug.Log("[AIT] ✓ 로딩 화면 적용: " + projectLoadingPath);
+                    loadingContent = File.ReadAllText(sdkTemplatePath);
+                    Debug.Log("[AIT] ✓ SDK 기본 로딩 화면 적용");
                 }
                 else
                 {
-                    // 폴백: SDK 기본 템플릿 직접 사용 (초기화가 실행되지 않은 경우)
-                    string sdkTemplatePath = AITPackageInitializer.GetSDKLoadingTemplatePath();
-                    if (sdkTemplatePath != null)
-                    {
-                        loadingContent = File.ReadAllText(sdkTemplatePath);
-                        Debug.Log("[AIT] ✓ SDK 기본 로딩 화면 적용");
-                    }
-                    else
-                    {
-                        Debug.LogWarning("[AIT] 로딩 화면 파일을 찾을 수 없습니다. 빈 로딩 화면이 사용됩니다.");
-                    }
+                    Debug.LogWarning("[AIT] 로딩 화면 파일을 찾을 수 없습니다. 빈 로딩 화면이 사용됩니다.");
                 }
+            }
 
-                // %AIT_LOADING_SCREEN% 플레이스홀더 치환
-                indexContent = indexContent.Replace("%AIT_LOADING_SCREEN%", loadingContent);
+            // %AIT_LOADING_SCREEN% 플레이스홀더 치환
+            indexContent = indexContent.Replace("%AIT_LOADING_SCREEN%", loadingContent);
 
-                File.WriteAllText(indexDest, indexContent, System.Text.Encoding.UTF8);
-                Debug.Log("[AIT] index.html → 프로젝트 루트에 생성");
+            File.WriteAllText(indexDest, indexContent, System.Text.Encoding.UTF8);
+            Debug.Log("[AIT] index.html → 프로젝트 루트에 생성");
 
-                // 플레이스홀더 치환 결과 검증
-                if (!AITBuildValidator.ValidatePlaceholderSubstitution(indexContent, indexDest))
-                {
-                    return AITConvertCore.AITExportError.WEBGL_BUILD_INCOMPLETE;
-                }
+            // 플레이스홀더 치환 결과 검증
+            if (!AITBuildValidator.ValidatePlaceholderSubstitution(indexContent, indexDest))
+            {
+                return AITConvertCore.AITExportError.WEBGL_BUILD_INCOMPLETE;
             }
 
             // Runtime/appsintoss-unity-bridge.js 파일도 치환
             string bridgeSrc = Path.Combine(publicPath, "Runtime", "appsintoss-unity-bridge.js");
             if (File.Exists(bridgeSrc))
             {
-                // 프로필 기반 설정값 (Mock 브릿지가 비활성화되면 프로덕션 모드로 간주)
-                string isProduction = profile.enableMockBridge ? "false" : "true";
-
                 string bridgeContent = File.ReadAllText(bridgeSrc);
                 bridgeContent = bridgeContent.Replace("%AIT_IS_PRODUCTION%", isProduction);
                 File.WriteAllText(bridgeSrc, bridgeContent, System.Text.Encoding.UTF8);

--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AppsInTossSDKEditor.Tests")]
+[assembly: InternalsVisibleTo("AppsInTossEditModeTests")]

--- a/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
+++ b/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
@@ -149,7 +149,23 @@ public static class BuildOutputValidator
         if (!hasWasm) errors.Add("Missing .wasm file in Build/");
         if (!hasData) errors.Add("Missing .data file in Build/");
 
-        // 9. 빌드 크기 계산
+        // 9. Build/ 파일 수 검증 — 선별 복사 회귀 감지
+        int expectedMaxFiles = 6; // loader, data, framework, wasm + symbols + 여유 1
+        if (buildFiles.Length > expectedMaxFiles)
+        {
+            warnings.Add($"Build/ contains {buildFiles.Length} files (expected ≤{expectedMaxFiles}). Possible orphaned files from previous builds.");
+        }
+
+        // 허용된 파일 타입만 있는지 검증
+        foreach (var detail in files)
+        {
+            if (detail.type == "other")
+            {
+                warnings.Add($"Unexpected file in Build/: {detail.name}");
+            }
+        }
+
+        // 10. 빌드 크기 계산
         float buildSizeMB = GetDirectorySizeMB(distWebPath);
         int fileCount = files.Count;
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AppsInTossEditModeTests.asmdef
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AppsInTossEditModeTests.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "",
     "references": [
         "AppsInTossSDK",
+        "AppsInTossSDKEditor",
         "AppsInToss.Helpers",
         "AppsInTossTestScripts"
     ],

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -1,0 +1,149 @@
+// -----------------------------------------------------------------------
+// BuildFileSelectionTests.cs - EditMode Build 파일 선별 테스트
+// Level 0: FindFileInBuild의 패턴 매칭 및 중복 파일 최신 선택 로직 검증
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class BuildFileSelectionTests
+{
+    private string tempDir;
+
+    [SetUp]
+    public void Setup()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "ait-test-build-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+        Directory.CreateDirectory(tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    // =====================================================
+    // 단일 매치 — 정확한 파일명 반환
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_SingleMatch_ReturnsFileName()
+    {
+        string filePath = Path.Combine(tempDir, "build.loader.js");
+        File.WriteAllText(filePath, "// loader");
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+        Assert.AreEqual("build.loader.js", result);
+    }
+
+    // =====================================================
+    // 다중 매치 — 최신 파일 선택
+    // Build 선별 복사의 핵심 변경을 검증:
+    // 이전 코드는 파일시스템 순서로 반환했지만,
+    // 현재 코드는 LastWriteTime 기준 최신 파일을 선택함
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_MultipleMatches_SelectsNewestFile()
+    {
+        // 오래된 파일 (이전 빌드 잔여물)
+        string oldFile = Path.Combine(tempDir, "old_hash.loader.js");
+        File.WriteAllText(oldFile, "// old loader");
+        File.SetLastWriteTime(oldFile, new DateTime(2025, 1, 1, 0, 0, 0));
+
+        // 최신 파일 (현재 빌드)
+        string newFile = Path.Combine(tempDir, "new_hash.loader.js");
+        File.WriteAllText(newFile, "// new loader");
+        File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1, 0, 0, 0));
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+        Assert.AreEqual("new_hash.loader.js", result,
+            "FindFileInBuild should select the newest file when multiple matches exist");
+    }
+
+    // =====================================================
+    // 매치 없음 — 빈 문자열 반환
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_NoMatch_ReturnsEmpty()
+    {
+        // Build 폴더에 관련 없는 파일만 존재
+        File.WriteAllText(Path.Combine(tempDir, "unrelated.txt"), "nothing");
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+        Assert.AreEqual("", result);
+    }
+
+    // =====================================================
+    // 압축 확장자 (.br, .gz) 매치
+    // Unity 압축 설정에 따라 .wasm.br, .wasm.gz 파일이 생성됨
+    // =====================================================
+
+    [TestCase("build.wasm.br", "*.wasm*")]
+    [TestCase("build.wasm.gz", "*.wasm*")]
+    [TestCase("build.data.unityweb", "*.data*")]
+    [TestCase("build.framework.js.br", "*.framework.js*")]
+    public void FindFileInBuild_CompressedExtensions_Matches(string fileName, string pattern)
+    {
+        File.WriteAllText(Path.Combine(tempDir, fileName), "compressed");
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, pattern);
+
+        Assert.AreEqual(fileName, result,
+            $"Pattern '{pattern}' should match compressed file '{fileName}'");
+    }
+
+    // =====================================================
+    // 존재하지 않는 경로 — 빈 문자열 반환
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_NonExistentPath_ReturnsEmpty()
+    {
+        string fakePath = Path.Combine(tempDir, "nonexistent");
+
+        string result = AITBuildValidator.FindFileInBuild(fakePath, "*.loader.js");
+
+        Assert.AreEqual("", result);
+    }
+
+    // =====================================================
+    // 다중 매치 3개 이상 — 가장 최신 파일 선택
+    // 이전 빌드가 여러 번 쌓인 경우를 시뮬레이션
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_ThreeMatches_SelectsNewest()
+    {
+        // 가장 오래된 파일
+        string file1 = Path.Combine(tempDir, "aaa.data");
+        File.WriteAllText(file1, "data1");
+        File.SetLastWriteTime(file1, new DateTime(2025, 1, 1));
+
+        // 중간 파일
+        string file2 = Path.Combine(tempDir, "bbb.data");
+        File.WriteAllText(file2, "data2");
+        File.SetLastWriteTime(file2, new DateTime(2025, 6, 1));
+
+        // 최신 파일
+        string file3 = Path.Combine(tempDir, "ccc.data");
+        File.WriteAllText(file3, "data3");
+        File.SetLastWriteTime(file3, new DateTime(2026, 2, 1));
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, "*.data*");
+
+        Assert.AreEqual("ccc.data", result,
+            "FindFileInBuild should select the newest among 3+ matching files");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79d6b147bf5246698424ca179706aa3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Build/ 폴더 전체 복사(`CopyDirectory`)를 필수 파일만 선별 복사로 변경
- Clean Build 없이 재빌드 시 이전 빌드 잔여 파일이 번들에 포함되어 로딩 실패를 유발하던 문제 해결
- `FindFileInBuild`에 중복 파일 감지 시 최신 파일 우선 선택 + 경고 추가

## Background
비공개 파일럿 프로젝트의 `.ait` 번들 분석 결과, Build/ 디렉토리에 이전 빌드의 잔여 파일이 포함되어 번들의 **45.6% (57.6MB)**가 어디서도 참조되지 않는 고아 파일이었음. Unity WebGL 빌드는 출력 디렉토리를 자동 정리하지 않으므로 `CopyDirectory()`가 고아 파일까지 번들에 포함시킴.

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `Editor/AITPackageBuilder.cs` | `CopyDirectory` → 선별 복사 (loader, data, framework, wasm, symbols만) |
| `Editor/AITBuildValidator.cs` | 중복 파일 감지 경고 + 최신 파일 우선 선택 |
| `Editor/AITFileUtils.cs` | `EnsureFileReadable` 가시성 `private` → `internal` |

## Test plan
- [x] `pnpm validate` (186 tests passed)
- [x] `./run-local-tests.sh --validate` (3/3 passed)
- [ ] Package Only 빌드 후 `ait-build/public/Build/`에 필수 파일만 존재하는지 확인
- [ ] E2E 테스트 통과 확인
