### PR TITLE
수정: CopyDirectory에서 .meta 파일 복사 제외하여 GUID 충돌 해결

### DIFF
--- a/Editor/AITFileUtils.cs
+++ b/Editor/AITFileUtils.cs
@@ -57,6 +57,9 @@ namespace AppsInToss
 
             foreach (var file in Directory.GetFiles(sourceDir))
             {
+                if (file.EndsWith(".meta"))
+                    continue;
+
                 string targetFile = Path.Combine(targetDir, Path.GetFileName(file));
                 File.Copy(file, targetFile, true);
                 // Unity WebGL 빌드 파일(.unityweb)이 600 권한으로 생성되는 문제 해결

--- a/Editor/AITFileUtils.cs
+++ b/Editor/AITFileUtils.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
@@ -57,7 +58,8 @@ namespace AppsInToss
 
             foreach (var file in Directory.GetFiles(sourceDir))
             {
-                if (file.EndsWith(".meta"))
+                // .meta 파일은 SDK GUID 충돌 방지를 위해 복사하지 않음 (Unity가 대상 위치에 새로 생성)
+                if (file.EndsWith(".meta", System.StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 string targetFile = Path.Combine(targetDir, Path.GetFileName(file));
@@ -82,8 +84,10 @@ namespace AppsInToss
             if (!Directory.Exists(dir1) || !Directory.Exists(dir2))
                 return false;
 
-            var files1 = Directory.GetFiles(dir1, "*", SearchOption.AllDirectories);
-            var files2 = Directory.GetFiles(dir2, "*", SearchOption.AllDirectories);
+            var files1 = Directory.GetFiles(dir1, "*", SearchOption.AllDirectories)
+                .Where(f => !f.EndsWith(".meta", System.StringComparison.OrdinalIgnoreCase)).ToArray();
+            var files2 = Directory.GetFiles(dir2, "*", SearchOption.AllDirectories)
+                .Where(f => !f.EndsWith(".meta", System.StringComparison.OrdinalIgnoreCase)).ToArray();
 
             if (files1.Length != files2.Length)
                 return false;

--- a/Editor/AITFileUtils.cs
+++ b/Editor/AITFileUtils.cs
@@ -62,7 +62,7 @@ namespace AppsInToss
             foreach (var file in Directory.GetFiles(sourceDir))
             {
                 // .meta 파일은 SDK GUID 충돌 방지를 위해 복사하지 않음 (Unity가 대상 위치에 새로 생성)
-                if (file.EndsWith(".meta", System.StringComparison.OrdinalIgnoreCase))
+                if (IsMetaFile(file))
                     continue;
 
                 string targetFile = Path.Combine(targetDir, Path.GetFileName(file));
@@ -88,9 +88,9 @@ namespace AppsInToss
                 return false;
 
             var files1 = Directory.GetFiles(dir1, "*", SearchOption.AllDirectories)
-                .Where(f => !f.EndsWith(".meta", System.StringComparison.OrdinalIgnoreCase)).ToArray();
+                .Where(f => !IsMetaFile(f)).ToArray();
             var files2 = Directory.GetFiles(dir2, "*", SearchOption.AllDirectories)
-                .Where(f => !f.EndsWith(".meta", System.StringComparison.OrdinalIgnoreCase)).ToArray();
+                .Where(f => !IsMetaFile(f)).ToArray();
 
             if (files1.Length != files2.Length)
                 return false;
@@ -118,6 +118,9 @@ namespace AppsInToss
 
             return true;
         }
+
+        private static bool IsMetaFile(string path)
+            => path.EndsWith(".meta", System.StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// 파일에 읽기 권한 부여 (macOS/Linux에서 chmod 644 효과)

--- a/Editor/AITFileUtils.cs
+++ b/Editor/AITFileUtils.cs
@@ -52,6 +52,9 @@ namespace AppsInToss
             return config;
         }
 
+        /// <summary>
+        /// 소스 디렉토리를 대상 디렉토리로 재귀 복사 (.meta 파일 제외)
+        /// </summary>
         public static void CopyDirectory(string sourceDir, string targetDir)
         {
             Directory.CreateDirectory(targetDir);
@@ -77,7 +80,7 @@ namespace AppsInToss
         }
 
         /// <summary>
-        /// 두 디렉토리의 내용이 동일한지 비교 (파일명, 크기 기준)
+        /// 두 디렉토리의 내용이 동일한지 비교 (파일명, 크기 기준, .meta 파일 제외)
         /// </summary>
         public static bool DirectoriesEqual(string dir1, string dir2)
         {

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-14T11:51:13Z
+// Updated at: 2026-04-15T07:46:55Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260414_1151";
+        public const string ReleaseDateTime = "20260415_0746";
         public const string CommitHash = "eb4f023";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-15T07:46:55Z
+// Updated at: 2026-04-15T07:48:54Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_0746";
-        public const string CommitHash = "eb4f023";
+        public const string ReleaseDateTime = "20260415_0748";
+        public const string CommitHash = "15ceb98";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-15T07:48:54Z
+// Updated at: 2026-04-15T07:50:18Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_0748";
-        public const string CommitHash = "15ceb98";
+        public const string ReleaseDateTime = "20260415_0750";
+        public const string CommitHash = "15cf614";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-15T07:50:18Z
+// Updated at: 2026-04-15T07:52:05Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_0750";
-        public const string CommitHash = "15cf614";
+        public const string ReleaseDateTime = "20260415_0752";
+        public const string CommitHash = "a0976e5";
     }
 }


### PR DESCRIPTION
## Summary

SDK 패키지(`Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/`)의 `.meta` 파일이 사용자 프로젝트 `Assets/WebGLTemplates/AITTemplate/`로 그대로 복사되면서 Unity GUID 충돌 경고가 발생하는 문제를 수정합니다.

## Changes

- `CopyDirectory()`에서 `.meta` 파일을 건너뛰도록 수정 (Unity가 대상 위치에 새 GUID로 자동 생성)
- `DirectoriesEqual()`에서도 `.meta` 파일을 비교 대상에서 제외하여 일관성 유지 (불필요한 재복사 방지)
- `IsMetaFile()` 헬퍼 추출 (대소문자 무시 비교)

## Sentry Issues Resolved

Fixes APPS-IN-TOSS-UNITY-SDK-2T
Fixes APPS-IN-TOSS-UNITY-SDK-2S
Fixes APPS-IN-TOSS-UNITY-SDK-2V
Fixes APPS-IN-TOSS-UNITY-SDK-2W
Fixes APPS-IN-TOSS-UNITY-SDK-30
Fixes APPS-IN-TOSS-UNITY-SDK-31
Fixes APPS-IN-TOSS-UNITY-SDK-32
Fixes APPS-IN-TOSS-UNITY-SDK-33
Fixes APPS-IN-TOSS-UNITY-SDK-34
Fixes APPS-IN-TOSS-UNITY-SDK-35
Fixes APPS-IN-TOSS-UNITY-SDK-36
Fixes APPS-IN-TOSS-UNITY-SDK-37
Fixes APPS-IN-TOSS-UNITY-SDK-39

## Test plan

- [ ] Validate CI 통과 확인 (`.meta` 관련 lint 포함)
- [ ] E2E 테스트에서 WebGL 템플릿 복사가 정상 동작하는지 확인
- [ ] Unity Editor에서 GUID 충돌 경고가 더 이상 발생하지 않는지 확인