### PR TITLE
수정: 의도적 설정 변경 로그의 Warning 레벨을 Log로 조정하여 Sentry 노이즈 제거

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -65,7 +65,7 @@ namespace AppsInToss.Editor
                 PlayerSettings.SetUseDefaultGraphicsAPIs(BuildTarget.WebGL, false);
                 PlayerSettings.SetGraphicsAPIs(BuildTarget.WebGL,
                     new[] { UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3 });
-                Debug.LogWarning($"[AIT] Graphics API를 WebGL 2.0 전용으로 변경했습니다. (이전: {previousAPIs})");
+                Debug.Log($"[AIT] Graphics API를 WebGL 2.0 전용으로 변경했습니다. (이전: {previousAPIs})");
             }
 
             // ===== Run In Background (사용자 지정 또는 자동) =====
@@ -115,7 +115,7 @@ namespace AppsInToss.Editor
             PlayerSettings.WebGL.nameFilesAsHashes = false;
             if (editorConfig.nameFilesAsHashes)
             {
-                Debug.LogWarning("[AIT] Unity 2021.x에서는 '파일명 해싱' 옵션이 빌드 오류를 유발하여 자동으로 비활성화됩니다. Unity 2022.3 이상으로 업그레이드를 권장합니다.");
+                Debug.Log("[AIT] Unity 2021.x에서는 '파일명 해싱' 옵션이 빌드 오류를 유발하여 자동으로 비활성화됩니다. Unity 2022.3 이상으로 업그레이드를 권장합니다.");
             }
 #endif
 

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-15T08:46:16Z
+// Updated at: 2026-04-15T09:10:13Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_0846";
-        public const string CommitHash = "1fcfe4b";
+        public const string ReleaseDateTime = "20260415_0910";
+        public const string CommitHash = "d8ac5e0";
     }
 }


### PR DESCRIPTION
## Summary
- `AITBuildInitializer.cs`에서 SDK가 의도적으로 수행하는 설정 변경 알림 로그의 레벨을 `Debug.LogWarning` → `Debug.Log`로 변경
- Graphics API 변경 알림 (line 68)과 Unity 2021.x 파일명 해싱 비활성화 알림 (line 118)이 대상
- `AITEditorErrorTracker`가 Warning 레벨을 Sentry에 캡처하므로, 의도적 동작은 Log 레벨로 내려서 노이즈 제거

## 변경 내용
| 위치 | 변경 | 이유 |
|------|------|------|
| Line 68 | `LogWarning` → `Log` | Graphics API를 WebGL 2.0으로 변경하는 것은 SDK의 의도적 동작 |
| Line 118 | `LogWarning` → `Log` | Unity 2021.x에서 파일명 해싱을 비활성화하는 것은 SDK의 의도적 동작 |
| Line 281, 296 | `LogWarning` 유지 | 환경 변수 파싱 실패는 실제 에러 상황 |

## 관련 이슈
- Sentry SDK-38

## Test plan
- [ ] Warning으로 출력되던 로그가 Log 레벨로 변경되었는지 확인
- [ ] 환경 변수 파싱 실패 시 여전히 Warning으로 출력되는지 확인