### PR TITLE
수정: SerializationTester SDK 버전 호환성 분기 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Runtime/AppsInTossTestScripts.asmdef
+++ b/Tests~/E2E/SharedScripts/Runtime/AppsInTossTestScripts.asmdef
@@ -31,6 +31,11 @@
             "define": "AIT_SDK_1_7_1_OR_LATER"
         },
         {
+            "name": "im.toss.apps-in-toss-unity-sdk",
+            "expression": "2.4.4",
+            "define": "AIT_SDK_2_4_4_OR_LATER"
+        },
+        {
             "name": "io.sentry.unity",
             "expression": "4.0.0",
             "define": "AIT_SENTRY_AVAILABLE"

--- a/Tests~/E2E/SharedScripts/Runtime/SerializationTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/SerializationTester.cs
@@ -264,9 +264,9 @@ public class SerializationTester : MonoBehaviour
         TestResultDeserialization<GetUserKeyResult>("GetUserKeyResult.Success", successJson, result =>
             result.IsSuccess && result.GetSuccess()?.Hash == "test-hash-123");
 
-        var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""ERROR""}";
+        var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""INVALID_CATEGORY""}";
         TestResultDeserialization<GetUserKeyResult>("GetUserKeyResult.Error", errorJson, result =>
-            result.IsError && result.GetErrorCode() == "ERROR");
+            result.IsError && result.GetErrorCode() == "INVALID_CATEGORY");
 #else
         // v2.4.3 이하: GetUserKeyForGameResult
         var successJson = @"{""_type"":""success"",""_successJson"":{""hash"":""test-hash-123"",""type"":""test-type""},""_errorCode"":null}";

--- a/Tests~/E2E/SharedScripts/Runtime/SerializationTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/SerializationTester.cs
@@ -258,15 +258,25 @@ public class SerializationTester : MonoBehaviour
     {
         Debug.Log("[SerializationTester] Testing Result type (discriminated union) serialization...");
 
-        // GetUserKeyForGameResult 성공 케이스 시뮬레이션
+#if AIT_SDK_2_4_4_OR_LATER
+        // v2.4.4+: GetUserKeyForGameResult → GetUserKeyResult로 변경됨
+        var successJson = @"{""_type"":""success"",""_successJson"":{""hash"":""test-hash-123"",""type"":""test-type""},""_errorCode"":null}";
+        TestResultDeserialization<GetUserKeyResult>("GetUserKeyResult.Success", successJson, result =>
+            result.IsSuccess && result.GetSuccess()?.Hash == "test-hash-123");
+
+        var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""ERROR""}";
+        TestResultDeserialization<GetUserKeyResult>("GetUserKeyResult.Error", errorJson, result =>
+            result.IsError && result.GetErrorCode() == "ERROR");
+#else
+        // v2.4.3 이하: GetUserKeyForGameResult
         var successJson = @"{""_type"":""success"",""_successJson"":{""hash"":""test-hash-123"",""type"":""test-type""},""_errorCode"":null}";
         TestResultDeserialization<GetUserKeyForGameResult>("GetUserKeyForGameResult.Success", successJson, result =>
             result.IsSuccess && result.GetSuccess()?.Hash == "test-hash-123");
 
-        // GetUserKeyForGameResult 에러 케이스 시뮬레이션
         var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""INVALID_CATEGORY""}";
         TestResultDeserialization<GetUserKeyForGameResult>("GetUserKeyForGameResult.Error", errorJson, result =>
             result.IsError && result.GetErrorCode() == "INVALID_CATEGORY");
+#endif
     }
 
     void TestResultDeserialization<T>(string testName, string inputJson, Func<T, bool> validate) where T : class

--- a/Tests~/E2E/SharedScripts/Runtime/SerializationTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/SerializationTester.cs
@@ -258,22 +258,19 @@ public class SerializationTester : MonoBehaviour
     {
         Debug.Log("[SerializationTester] Testing Result type (discriminated union) serialization...");
 
+        var successJson = @"{""_type"":""success"",""_successJson"":{""hash"":""test-hash-123"",""type"":""test-type""},""_errorCode"":null}";
+        var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""INVALID_CATEGORY""}";
+
 #if AIT_SDK_2_4_4_OR_LATER
         // v2.4.4+: GetUserKeyForGameResult → GetUserKeyResult로 변경됨
-        var successJson = @"{""_type"":""success"",""_successJson"":{""hash"":""test-hash-123"",""type"":""test-type""},""_errorCode"":null}";
         TestResultDeserialization<GetUserKeyResult>("GetUserKeyResult.Success", successJson, result =>
             result.IsSuccess && result.GetSuccess()?.Hash == "test-hash-123");
-
-        var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""INVALID_CATEGORY""}";
         TestResultDeserialization<GetUserKeyResult>("GetUserKeyResult.Error", errorJson, result =>
             result.IsError && result.GetErrorCode() == "INVALID_CATEGORY");
 #else
         // v2.4.3 이하: GetUserKeyForGameResult
-        var successJson = @"{""_type"":""success"",""_successJson"":{""hash"":""test-hash-123"",""type"":""test-type""},""_errorCode"":null}";
         TestResultDeserialization<GetUserKeyForGameResult>("GetUserKeyForGameResult.Success", successJson, result =>
             result.IsSuccess && result.GetSuccess()?.Hash == "test-hash-123");
-
-        var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""INVALID_CATEGORY""}";
         TestResultDeserialization<GetUserKeyForGameResult>("GetUserKeyForGameResult.Error", errorJson, result =>
             result.IsError && result.GetErrorCode() == "INVALID_CATEGORY");
 #endif


### PR DESCRIPTION
## Summary
- v2.4.4에서 `GetUserKeyForGameResult` → `GetUserKeyResult`로 타입명 변경으로 인해 E2E 테스트가 전 버전에서 컴파일 실패하던 문제 해결
- asmdef `versionDefines`에 `AIT_SDK_2_4_4_OR_LATER` 추가하여 `#if` 분기로 양쪽 버전 모두 테스트 커버리지 유지

## Test plan
- [x] E2E Tests 전체 통과 확인 (13/13 success — macOS + Windows, 5개 Unity 버전)
- [x] 코드 리뷰 3 pass 클린