### PR TITLE
개선: 빌드 실패 시 BuildReport 상세 에러 로깅 추가

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -831,27 +831,44 @@ namespace AppsInToss
                 sb.AppendLine($"  결과: {result.summary.result}");
                 sb.AppendLine($"  총 에러: {result.summary.totalErrors}, 총 경고: {result.summary.totalWarnings}");
 
-                int errorCount = 0;
-                const int maxErrors = 10;
+                int messageCount = 0;
+                const int maxMessages = 10;
+
+                // 에러 메시지를 먼저 출력 (실패 원인 우선)
                 foreach (var step in result.steps)
                 {
                     foreach (var message in step.messages)
                     {
-                        if (message.type == LogType.Error ||
-                            message.type == LogType.Warning)
+                        if (message.type == LogType.Error)
                         {
-                            if (errorCount < maxErrors)
+                            if (messageCount < maxMessages)
                             {
                                 sb.AppendLine($"  [{message.type}] {message.content}");
                             }
-                            errorCount++;
+                            messageCount++;
                         }
                     }
                 }
 
-                if (errorCount > maxErrors)
+                // 경고 메시지는 남은 슬롯에 출력
+                foreach (var step in result.steps)
                 {
-                    sb.AppendLine($"  ... 외 {errorCount - maxErrors}개 메시지 생략");
+                    foreach (var message in step.messages)
+                    {
+                        if (message.type == LogType.Warning)
+                        {
+                            if (messageCount < maxMessages)
+                            {
+                                sb.AppendLine($"  [{message.type}] {message.content}");
+                            }
+                            messageCount++;
+                        }
+                    }
+                }
+
+                if (messageCount > maxMessages)
+                {
+                    sb.AppendLine($"  ... 외 {messageCount - maxMessages}개 메시지 생략");
                 }
 
                 Debug.LogError(sb.ToString());

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -839,7 +839,9 @@ namespace AppsInToss
                 {
                     foreach (var message in step.messages)
                     {
-                        if (message.type == LogType.Error)
+                        if (message.type == LogType.Error ||
+                            message.type == LogType.Exception ||
+                            message.type == LogType.Assert)
                         {
                             if (messageCount < maxMessages)
                             {
@@ -868,10 +870,10 @@ namespace AppsInToss
 
                 if (messageCount > maxMessages)
                 {
-                    sb.AppendLine($"  ... 외 {messageCount - maxMessages}개 메시지 생략");
+                    sb.Append($"  ... 외 {messageCount - maxMessages}개 메시지 생략");
                 }
 
-                Debug.LogError(sb.ToString());
+                Debug.LogError(sb.ToString().TrimEnd());
                 return AITExportError.BUILD_WEBGL_FAILED;
             }
 

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -826,7 +826,35 @@ namespace AppsInToss
 
             if (result.summary.result != UnityEditor.Build.Reporting.BuildResult.Succeeded)
             {
-                Debug.LogError("WebGL 빌드가 실패했습니다.");
+                var sb = new System.Text.StringBuilder();
+                sb.AppendLine("WebGL 빌드가 실패했습니다.");
+                sb.AppendLine($"  결과: {result.summary.result}");
+                sb.AppendLine($"  총 에러: {result.summary.totalErrors}, 총 경고: {result.summary.totalWarnings}");
+
+                int errorCount = 0;
+                const int maxErrors = 10;
+                foreach (var step in result.steps)
+                {
+                    foreach (var message in step.messages)
+                    {
+                        if (message.type == LogType.Error ||
+                            message.type == LogType.Warning)
+                        {
+                            if (errorCount < maxErrors)
+                            {
+                                sb.AppendLine($"  [{message.type}] {message.content}");
+                            }
+                            errorCount++;
+                        }
+                    }
+                }
+
+                if (errorCount > maxErrors)
+                {
+                    sb.AppendLine($"  ... 외 {errorCount - maxErrors}개 메시지 생략");
+                }
+
+                Debug.LogError(sb.ToString());
                 return AITExportError.BUILD_WEBGL_FAILED;
             }
 


### PR DESCRIPTION
## Summary
- BuildPipeline.BuildPlayer() 실패 시 BuildReport에서 상세 에러 정보를 추출하여 Debug.LogError로 출력
- 에러(Error/Exception/Assert) 메시지를 경고(Warning)보다 우선 출력하여 실패 원인이 10개 제한에 잘리지 않도록 함
- Sentry SDK-41 이슈 해결: 기존 'WebGL 빌드가 실패했습니다.' 메시지에 구체적 원인 추가

## 변경 내용
- `Editor/AITConvertCore.cs`: 빌드 실패 시 result.summary(에러/경고 수) 및 result.steps의 메시지를 StringBuilder로 조합하여 출력 (최대 10개, 초과분 생략 표시)

## Test plan
- [ ] Unity Editor에서 의도적으로 빌드 실패를 유발하여 상세 에러 메시지가 Console에 출력되는지 확인
- [ ] Sentry에 상세 에러 메시지가 전달되는지 확인
- [ ] CI Validate 워크플로우 통과 확인