### PR TITLE
개선: 빌드 파이프라인 예외 로그에 스택트레이스 포함 (SDK-5V)

### DIFF
--- a/Editor/AITAsyncCommandRunner.cs
+++ b/Editor/AITAsyncCommandRunner.cs
@@ -116,7 +116,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT Async] 프로세스 종료 실패: {e.Message}");
+                Debug.LogWarning($"[AIT Async] 프로세스 종료 실패: {e}");
             }
         }
 
@@ -314,7 +314,7 @@ namespace AppsInToss.Editor
 
                 EnqueueMainThread(() =>
                 {
-                    Debug.LogError($"[AIT Async] 명령 실행 예외: {e.Message}");
+                    Debug.LogError($"[AIT Async] 명령 실행 예외: {e}");
                     task.OnComplete?.Invoke(result);
                 });
             }

--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -69,7 +69,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] SDK 자동 업데이트 체크 중 예외 발생 (무시됨): {e.Message}");
+                Debug.LogWarning($"[AIT] SDK 자동 업데이트 체크 중 예외 발생 (무시됨): {e}");
             }
         }
 
@@ -185,7 +185,7 @@ namespace AppsInToss.Editor
                         catch (Exception e)
                         {
                             Debug.LogWarning(
-                                $"[AIT] SDK 업데이트 적용 중 예외 발생 (무시됨): {e.Message}"
+                                $"[AIT] SDK 업데이트 적용 중 예외 발생 (무시됨): {e}"
                             );
                         }
                     };
@@ -195,7 +195,7 @@ namespace AppsInToss.Editor
                     EditorApplication.delayCall += () =>
                     {
                         Debug.LogWarning(
-                            $"[AIT] SDK 원격 버전 확인 실패 (무시됨): {e.Message}"
+                            $"[AIT] SDK 원격 버전 확인 실패 (무시됨): {e}"
                         );
                     };
                 }
@@ -528,7 +528,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] SDK 자동 업데이트 체크 중 예외 발생: {e.Message}");
+                Debug.LogWarning($"[AIT] SDK 자동 업데이트 체크 중 예외 발생: {e}");
             }
         }
 

--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -398,7 +398,7 @@ namespace AppsInToss.Editor
             }
             catch (System.Exception e)
             {
-                Debug.LogWarning($"[AIT] 캐시 통계 출력 실패: {e.Message}");
+                Debug.LogWarning($"[AIT] 캐시 통계 출력 실패: {e}");
             }
         }
     }

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -277,7 +277,7 @@ namespace AppsInToss
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] 빌드 마커 읽기 실패: {e.Message}");
+                Debug.LogWarning($"[AIT] 빌드 마커 읽기 실패: {e}");
                 return null;
             }
         }
@@ -458,7 +458,7 @@ namespace AppsInToss
             }
             catch (Exception e)
             {
-                Debug.LogError($"변환 중 오류가 발생했습니다: {e.Message}");
+                Debug.LogError($"변환 중 오류가 발생했습니다: {e}");
                 transaction?.Finish("internal_error");
                 return AITExportError.BUILD_WEBGL_FAILED;
             }
@@ -630,7 +630,7 @@ namespace AppsInToss
             }
             catch (Exception e)
             {
-                Debug.LogError($"[AIT] 변환 중 오류가 발생했습니다: {e.Message}");
+                Debug.LogError($"[AIT] 변환 중 오류가 발생했습니다: {e}");
                 settingsBackup.Restore();
                 onComplete?.Invoke(AITExportError.BUILD_WEBGL_FAILED);
             }
@@ -907,7 +907,7 @@ namespace AppsInToss
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] 빌드 마커 생성 실패 (무시됨): {e.Message}");
+                Debug.LogWarning($"[AIT] 빌드 마커 생성 실패 (무시됨): {e}");
             }
 
             return AITExportError.SUCCEED;

