### PR TITLE
수정: Unity 2022.3에서 RGBA4444/RGB16 컴파일 에러 해결

### DIFF
--- a/Editor/AITBuildOptimizationScanner.cs
+++ b/Editor/AITBuildOptimizationScanner.cs
@@ -299,8 +299,6 @@ namespace AppsInToss.Editor
                    format == TextureImporterFormat.RGB24 ||
                    format == TextureImporterFormat.Alpha8 ||
                    format == TextureImporterFormat.RGBA16 ||
-                   format == TextureImporterFormat.RGBA4444 ||
-                   format == TextureImporterFormat.RGB16 ||
                    format == TextureImporterFormat.R8 ||
                    format == TextureImporterFormat.R16 ||
                    format == TextureImporterFormat.RG16 ||


### PR DESCRIPTION
## Summary
- `TextureImporterFormat.RGBA4444`와 `RGB16`이 Unity 2022.3에서 존재하지 않아 E2E 빌드 전체 실패
- 드물게 사용되는 포맷이므로 비압축 포맷 검출 목록에서 제거

## Test plan
- [ ] Unity .meta files check 통과
- [ ] SDK Generator Unit Tests 통과
- [ ] E2E 빌드 컴파일 에러 해소 확인