### PR TITLE
수정: Sentry 더미 GUID 교체 및 commit hash 태그 추가

### DIFF
--- a/Editor/Sentry/AITSentryBuildProcessor.cs.meta
+++ b/Editor/Sentry/AITSentryBuildProcessor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2
+guid: 0a0af4e8832546beac32a572bf96a359
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Editor/Sentry/AppsInToss.Sentry.Editor.asmdef.meta
+++ b/Editor/Sentry/AppsInToss.Sentry.Editor.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1
+guid: 3c40c44751c5484e9ecc13b0566f5489
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData:

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-14T04:24:21Z
+// Updated at: 2026-04-14T02:54:41Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260414_0424";
-        public const string CommitHash = "dfe490f";
+        public const string ReleaseDateTime = "20260414_0254";
+        public const string CommitHash = "3e70dfe";
     }
 }

--- a/Runtime/Sentry/AITSentryContextEnricher.cs.meta
+++ b/Runtime/Sentry/AITSentryContextEnricher.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9
+guid: 9cee6e53ee034c4b8adc6b0c0e051cbc
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Sentry/AITSentryIntegration.cs
+++ b/Runtime/Sentry/AITSentryIntegration.cs
@@ -62,6 +62,11 @@ namespace AppsInToss.Sentry
             {
                 scope.SetTag("ait.sdk_version", AITVersion.FullVersion);
                 scope.SetTag("ait.unity_version", Application.unityVersion);
+
+                if (!string.IsNullOrEmpty(AITVersion.CommitHash))
+                {
+                    scope.SetTag("ait.commit_hash", AITVersion.CommitHash);
+                }
             });
         }
 

--- a/Runtime/Sentry/AITSentryIntegration.cs.meta
+++ b/Runtime/Sentry/AITSentryIntegration.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8
+guid: 02d677730c04416ab0a495f63052b94c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Sentry/AppsInToss.Sentry.asmdef.meta
+++ b/Runtime/Sentry/AppsInToss.Sentry.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7
+guid: 74724ae654ba4b6497d33a2714b482a1
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData:

--- a/Runtime/Sentry/link.xml.meta
+++ b/Runtime/Sentry/link.xml.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d7
+guid: 4f935467e98949c199d230a2be1f75a4
 TextScriptImporter:
   externalObjects: {}
   userData:


### PR DESCRIPTION
## Summary
- Sentry 모듈 `.meta` 파일 6개의 순차적 더미 GUID를 실제 랜덤 GUID로 교체하여 Unity "File may be corrupted" 에러 해결
- `ait.commit_hash` 태그를 Sentry 이벤트에 명시적으로 추가하여 SDK git commit 버전 추적 가능하도록 개선

Fixes APPS-IN-TOSS-UNITY-SDK-2Q

## Test plan
- [ ] Unity Editor에서 Sentry 모듈 포함 프로젝트가 에러 없이 로드되는지 확인
- [ ] Sentry 이벤트에 `ait.commit_hash` 태그가 정상적으로 표시되는지 확인
- [ ] 기존 `ait.sdk_version`, `ait.unity_version` 태그가 영향받지 않는지 확인