--- a/Editor/AITDeprecationChecker.cs
+++ b/Editor/AITDeprecationChecker.cs
@@ -88,7 +88,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] 최소 버전 조회 실패, 폴백 사용: {e.Message}");
+                Debug.LogWarning($"[AIT] 최소 버전 조회 실패, 폴백 사용: {e}");
                 _cachedMinVersion = FallbackDeprecationThreshold;
             }
 
@@ -124,7 +124,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] sdk-policy.json fetch 실패: {e.Message}");
+                Debug.LogWarning($"[AIT] sdk-policy.json fetch 실패: {e}");
                 return null;
             }
 
@@ -184,7 +184,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] minVersion 파싱 실패: {policy.minVersion} — {e.Message}");
+                Debug.LogWarning($"[AIT] minVersion 파싱 실패: {policy.minVersion} — {e}");
                 return null;
             }
         }
@@ -400,7 +400,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] 최신 태그 조회 실패: {e.Message}");
+                Debug.LogWarning($"[AIT] 최신 태그 조회 실패: {e}");
                 return null;
             }
         }

--- a/Editor/AITNodeJSDownloader.cs
+++ b/Editor/AITNodeJSDownloader.cs
@@ -159,7 +159,7 @@ namespace AppsInToss.Editor
                         }
                         catch (Exception e)
                         {
-                            Debug.LogWarning($"[NodeJS] 다운로드 실패 ({url}): {e.Message}");
+                            Debug.LogWarning($"[NodeJS] 다운로드 실패 ({url}): {e}");
                             lastException = e;
 
                             // 다운로드 실패 시 임시 파일 삭제
@@ -227,7 +227,7 @@ namespace AppsInToss.Editor
                         }
                         catch (Exception e)
                         {
-                            Debug.LogWarning($"[NodeJS] 대체 미러 다운로드 실패: {e.Message}");
+                            Debug.LogWarning($"[NodeJS] 대체 미러 다운로드 실패: {e}");
                             if (File.Exists(tempFile)) File.Delete(tempFile);
                         }
                     }
@@ -312,7 +312,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogError($"[NodeJS] 다운로드 실패: {e.Message}");
+                Debug.LogError($"[NodeJS] 다운로드 실패: {e}");
 
                 // CI/배치 모드에서는 다이얼로그 스킵
                 AITPlatformHelper.ShowInfoDialog("다운로드 실패",
@@ -547,7 +547,7 @@ namespace AppsInToss.Editor
                     }
                     catch (Exception e)
                     {
-                        Debug.LogWarning($"[NodeJS] 임시 폴더 삭제 실패 (무시됨): {e.Message}");
+                        Debug.LogWarning($"[NodeJS] 임시 폴더 삭제 실패 (무시됨): {e}");
                     }
                 }
             }
@@ -578,7 +578,7 @@ namespace AppsInToss.Editor
             }
             catch (IOException ex)
             {
-                Debug.LogWarning($"[NodeJS] 드라이브 루트 접근 실패 ({ex.Message}), 표준 임시 디렉토리로 폴백");
+                Debug.LogWarning($"[NodeJS] 드라이브 루트 접근 실패 ({ex}), 표준 임시 디렉토리로 폴백");
             }
 
             // 2순위: 표준 임시 디렉토리 사용 (권한 보장)
@@ -636,7 +636,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[NodeJS] pnpm 설치 중 예외 발생: {e.Message}");
+                Debug.LogWarning($"[NodeJS] pnpm 설치 중 예외 발생: {e}");
                 return false;
             }
         }

--- a/Editor/AITNpmRunner.cs
+++ b/Editor/AITNpmRunner.cs
@@ -115,7 +115,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"[AIT] pnpm 버전 확인 실패: {ex.Message}");
+                Debug.LogWarning($"[AIT] pnpm 버전 확인 실패: {ex}");
             }
             return null;
         }
