### PR TITLE
수정: AITLog 래퍼 도입으로 Sentry 캡처를 로그 레벨과 분리

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -394,7 +394,7 @@ namespace AppsInToss
 
                 if (editorConfig == null)
                 {
-                    Debug.LogError("Apps in Toss 설정을 찾을 수 없습니다.");
+                    AITLog.Error("Apps in Toss 설정을 찾을 수 없습니다.", sentryCapture: false);
                     transaction?.Finish("internal_error");
                     return AITExportError.INVALID_APP_CONFIG;
                 }
@@ -513,7 +513,7 @@ namespace AppsInToss
 
                 if (editorConfig == null)
                 {
-                    Debug.LogError("Apps in Toss 설정을 찾을 수 없습니다.");
+                    AITLog.Error("Apps in Toss 설정을 찾을 수 없습니다.", sentryCapture: false);
                     settingsBackup.Restore();
                     onComplete?.Invoke(AITExportError.INVALID_APP_CONFIG);
                     return;
@@ -658,7 +658,7 @@ namespace AppsInToss
 
             if (!Directory.Exists(webglPath))
             {
-                Debug.LogError("[AIT] WebGL 빌드 결과를 찾을 수 없습니다. WebGL 빌드를 먼저 실행하세요.");
+                AITLog.Error("[AIT] WebGL 빌드 결과를 찾을 수 없습니다. WebGL 빌드를 먼저 실행하세요.", sentryCapture: false);
                 settingsBackup.Restore();
                 onComplete?.Invoke(AITExportError.BUILD_WEBGL_FAILED);
                 return;
@@ -741,7 +741,7 @@ namespace AppsInToss
                 Debug.Log($"[AIT] 빌드 타겟을 {EditorUserBuildSettings.activeBuildTarget}에서 WebGL로 전환합니다...");
                 if (!EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WebGL, BuildTarget.WebGL))
                 {
-                    Debug.LogError("[AIT] WebGL 빌드 타겟으로 전환할 수 없습니다. WebGL Build Support 모듈이 설치되어 있는지 확인하세요.");
+                    AITLog.Error("[AIT] WebGL 빌드 타겟으로 전환할 수 없습니다. WebGL Build Support 모듈이 설치되어 있는지 확인하세요.", sentryCapture: false);
                     return AITExportError.BUILD_WEBGL_FAILED;
                 }
             }
@@ -875,7 +875,7 @@ namespace AppsInToss
 
             if (!Directory.Exists(webglPath))
             {
-                Debug.LogError("WebGL 빌드 결과를 찾을 수 없습니다. WebGL 빌드를 먼저 실행하세요.");
+                AITLog.Error("WebGL 빌드 결과를 찾을 수 없습니다. WebGL 빌드를 먼저 실행하세요.", sentryCapture: false);
                 return AITExportError.BUILD_WEBGL_FAILED;
             }
 

