### PR TITLE
수정: SerializationTester mock 타입으로 전환하여 SDK 버전 무관하게 동작

### DIFF
--- a/Tests~/E2E/SharedScripts/Runtime/AppsInTossTestScripts.asmdef
+++ b/Tests~/E2E/SharedScripts/Runtime/AppsInTossTestScripts.asmdef
@@ -31,11 +31,6 @@
             "define": "AIT_SDK_1_7_1_OR_LATER"
         },
         {
-            "name": "im.toss.apps-in-toss-unity-sdk",
-            "expression": "2.4.4",
-            "define": "AIT_SDK_2_4_4_OR_LATER"
-        },
-        {
             "name": "io.sentry.unity",
             "expression": "4.0.0",
             "define": "AIT_SENTRY_AVAILABLE"

--- a/Tests~/E2E/SharedScripts/Runtime/SerializationTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/SerializationTester.cs
@@ -259,21 +259,12 @@ public class SerializationTester : MonoBehaviour
         Debug.Log("[SerializationTester] Testing Result type (discriminated union) serialization...");
 
         var successJson = @"{""_type"":""success"",""_successJson"":{""hash"":""test-hash-123"",""type"":""test-type""},""_errorCode"":null}";
-        var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""INVALID_CATEGORY""}";
+        TestResultDeserialization<MockDiscriminatedUnionResult>("DiscriminatedUnion.Success", successJson, result =>
+            result.IsSuccess && result.GetSuccess()?.Hash == "test-hash-123");
 
-#if AIT_SDK_2_4_4_OR_LATER
-        // v2.4.4+: GetUserKeyForGameResult → GetUserKeyResult로 변경됨
-        TestResultDeserialization<GetUserKeyResult>("GetUserKeyResult.Success", successJson, result =>
-            result.IsSuccess && result.GetSuccess()?.Hash == "test-hash-123");
-        TestResultDeserialization<GetUserKeyResult>("GetUserKeyResult.Error", errorJson, result =>
+        var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""INVALID_CATEGORY""}";
+        TestResultDeserialization<MockDiscriminatedUnionResult>("DiscriminatedUnion.Error", errorJson, result =>
             result.IsError && result.GetErrorCode() == "INVALID_CATEGORY");
-#else
-        // v2.4.3 이하: GetUserKeyForGameResult
-        TestResultDeserialization<GetUserKeyForGameResult>("GetUserKeyForGameResult.Success", successJson, result =>
-            result.IsSuccess && result.GetSuccess()?.Hash == "test-hash-123");
-        TestResultDeserialization<GetUserKeyForGameResult>("GetUserKeyForGameResult.Error", errorJson, result =>
-            result.IsError && result.GetErrorCode() == "INVALID_CATEGORY");
-#endif
     }
 
     void TestResultDeserialization<T>(string testName, string inputJson, Func<T, bool> validate) where T : class
@@ -493,5 +484,33 @@ public class SerializationTester : MonoBehaviour
         public int successCount;
         public int failCount;
         public List<SerializationTestResult> results;
+    }
+
+    [Serializable]
+    public class MockDiscriminatedUnionResult
+    {
+        [JsonProperty("_type")]
+        public string _type;
+
+        [JsonProperty("_successJson")]
+        public MockSuccessData _successData;
+
+        [JsonProperty("_errorCode")]
+        public string _errorCode;
+
+        public bool IsSuccess => _type == "success";
+        public bool IsError => _type == "error";
+        public MockSuccessData GetSuccess() => IsSuccess ? _successData : null;
+        public string GetErrorCode() => IsError ? _errorCode : null;
+    }
+
+    [Serializable]
+    public class MockSuccessData
+    {
+        [JsonProperty("hash")]
+        public string Hash;
+
+        [JsonProperty("type")]
+        public string Type;
     }
 }


### PR DESCRIPTION
## Summary
- PR #378 후속 수정: discriminated union 테스트를 SDK 타입 대신 테스트 전용 mock 타입으로 전환
- SDK 버전마다 타입명이 바뀌는 문제 근본 해결 (v2.4.3: `GetUserKeyForGameResult`, v2.4.4: `GetUserKeyResult`, v2.4.5: 삭제)
- `AIT_SDK_2_4_4_OR_LATER` versionDefine 및 `#if` 분기 제거

## Test plan
- [ ] PR checks 통과 (Validate, Lint)
- [ ] PR #372 (v2.4.4) E2E 테스트 통과
- [ ] PR #373 (v2.4.5) E2E 테스트 통과