### PR TITLE
개선: .claude/scheduled_tasks.lock을 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ Desktop.ini
 
 # Claude Code (로컬 설정은 커밋 제외)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Node modules
 node_modules/

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-13T13:04:01Z
+// Updated at: 2026-04-13T15:35:39Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
-        public const string Version = "2.4.5";
-        public const string ReleaseDateTime = "20260413_1304";
-        public const string CommitHash = "794d45c";
+        public const string Version = "2.4.6";
+        public const string ReleaseDateTime = "20260413_1535";
+        public const string CommitHash = "dadef75";
     }
 }


### PR DESCRIPTION
## Summary
- `.claude/scheduled_tasks.lock` 파일을 `.gitignore`에 추가
- Claude Code의 스케줄링 기능이 생성하는 로컬 락 파일이 커밋되지 않도록 방지

## Test plan
- [ ] `.claude/scheduled_tasks.lock` 파일이 `git status`에 표시되지 않는지 확인