@@ -339,7 +339,7 @@ namespace AppsInToss.Editor
             catch (Exception e)
             {
                 EditorUtility.ClearProgressBar();
-                Debug.LogError($"[{pmName}] 명령 실행 오류: {e.Message}");
+                Debug.LogError($"[{pmName}] 명령 실행 오류: {e}");
                 return AITConvertCore.AITExportError.NODE_NOT_FOUND;
             }
         }

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -255,7 +255,7 @@ namespace AppsInToss.Editor
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"[AIT] [병렬] 백그라운드 pnpm install 예외: {e.Message}");
+                    Debug.LogError($"[AIT] [병렬] 백그라운드 pnpm install 예외: {e}");
                     earlyCtx.PnpmInstallResult = AITConvertCore.AITExportError.FAIL_NPM_BUILD;
                 }
             });
@@ -356,7 +356,7 @@ namespace AppsInToss.Editor
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"[AIT] [병렬] pnpm {label} 실행 오류: {e.Message}");
+                    Debug.LogError($"[AIT] [병렬] pnpm {label} 실행 오류: {e}");
                 }
 
                 Debug.LogWarning($"[AIT] [병렬] pnpm install ({label}) 실패, 다음 단계로...");
@@ -662,7 +662,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] package.json 머지 실패: {e.Message}, SDK 버전 사용");
+                Debug.LogWarning($"[AIT] package.json 머지 실패: {e}, SDK 버전 사용");
                 File.Copy(sdkFile, destFile, true);
             }
         }
@@ -790,7 +790,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] tsconfig.json 머지 실패: {e.Message}, SDK 버전 사용");
+                Debug.LogWarning($"[AIT] tsconfig.json 머지 실패: {e}, SDK 버전 사용");
                 File.Copy(sdkFile, destFile, true);
             }
         }
@@ -1811,7 +1811,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] node_modules 무결성 검증 중 오류 (무시됨): {e.Message}");
+                Debug.LogWarning($"[AIT] node_modules 무결성 검증 중 오류 (무시됨): {e}");
                 return true; // 검증 실패 시 기존 동작 유지
             }
         }
@@ -1835,7 +1835,7 @@ namespace AppsInToss.Editor
                 }
                 catch (Exception e)
                 {
-                    Debug.LogWarning($"[AIT] node_modules 삭제 실패: {e.Message}");
+                    Debug.LogWarning($"[AIT] node_modules 삭제 실패: {e}");
                 }
             }
 
@@ -1850,7 +1850,7 @@ namespace AppsInToss.Editor
                 }
                 catch (Exception e)
                 {
-                    Debug.LogWarning($"[AIT] .npm-cache 삭제 실패: {e.Message}");
+                    Debug.LogWarning($"[AIT] .npm-cache 삭제 실패: {e}");
                 }
             }
         }
@@ -1909,7 +1909,7 @@ namespace AppsInToss.Editor
                     }
                     catch (Exception e)
                     {
-                        Debug.LogWarning($"[AIT] 삭제 실패: {itemName} - {e.Message}");
+                        Debug.LogWarning($"[AIT] 삭제 실패: {itemName} - {e}");
                     }
                 }
             }

--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -104,7 +104,7 @@ namespace AppsInToss.Editor
                 catch (Exception e)
                 {
                     // 초기화 실패해도 Unity는 정상 작동해야 함
-                    Debug.LogWarning($"[AIT] SDK 초기화 중 예외 발생 (무시됨): {e.Message}");
+                    Debug.LogWarning($"[AIT] SDK 초기화 중 예외 발생 (무시됨): {e}");
                 }
             };
         }
@@ -263,7 +263,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogError($"[AIT] 패키지 매니저 체크 중 예외 발생: {e.Message}");
+                Debug.LogError($"[AIT] 패키지 매니저 체크 중 예외 발생: {e}");
             }
             finally
             {
@@ -453,7 +453,7 @@ namespace AppsInToss.Editor
             catch (Exception e)
             {
                 MarkInstallationCompleted();
-                Debug.LogWarning($"[AIT] pnpm 글로벌 설치 중 예외 발생: {e.Message}");
+                Debug.LogWarning($"[AIT] pnpm 글로벌 설치 중 예외 발생: {e}");
             }
         }
     }