--- a/Editor/AITLog.cs
+++ b/Editor/AITLog.cs
@@ -1,0 +1,72 @@
+using System;
+using UnityEngine;
+using AppsInToss.Editor.ErrorTracker;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// Debug.Log/LogWarning/LogError 래퍼.
+    /// sentryCapture 옵션으로 Sentry 전송 여부를 로그 레벨과 독립적으로 제어합니다.
+    ///
+    /// 사용 예시:
+    ///   AITLog.Error("빌드 실패", sentryCapture: true);   // Console Error + Sentry 전송
+    ///   AITLog.Error("설정 누락", sentryCapture: false);  // Console Error만 (Sentry 전송 안 함)
+    ///   AITLog.Warning("캐시 미스", sentryCapture: true);  // Console Warning + Sentry 전송
+    /// </summary>
+    internal static class AITLog
+    {
+        /// <summary>
+        /// Sentry 캡처를 일시 억제하는 스코프.
+        /// using 문과 함께 사용하여 try-finally 패턴을 보장합니다.
+        /// </summary>
+        internal struct SuppressScope : IDisposable
+        {
+            private readonly bool _active;
+
+            internal SuppressScope(bool active)
+            {
+                _active = active;
+                if (_active)
+                    AITEditorErrorTracker.BeginSuppressLogCapture();
+            }
+
+            public void Dispose()
+            {
+                if (_active)
+                    AITEditorErrorTracker.EndSuppressLogCapture();
+            }
+        }
+
+        /// <summary>
+        /// Debug.Log를 호출합니다. Sentry에는 전송되지 않습니다 (Info 레벨은 수집 대상 아님).
+        /// </summary>
+        internal static void Info(string message)
+        {
+            Debug.Log(message);
+        }
+
+        /// <summary>
+        /// Debug.LogWarning을 호출합니다.
+        /// sentryCapture가 false이면 Sentry 전송을 억제합니다.
+        /// </summary>
+        internal static void Warning(string message, bool sentryCapture = true)
+        {
+            using (new SuppressScope(!sentryCapture))
+            {
+                Debug.LogWarning(message);
+            }
+        }
+
+        /// <summary>
+        /// Debug.LogError를 호출합니다.
+        /// sentryCapture가 false이면 Sentry 전송을 억제합니다.
+        /// </summary>
+        internal static void Error(string message, bool sentryCapture = true)
+        {
+            using (new SuppressScope(!sentryCapture))
+            {
+                Debug.LogError(message);
+            }
+        }
+    }
+}

--- a/Editor/AITLog.cs.meta
+++ b/Editor/AITLog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29493e6664a244329b456a09f1333d92
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -132,7 +132,7 @@ namespace AppsInToss.Editor
             string npmPath = AITNpmRunner.FindNpmPath();
             if (string.IsNullOrEmpty(npmPath))
             {
-                Debug.LogError("[AIT] npm을 찾을 수 없습니다. Node.js가 설치되어 있는지 확인하세요.");
+                AITLog.Error("[AIT] npm을 찾을 수 없습니다. Node.js가 설치되어 있는지 확인하세요.", sentryCapture: false);
                 return (null, AITConvertCore.AITExportError.NODE_NOT_FOUND);
             }
 

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -311,7 +311,7 @@ namespace AppsInToss
             string deploymentKey = AITCredentialsUtil.GetDeploymentKey();
             if (string.IsNullOrWhiteSpace(deploymentKey))
             {
-                Debug.LogError("AIT: 배포 키가 설정되지 않았습니다.");
+                AITLog.Error("AIT: 배포 키가 설정되지 않았습니다.", sentryCapture: false);
                 AITPlatformHelper.ShowInfoDialog("오류", "배포 키가 설정되지 않았습니다.\n\nApps in Toss > Configuration에서 배포 키를 입력해주세요.", "확인");
                 return;
             }
@@ -675,7 +675,7 @@ namespace AppsInToss
             string deploymentKey = AITCredentialsUtil.GetDeploymentKey();
             if (string.IsNullOrWhiteSpace(deploymentKey))
             {
-                Debug.LogError("AIT: 배포 키가 설정되지 않았습니다.");
+                AITLog.Error("AIT: 배포 키가 설정되지 않았습니다.", sentryCapture: false);
                 AITPlatformHelper.ShowInfoDialog("오류", "배포 키가 설정되지 않았습니다.\n\nApps in Toss > Configuration에서 배포 키를 입력해주세요.", "확인");
                 return;
             }
@@ -687,7 +687,7 @@ namespace AppsInToss
             string npmPath = FindNpmPath();
             if (string.IsNullOrEmpty(npmPath))
             {
-                Debug.LogError("AIT: npm을 찾을 수 없습니다. Node.js가 설치되어 있는지 확인하세요.");
+                AITLog.Error("AIT: npm을 찾을 수 없습니다. Node.js가 설치되어 있는지 확인하세요.", sentryCapture: false);
                 AITPlatformHelper.ShowInfoDialog("오류", "npm을 찾을 수 없습니다.\n\nNode.js가 설치되어 있는지 확인하세요.", "확인");
                 return;
             }
