### PR TITLE
수정: ParseMinVersionFromJson malformed JSON 예외 처리

### DIFF
--- a/Editor/AITDeprecationChecker.cs
+++ b/Editor/AITDeprecationChecker.cs
@@ -143,9 +143,17 @@ namespace AppsInToss.Editor
                 return null;
             }
 
-            // JsonUtility.FromJson은 malformed JSON에서 null이 아닌 기본값 객체를 반환합니다.
-            // policy == null 체크는 방어적 코딩이며, 실제로는 schemaVersion=0, minVersion=null이 됩니다.
-            var policy = JsonUtility.FromJson<SdkPolicy>(json);
+            SdkPolicy policy;
+            try
+            {
+                policy = JsonUtility.FromJson<SdkPolicy>(json);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] sdk-policy.json 파싱 실패: {e}");
+                return null;
+            }
+
             if (policy == null || string.IsNullOrEmpty(policy.minVersion))
             {
                 Debug.LogWarning("[AIT] sdk-policy.json 파싱 실패: minVersion이 없습니다");

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:28:38Z
+// Updated at: 2026-04-16T04:49:25Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0428";
-        public const string CommitHash = "dc8736c";
+        public const string ReleaseDateTime = "20260416_0449";
+        public const string CommitHash = "ea52642";
     }
 }


### PR DESCRIPTION
## Summary
- `ParseMinVersionFromJson`에서 `JsonUtility.FromJson`이 완전히 invalid한 JSON에 대해 `ArgumentException`을 throw하는 케이스를 처리
- 기존 주석은 "기본값 객체를 반환"한다고 했으나, 실제로는 예외 발생

## Context
- EditMode 테스트 `ParseMinVersionFromJson_MalformedJson_ReturnsNull`이 모든 Unity 버전에서 실패
- main 브랜치(dc8736c)에서도 동일하게 실패하던 기존 버그
- #409 merge 후 target branch CI에서 발견

## Changes
- `JsonUtility.FromJson<SdkPolicy>(json)` 호출을 try-catch로 감싸서 `ArgumentException` 처리
- 예외 발생 시 `Debug.LogWarning`으로 로그 출력 후 `null` 반환

## Test plan
- [ ] `ParseMinVersionFromJson_MalformedJson_ReturnsNull` 테스트 통과 확인
- [ ] 나머지 195개 EditMode 테스트 regression 없음 확인