### PR TITLE
개선: Sentry 에러 로그 그룹핑 수정 및 이슈 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,23 @@
 - Playwright 테스트는 `Tests~/E2E/tests/` 디렉토리에서 실행
 - Level 0 테스트(EditMode)는 빌드 없이 ~10초만에 실행 가능
 
+### Sentry 이슈 관련
+- **무시해도 되는 이슈 패턴** (EditMode 통합 테스트에서 의도적으로 발생시키는 이벤트):
+  - `EditMode 통합 테스트: pnpm build 실패 시뮬레이션` (SDK-9)
+  - `EditMode 통합 테스트: 에러 이벤트 전송 확인` (SDK-B)
+  - `EditMode 통합 테스트: WebGL 빌드 실패 시뮬레이션` (SDK-C)
+  - `시뮬레이션: FAIL_NPM_BUILD` (SDK-8)
+  - `테스트 예외: Error Tracker 전송 확인용` (SDK-3)
+  - `테스트 에러: Error Tracker 전송 확인용` (SDK-2)
+  - `AITNpmRunner: pnpm install 실패 — ENOENT` (SDK-A) — 테스트 환경(`test: true`)에서만 78회 발생
+- 이 이슈들은 `ErrorTrackerIntegrationTests.cs`에서 Sentry 전송 기능을 검증하기 위해 의도적으로 생성됨
+- Sentry에서 이미 **ignored** 처리되어 있으므로, 새로 발생해도 별도 조치 불필요
+- **SDK 문제가 아닌 사용자 프로젝트/환경 이슈** (resolve 처리됨, 재발 시 모니터링):
+  - FMOD 오디오 오류 — 사용자 프로젝트의 WebGL 오디오 포맷 설정 문제
+  - GUI Layer/tk2dCamera 경고 — 레거시 Unity 컴포넌트 호환성 문제
+  - `Failed to compile player scripts` — 사용자 프로젝트 스크립트 컴파일 오류
+  - `FAIL_NPM_BUILD` — 사용자 빌드 환경(Node.js/pnpm) 문제
+
 ## 빠른 참조: 주요 명령어
 
 | 작업 | 명령어 |

--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -55,22 +55,16 @@ namespace AppsInToss.Editor
 
                 if (foundCritical.Count > 0)
                 {
-                    Debug.LogError("[AIT] ========================================");
-                    Debug.LogError("[AIT] ✗ 치명적: 필수 플레이스홀더 미치환!");
-                    Debug.LogError("[AIT] ========================================");
-                    foreach (var placeholder in foundCritical)
-                    {
-                        Debug.LogError($"[AIT]   - {placeholder}");
-                    }
-                    Debug.LogError($"[AIT] 파일: {filePath}");
-                    Debug.LogError("[AIT] ");
-                    Debug.LogError("[AIT] 이 플레이스홀더들이 치환되지 않으면 런타임에서");
-                    Debug.LogError("[AIT] 'createUnityInstance is not defined' 에러가 발생합니다.");
-                    Debug.LogError("[AIT] ");
-                    Debug.LogError("[AIT] 해결 방법:");
-                    Debug.LogError("[AIT]   1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.");
-                    Debug.LogError("[AIT]   2. AIT > Clean 메뉴로 빌드 폴더 삭제 후 재빌드하세요.");
-                    Debug.LogError("[AIT] ========================================");
+                    var placeholderList = string.Join("\n", foundCritical.ConvertAll(p => $"  - {p}"));
+                    Debug.LogError(
+                        "[AIT] ✗ 치명적: 필수 플레이스홀더 미치환!\n"
+                        + placeholderList + "\n"
+                        + $"파일: {filePath}\n"
+                        + "이 플레이스홀더들이 치환되지 않으면 런타임에서 'createUnityInstance is not defined' 에러가 발생합니다.\n"
+                        + "해결 방법:\n"
+                        + "  1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n"
+                        + "  2. AIT > Clean 메뉴로 빌드 폴더 삭제 후 재빌드하세요."
+                    );
                     hasError = true;
                 }
                 else
@@ -91,15 +85,13 @@ namespace AppsInToss.Editor
             // 잘못된 경로 패턴 검증 (예: Build/ 뒤에 파일명이 없는 경우)
             if (content.Contains("src=\"Build/\"") || content.Contains("\"Build/\"") || content.Contains("Build/\","))
             {
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError("[AIT] ✗ 치명적: 빈 파일 경로 발견!");
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError("[AIT] index.html에 'Build/' 뒤에 파일명이 없는 경로가 있습니다.");
-                Debug.LogError("[AIT] 이로 인해 'createUnityInstance is not defined' 에러가 발생합니다.");
-                Debug.LogError("[AIT] ");
-                Debug.LogError("[AIT] 원인: WebGL 빌드의 loader.js 파일을 찾지 못했습니다.");
-                Debug.LogError("[AIT] 해결: 위의 빌드 파일 검색 로그를 확인하세요.");
-                Debug.LogError("[AIT] ========================================");
+                Debug.LogError(
+                    "[AIT] ✗ 치명적: 빈 파일 경로 발견!\n"
+                    + "index.html에 'Build/' 뒤에 파일명이 없는 경로가 있습니다.\n"
+                    + "이로 인해 'createUnityInstance is not defined' 에러가 발생합니다.\n"
+                    + "원인: WebGL 빌드의 loader.js 파일을 찾지 못했습니다.\n"
+                    + "해결: 위의 빌드 파일 검색 로그를 확인하세요."
+                );
                 hasError = true;
             }
 