@@ -931,7 +931,7 @@ namespace AppsInToss
             // 빌드 결과물이 있는지 확인
             if (!Directory.Exists(buildPath))
             {
-                Debug.LogError($"AIT: 빌드 결과물이 없습니다. 먼저 Build & Package를 실행하세요. ({buildPath})");
+                AITLog.Error($"AIT: 빌드 결과물이 없습니다. 먼저 Build & Package를 실행하세요. ({buildPath})", sentryCapture: false);
                 AITPlatformHelper.ShowInfoDialog("빌드 필요", "빌드 결과물이 없습니다.\n먼저 Build & Package를 실행하세요.", "확인");
                 return;
             }
@@ -1375,7 +1375,7 @@ namespace AppsInToss
         {
             if (string.IsNullOrEmpty(npmPath))
             {
-                Debug.LogError("AIT: npm을 찾을 수 없습니다.");
+                AITLog.Error("AIT: npm을 찾을 수 없습니다.", sentryCapture: false);
                 AITPlatformHelper.ShowInfoDialog("오류", "npm을 찾을 수 없습니다.\n\nNode.js가 설치되어 있는지 확인하세요.", "확인");
                 return false;
             }
@@ -1399,7 +1399,7 @@ namespace AppsInToss
 
                 if (installResult != AITConvertCore.AITExportError.SUCCEED)
                 {
-                    Debug.LogError("AIT: pnpm install 실패");
+                    AITLog.Error("AIT: pnpm install 실패", sentryCapture: false);
                     AITPlatformHelper.ShowInfoDialog("오류", "pnpm install 실패\n\nConsole 로그를 확인하세요.", "확인");
                     return false;
                 }
@@ -1653,7 +1653,7 @@ namespace AppsInToss
                 }
                 else
                 {
-                    Debug.LogError($"[AIT] 사용 가능한 포트를 찾을 수 없습니다 (시도: {vitePort}-{vitePort+9})");
+                    AITLog.Error($"[AIT] 사용 가능한 포트를 찾을 수 없습니다 (시도: {vitePort}-{vitePort+9})", sentryCapture: false);
                     AITPlatformHelper.ShowInfoDialog("포트 오류", $"포트 {vitePort} 및 인근 포트가 모두 사용 중입니다.\n다른 포트를 Configuration에서 설정하거나, 사용 중인 프로세스를 종료하세요.", "확인");
                     return false;
                 }
@@ -1670,7 +1670,7 @@ namespace AppsInToss
                 }
                 else
                 {
-                    Debug.LogError($"[AIT] 사용 가능한 Granite 포트를 찾을 수 없습니다 (시도: {granitePort}-{granitePort+9})");
+                    AITLog.Error($"[AIT] 사용 가능한 Granite 포트를 찾을 수 없습니다 (시도: {granitePort}-{granitePort+9})", sentryCapture: false);
                     AITPlatformHelper.ShowInfoDialog("포트 오류", $"Granite 포트 {granitePort} 및 인근 포트가 모두 사용 중입니다.\n다른 포트를 Configuration에서 설정하거나, 사용 중인 프로세스를 종료하세요.", "확인");
                     return false;
                 }
