### PR TITLE
수정: Bee 캐시 무효화로 stale ref.dll E2E 빌드 실패 해결

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -404,8 +404,9 @@ jobs:
             echo "Cleaning Library cache (requested via input)..."
             rm -rf "${PROJECT_PATH}/Library" 2>/dev/null || true
           else
-            echo "Cleaning Bee build cache to prevent stale ref.dll issues..."
-            rm -rf "${PROJECT_PATH}/Library/Bee" 2>/dev/null || true
+            echo "Cleaning Bee artifacts cache to prevent stale ref.dll issues..."
+            echo "(Other Bee caches like shader/import are preserved for incremental builds)"
+            rm -rf "${PROJECT_PATH}/Library/Bee/artifacts" 2>/dev/null || true
           fi
           echo "Done."
 
@@ -423,8 +424,9 @@ jobs:
             echo Cleaning Library cache requested via input...
             if exist "%PROJECT_PATH%\Library" rmdir /s /q "%PROJECT_PATH%\Library"
           ) else (
-            echo Cleaning Bee build cache to prevent stale ref.dll issues...
-            if exist "%PROJECT_PATH%\Library\Bee" rmdir /s /q "%PROJECT_PATH%\Library\Bee"
+            echo Cleaning Bee artifacts cache to prevent stale ref.dll issues...
+            echo (Other Bee caches like shader/import are preserved for incremental builds)
+            if exist "%PROJECT_PATH%\Library\Bee\artifacts" rmdir /s /q "%PROJECT_PATH%\Library\Bee\artifacts"
           )
           echo Done.
 

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -425,7 +425,7 @@ jobs:
             if exist "%PROJECT_PATH%\Library" rmdir /s /q "%PROJECT_PATH%\Library"
           ) else (
             echo Cleaning Bee artifacts cache to prevent stale ref.dll issues...
-            echo (Other Bee caches like shader/import are preserved for incremental builds)
+            echo Other Bee caches like shader/import are preserved for incremental builds.
             if exist "%PROJECT_PATH%\Library\Bee\artifacts" rmdir /s /q "%PROJECT_PATH%\Library\Bee\artifacts"
           )
           echo Done.

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -405,7 +405,7 @@ jobs:
             rm -rf "${PROJECT_PATH}/Library" 2>/dev/null || true
           else
             echo "Cleaning Bee artifacts cache to prevent stale ref.dll issues..."
-            echo "(Other Bee caches like shader/import are preserved for incremental builds)"
+            echo "Removing: ${PROJECT_PATH}/Library/Bee/artifacts"
             rm -rf "${PROJECT_PATH}/Library/Bee/artifacts" 2>/dev/null || true
           fi
           echo "Done."
@@ -425,7 +425,7 @@ jobs:
             if exist "%PROJECT_PATH%\Library" rmdir /s /q "%PROJECT_PATH%\Library"
           ) else (
             echo Cleaning Bee artifacts cache to prevent stale ref.dll issues...
-            echo Other Bee caches like shader/import are preserved for incremental builds.
+            echo Removing: %PROJECT_PATH%\Library\Bee\artifacts
             if exist "%PROJECT_PATH%\Library\Bee\artifacts" rmdir /s /q "%PROJECT_PATH%\Library\Bee\artifacts"
           )
           echo Done.

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -403,6 +403,9 @@ jobs:
           if [ "${{ inputs.clean-library }}" = "true" ]; then
             echo "Cleaning Library cache (requested via input)..."
             rm -rf "${PROJECT_PATH}/Library" 2>/dev/null || true
+          else
+            echo "Cleaning Bee build cache to prevent stale ref.dll issues..."
+            rm -rf "${PROJECT_PATH}/Library/Bee" 2>/dev/null || true
           fi
           echo "Done."
 
@@ -419,6 +422,9 @@ jobs:
           if "%CLEAN_LIBRARY%"=="true" (
             echo Cleaning Library cache requested via input...
             if exist "%PROJECT_PATH%\Library" rmdir /s /q "%PROJECT_PATH%\Library"
+          ) else (
+            echo Cleaning Bee build cache to prevent stale ref.dll issues...
+            if exist "%PROJECT_PATH%\Library\Bee" rmdir /s /q "%PROJECT_PATH%\Library\Bee"
           )
           echo Done.
 

--- a/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
+++ b/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
@@ -101,9 +101,9 @@ public class E2EBuildRunner
         // 4. SDK의 빌드 & 패키징 실행
         Debug.Log("[4/5] Building WebGL and packaging with SDK...");
 
-        // Library/Bee 캐시를 유지하여 증분 빌드 활용 (self-hosted runner 성능 최적화)
-        // cleanBuild: false로 설정하여 이전 빌드 캐시 재사용
-        // 캐시 문제 발생 시 workflow_dispatch에서 clean_library=true로 실행
+        // Library/Bee/artifacts/는 CI에서 매 빌드 전 삭제됨 (stale ref.dll 방지)
+        // cleanBuild: false로 설정하여 Unity 측 증분 빌드 캐시 재사용
+        // 전체 Library 삭제가 필요한 경우 workflow_dispatch에서 clean_library=true로 실행
         // E2E 테스트에서는 프로덕션 환경을 시뮬레이션하기 위해 productionProfile 사용
         var result = AITConvertCore.DoExport(
             buildWebGL: true,

--- a/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
+++ b/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
@@ -102,6 +102,7 @@ public class E2EBuildRunner
         Debug.Log("[4/5] Building WebGL and packaging with SDK...");
 
         // Library/Bee/artifacts/는 CI에서 매 빌드 전 삭제됨 (stale ref.dll 방지)
+        // 로컬 환경에서는 캐시 문제 발생 시 Library/Bee/artifacts/ 수동 삭제 필요
         // cleanBuild: false로 설정하여 Unity 측 증분 빌드 캐시 재사용
         // 전체 Library 삭제가 필요한 경우 workflow_dispatch에서 clean_library=true로 실행
         // E2E 테스트에서는 프로덕션 환경을 시뮬레이션하기 위해 productionProfile 사용


### PR DESCRIPTION
## Summary
- self-hosted runner에서 이전 SDK 버전의 ref.dll이 `Library/Bee/artifacts/` 캐시에 남아 E2E 빌드가 CS0246 에러로 실패하는 문제 해결
- `clean_library=false`(기본값)일 때 `Library/Bee/artifacts/`를 매 빌드 전 자동 삭제
- `Library/Bee/` 전체가 아닌 `artifacts/`만 삭제하여 shader/import 등 증분 빌드 캐시 유지

## Changes
- `.github/workflows/unity-build.yml`: macOS/Windows 빌드 정리 단계에 Bee artifacts 삭제 추가
- `Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs`: 캐시 전략 코멘트 업데이트

## Test plan
- [ ] `clean_library=false`로 E2E 트리거 시 Bee artifacts 삭제 로그 확인
- [ ] E2E 테스트 15/15 통과 확인
- [ ] 빌드 시간이 `clean_library=true` 대비 개선되었는지 확인