### PR TITLE
기능: SDK 최소 버전 정책을 하드코딩에서 동적 로딩으로 변경

### DIFF
--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -1,5 +1,5 @@
 name: Bulk Release
-run-name: "Bulk Release${{ inputs.versions && format(' - {0}', inputs.versions) || '' }}${{ inputs.min_version && inputs.min_version != '2.0.0' && format(' (min: v{0})', inputs.min_version) || '' }}"
+run-name: "Bulk Release${{ inputs.versions && format(' - {0}', inputs.versions) || '' }}${{ inputs.min_version && format(' (min: v{0})', inputs.min_version) || '' }}"
 
 on:
   workflow_dispatch:
@@ -14,10 +14,9 @@ on:
         type: number
         default: 2
       min_version:
-        description: '최소 버전 (기본: 2.0.0). SDK 1.x 배포가 필요하면 1.5.0으로 지정'
+        description: '최소 버전 (비워두면 sdk-policy.json에서 읽음). 이전 버전 배포가 필요하면 낮은 버전으로 지정'
         required: false
         type: string
-        default: '2.0.0'
       build_strategy:
         description: '빌드 전략: full (10빌드), standard (5빌드), minimal (1빌드), skip-build (0빌드) - 기본: minimal'
         required: false
@@ -40,6 +39,7 @@ jobs:
     outputs:
       versions: ${{ steps.extract.outputs.versions }}
       version_count: ${{ steps.extract.outputs.count }}
+      min_version: ${{ steps.extract.outputs.min_version }}
 
     steps:
       - name: Checkout
@@ -52,8 +52,21 @@ jobs:
         id: extract
         run: |
           INPUT_VERSIONS="${{ inputs.versions }}"
-          MIN_VERSION="${{ inputs.min_version || '2.0.0' }}"
+
+          # sdk-policy.json에서 기본 최소 버전을 읽어옴 (수동 입력이 없을 경우)
+          POLICY_MIN_VERSION=$(jq -r '.minVersion // empty' sdk-policy.json 2>/dev/null || echo "")
+          if [ -z "$POLICY_MIN_VERSION" ]; then
+            # 이 값은 AITDeprecationChecker.cs의 FallbackDeprecationThreshold와 일치해야 합니다.
+            POLICY_MIN_VERSION="2.4.1"
+            echo "sdk-policy.json에서 minVersion을 읽지 못해 폴백 사용: ${POLICY_MIN_VERSION}"
+          fi
+
+          MIN_VERSION="${{ inputs.min_version || '' }}"
+          if [ -z "$MIN_VERSION" ]; then
+            MIN_VERSION="$POLICY_MIN_VERSION"
+          fi
           echo "최소 버전: ${MIN_VERSION}"
+          echo "min_version=${MIN_VERSION}" >> $GITHUB_OUTPUT
 
           if [ -n "$INPUT_VERSIONS" ]; then
             echo "=== 입력된 버전 사용 ==="