@@ -1686,11 +1686,8 @@ namespace AppsInToss
         {
             string errorMessage = AITConvertCore.GetErrorMessage(result);
 
-            // 자동 에러 전송 — CaptureBuildError가 로그 억제를 시작하고,
-            // Debug.LogError 후에 EndSuppressLogCapture로 해제하여 이중 캡처 방지
-            AppsInToss.Editor.ErrorTracker.AITEditorErrorTracker.CaptureBuildError(result, callerName);
-            try { Debug.LogError($"AIT: 빌드 실패: {result}"); }
-            finally { AppsInToss.Editor.ErrorTracker.AITEditorErrorTracker.EndSuppressLogCapture(); }
+            // 자동 에러 전송 — Sentry에 빌드 에러 캡처 + Console에 로그 출력 (이중 캡처 방지 내장)
+            AppsInToss.Editor.ErrorTracker.AITEditorErrorTracker.CaptureBuildError(result, $"AIT: 빌드 실패: {result}", callerName);
 
             int choice = AITPlatformHelper.ShowComplexDialog(
                 "빌드 실패",
@@ -1729,7 +1726,7 @@ namespace AppsInToss
 
             if (string.IsNullOrWhiteSpace(config.appName))
             {
-                Debug.LogError("AIT: App Name이 설정되지 않았습니다.");
+                AITLog.Error("AIT: App Name이 설정되지 않았습니다.", sentryCapture: false);
                 AITPlatformHelper.ShowInfoDialog("오류", "App Name이 설정되지 않았습니다.\n\nAIT > Configuration에서 App Name을 입력해주세요.", "확인");
                 return false;
             }

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -56,9 +56,9 @@ namespace AppsInToss.Editor.ErrorTracker
 
         private static readonly Dictionary<int, DateTime> _recentErrors = new Dictionary<int, DateTime>();
 
-        // CaptureBuildError 호출 직후 로그 핸들러의 이중 캡처를 방지하기 위한 억제 플래그
-        // 주로 메인 스레드에서 사용되지만, 백그라운드 스레드의 로그 콜백에 대비하여 volatile 선언
-        private static volatile bool _suppressLogCapture;
+        // CaptureBuildError/AITLog에서 로그 핸들러의 Sentry 캡처를 억제하기 위한 카운터
+        // 중첩 호출을 지원하며, Interlocked으로 스레드 안전성 보장
+        private static volatile int _suppressLogCaptureCount;
 
         #endregion
 
@@ -197,18 +197,36 @@ namespace AppsInToss.Editor.ErrorTracker
 
         private static void OnLogMessageReceived(string message, string stackTrace, LogType type)
         {
-            if (type != LogType.Error && type != LogType.Exception)
+            if (type != LogType.Error && type != LogType.Exception && type != LogType.Warning)
                 return;
 
-            // CaptureBuildError에서 이미 명시적으로 캡처한 에러의 이중 전송 방지
-            if (_suppressLogCapture)
+            // CaptureBuildError 또는 AITLog에서 억제된 로그의 이중 전송 방지
+            if (_suppressLogCaptureCount > 0)
                 return;
 
             if (!IsAitRelated(message, stackTrace))
                 return;
 
-            string exceptionType = type == LogType.Exception ? ExtractExceptionType(message) : "UnityError";
-            CaptureError(exceptionType, message, stackTrace, "error");
+            string level;
+            string exceptionType;
+
+            if (type == LogType.Exception)
+            {
+                exceptionType = ExtractExceptionType(message);
+                level = "error";
+            }
+            else if (type == LogType.Error)
+            {
+                exceptionType = "UnityError";
+                level = "error";
+            }
+            else
+            {
+                exceptionType = "UnityWarning";
+                level = "warning";
+            }
+
+            CaptureError(exceptionType, message, stackTrace, level);
         }
 
         /// <summary>
@@ -286,29 +304,54 @@ namespace AppsInToss.Editor.ErrorTracker
         }
 
         /// <summary>
-        /// 빌드 에러를 캡처하고, 직후의 Debug.LogError 이중 캡처를 방지하기 위해
-        /// 로그 핸들러를 일시 억제합니다. 호출자는 Debug.LogError 후에
-        /// EndSuppressLogCapture()를 호출해야 합니다.
+        /// 빌드 에러를 Sentry에 캡처하고, Console에 에러 로그를 출력합니다.
+        /// 로그 핸들러의 이중 캡처를 내부적으로 방지하므로 호출자가 suppress를 관리할 필요 없습니다.
         /// </summary>
         internal static void CaptureBuildError(
             AITConvertCore.AITExportError errorCode,
+            string logMessage,
             string profileName = null)
         {
             if (errorCode == AITConvertCore.AITExportError.SUCCEED ||
                 errorCode == AITConvertCore.AITExportError.CANCELLED)
                 return;
 
-            // 내부 캡처 도중의 로그도 억제됨 — 호출자가 EndSuppressLogCapture()로 해제
-            _suppressLogCapture = true;
-            CaptureBuildErrorInternal(errorCode, profileName);
+            BeginSuppressLogCapture();
+            try
+            {
+                CaptureBuildErrorInternal(errorCode, profileName);
+                UnityEngine.Debug.LogError(logMessage);
+            }
+            finally
+            {
+                EndSuppressLogCapture();
+            }
         }
 
         /// <summary>
-        /// CaptureBuildError 후 로그 억제를 해제합니다.
+        /// 로그 핸들러의 Sentry 캡처를 일시 억제합니다.
+        /// 반드시 EndSuppressLogCapture()와 쌍으로 사용해야 합니다.
+        /// </summary>
+        internal static void BeginSuppressLogCapture()
+        {
+            System.Threading.Interlocked.Increment(ref _suppressLogCaptureCount);
+        }
+
+        /// <summary>
+        /// BeginSuppressLogCapture 후 로그 억제를 해제합니다.
         /// </summary>
         internal static void EndSuppressLogCapture()
         {
-            _suppressLogCapture = false;
+            // 원자적 underflow 방지: 0 이하로 내려가지 않도록 CAS 루프
+            int current;
+            do
+            {
+                current = _suppressLogCaptureCount;
+                if (current <= 0)
+                    return;
+            }
+            while (System.Threading.Interlocked.CompareExchange(
+                ref _suppressLogCaptureCount, current - 1, current) != current);
         }
 
         private static void CaptureBuildErrorInternal(

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-14T02:54:41Z
+// Updated at: 2026-04-14T11:51:13Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260414_0254";
-        public const string CommitHash = "3e70dfe";
+        public const string ReleaseDateTime = "20260414_1151";
+        public const string CommitHash = "eb4f023";
     }
 }


