### PR TITLE
수정: Library/Bee/ 전체 삭제로 stale ref.dll 문제 완전 해결

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -404,9 +404,9 @@ jobs:
             echo "Cleaning Library cache (requested via input)..."
             rm -rf "${PROJECT_PATH}/Library" 2>/dev/null || true
           else
-            echo "Cleaning Bee artifacts cache to prevent stale ref.dll issues..."
-            echo "Removing: ${PROJECT_PATH}/Library/Bee/artifacts"
-            rm -rf "${PROJECT_PATH}/Library/Bee/artifacts" 2>/dev/null || true
+            echo "Cleaning Bee build cache to prevent stale ref.dll issues..."
+            echo "Removing: ${PROJECT_PATH}/Library/Bee"
+            rm -rf "${PROJECT_PATH}/Library/Bee" 2>/dev/null || true
           fi
           echo "Done."
 
@@ -424,9 +424,9 @@ jobs:
             echo Cleaning Library cache requested via input...
             if exist "%PROJECT_PATH%\Library" rmdir /s /q "%PROJECT_PATH%\Library"
           ) else (
-            echo Cleaning Bee artifacts cache to prevent stale ref.dll issues...
-            echo Removing: %PROJECT_PATH%\Library\Bee\artifacts
-            if exist "%PROJECT_PATH%\Library\Bee\artifacts" rmdir /s /q "%PROJECT_PATH%\Library\Bee\artifacts"
+            echo Cleaning Bee build cache to prevent stale ref.dll issues...
+            echo Removing: %PROJECT_PATH%\Library\Bee
+            if exist "%PROJECT_PATH%\Library\Bee" rmdir /s /q "%PROJECT_PATH%\Library\Bee"
           )
           echo Done.
 

--- a/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
+++ b/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
@@ -101,8 +101,8 @@ public class E2EBuildRunner
         // 4. SDK의 빌드 & 패키징 실행
         Debug.Log("[4/5] Building WebGL and packaging with SDK...");
 
-        // Library/Bee/artifacts/는 CI에서 매 빌드 전 삭제됨 (stale ref.dll 방지)
-        // 로컬 환경에서는 캐시 문제 발생 시 Library/Bee/artifacts/ 수동 삭제 필요
+        // Library/Bee/는 CI에서 매 빌드 전 삭제됨 (stale ref.dll 방지)
+        // 로컬 환경에서는 캐시 문제 발생 시 Library/Bee/ 수동 삭제 필요
         // cleanBuild: false로 설정하여 Unity 측 증분 빌드 캐시 재사용
         // 전체 Library 삭제가 필요한 경우 workflow_dispatch에서 clean_library=true로 실행
         // E2E 테스트에서는 프로덕션 환경을 시뮬레이션하기 위해 productionProfile 사용


### PR DESCRIPTION
## Summary
- #376 에서 `Library/Bee/artifacts/`만 삭제했으나 여전히 stale ref.dll (CS0246) 발생 확인
- `Library/Bee/` 전체를 삭제하도록 변경하여 Bee 빌드 캐시를 완전히 무효화
- `Library/` 전체 삭제 대비 PackageCache 등은 유지되어 빌드 시간 절감

## Root cause
`Library/Bee/artifacts/` 외에도 Bee 내부의 다른 캐시 디렉토리에 stale 컴파일 결과가 남아있어 artifacts만 삭제해서는 불충분했음

## Test plan
- [ ] E2E 테스트 트리거하여 전 버전 통과 확인