@@ -358,26 +350,24 @@ namespace AppsInToss.Editor
 
             if (aitFiles.Length == 0)
             {
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError("[AIT] ✗ .ait 파일이 생성되지 않았습니다!");
-                Debug.LogError($"[AIT]   빌드 경로: {buildProjectPath}");
+                var msg = $"[AIT] ✗ .ait 파일이 생성되지 않았습니다!\n빌드 경로: {buildProjectPath}";
                 if (Directory.Exists(distPath))
                 {
                     var distFiles = Directory.GetFiles(distPath);
                     if (distFiles.Length > 0)
                     {
-                        Debug.LogError("[AIT]   dist/ 폴더의 실제 파일들:");
+                        msg += "\ndist/ 폴더의 실제 파일들:";
                         foreach (var file in distFiles)
                         {
-                            Debug.LogError($"[AIT]     - {Path.GetFileName(file)}");
+                            msg += $"\n  - {Path.GetFileName(file)}";
                         }
                     }
                 }
                 else
                 {
-                    Debug.LogError("[AIT]   dist/ 폴더도 존재하지 않습니다.");
+                    msg += "\ndist/ 폴더도 존재하지 않습니다.";
                 }
-                Debug.LogError("[AIT] ========================================");
+                Debug.LogError(msg);
                 return AITConvertCore.AITExportError.AIT_FILE_MISSING;
             }
 

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -1157,10 +1157,10 @@ namespace AppsInToss.Editor
 
             if (!Directory.Exists(buildSrc))
             {
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError("[AIT] ✗ 치명적: Build 폴더를 찾을 수 없습니다!");
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError($"[AIT] 검색 경로: {buildSrc}");
+                Debug.LogError(
+                    "[AIT] ✗ 치명적: Build 폴더를 찾을 수 없습니다!\n"
+                    + $"검색 경로: {buildSrc}"
+                );
                 return AITConvertCore.AITExportError.BUILD_FOLDER_MISSING;
             }
 
@@ -1213,20 +1213,17 @@ namespace AppsInToss.Editor
 
             if (missingFiles.Count > 0)
             {
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError("[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락!");
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError($"[AIT] 누락된 필수 파일: {string.Join(", ", missingFiles)}");
-                Debug.LogError("[AIT] ");
-                Debug.LogError("[AIT] 가능한 원인:");
-                Debug.LogError("[AIT]   1. Unity WebGL 빌드가 완료되지 않았습니다.");
-                Debug.LogError("[AIT]   2. WebGL 빌드가 실패했지만 부분 결과물만 남아있습니다.");
-                Debug.LogError("[AIT]   3. 빌드 설정(압축 방식 등)이 예상과 다릅니다.");
-                Debug.LogError("[AIT] ");
-                Debug.LogError("[AIT] 해결 방법:");
-                Debug.LogError("[AIT]   1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.");
-                Debug.LogError("[AIT]   2. Unity Console에서 빌드 에러를 확인하세요.");
-                Debug.LogError("[AIT] ========================================");
+                Debug.LogError(
+                    $"[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락!\n"
+                    + $"누락된 필수 파일: {string.Join(", ", missingFiles)}\n"
+                    + "가능한 원인:\n"
+                    + "  1. Unity WebGL 빌드가 완료되지 않았습니다.\n"
+                    + "  2. WebGL 빌드가 실패했지만 부분 결과물만 남아있습니다.\n"
+                    + "  3. 빌드 설정(압축 방식 등)이 예상과 다릅니다.\n"
+                    + "해결 방법:\n"
+                    + "  1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n"
+                    + "  2. Unity Console에서 빌드 에러를 확인하세요."
+                );
                 return AITConvertCore.AITExportError.REQUIRED_FILE_MISSING;
             }
 