@@ -114,7 +127,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**총 ${{ steps.extract.outputs.count }}개 버전**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**최소 버전**: ${{ inputs.min_version || '2.0.0' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**최소 버전**: ${{ steps.extract.outputs.min_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**동시 실행 수**: ${{ inputs.max_parallel || 2 }}" >> $GITHUB_STEP_SUMMARY
           echo "**빌드 전략**: ${{ inputs.build_strategy || 'minimal' }}" >> $GITHUB_STEP_SUMMARY
 

--- a/Editor/AITDeprecationChecker.cs
+++ b/Editor/AITDeprecationChecker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Net;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
@@ -8,41 +9,205 @@ using Debug = UnityEngine.Debug;
 namespace AppsInToss.Editor
 {
     /// <summary>
-    /// SDK 2.0.0 미만 버전 감지 시 빌드를 차단하고 최신 버전으로 업그레이드를 유도합니다.
+    /// SDK 최소 버전 미만 감지 시 빌드를 차단하고 최신 버전으로 업그레이드를 유도합니다.
+    /// 최소 버전은 GitHub의 sdk-policy.json에서 동적으로 가져오며, 실패 시 하드코딩 폴백을 사용합니다.
     /// </summary>
     [InitializeOnLoad]
     public static class AITDeprecationChecker
     {
-        private static readonly Version DeprecationThreshold = new Version(2, 0, 0);
+        private static readonly Version FallbackDeprecationThreshold = new Version(2, 4, 1);
         private const string GIT_REPO_URL = "https://github.com/toss/apps-in-toss-unity-sdk.git";
-        // git ls-remote 실패 시 사용할 폴백 태그. 새 2.x 릴리즈 시 갱신 필요.
-        private const string FALLBACK_UPGRADE_TAG = "release/v2.0.5";
+        // SDK는 main 브랜치의 sdk-policy.json을 런타임에 fetch합니다.
+        // 로컬 패키지에도 같은 파일이 포함되어 있으나, 정책의 정본(source of truth)은 main 브랜치입니다.
+        private const string POLICY_URL = "https://raw.githubusercontent.com/toss/apps-in-toss-unity-sdk/main/sdk-policy.json";
+        // git ls-remote 실패 시 사용할 폴백 태그.
+        // 불변 조건: 이 태그의 버전은 반드시 FallbackDeprecationThreshold 이상이어야 합니다.
+        private const string FALLBACK_UPGRADE_TAG = "release/v2.4.1";
         private const int GIT_TIMEOUT_MS = 10000;
+        private const int SUPPORTED_SCHEMA_VERSION = 1;
+
+        // 동적으로 가져온 minVersion이 이 값을 초과하면 무시합니다.
+        // 손상된 정책 파일이 모든 사용자를 차단하는 것을 방지합니다.
+        private static readonly Version MaxReasonableMinVersion = new Version(10, 0, 0);
 
         // 최신 태그 캐시 (세션 중 1회만 조회)
         private static string _cachedLatestTag;
         private static bool _tagLookupDone;
 
-        // 업그레이드 시작 후 다이얼로그 반복을 멈추기 위한 플래그
+        // 동적 최소 버전 캐시 (세션 중 1회만 조회)
+        private static Version _cachedMinVersion;
+        private static bool _minVersionLookupDone;
+
+        // 업그레이드 시작 후 다이얼로그 반복을 멈추기 위한 플래그.
+        // PackageManager.Client.Add() 호출 후 리셋되지 않으며, 세션 동안 유지됩니다.
+        // 업그레이드가 실패해도 다이얼로그가 다시 표시되려면 Unity를 재시작해야 합니다.
         private static bool _upgradeInProgress;
+
+        /// <summary>
+        /// WebClient에 timeout을 지정하기 위한 서브클래스.
+        /// WebClient는 직접 timeout 프로퍼티를 노출하지 않으므로 GetWebRequest를 오버라이드합니다.
+        /// </summary>
+        private class TimeoutWebClient : WebClient
+        {
+            private readonly int _timeoutMs;
+
+            public TimeoutWebClient(int timeoutMs = GIT_TIMEOUT_MS)
+            {
+                _timeoutMs = timeoutMs;
+            }
+
+            protected override WebRequest GetWebRequest(Uri uri)
+            {
+                var request = base.GetWebRequest(uri);
+                request.Timeout = _timeoutMs;
+                return request;
+            }
+        }
 
         static AITDeprecationChecker()
         {
-            EditorApplication.delayCall += OnEditorReady;
+            // delayCall에서 캐시를 미리 프라이밍하여 GUI repaint 중 네트워크 호출 방지
+            EditorApplication.delayCall += () =>
+            {
+                GetMinVersionCached();
+                OnEditorReady();
+            };
         }
 
         /// <summary>
-        /// 최신 2.x 태그를 조회하고 캐싱합니다. 이미 조회한 경우 캐시를 반환합니다.
+        /// 동적 최소 버전을 조회하고 캐싱합니다. 이미 조회한 경우 캐시를 반환합니다.
         /// </summary>
-        private static string GetLatestV2TagCached()
+        internal static Version GetMinVersionCached()
+        {
+            if (_minVersionLookupDone) return _cachedMinVersion;
+            _minVersionLookupDone = true;
+
+            try
+            {
+                _cachedMinVersion = FetchMinVersion();
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] 최소 버전 조회 실패, 폴백 사용: {e.Message}");
+                _cachedMinVersion = FallbackDeprecationThreshold;
+            }
+
+            if (_cachedMinVersion == null)
+            {
+                _cachedMinVersion = FallbackDeprecationThreshold;
+            }
+
+            Debug.Log($"[AIT] SDK 최소 버전 정책: v{_cachedMinVersion}");
+            return _cachedMinVersion;
+        }
+
+        /// <summary>
+        /// GitHub raw content에서 sdk-policy.json을 가져와 minVersion을 파싱합니다.
+        /// System.Net.WebClient를 사용하여 동기적으로 처리합니다 (UnityWebRequest는 메인 스레드에서
+        /// busy-wait 시 이벤트 루프 의존성으로 인해 교착 상태가 발생할 수 있음).
+        /// TimeoutWebClient로 GIT_TIMEOUT_MS(10초) timeout을 적용합니다.
+        /// 참고: delayCall에서 호출되므로 메인 스레드를 최대 10초간 차단할 수 있습니다.
+        /// 비동기 처리로 이를 완전히 해결할 수 있으나, 복잡도 대비 10초 worst-case가 수용 가능하다고 판단했습니다.
+        /// </summary>
+        private static Version FetchMinVersion()
+        {
+            string json;
+            try
+            {
+#pragma warning disable SYSLIB0014 // WebClient is obsolete in .NET 6+ but Unity still uses .NET Standard 2.1
+                using (var client = new TimeoutWebClient())
+                {
+                    client.Headers.Add("User-Agent", "AppsInTossUnitySDK");
+                    json = client.DownloadString(POLICY_URL);
+                }
+#pragma warning restore SYSLIB0014
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] sdk-policy.json fetch 실패: {e.Message}");
+                return null;
+            }
+
+            return ParseMinVersionFromJson(json);
+        }
+
+        /// <summary>
+        /// sdk-policy.json 문자열에서 minVersion을 파싱합니다.
+        /// 2-part 버전(예: "2.4")은 3-part(예: "2.4.0")로 정규화합니다.
+        /// </summary>
+        internal static Version ParseMinVersionFromJson(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+            {
+                Debug.LogWarning("[AIT] sdk-policy.json이 비어 있습니다");
+                return null;
+            }
+
+            // JsonUtility.FromJson은 malformed JSON에서 null이 아닌 기본값 객체를 반환합니다.
+            // policy == null 체크는 방어적 코딩이며, 실제로는 schemaVersion=0, minVersion=null이 됩니다.
+            var policy = JsonUtility.FromJson<SdkPolicy>(json);
+            if (policy == null || string.IsNullOrEmpty(policy.minVersion))
+            {
+                Debug.LogWarning("[AIT] sdk-policy.json 파싱 실패: minVersion이 없습니다");
+                return null;
+            }
+
+            if (policy.schemaVersion != SUPPORTED_SCHEMA_VERSION)
+            {
+                Debug.LogWarning($"[AIT] 지원하지 않는 sdk-policy.json schemaVersion: {policy.schemaVersion} (지원: {SUPPORTED_SCHEMA_VERSION})");
+                return null;
+            }
+
+            try
+            {
+                var version = new Version(policy.minVersion);
+
+                // 3-part로 정규화 (System.Version에서 2.4 < 2.4.0, 2.4.1 < 2.4.1.0이므로)
+                // sdk-policy.json의 minVersion은 반드시 x.y.z 형식이어야 하지만, 방어적으로 정규화합니다.
+                if (version.Build < 0)
+                {
+                    version = new Version(version.Major, version.Minor, 0);
+                }
+                else if (version.Revision >= 0)
+                {
+                    version = new Version(version.Major, version.Minor, version.Build);
+                }
+
+                // 비정상적으로 높은 minVersion은 정책 파일 손상으로 간주
+                if (version > MaxReasonableMinVersion)
+                {
+                    Debug.LogWarning($"[AIT] minVersion {version}이 비정상적으로 높습니다. 폴백 사용.");
+                    return null;
+                }
+
+                return version;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] minVersion 파싱 실패: {policy.minVersion} — {e.Message}");
+                return null;
+            }
+        }
+
+        [Serializable]
+        private class SdkPolicy
+        {
+            public int schemaVersion;
+            public string minVersion;
+        }
+
+        /// <summary>
+        /// 최신 태그를 조회하고 캐싱합니다. 이미 조회한 경우 캐시를 반환합니다.
+        /// </summary>
+        private static string GetLatestTagCached()
         {
             if (_tagLookupDone) return _cachedLatestTag;
             _tagLookupDone = true;
 
-            EditorUtility.DisplayProgressBar("SDK 업그레이드", "최신 2.x 버전을 확인하는 중...", 0.3f);
+            EditorUtility.DisplayProgressBar("SDK 업그레이드", "최신 버전을 확인하는 중...", 0.3f);
             try
             {
-                _cachedLatestTag = FindLatestV2Tag();
+                _cachedLatestTag = FindLatestTag();
             }
             finally
             {
@@ -53,13 +218,13 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// 캐시된 태그에서 버전 문자열을 추출합니다 (예: "release/v2.0.5" → "2.0.5").
+        /// 캐시된 태그에서 버전 문자열을 추출합니다 (예: "release/v2.4.1" → "2.4.1").
         /// </summary>
         private static string GetLatestVersionDisplay()
         {
-            string tag = GetLatestV2TagCached() ?? FALLBACK_UPGRADE_TAG;
+            string tag = GetLatestTagCached() ?? FALLBACK_UPGRADE_TAG;
             var match = Regex.Match(tag, @"release/v(.+)$");
-            return match.Success ? match.Groups[1].Value : "2.x";
+            return match.Success ? match.Groups[1].Value : "최신 버전";
         }
 
         /// <summary>
@@ -76,7 +241,8 @@ namespace AppsInToss.Editor
             try
             {
                 var current = new Version(versionStr);
-                return current < DeprecationThreshold;
+                var minVersion = GetMinVersionCached();
+                return current < minVersion;
             }
             catch (Exception)
             {
@@ -101,14 +267,16 @@ namespace AppsInToss.Editor
         public static void ShowDeprecationDialog()
         {
             string latestVersion = GetLatestVersionDisplay();
+            var minVersion = GetMinVersionCached();
+            // Version(2,4,1).ToString() → "2.4.1" (3-part 보장: ParseMinVersionFromJson에서 정규화)
             bool shouldUpdate = EditorUtility.DisplayDialog(
                 "SDK 지원 종료 안내",
                 $"현재 사용 중인 Apps in Toss Unity SDK v{AITVersion.Version}은 " +
                 "지원이 종료되었습니다.\n\n" +
-                "SDK 1.x 버전으로는 더 이상 빌드 및 배포가 불가능합니다.\n" +
-                "앱인토스 콘솔에서도 2.0.0 미만 번들은 거부됩니다.\n\n" +
-                $"최신 SDK v{latestVersion}으로 업그레이드해 주세요.",
-                $"v{latestVersion}으로 업데이트",
+                $"SDK v{minVersion} 미만 버전으로는 더 이상 빌드 및 배포가 불가능합니다.\n" +
+                $"앱인토스 콘솔에서도 v{minVersion} 미만 번들은 거부됩니다.\n\n" +
+                $"SDK {latestVersion}으로 업그레이드해 주세요.",
+                $"{latestVersion}으로 업데이트",
                 "닫기"
             );
 
@@ -119,16 +287,16 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// 최신 2.x 태그를 찾아 UPM으로 업그레이드합니다.
+        /// 최신 태그를 찾아 UPM으로 업그레이드합니다.
         /// </summary>
         public static void UpgradeToLatest()
         {
             _upgradeInProgress = true;
-            string tag = GetLatestV2TagCached();
+            string tag = GetLatestTagCached();
             if (string.IsNullOrEmpty(tag))
             {
                 tag = FALLBACK_UPGRADE_TAG;
-                Debug.LogWarning($"[AIT] 최신 2.x 태그를 자동 감지하지 못했습니다. 기본값 사용: {tag}");
+                Debug.LogWarning($"[AIT] 최신 태그를 자동 감지하지 못했습니다. 기본값 사용: {tag}");
             }
 
             string url = $"{GIT_REPO_URL}#{tag}";
@@ -147,11 +315,11 @@ namespace AppsInToss.Editor
             string latestVersion = GetLatestVersionDisplay();
             EditorGUILayout.HelpBox(
                 $"이 SDK 버전(v{AITVersion.Version})은 지원이 종료되었습니다.\n" +
-                $"빌드 및 배포가 차단됩니다. 최신 SDK v{latestVersion}으로 업그레이드해 주세요.",
+                $"빌드 및 배포가 차단됩니다. SDK {latestVersion}으로 업그레이드해 주세요.",
                 MessageType.Error
             );
 
-            if (GUILayout.Button($"v{latestVersion}으로 업데이트"))
+            if (GUILayout.Button($"{latestVersion}으로 업데이트"))
             {
                 UpgradeToLatest();
             }
@@ -188,16 +356,19 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// git ls-remote로 최신 release/v2.* 태그를 찾습니다.
+        /// git ls-remote로 최신 release/v* 태그 중 minVersion 이상인 최신 태그를 찾습니다.
+        /// release/v* 전체를 조회하여 동적 minVersion에 따라 클라이언트 측에서 필터링합니다.
+        /// 참고: 릴리즈 태그가 많아지면 네트워크 페이로드가 증가할 수 있습니다.
+        /// git glob이 범위 필터를 지원하지 않아 서버 측 필터링이 불가능합니다.
         /// </summary>
-        private static string FindLatestV2Tag()
+        private static string FindLatestTag()
         {
             try
             {
                 var psi = new ProcessStartInfo
                 {
                     FileName = "git",
-                    Arguments = $"ls-remote --tags \"{GIT_REPO_URL}\" \"refs/tags/release/v2.*\"",
+                    Arguments = $"ls-remote --tags \"{GIT_REPO_URL}\" \"refs/tags/release/v*\"",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
@@ -208,6 +379,9 @@ namespace AppsInToss.Editor
                 using (var process = Process.Start(psi))
                 {
                     process.BeginErrorReadLine();
+                    // ReadToEnd()는 프로세스가 stdout을 닫을 때까지 블로킹됩니다.
+                    // 따라서 아래 WaitForExit timeout은 ReadToEnd 완료 후에만 도달합니다.
+                    // git ls-remote의 응답이 작으므로 실질적 문제는 없으나, 알려진 제한사항입니다.
                     string output = process.StandardOutput.ReadToEnd();
 
                     if (!process.WaitForExit(GIT_TIMEOUT_MS))
@@ -221,7 +395,7 @@ namespace AppsInToss.Editor
                         return null;
                     }
 
-                    return ParseLatestTag(output);
+                    return ParseLatestTag(output, GetMinVersionCached());
                 }
             }
             catch (Exception e)
@@ -232,9 +406,10 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// git ls-remote 출력에서 가장 높은 버전의 태그를 추출합니다.
+        /// git ls-remote 출력에서 minVersion 이상인 가장 높은 버전의 태그를 추출합니다.
+        /// minVersion 필터링은 업그레이드 대상으로 deprecated 버전을 제시하지 않기 위함입니다.
         /// </summary>
-        private static string ParseLatestTag(string output)
+        internal static string ParseLatestTag(string output, Version minVersion)
         {
             Version bestVersion = null;
             string bestTag = null;
@@ -259,6 +434,7 @@ namespace AppsInToss.Editor
                 try
                 {
                     var version = new Version(versionStr);
+                    if (version < minVersion) continue;
                     if (bestVersion == null || version > bestVersion)
                     {
                         bestVersion = version;
@@ -272,6 +448,27 @@ namespace AppsInToss.Editor
             }
 
             return bestTag;
+        }
+
+        /// <summary>
+        /// 테스트용: 캐시를 초기화합니다.
+        /// </summary>
+        internal static void ResetCache()
+        {
+            _cachedLatestTag = null;
+            _tagLookupDone = false;
+            _cachedMinVersion = null;
+            _minVersionLookupDone = false;
+            _upgradeInProgress = false;
+        }
+
+        /// <summary>
+        /// 테스트용: 최소 버전 캐시를 직접 설정합니다.
+        /// </summary>
+        internal static void SetMinVersionForTesting(Version version)
+        {
+            _cachedMinVersion = version;
+            _minVersionLookupDone = true;
         }
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-15T09:10:13Z
+// Updated at: 2026-04-15T16:10:50Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_0913";
-        public const string CommitHash = "63d13aa";
+        public const string ReleaseDateTime = "20260415_1610";
+        public const string CommitHash = "d8ac5e0";
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeprecationCheckerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeprecationCheckerTests.cs
@@ -1,11 +1,12 @@
 // -----------------------------------------------------------------------
 // DeprecationCheckerTests.cs - EditMode SDK Deprecation 검증 테스트
-// Level 0: 버전 비교 로직 및 git tag 파싱 로직을 검증
+// Level 0: 버전 비교 로직, git tag 파싱 로직, 동적 최소 버전 폴백을 검증
 // -----------------------------------------------------------------------
 
 using NUnit.Framework;
 using System;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using AppsInToss.Editor;
 
 [TestFixture]
@@ -18,6 +19,13 @@ public class DeprecationCheckerTests
     {
         checkerType = typeof(AITDeprecationChecker);
         Assert.IsNotNull(checkerType, "AITDeprecationChecker type should exist");
+        AITDeprecationChecker.ResetCache();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        AITDeprecationChecker.ResetCache();
     }
 
     // =====================================================
@@ -62,106 +70,260 @@ public class DeprecationCheckerTests
     // ParseLatestTag: git ls-remote 출력 파싱 검증
     // =====================================================
 
-    private MethodInfo GetParseLatestTagMethod()
-    {
-        var method = checkerType.GetMethod("ParseLatestTag",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.IsNotNull(method, "ParseLatestTag should exist as a private static method");
-        return method;
-    }
-
     [Test]
     public void ParseLatestTag_SingleTag_ReturnsCorrectTag()
     {
-        var method = GetParseLatestTagMethod();
         string input = "abc123def456\trefs/tags/release/v2.0.0\n";
-        string result = (string)method.Invoke(null, new object[] { input });
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(2, 0, 0));
         Assert.AreEqual("release/v2.0.0", result);
     }
 
     [Test]
     public void ParseLatestTag_MultipleTags_ReturnsHighestVersion()
     {
-        var method = GetParseLatestTagMethod();
         string input =
             "aaa\trefs/tags/release/v2.0.0\n" +
             "bbb\trefs/tags/release/v2.0.3\n" +
             "ccc\trefs/tags/release/v2.0.1\n" +
             "ddd\trefs/tags/release/v2.0.5\n" +
             "eee\trefs/tags/release/v2.0.2\n";
-        string result = (string)method.Invoke(null, new object[] { input });
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(2, 0, 0));
         Assert.AreEqual("release/v2.0.5", result);
     }
 
     [Test]
     public void ParseLatestTag_WithAnnotatedTagDerefs_IgnoresThem()
     {
-        var method = GetParseLatestTagMethod();
         string input =
             "aaa\trefs/tags/release/v2.0.5\n" +
             "bbb\trefs/tags/release/v2.0.5^{}\n" +
             "ccc\trefs/tags/release/v2.1.0\n" +
             "ddd\trefs/tags/release/v2.1.0^{}\n";
-        string result = (string)method.Invoke(null, new object[] { input });
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(2, 0, 0));
         Assert.AreEqual("release/v2.1.0", result);
     }
 
     [Test]
     public void ParseLatestTag_EmptyOutput_ReturnsNull()
     {
-        var method = GetParseLatestTagMethod();
-        string result = (string)method.Invoke(null, new object[] { "" });
+        string result = AITDeprecationChecker.ParseLatestTag("", new Version(2, 0, 0));
         Assert.IsNull(result);
     }
 
     [Test]
     public void ParseLatestTag_InvalidLines_ReturnsNull()
     {
-        var method = GetParseLatestTagMethod();
         string input = "not-a-valid-line\nanother-invalid\n";
-        string result = (string)method.Invoke(null, new object[] { input });
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(2, 0, 0));
         Assert.IsNull(result);
     }
 
     [Test]
     public void ParseLatestTag_MixedValidAndInvalid_ReturnsHighestValid()
     {
-        var method = GetParseLatestTagMethod();
         string input =
             "aaa\trefs/tags/release/v2.0.0\n" +
             "invalid-line\n" +
             "bbb\trefs/tags/not-a-release/v9.9.9\n" +
             "ccc\trefs/tags/release/v2.1.0\n";
-        string result = (string)method.Invoke(null, new object[] { input });
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(2, 0, 0));
         Assert.AreEqual("release/v2.1.0", result);
     }
 
     [Test]
     public void ParseLatestTag_HigherMinorAndPatch_ComparesCorrectly()
     {
-        var method = GetParseLatestTagMethod();
         string input =
             "aaa\trefs/tags/release/v2.0.9\n" +
             "bbb\trefs/tags/release/v2.1.0\n" +
             "ccc\trefs/tags/release/v2.0.10\n";
-        string result = (string)method.Invoke(null, new object[] { input });
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(2, 0, 0));
         Assert.AreEqual("release/v2.1.0", result);
     }
 
     // =====================================================
-    // DeprecationThreshold: 상수 검증
+    // ParseLatestTag: minVersion 필터링 검증
     // =====================================================
 
     [Test]
-    public void DeprecationThreshold_Is_v2_0_0()
+    public void ParseLatestTag_FiltersOutTagsBelowMinVersion()
     {
-        var field = checkerType.GetField("DeprecationThreshold",
+        string input =
+            "aaa\trefs/tags/release/v2.0.0\n" +
+            "bbb\trefs/tags/release/v2.3.0\n" +
+            "ccc\trefs/tags/release/v2.4.0\n" +
+            "ddd\trefs/tags/release/v2.4.1\n" +
+            "eee\trefs/tags/release/v2.5.0\n";
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(2, 4, 1));
+        Assert.AreEqual("release/v2.5.0", result);
+    }
+
+    [Test]
+    public void ParseLatestTag_AllTagsBelowMinVersion_ReturnsNull()
+    {
+        string input =
+            "aaa\trefs/tags/release/v2.0.0\n" +
+            "bbb\trefs/tags/release/v2.4.1\n" +
+            "ccc\trefs/tags/release/v2.5.0\n";
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(3, 0, 0));
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void ParseLatestTag_IncludesV1Tags_WhenMinVersionIsLow()
+    {
+        string input =
+            "aaa\trefs/tags/release/v1.5.0\n" +
+            "bbb\trefs/tags/release/v2.0.0\n" +
+            "ccc\trefs/tags/release/v2.4.1\n";
+        string result = AITDeprecationChecker.ParseLatestTag(input, new Version(1, 0, 0));
+        Assert.AreEqual("release/v2.4.1", result);
+    }
+
+    // =====================================================
+    // ParseMinVersionFromJson: JSON 파싱 검증
+    // =====================================================
+
+    [Test]
+    public void ParseMinVersionFromJson_ValidJson_ReturnsVersion()
+    {
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"2.4.1\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.AreEqual(new Version(2, 4, 1), result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_EmptyJson_ReturnsNull()
+    {
+        var result = AITDeprecationChecker.ParseMinVersionFromJson("");
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_NullJson_ReturnsNull()
+    {
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(null);
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_MissingMinVersion_ReturnsNull()
+    {
+        string json = "{\"schemaVersion\":1,\"otherField\":\"value\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_MalformedJson_ReturnsNull()
+    {
+        var result = AITDeprecationChecker.ParseMinVersionFromJson("not json at all");
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_InvalidVersionString_ReturnsNull()
+    {
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"not-a-version\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_TwoPartVersion_NormalizesToThreePart()
+    {
+        // "2.4"는 "2.4.0"으로 정규화되어야 합니다 (System.Version에서 2.4 < 2.4.0이므로)
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"2.4\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.AreEqual(new Version(2, 4, 0), result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_FourPartVersion_NormalizesToThreePart()
+    {
+        // 4-part 버전(예: "2.4.1.0")은 3-part(2.4.1)로 정규화됩니다.
+        // System.Version에서 2.4.1 < 2.4.1.0이므로 일관된 비교를 위해 필요합니다.
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"2.4.1.0\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.AreEqual(new Version(2, 4, 1), result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_UnreasonablyHighVersion_ReturnsNull()
+    {
+        // MaxReasonableMinVersion(10.0.0) 초과 시 거부
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"11.0.0\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.IsNull(result, "Unreasonably high minVersion should be rejected");
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_ExactMaxReasonableVersion_ReturnsVersion()
+    {
+        // MaxReasonableMinVersion(10.0.0)과 동일한 값은 허용 (> 비교이므로)
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"10.0.0\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.AreEqual(new Version(10, 0, 0), result,
+            "minVersion equal to MaxReasonableMinVersion should be allowed");
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_ReasonableHighVersion_ReturnsVersion()
+    {
+        // MaxReasonableMinVersion(10.0.0) 이하는 허용
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"9.0.0\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.AreEqual(new Version(9, 0, 0), result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_WithSchemaVersion1_ReturnsVersion()
+    {
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"2.4.1\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.AreEqual(new Version(2, 4, 1), result);
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_UnsupportedSchemaVersion_ReturnsNull()
+    {
+        string json = "{\"schemaVersion\":2,\"minVersion\":\"2.4.1\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.IsNull(result, "Unsupported schemaVersion should be rejected");
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_MissingSchemaVersion_ReturnsNull()
+    {
+        // schemaVersion이 없으면 기본값 0이므로 검증 실패
+        string json = "{\"minVersion\":\"2.4.1\"}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.IsNull(result, "Missing schemaVersion should be rejected");
+    }
+
+    [Test]
+    public void ParseMinVersionFromJson_ExtraUnknownFields_IgnoredAndReturnsVersion()
+    {
+        // JsonUtility.FromJson은 알 수 없는 필드를 무시합니다
+        string json = "{\"schemaVersion\":1,\"minVersion\":\"2.4.1\",\"newField\":\"value\",\"anotherField\":42}";
+        var result = AITDeprecationChecker.ParseMinVersionFromJson(json);
+        Assert.AreEqual(new Version(2, 4, 1), result);
+    }
+
+    // =====================================================
+    // FallbackDeprecationThreshold: 상수 검증
+    // =====================================================
+
+    [Test]
+    public void FallbackDeprecationThreshold_Is_v2_4_1()
+    {
+        var field = checkerType.GetField("FallbackDeprecationThreshold",
             BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.IsNotNull(field, "DeprecationThreshold field should exist");
+        Assert.IsNotNull(field, "FallbackDeprecationThreshold field should exist");
 
         var threshold = (Version)field.GetValue(null);
-        Assert.AreEqual(new Version(2, 0, 0), threshold,
-            "Deprecation threshold should be 2.0.0");
+        Assert.AreEqual(new Version(2, 4, 1), threshold,
+            "Fallback deprecation threshold should be 2.4.1");
     }
 
     [Test]
@@ -172,8 +334,88 @@ public class DeprecationCheckerTests
         Assert.IsNotNull(field, "FALLBACK_UPGRADE_TAG field should exist");
 
         string tag = (string)field.GetValue(null);
-        Assert.IsTrue(tag.StartsWith("release/v2."),
-            $"Fallback tag should start with 'release/v2.', got: {tag}");
+        Assert.IsTrue(tag.StartsWith("release/v"),
+            $"Fallback tag should start with 'release/v', got: {tag}");
+    }
+
+    [Test]
+    public void FallbackUpgradeTag_IsAtLeastFallbackThreshold()
+    {
+        // 불변 조건: FALLBACK_UPGRADE_TAG의 버전은 FallbackDeprecationThreshold 이상이어야 합니다.
+        // 그렇지 않으면 폴백 태그로 업그레이드해도 여전히 deprecated 상태가 됩니다.
+        var tagField = checkerType.GetField("FALLBACK_UPGRADE_TAG",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var thresholdField = checkerType.GetField("FallbackDeprecationThreshold",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        string tag = (string)tagField.GetValue(null);
+        var threshold = (Version)thresholdField.GetValue(null);
+
+        var match = Regex.Match(tag, @"release/v(\d+\.\d+\.\d+)$");
+        Assert.IsTrue(match.Success, $"FALLBACK_UPGRADE_TAG should match version pattern: {tag}");
+
+        var tagVersion = new Version(match.Groups[1].Value);
+        Assert.IsTrue(tagVersion >= threshold,
+            $"FALLBACK_UPGRADE_TAG version ({tagVersion}) must be >= FallbackDeprecationThreshold ({threshold})");
+    }
+
+    // =====================================================
+    // 동적 최소 버전: GetMinVersionCached 검증
+    // =====================================================
+
+    [Test]
+    public void GetMinVersionCached_WithTestOverride_ReturnsOverriddenVersion()
+    {
+        var testVersion = new Version(3, 0, 0);
+        AITDeprecationChecker.SetMinVersionForTesting(testVersion);
+        var result = AITDeprecationChecker.GetMinVersionCached();
+        Assert.AreEqual(testVersion, result);
+    }
+
+    [Test]
+    public void GetMinVersionCached_AfterReset_ThenSetNew_ReturnsNewValue()
+    {
+        // 캐시 리셋 후 새로운 값을 설정하면 새 값이 반환되는지 확인
+        // (네트워크 호출 없이 캐시 리셋 동작만 검증)
+        AITDeprecationChecker.SetMinVersionForTesting(new Version(9, 9, 9));
+        Assert.AreEqual(new Version(9, 9, 9), AITDeprecationChecker.GetMinVersionCached());
+
+        AITDeprecationChecker.ResetCache();
+        AITDeprecationChecker.SetMinVersionForTesting(new Version(3, 0, 0));
+        Assert.AreEqual(new Version(3, 0, 0), AITDeprecationChecker.GetMinVersionCached(),
+            "After reset + set, should return newly set version");
+    }
+
+    [Test]
+    public void SetMinVersionForTesting_AffectsIsDeprecated()
+    {
+        string currentVersion = AppsInToss.AITVersion.Version;
+        if (currentVersion == "unknown" || string.IsNullOrEmpty(currentVersion))
+        {
+            Assert.Inconclusive("SDK version is unknown — cannot verify IsDeprecated behavior");
+            return;
+        }
+
+        // Set a very high min version so current SDK is deprecated
+        AITDeprecationChecker.SetMinVersionForTesting(new Version(99, 0, 0));
+        Assert.IsTrue(AITDeprecationChecker.IsDeprecated(),
+            "SDK should be deprecated when minVersion is 99.0.0");
+    }
+
+    [Test]
+    public void SetMinVersionForTesting_LowVersion_NotDeprecated()
+    {
+        string currentVersion = AppsInToss.AITVersion.Version;
+        if (currentVersion == "unknown" || string.IsNullOrEmpty(currentVersion))
+        {
+            Assert.Inconclusive("SDK version is unknown — cannot verify IsDeprecated behavior");
+            return;
+        }
+
+        // Set a very low min version so current SDK is not deprecated
+        AITDeprecationChecker.SetMinVersionForTesting(new Version(0, 0, 1));
+        Assert.IsFalse(AITDeprecationChecker.IsDeprecated(),
+            "SDK should not be deprecated when minVersion is 0.0.1");
     }
 
     // =====================================================
@@ -181,25 +423,24 @@ public class DeprecationCheckerTests
     // =====================================================
 
     [Test]
-    public void IsDeprecated_CurrentSDK_ReturnsExpectedValue()
+    public void IsDeprecated_CurrentSDK_WithKnownMinVersion_ReturnsExpectedValue()
     {
-        // 현재 SDK 버전을 기준으로 IsDeprecated가 올바르게 동작하는지 확인
+        // 고정된 minVersion으로 설정하여 네트워크 의존성 없이 테스트
         string currentVersion = AppsInToss.AITVersion.Version;
-        bool isDeprecated = AITDeprecationChecker.IsDeprecated();
-
         if (currentVersion == "unknown" || string.IsNullOrEmpty(currentVersion))
         {
-            Assert.IsFalse(isDeprecated,
-                "IsDeprecated should return false for unknown version");
+            Assert.Inconclusive("SDK version is unknown — cannot verify IsDeprecated behavior");
+            return;
         }
-        else
-        {
-            var version = new Version(currentVersion);
-            var threshold = new Version(2, 0, 0);
-            bool expected = version < threshold;
-            Assert.AreEqual(expected, isDeprecated,
-                $"IsDeprecated should return {expected} for SDK v{currentVersion}");
-        }
+
+        var testMinVersion = new Version(2, 4, 1);
+        AITDeprecationChecker.SetMinVersionForTesting(testMinVersion);
+
+        var version = new Version(currentVersion);
+        bool expected = version < testMinVersion;
+        bool isDeprecated = AITDeprecationChecker.IsDeprecated();
+        Assert.AreEqual(expected, isDeprecated,
+            $"IsDeprecated should return {expected} for SDK v{currentVersion} (minVersion: {testMinVersion})");
     }
 
     // =====================================================
@@ -209,18 +450,19 @@ public class DeprecationCheckerTests
     [TestCase("1.0.0", true)]
     [TestCase("1.5.0", true)]
     [TestCase("1.14.1", true)]
-    [TestCase("1.99.99", true)]
-    [TestCase("2.0.0", false)]
-    [TestCase("2.0.1", false)]
-    [TestCase("2.1.0", false)]
+    [TestCase("2.0.0", true)]
+    [TestCase("2.4.0", true)]
+    [TestCase("2.4.1", false)]
+    [TestCase("2.4.2", false)]
+    [TestCase("2.5.0", false)]
     [TestCase("3.0.0", false)]
-    public void VersionComparison_MatchesExpected(string versionStr, bool expectedDeprecated)
+    public void VersionComparison_AgainstMinVersion_MatchesExpected(string versionStr, bool expectedDeprecated)
     {
         var version = new Version(versionStr);
-        var threshold = new Version(2, 0, 0);
+        var threshold = new Version(2, 4, 1);
         bool result = version < threshold;
         Assert.AreEqual(expectedDeprecated, result,
-            $"Version {versionStr} should {(expectedDeprecated ? "" : "not ")}be deprecated");
+            $"Version {versionStr} should {(expectedDeprecated ? "" : "not ")}be deprecated (minVersion: 2.4.1)");
     }
 
     // =====================================================
@@ -234,5 +476,25 @@ public class DeprecationCheckerTests
             BindingFlags.NonPublic | BindingFlags.Static);
         Assert.IsNotNull(method,
             "ShowDeprecationDialogPersistent should exist for persistent dialog behavior");
+    }
+
+    // =====================================================
+    // ResetCache / SetMinVersionForTesting: 내부 API 존재 확인
+    // =====================================================
+
+    [Test]
+    public void ResetCache_MethodExists()
+    {
+        var method = checkerType.GetMethod("ResetCache",
+            BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public);
+        Assert.IsNotNull(method, "ResetCache() should exist");
+    }
+
+    [Test]
+    public void SetMinVersionForTesting_MethodExists()
+    {
+        var method = checkerType.GetMethod("SetMinVersionForTesting",
+            BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public);
+        Assert.IsNotNull(method, "SetMinVersionForTesting() should exist");
     }
 }

--- a/sdk-policy.json
+++ b/sdk-policy.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "minVersion": "2.4.1"
+}

--- a/sdk-policy.json.meta
+++ b/sdk-policy.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a7e3b1c4d5f64890b2c1e3a7f9d08b56
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- `sdk-policy.json` 파일을 repo 루트에 추가하여 SDK 최소 버전 정책을 중앙에서 관리
- `AITDeprecationChecker`에서 GitHub raw content URL로 최소 버전을 동적으로 fetch (10초 timeout, 세션 1회 캐싱)
- Bulk Release 워크플로우가 `sdk-policy.json`의 minVersion을 기본값으로 사용

## Background
앱인토스 플랫폼이 SDK 2.4.1 미만 앱의 등록을 거부하고 있으나, 최소 버전이 하드코딩되어 있어 정책 변경 시마다 SDK 릴리즈가 필요한 닭과 달걀 문제가 존재했습니다.

## Changes
- **sdk-policy.json**: `schemaVersion: 1`, `minVersion: "2.4.1"`
- **AITDeprecationChecker.cs**: TimeoutWebClient 동적 fetch, delayCall 캐시 프라이밍, schemaVersion 검증, MaxReasonableMinVersion(10.0.0) 상한, 2/4-part→3-part 정규화, fetch 실패 시 폴백(2.4.1)
- **bulk-release.yml**: sdk-policy.json에서 minVersion 동적 읽기, min_version job output 추가
- **DeprecationCheckerTests.cs**: ParseMinVersionFromJson, 태그 파싱, FALLBACK_UPGRADE_TAG 불변 조건 등 테스트 추가

## Test plan
- [ ] EditMode 테스트 통과 확인 (Level 0)
- [ ] sdk-policy.json이 raw.githubusercontent.com에서 접근 가능한지 merge 후 확인
- [ ] Bulk Release 워크플로우에서 min_version이 sdk-policy.json에서 읽히는지 확인