### PR TITLE
기능: Sentry 이벤트에 error_source 태그 추가

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -282,7 +282,8 @@ namespace AppsInToss.Editor.ErrorTracker
                 { "sdk_version", AITVersion.Version },
                 { "unity_version", Application.unityVersion },
                 { "os", SystemInfo.operatingSystem },
-                { "editor_platform", Application.platform.ToString() }
+                { "editor_platform", Application.platform.ToString() },
+                { "error_source", DetermineErrorSource(stackTrace, message) }
             };
 
             if (extraTags != null)
@@ -470,6 +471,49 @@ namespace AppsInToss.Editor.ErrorTracker
 
             return "Exception";
         }
+
+        #region Error Source Detection
+
+        private const string SdkPackagePath = "Packages/im.toss.apps-in-toss-unity-sdk/";
+        private const string SdkPackageCachePath = "Library/PackageCache/im.toss.apps-in-toss-unity-sdk@";
+        private const string UserProjectPathPrefix = "Assets/";
+
+        /// <summary>
+        /// 스택트레이스와 메시지를 분석하여 에러의 출처를 결정합니다.
+        /// </summary>
+        internal static string DetermineErrorSource(string stackTrace, string message)
+        {
+            if (!string.IsNullOrEmpty(stackTrace))
+            {
+                var frames = AITSentryEnvelope.ParseStackTrace(stackTrace);
+                if (frames.Count > 0)
+                {
+                    // ParseStackTrace는 Sentry 컨벤션(oldest first)으로 reverse되어 있으므로,
+                    // 최상위 프레임(호출 스택 최상단)은 리스트의 마지막 요소
+                    for (int i = frames.Count - 1; i >= 0; i--)
+                    {
+                        string filename = frames[i].Filename;
+                        if (string.IsNullOrEmpty(filename))
+                            continue;
+
+                        if (filename.StartsWith(SdkPackagePath, StringComparison.Ordinal) ||
+                            filename.StartsWith(SdkPackageCachePath, StringComparison.Ordinal))
+                            return "sdk";
+
+                        if (filename.StartsWith(UserProjectPathPrefix, StringComparison.Ordinal))
+                            return "user_project";
+                    }
+                }
+            }
+
+            // 스택트레이스가 없거나 판별 불가한 경우, 메시지의 [AIT] 접두사로 판단
+            if (!string.IsNullOrEmpty(message) && message.StartsWith("[AIT]", StringComparison.Ordinal))
+                return "sdk";
+
+            return "unknown";
+        }
+
+        #endregion
 
         // 세션 내 중복 검출용 — GetHashCode()는 Mono 런타임에서 프로세스 내 결정적이며,
         // CoreCLR 전환 시 프로세스 간 비결정적이 되지만, 세션 스코프이므로 문제 없음

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -379,7 +379,8 @@ namespace AppsInToss.Editor.ErrorTracker
             var extraTags = new Dictionary<string, string>
             {
                 { "error_code", errorCode.ToString() },
-                { "error_code_int", ((int)errorCode).ToString() }
+                { "error_code_int", ((int)errorCode).ToString() },
+                { "error_source", "sdk" }
             };
 
             if (!string.IsNullOrEmpty(profileName))
@@ -472,14 +473,15 @@ namespace AppsInToss.Editor.ErrorTracker
             return "Exception";
         }
 
-        #region Error Source Detection
-
         private const string SdkPackagePath = "Packages/im.toss.apps-in-toss-unity-sdk/";
         private const string SdkPackageCachePath = "Library/PackageCache/im.toss.apps-in-toss-unity-sdk@";
+        private const string SdkPackageCachePathNoVersion = "Library/PackageCache/im.toss.apps-in-toss-unity-sdk/";
         private const string UserProjectPathPrefix = "Assets/";
 
         /// <summary>
         /// 스택트레이스와 메시지를 분석하여 에러의 출처를 결정합니다.
+        /// "에러가 throw된 위치" 기준으로 판별합니다 (최상위 프레임 우선).
+        /// 누가 호출했는지(trigger)가 아닌 어디서 발생했는지(origin)를 반환합니다.
         /// </summary>
         internal static string DetermineErrorSource(string stackTrace, string message)
         {
@@ -497,7 +499,8 @@ namespace AppsInToss.Editor.ErrorTracker
                             continue;
 
                         if (filename.StartsWith(SdkPackagePath, StringComparison.Ordinal) ||
-                            filename.StartsWith(SdkPackageCachePath, StringComparison.Ordinal))
+                            filename.StartsWith(SdkPackageCachePath, StringComparison.Ordinal) ||
+                            filename.StartsWith(SdkPackageCachePathNoVersion, StringComparison.Ordinal))
                             return "sdk";
 
                         if (filename.StartsWith(UserProjectPathPrefix, StringComparison.Ordinal))
