### PR TITLE
개선: Build 폴더 미복사 파일 경고 로그 레벨 조정

### DIFF
--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -1253,7 +1253,7 @@ namespace AppsInToss.Editor
 
             Debug.Log($"[AIT] ✓ Build 파일 {filesToCopy.Count}개 선별 복사 완료 ({totalBytes / 1024.0 / 1024.0:0.#}MB)");
 
-            // 안전장치: Build/ 폴더에 인식되지 않은 파일이 있으면 경고
+            // 안전장치: Build/ 폴더에 인식되지 않은 파일이 있으면 로그 출력
             var allBuildFiles = Directory.GetFiles(buildSrc);
             var copiedFileNames = new HashSet<string>(filesToCopy);
             foreach (var file in allBuildFiles)
@@ -1261,7 +1261,7 @@ namespace AppsInToss.Editor
                 string name = Path.GetFileName(file);
                 if (!copiedFileNames.Contains(name))
                 {
-                    Debug.LogWarning($"[AIT] ⚠️ Build 폴더에 복사되지 않은 파일: {name}");
+                    Debug.Log($"[AIT] Build 폴더에 복사되지 않은 파일: {name}");
                 }
             }
 

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:33:36Z
+// Updated at: 2026-04-16T04:28:38Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0433";
-        public const string CommitHash = "282f581";
+        public const string ReleaseDateTime = "20260416_0428";
+        public const string CommitHash = "dc8736c";
     }
 }


### PR DESCRIPTION
## Summary
- `Debug.LogWarning` → `Debug.Log`로 변경하여 ErrorTracker(Sentry)가 정보성 메시지를 캡처하지 않도록 수정
- Build 폴더에 복사되지 않은 파일 메시지는 빌드에 영향이 없는 정보성 로그이므로 Warning이 아닌 Log 레벨이 적절

## Changes
- `Editor/AITPackageBuilder.cs`: `Debug.LogWarning` → `Debug.Log`, 경고 이모지 제거, 주석 업데이트
- `Runtime/Helpers/AITVersionConstants.cs`: pre-commit hook에 의한 자동 갱신 (정상)

## Test plan
- [ ] ErrorTracker(`AITEditorErrorTracker.cs:209`)가 `LogType.Warning`만 캡처하므로, `Debug.Log`로 변경 시 Sentry에 전송되지 않음을 확인
- [ ] Unity Console에서 해당 메시지가 여전히 Info 레벨로 출력되는지 확인

Resolves: SDK-5R