### PR TITLE
수정: WebGL Build Support 미설치 사전 감지 추가

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -767,7 +767,7 @@ namespace AppsInToss
                 cleanBuild = true;
             }
 
-            Debug.Log($"WebGL 빌드를 시작합니다... ({(cleanBuild ? "클린 빌드" : "증분 빌드")})");
+            Debug.Log($"[AIT] WebGL 빌드를 시작합니다... ({(cleanBuild ? "클린 빌드" : "증분 빌드")})");
 
             // 클린 빌드 시에만 기존 빌드 폴더 삭제
             if (cleanBuild && Directory.Exists(outputPath))
@@ -887,7 +887,7 @@ namespace AppsInToss
                 return AITExportError.BUILD_WEBGL_FAILED;
             }
 
-            Debug.Log("WebGL 빌드가 완료되었습니다.");
+            Debug.Log("[AIT] WebGL 빌드가 완료되었습니다.");
 
             // AIT 빌드 마커 파일 생성 (빌드 정보 기록용)
             try

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -723,6 +723,16 @@ namespace AppsInToss
 
         private static AITExportError BuildWebGL(bool cleanBuild = false, AITBuildProfile profile = null)
         {
+            // WebGL Build Support 모듈 설치 여부 사전 체크
+            if (!BuildPipeline.IsBuildTargetSupported(BuildTargetGroup.WebGL, BuildTarget.WebGL))
+            {
+                Debug.LogError(
+                    "[AIT] ✗ WebGL Build Support 모듈이 설치되지 않았습니다.\n" +
+                    "Unity Hub를 열고 현재 Unity 버전(" + Application.unityVersion + ")에 WebGL Build Support를 추가 설치하세요.\n" +
+                    "Unity Hub > Installs > Unity " + Application.unityVersion + " > Add Modules > WebGL Build Support");
+                return AITExportError.BUILD_WEBGL_FAILED;
+            }
+
             if (EditorUserBuildSettings.activeBuildTarget != BuildTarget.WebGL)
             {
                 bool confirm = AITPlatformHelper.ShowConfirmDialog(
@@ -744,16 +754,6 @@ namespace AppsInToss
                     AITLog.Error("[AIT] ✗ WebGL 빌드 타겟으로 전환할 수 없습니다.", sentryCapture: false);
                     return AITExportError.BUILD_WEBGL_FAILED;
                 }
-            }
-
-            // WebGL Build Support 모듈 설치 여부 사전 체크
-            if (!BuildPipeline.IsBuildTargetSupported(BuildTargetGroup.WebGL, BuildTarget.WebGL))
-            {
-                Debug.LogError(
-                    "[AIT] ✗ WebGL Build Support 모듈이 설치되지 않았습니다.\n" +
-                    "Unity Hub를 열고 현재 Unity 버전(" + Application.unityVersion + ")에 WebGL Build Support를 추가 설치하세요.\n" +
-                    "Unity Hub > Installs > Unity " + Application.unityVersion + " > Add Modules > WebGL Build Support");
-                return AITExportError.BUILD_WEBGL_FAILED;
             }
 
             string[] scenes = UnityUtil.GetBuildScenes();

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -741,7 +741,7 @@ namespace AppsInToss
                 Debug.Log($"[AIT] 빌드 타겟을 {EditorUserBuildSettings.activeBuildTarget}에서 WebGL로 전환합니다...");
                 if (!EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WebGL, BuildTarget.WebGL))
                 {
-                    AITLog.Error("[AIT] WebGL 빌드 타겟으로 전환할 수 없습니다. WebGL Build Support 모듈이 설치되어 있는지 확인하세요.", sentryCapture: false);
+                    AITLog.Error("[AIT] ✗ WebGL 빌드 타겟으로 전환할 수 없습니다.", sentryCapture: false);
                     return AITExportError.BUILD_WEBGL_FAILED;
                 }
             }

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -746,6 +746,16 @@ namespace AppsInToss
                 }
             }
 
+            // WebGL Build Support 모듈 설치 여부 사전 체크
+            if (!BuildPipeline.IsBuildTargetSupported(BuildTargetGroup.WebGL, BuildTarget.WebGL))
+            {
+                Debug.LogError(
+                    "[AIT] ✗ WebGL Build Support 모듈이 설치되지 않았습니다.\n" +
+                    "Unity Hub를 열고 현재 Unity 버전(" + Application.unityVersion + ")에 WebGL Build Support를 추가 설치하세요.\n" +
+                    "Unity Hub > Installs > Unity " + Application.unityVersion + " > Add Modules > WebGL Build Support");
+                return AITExportError.BUILD_WEBGL_FAILED;
+            }
+
             string[] scenes = UnityUtil.GetBuildScenes();
             string outputPath = Path.Combine(UnityUtil.GetProjectPath(), webglDir);
 
@@ -827,7 +837,7 @@ namespace AppsInToss
             if (result.summary.result != UnityEditor.Build.Reporting.BuildResult.Succeeded)
             {
                 var sb = new System.Text.StringBuilder();
-                sb.AppendLine("WebGL 빌드가 실패했습니다.");
+                sb.AppendLine("[AIT] WebGL 빌드가 실패했습니다.");
                 sb.AppendLine($"  결과: {result.summary.result}");
                 sb.AppendLine($"  총 에러: {result.summary.totalErrors}, 총 경고: {result.summary.totalWarnings}");
 


### PR DESCRIPTION
## Summary
- WebGL Build Support 모듈 미설치 상태에서 빌드 시도 시 발생하던 **연쇄 에러 5개**를 **안내 메시지 1개**로 줄임
- `BuildWebGL()` 함수 최상단에 `BuildPipeline.IsBuildTargetSupported()` guard clause 추가
- Unity Hub 설치 경로를 포함한 친절한 안내 메시지 출력 후 즉시 반환
- 함수 내 로그 메시지에 `[AIT]` prefix 일관성 적용

## Background
Sentry에서 한 명의 사용자(one-block-island 프로젝트)가 WebGL Build Support 미설치 상태에서 빌드를 시도하여 5개 연쇄 에러 발생:
1. SDK-44: Build target 'WebGL' not supported
2. SDK-3R/41: WebGL 빌드 실패
3. SDK-46: 빌드 마커 생성 실패
4. SDK-45/47: Build 폴더를 찾을 수 없습니다

## Changes
- `Editor/AITConvertCore.cs`: `BuildWebGL()` 최상단에 WebGL 모듈 사전 체크 guard clause 추가
- `SwitchActiveBuildTarget` 실패 메시지 단순화 (모듈 체크가 이미 통과한 후이므로)
- `BuildWebGL()` 함수 내 기존 로그 메시지에 `[AIT]` prefix 추가

## Test plan
- [ ] WebGL Build Support 미설치 환경에서 빌드 시도 → 안내 메시지 1개만 출력 확인
- [ ] WebGL Build Support 설치된 환경에서 빌드 → 정상 동작 확인
- [ ] 빌드 실패 시 `[AIT]` prefix가 포함된 로그 메시지 출력 확인