@@ -512,8 +515,6 @@ namespace AppsInToss.Editor.ErrorTracker
 
             return "unknown";
         }
-
-        #endregion
 
         // 세션 내 중복 검출용 — GetHashCode()는 Mono 런타임에서 프로세스 내 결정적이며,
         // CoreCLR 전환 시 프로세스 간 비결정적이 되지만, 세션 스코프이므로 문제 없음

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -5,7 +5,7 @@ namespace AppsInToss
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_0910";
-        public const string CommitHash = "d8ac5e0";
+        public const string ReleaseDateTime = "20260415_0913";
+        public const string CommitHash = "63d13aa";
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorSourceTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorSourceTests.cs
@@ -1,0 +1,158 @@
+// ---------------------------------------------------------------------------
+// ErrorSourceTests.cs - DetermineErrorSource 단위 테스트
+// 스택트레이스/메시지 분석을 통한 에러 출처 분류 로직을 검증합니다.
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+[Category("Unit")]
+public class ErrorSourceTests
+{
+    #region SDK Path Tests
+
+    [Test]
+    public void SdkPath_InPackages_ReturnsSdk()
+    {
+        string stackTrace =
+            "at AppsInToss.Editor.AITConvertCore.DoExport () in Packages/im.toss.apps-in-toss-unity-sdk/Editor/AITConvertCore.cs:42";
+
+        Assert.AreEqual("sdk", AITEditorErrorTracker.DetermineErrorSource(stackTrace, "some error"));
+    }
+
+    [Test]
+    public void SdkPath_InPackageCacheWithVersion_ReturnsSdk()
+    {
+        string stackTrace =
+            "at AppsInToss.Editor.AITConvertCore.DoExport () in Library/PackageCache/im.toss.apps-in-toss-unity-sdk@2.4.1/Editor/AITConvertCore.cs:42";
+
+        Assert.AreEqual("sdk", AITEditorErrorTracker.DetermineErrorSource(stackTrace, "some error"));
+    }
+
+    [Test]
+    public void SdkPath_InPackageCacheWithoutVersion_ReturnsSdk()
+    {
+        // Unity 6+ may use PackageCache without @version suffix
+        string stackTrace =
+            "at AppsInToss.Editor.AITConvertCore.DoExport () in Library/PackageCache/im.toss.apps-in-toss-unity-sdk/Editor/AITConvertCore.cs:42";
+
+        Assert.AreEqual("sdk", AITEditorErrorTracker.DetermineErrorSource(stackTrace, "some error"));
+    }
+
+    #endregion
+
+    #region User Project Path Tests
+
+    [Test]
+    public void UserPath_InAssets_ReturnsUserProject()
+    {
+        string stackTrace =
+            "at MyGame.PlayerController.Start () in Assets/Scripts/PlayerController.cs:15";
+
+        Assert.AreEqual("user_project", AITEditorErrorTracker.DetermineErrorSource(stackTrace, "some error"));
+    }
+
+    [Test]
+    public void UserPath_InAssetsPlugins_ReturnsUserProject()
+    {
+        string stackTrace =
+            "at ThirdParty.Plugin.Init () in Assets/Plugins/ThirdParty/Plugin.cs:10";
+
+        Assert.AreEqual("user_project", AITEditorErrorTracker.DetermineErrorSource(stackTrace, "some error"));
+    }
+
+    #endregion
+
+    #region Mixed Frame Tests
+
+    [Test]
+    public void MixedFrames_TopmostIsSdk_ReturnsSdk()
+    {
+        // User code calls SDK, SDK throws — topmost frame is SDK
+        string stackTrace =
+            "at AppsInToss.SDK.AIT.GetDeviceId () in Packages/im.toss.apps-in-toss-unity-sdk/Runtime/SDK/AIT.SystemInfo.cs:20\n" +
+            "at MyGame.GameManager.Init () in Assets/Scripts/GameManager.cs:50";
+
+        Assert.AreEqual("sdk", AITEditorErrorTracker.DetermineErrorSource(stackTrace, ""));
+    }
+
+    [Test]
+    public void MixedFrames_TopmostIsUser_ReturnsUserProject()
+    {
+        // SDK calls user callback, user code throws — topmost frame is user
+        string stackTrace =
+            "at MyGame.Callback.OnResult () in Assets/Scripts/Callback.cs:30\n" +
+            "at AppsInToss.SDK.AIT.InvokeCallback () in Packages/im.toss.apps-in-toss-unity-sdk/Runtime/SDK/AITCore.cs:100";
+
+        Assert.AreEqual("user_project", AITEditorErrorTracker.DetermineErrorSource(stackTrace, ""));
+    }
+
+    #endregion
+
+    #region Fallback Tests
+
+    [Test]
+    public void NoStackTrace_AitPrefixMessage_ReturnsSdk()
+    {
+        Assert.AreEqual("sdk", AITEditorErrorTracker.DetermineErrorSource(null, "[AIT] Build failed"));
+    }
+
+    [Test]
+    public void NoStackTrace_NonAitMessage_ReturnsUnknown()
+    {
+        Assert.AreEqual("unknown", AITEditorErrorTracker.DetermineErrorSource(null, "Something went wrong"));
+    }
+
+    [Test]
+    public void EmptyStackTrace_AitPrefixMessage_ReturnsSdk()
+    {
+        Assert.AreEqual("sdk", AITEditorErrorTracker.DetermineErrorSource("", "[AIT] Error occurred"));
+    }
+
+    [Test]
+    public void EmptyStackTrace_NonAitMessage_ReturnsUnknown()
+    {
+        Assert.AreEqual("unknown", AITEditorErrorTracker.DetermineErrorSource("", "generic error"));
+    }
+
+    #endregion
+
+    #region Null/Empty Input Tests
+
+    [Test]
+    public void NullInputs_ReturnsUnknown()
+    {
+        Assert.AreEqual("unknown", AITEditorErrorTracker.DetermineErrorSource(null, null));
+    }
+
+    [Test]
+    public void EmptyInputs_ReturnsUnknown()
+    {
+        Assert.AreEqual("unknown", AITEditorErrorTracker.DetermineErrorSource("", ""));
+    }
+
+    #endregion
+
+    #region Unparseable Stack Trace Tests
+
+    [Test]
+    public void UnparseableStackTrace_NoAitMessage_ReturnsUnknown()
+    {
+        // Stack trace with no "at" lines — no frames parsed
+        string stackTrace = "some random log output\nwithout stack frames";
+
+        Assert.AreEqual("unknown", AITEditorErrorTracker.DetermineErrorSource(stackTrace, "error"));
+    }
+
+    [Test]
+    public void FramesWithoutFilename_FallsBackToMessage()
+    {
+        // Frames without file paths (e.g., native or stripped)
+        string stackTrace = "at System.String.Format (System.String format)";
+
+        Assert.AreEqual("sdk", AITEditorErrorTracker.DetermineErrorSource(stackTrace, "[AIT] format error"));
+    }
+
+    #endregion
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorSourceTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorSourceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32fe8a395daf406faad7becc15cfff6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Sentry 이벤트에 `error_source` 태그를 추가하여 SDK 자체 에러와 사용자 프로젝트 에러를 구별
- 스택트레이스의 최상위 프레임 파일 경로를 분석하여 `sdk`, `user_project`, `unknown` 중 하나로 분류
- `CaptureBuildError` 경로는 항상 `sdk`로 태그

## 변경 사항
- `AITEditorErrorTracker.DetermineErrorSource()` 메서드 추가
- `CaptureError`에서 `error_source` 태그 자동 삽입
- `CaptureBuildErrorInternal`에서 `error_source: "sdk"` 명시
- Unity 6+ PackageCache 경로 형식(`@version` 없는 형식) 대응
- `DetermineErrorSource` 단위 테스트 13개 추가

## 구별 기준
| error_source | 조건 |
|---|---|
| `sdk` | 최상위 프레임이 `Packages/im.toss.apps-in-toss-unity-sdk/` 또는 `Library/PackageCache/im.toss.apps-in-toss-unity-sdk@` |
| `user_project` | 최상위 프레임이 `Assets/` 경로 |
| `unknown` | 스택트레이스 없거나 판별 불가 (단, `[AIT]` 접두사 메시지는 `sdk`) |

## Test plan
- [x] `DetermineErrorSource` 단위 테스트 13개 작성
- [ ] EditMode 테스트 실행
- [ ] CI E2E 테스트 통과 확인