@@ -1317,20 +1314,17 @@ namespace AppsInToss.Editor
             // index.html 필수 검증
             if (!File.Exists(indexSrc))
             {
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError("[AIT] ✗ 치명적: index.html을 찾을 수 없습니다!");
-                Debug.LogError("[AIT] ========================================");
-                Debug.LogError($"[AIT] 검색 경로: {indexSrc}");
-                Debug.LogError("[AIT] ");
-                Debug.LogError("[AIT] 가능한 원인:");
-                Debug.LogError("[AIT]   1. Unity WebGL 빌드가 완료되지 않았습니다.");
-                Debug.LogError("[AIT]   2. WebGL 템플릿이 올바르게 설정되지 않았습니다.");
-                Debug.LogError("[AIT]   3. 이전 빌드가 손상되었습니다.");
-                Debug.LogError("[AIT] ");
-                Debug.LogError("[AIT] 해결 방법:");
-                Debug.LogError("[AIT]   1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.");
-                Debug.LogError("[AIT]   2. AIT > Clean 메뉴로 빌드 폴더를 삭제 후 재빌드하세요.");
-                Debug.LogError("[AIT] ========================================");
+                Debug.LogError(
+                    "[AIT] ✗ 치명적: index.html을 찾을 수 없습니다!\n"
+                    + $"검색 경로: {indexSrc}\n"
+                    + "가능한 원인:\n"
+                    + "  1. Unity WebGL 빌드가 완료되지 않았습니다.\n"
+                    + "  2. WebGL 템플릿이 올바르게 설정되지 않았습니다.\n"
+                    + "  3. 이전 빌드가 손상되었습니다.\n"
+                    + "해결 방법:\n"
+                    + "  1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n"
+                    + "  2. AIT > Clean 메뉴로 빌드 폴더를 삭제 후 재빌드하세요."
+                );
                 return AITConvertCore.AITExportError.INDEX_HTML_MISSING;
             }
 

--- a/Editor/AITPackageManagerHelper.cs
+++ b/Editor/AITPackageManagerHelper.cs
@@ -138,17 +138,14 @@ namespace AppsInToss.Editor
         public static void LogInstallationFailure(string tag)
         {
             string nodejsPath = GetNodejsPathDescription();
-            Debug.LogError($"[{tag}] ========================================");
-            Debug.LogError($"[{tag}] ✗ pnpm을 설치할 수 없습니다.");
-            Debug.LogError($"[{tag}] ========================================");
-            Debug.LogError($"[{tag}] ");
-            Debug.LogError($"[{tag}] 내장 Node.js 다운로드 또는 pnpm 설치에 실패했습니다.");
-            Debug.LogError($"[{tag}] ");
-            Debug.LogError($"[{tag}] 해결 방법:");
-            Debug.LogError($"[{tag}]   1. 네트워크 연결을 확인하세요.");
-            Debug.LogError($"[{tag}]   2. {nodejsPath} 폴더를 삭제 후 Unity를 재시작하세요.");
-            Debug.LogError($"[{tag}]   3. 방화벽/프록시가 nodejs.org를 차단하고 있는지 확인하세요.");
-            Debug.LogError($"[{tag}] ========================================");
+            Debug.LogError(
+                $"[{tag}] ✗ pnpm을 설치할 수 없습니다.\n"
+                + $"내장 Node.js 다운로드 또는 pnpm 설치에 실패했습니다.\n"
+                + $"해결 방법:\n"
+                + $"  1. 네트워크 연결을 확인하세요.\n"
+                + $"  2. {nodejsPath} 폴더를 삭제 후 Unity를 재시작하세요.\n"
+                + $"  3. 방화벽/프록시가 nodejs.org를 차단하고 있는지 확인하세요."
+            );
         }
 
         /// <summary>

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-13T05:51:48Z
+// Updated at: 2026-04-13T13:04:01Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
-        public const string Version = "2.4.3";
-        public const string ReleaseDateTime = "20260413_0551";
-        public const string CommitHash = "bd75ac2";
+        public const string Version = "2.4.5";
+        public const string ReleaseDateTime = "20260413_1304";
+        public const string CommitHash = "794d45c";
     }
 }


### PR DESCRIPTION
## Summary
- 다중 `Debug.LogError()` 호출을 단일 호출로 통합하여 Sentry에서 하나의 에러가 여러 이슈로 분리되는 문제 수정
- Sentry 86개 미해결 이슈 전수 리뷰 및 정리 (테스트 이벤트 ignored, 노이즈 이슈 resolved)
- CLAUDE.md에 Sentry 이슈 관련 가이드라인 추가

## 변경 내용

### 코드 수정 (3개 파일)
| 파일 | 수정 내용 |
|------|----------|
| `Editor/AITPackageManagerHelper.cs` | `LogInstallationFailure()` — 12줄 Debug.LogError → 1줄 |
| `Editor/AITPackageBuilder.cs` | 빌드 파일 누락, index.html 누락, Build 폴더 누락 에러 (3곳) |
| `Editor/AITBuildValidator.cs` | 플레이스홀더 미치환, 빈 파일 경로, .ait 파일 누락 에러 (3곳) |

### Sentry 이슈 정리
| 처리 | 개수 | 대상 |
|------|------|------|
| Ignored | 7개 | 테스트/시뮬레이션 이벤트 |
| Resolved | 79개 | FMOD 오디오, GUI Layer, 에러 메시지 분리, 샘플 이벤트 등 |

### CLAUDE.md
- Sentry 이슈 관련 섹션 추가 (무시해도 되는 패턴, SDK 문제가 아닌 사용자 이슈 패턴)

## Test plan
- [ ] Unity Editor에서 빌드 실패 시 에러 메시지가 Unity Console에 올바르게 표시되는지 확인
- [ ] Sentry에 에러가 단일 이슈로 그룹핑되는지 확인