--- a/Editor/AITPackageManagerHelper.cs
+++ b/Editor/AITPackageManagerHelper.cs
@@ -334,7 +334,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                if (verbose) Debug.LogError($"[Package Manager] 명령 실행 중 예외 발생: {e.Message}");
+                if (verbose) Debug.LogError($"[Package Manager] 명령 실행 중 예외 발생: {e}");
                 return false;
             }
         }
@@ -455,7 +455,7 @@ namespace AppsInToss.Editor
                 {
                     EditorUtility.ClearProgressBar();
                 }
-                if (verbose) Debug.LogError($"[Package Manager] 명령 실행 중 예외 발생: {e.Message}");
+                if (verbose) Debug.LogError($"[Package Manager] 명령 실행 중 예외 발생: {e}");
                 return false;
             }
         }

--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -432,7 +432,7 @@ namespace AppsInToss.Editor
 
                 if (verbose)
                 {
-                    Debug.LogError($"[Platform] 명령 실행 예외: {e.Message}");
+                    Debug.LogError($"[Platform] 명령 실행 예외: {e}");
                 }
             }
 
@@ -590,7 +590,7 @@ namespace AppsInToss.Editor
             {
                 if (verbose)
                 {
-                    Debug.LogWarning($"[Platform] 시스템 검색 실패: {e.Message}");
+                    Debug.LogWarning($"[Platform] 시스템 검색 실패: {e}");
                 }
             }
 
@@ -639,7 +639,7 @@ namespace AppsInToss.Editor
             {
                 if (verbose)
                 {
-                    Debug.LogWarning($"[Platform] 실행 권한 부여 실패: {e.Message}");
+                    Debug.LogWarning($"[Platform] 실행 권한 부여 실패: {e}");
                 }
             }
         }

--- a/Editor/AITProcessTreeManager.cs
+++ b/Editor/AITProcessTreeManager.cs
@@ -225,7 +225,7 @@ namespace AppsInToss.Editor
                 }
                 catch (Exception ex)
                 {
-                    Debug.LogWarning($"[AITProcessTreeManager] Job Object 종료 실패: {ex.Message}");
+                    Debug.LogWarning($"[AITProcessTreeManager] Job Object 종료 실패: {ex}");
                 }
             }
 
@@ -292,7 +292,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"[AITProcessTreeManager] 자식 프로세스 종료 실패: {ex.Message}");
+                Debug.LogWarning($"[AITProcessTreeManager] 자식 프로세스 종료 실패: {ex}");
             }
 
             // 부모 프로세스도 종료

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -426,7 +426,7 @@ namespace AppsInToss
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"AIT: webgl/ 폴더 삭제 실패: {e.Message}");
+                    Debug.LogError($"AIT: webgl/ 폴더 삭제 실패: {e}");
                 }
             }
 
@@ -440,7 +440,7 @@ namespace AppsInToss
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"AIT: ait-build/ 폴더 삭제 실패: {e.Message}");
+                    Debug.LogError($"AIT: ait-build/ 폴더 삭제 실패: {e}");
                 }
             }
 
@@ -522,7 +522,7 @@ namespace AppsInToss
             }
             catch (Exception e)
             {
-                Debug.LogError($"[AIT] 로딩 화면 초기화 실패: {e.Message}");
+                Debug.LogError($"[AIT] 로딩 화면 초기화 실패: {e}");
                 AITPlatformHelper.ShowInfoDialog("오류", $"로딩 화면 초기화 실패: {e.Message}", "확인");
             }
         }
@@ -795,7 +795,7 @@ namespace AppsInToss
             }
             catch (Exception e)
             {
-                Debug.LogError($"AIT: 배포 오류: {e.Message}");
+                Debug.LogError($"AIT: 배포 오류: {e}");
                 AITPlatformHelper.ShowInfoDialog("오류", $"배포 오류:\n{e.Message}", "확인");
             }
         }
