### PR TITLE
개선: ParseMinVersionFromJson 예외 처리 범위 축소 (ArgumentException)

### DIFF
--- a/Editor/AITDeprecationChecker.cs
+++ b/Editor/AITDeprecationChecker.cs
@@ -143,14 +143,15 @@ namespace AppsInToss.Editor
                 return null;
             }
 
+            // JsonUtility.FromJson은 malformed JSON에서 ArgumentException을 throw할 수 있습니다.
             SdkPolicy policy;
             try
             {
                 policy = JsonUtility.FromJson<SdkPolicy>(json);
             }
-            catch (Exception e)
+            catch (ArgumentException e)
             {
-                Debug.LogWarning($"[AIT] sdk-policy.json 파싱 실패: {e}");
+                Debug.LogWarning($"[AIT] sdk-policy.json 파싱 실패: {e.Message}");
                 return null;
             }
 


### PR DESCRIPTION
## Summary
- `ParseMinVersionFromJson`의 `JsonUtility.FromJson` catch 범위를 `Exception`에서 `ArgumentException`으로 축소
- 로그 메시지를 `{e}` (full stack trace) 대신 `{e.Message}`로 변경하여 간결하게 개선
- `JsonUtility.FromJson`이 malformed JSON에서 `ArgumentException`을 throw한다는 코멘트 추가

## Context
#411 에서 malformed JSON 예외 처리를 위한 try-catch가 추가되었으나, catch 범위가 `Exception`으로 넓어 예상치 못한 오류까지 무시할 수 있었습니다. 이 PR은 해당 catch를 `ArgumentException`으로 좁혀 더 정확한 예외 처리를 합니다.

## Test plan
- [ ] 기존 EditMode 테스트 `ParseMinVersionFromJson_MalformedJson_ReturnsNull` 통과 확인
- [ ] Validate CI 통과 확인