### PR TITLE
수정: SDKSerializationTests에서도 mock 타입으로 전환

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/SDKSerializationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/SDKSerializationTests.cs
@@ -125,7 +125,7 @@ public class SDKSerializationTests
     {
         var successJson = @"{""_type"":""success"",""_successJson"":{""hash"":""test-hash-123"",""type"":""test-type""},""_errorCode"":null}";
 
-        var result = JsonConvert.DeserializeObject<GetUserKeyForGameResult>(successJson, settings);
+        var result = JsonConvert.DeserializeObject<SerializationTester.MockDiscriminatedUnionResult>(successJson, settings);
         Assert.IsNotNull(result, "Deserialization should succeed");
         Assert.IsTrue(result.IsSuccess, "Should be a success result");
         Assert.AreEqual("test-hash-123", result.GetSuccess()?.Hash, "Hash should match");
@@ -136,7 +136,7 @@ public class SDKSerializationTests
     {
         var errorJson = @"{""_type"":""error"",""_successJson"":null,""_errorCode"":""INVALID_CATEGORY""}";
 
-        var result = JsonConvert.DeserializeObject<GetUserKeyForGameResult>(errorJson, settings);
+        var result = JsonConvert.DeserializeObject<SerializationTester.MockDiscriminatedUnionResult>(errorJson, settings);
         Assert.IsNotNull(result, "Deserialization should succeed");
         Assert.IsTrue(result.IsError, "Should be an error result");
         Assert.AreEqual("INVALID_CATEGORY", result.GetErrorCode(), "Error code should match");


### PR DESCRIPTION
## Summary
- PR #380 후속: EditMode 테스트(`SDKSerializationTests.cs`)에서도 `GetUserKeyForGameResult` → `MockDiscriminatedUnionResult`로 전환
- 리베이스 E2E에서 EditMode 테스트 컴파일 실패 수정

## Test plan
- [ ] PR checks 통과
- [ ] 리베이스 후 PR #372, #373 E2E 통과