### PR TITLE
수정: Dev Server 로그가 Sentry에 잘못 캡처되는 문제 해결

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -41,6 +41,15 @@ namespace AppsInToss.Editor.ErrorTracker
             "AITNpmRunner"
         };
 
+        // Dev/Production Server 프로세스에서 리디렉션된 로그의 prefix 패턴.
+        // 이 로그는 granite dev 프로세스의 stdout/stderr를 Unity Console로 전달한 것이며,
+        // SDK 자체 에러가 아니므로 Sentry 캡처에서 제외해야 합니다.
+        private static readonly string[] ServerLogPrefixes =
+        {
+            "[Dev Server]",
+            "[Production Server]"
+        };
+
         #endregion
 
         #region Session State
@@ -202,6 +211,11 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // CaptureBuildError 또는 AITLog에서 억제된 로그의 이중 전송 방지
             if (_suppressLogCaptureCount > 0)
+                return;
+
+            // Dev/Production Server 프로세스에서 리디렉션된 로그는 Sentry에서 제외
+            // (granite dev의 stdout/stderr가 Debug.Log/LogError/LogWarning으로 전달된 것)
+            if (IsServerRedirectedLog(message))
                 return;
 
             if (!IsAitRelated(message, stackTrace))
@@ -410,6 +424,20 @@ namespace AppsInToss.Editor.ErrorTracker
         #endregion
 
         #region Private Helpers
+
+        private static bool IsServerRedirectedLog(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+                return false;
+
+            for (int i = 0; i < ServerLogPrefixes.Length; i++)
+            {
+                if (message.StartsWith(ServerLogPrefixes[i], StringComparison.Ordinal))
+                    return true;
+            }
+
+            return false;
+        }
 
         private static bool IsAitRelated(string message, string stackTrace)
         {

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-15T07:52:05Z
+// Updated at: 2026-04-15T08:46:16Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_0752";
-        public const string CommitHash = "a0976e5";
+        public const string ReleaseDateTime = "20260415_0846";
+        public const string CommitHash = "1fcfe4b";
     }
 }


### PR DESCRIPTION
## Summary
- Dev Server 실행 시 granite dev 프로세스의 stderr 출력(`[AIT Login] InitSession failed: FORBIDDEN_ORIGIN` 등)이 `Debug.LogError`로 리디렉션되면서 ErrorTracker의 `[AIT` 키워드 매칭에 걸려 Sentry에 전송되던 문제 수정
- `AITEditorErrorTracker.OnLogMessageReceived`에서 `[Dev Server]`, `[Production Server]` prefix로 시작하는 로그를 Sentry 캡처에서 제외

## Changes
- `ServerLogPrefixes` 배열 추가 (`[Dev Server]`, `[Production Server]`)
- `IsServerRedirectedLog()` 메서드 추가 — `StartsWith` prefix 매칭
- `OnLogMessageReceived`에서 `IsAitRelated` 체크 전에 서버 리디렉션 로그 조기 반환

## Impact
- Sentry SDK-2Y, SDK-2X 이슈 (environment=editor, 29건) 재발 방지
- Dev Server / Production Server의 Unity Console 로그 출력에는 영향 없음 (Sentry 캡처만 제외)