### PR DESCRIPTION
## Summary
- Sentry 이슈 [APPS-IN-TOSS-UNITY-SDK-2R](https://toss.sentry.io/issues/APPS-IN-TOSS-UNITY-SDK-2R) 수정
- `AITLog` 래퍼 클래스 도입: `sentryCapture` 옵션으로 Sentry 전송 여부를 로그 레벨과 독립적으로 제어
- ErrorTracker에서 `LogType.Warning`도 수집하도록 확장
- 사용자 설정/환경 검증 로그 15곳을 `AITLog.Error(..., sentryCapture: false)`로 전환
  - Unity Console에는 Error로 표시 (기존과 동일)
  - Sentry에는 전송 안 함

## 변경 내용
| 파일 | 변경 |
|------|------|
| `Editor/AITLog.cs` (신규) | `Debug.Log*` 래퍼. `sentryCapture` 옵션으로 Sentry 전송 제어 |
| `Editor/ErrorTracker/AITEditorErrorTracker.cs` | Warning 수집 추가, `BeginSuppressLogCapture()` API 추출 |
| `Editor/AppsInTossMenu.cs` | 9곳 전환 (App Name, 배포 키, npm, 빌드 결과, pnpm, 포트) |
| `Editor/AITConvertCore.cs` | 5곳 전환 (설정 객체, WebGL 빌드 결과, Build Support) |
| `Editor/AITPackageBuilder.cs` | 1곳 전환 (npm 미설치) |

## Test plan
- [ ] `AITLog.Error(msg, sentryCapture: false)` 호출 시 Unity Console에 Error 표시되는지 확인
- [ ] `AITLog.Error(msg, sentryCapture: false)` 호출 시 Sentry에 전송되지 않는지 확인
- [ ] `AITLog.Error(msg)` (기본값 `sentryCapture: true`) 호출 시 Sentry에 정상 전송되는지 확인
- [ ] `Debug.LogWarning` + AIT 키워드 시 Sentry에 warning 레벨로 수집되는지 확인
- [ ] 기존 `CaptureBuildError` + `EndSuppressLogCapture` 패턴이 정상 동작하는지 확인