@@ -1020,7 +1020,7 @@ namespace AppsInToss
             }
             catch (Exception e)
             {
-                Debug.LogError($"AIT: {label} 서버 시작 실패: {e.Message}");
+                Debug.LogError($"AIT: {label} 서버 시작 실패: {e}");
                 AITPlatformHelper.ShowInfoDialog("오류", $"{label} 서버 시작 실패:\n{e.Message}", "확인");
                 stateManager.OnServerFailed();
             }

--- a/Editor/ErrorTracker/AITSentryTransport.cs
+++ b/Editor/ErrorTracker/AITSentryTransport.cs
@@ -188,7 +188,7 @@ namespace AppsInToss.Editor.ErrorTracker
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AITSentryTransport] 동기 전송 실패: {e.Message}");
+                Debug.LogWarning($"[AITSentryTransport] 동기 전송 실패: {e}");
                 request.Dispose();
             }
         }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-15T16:10:50Z
+// Updated at: 2026-04-15T18:24:24Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_1610";
-        public const string CommitHash = "d8ac5e0";
+        public const string ReleaseDateTime = "20260415_1824";
+        public const string CommitHash = "dc8736c";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:33:06Z
+// Updated at: 2026-04-16T04:33:36Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
         public const string ReleaseDateTime = "20260416_0433";
-        public const string CommitHash = "fa23cbc";
+        public const string CommitHash = "282f581";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-15T18:24:24Z
+// Updated at: 2026-04-16T04:33:06Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260415_1824";
-        public const string CommitHash = "dc8736c";
+        public const string ReleaseDateTime = "20260416_0433";
+        public const string CommitHash = "fa23cbc";
     }
 }


### PR DESCRIPTION
## Summary
- 빌드 파이프라인의 모든 `catch` 블록에서 `e.Message` → `e` (`Exception.ToString()`)로 변경
- 예외 발생 시 타입, 메시지, **스택트레이스**가 모두 로그에 포함되도록 개선
- 사용자 다이얼로그(`ShowInfoDialog`)와 프로그래밍적 반환값(`result.Error`, `result.message`)에는 `e.Message` 유지

## Context
- **SDK-5V**: WebGL 빌드 시 `FileNotFoundException: Could not find file '.../webgl/Info.plist'` 발생
- 스택트레이스가 누락되어 정확한 발생 위치를 파악할 수 없었음
- SDK 코드에 Info.plist를 직접 참조하는 코드는 없음 (Unity 6000.3 또는 외부 플러그인 추정)

## Changes
14개 Editor 파일의 `Debug.Log*` 호출에서 `e.Message` → `e` 변경:

| 파일 | 변경 수 |
|------|--------|
| AITConvertCore.cs | 4 |
| AITPackageBuilder.cs | 8 |
| AITNpmRunner.cs | 2 |
| AITAsyncCommandRunner.cs | 2 |
| AITPackageInitializer.cs | 3 |
| AITNodeJSDownloader.cs | 6 |
| AppsInTossMenu.cs | 5 |
| AITPlatformHelper.cs | 3 |
| AITAutoUpdater.cs | 4 |
| AITProcessTreeManager.cs | 2 |
| AITPackageManagerHelper.cs | 2 |
| AITBuildValidator.cs | 1 |
| AITDeprecationChecker.cs | 4 |
| AITSentryTransport.cs | 1 |

## 변경 전략
| 사용처 | 패턴 | 이유 |
|--------|------|------|
| `Debug.Log*` | `{e}` | 스택트레이스 포함 (디버깅용) |
| `ShowInfoDialog` | `{e.Message}` | 사용자 UX (다이얼로그에 스택트레이스 불필요) |
| `result.Error`, `result.message` | `{e.Message}` | 프로그래밍적 필드 |

## Test plan
- [ ] 기존 EditMode 테스트 통과 확인 (CI Validate)
- [ ] 빌드 파이프라인 동작에 영향 없음 확인 (로그 포맷만 변경)