### PR TITLE
수정: FindForAssetPath 실패 시 FindForAssembly 폴백 추가

### DIFF
--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -94,9 +94,7 @@ namespace AppsInToss.Editor
         private static void CheckForUpdate(bool isManualCheck = false)
         {
             // 1. 현재 패키지 정보 수집
-            var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
-                "Packages/im.toss.apps-in-toss-unity-sdk"
-            );
+            var packageInfo = AITPackagePathResolver.FindSDKPackageInfo();
 
             if (packageInfo == null)
             {

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -1074,19 +1074,8 @@ namespace AppsInToss.Editor
             }
 
             // 경로 검색
-            string resolvedPath = AITPackagePathResolver.GetSDKResolvedPath();
-            string[] possiblePaths = resolvedPath != null
-                ? new string[]
-                {
-                    Path.Combine(resolvedPath, "WebGLTemplates/AITTemplate/BuildConfig~"),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/BuildConfig~")
-                }
-                : new string[]
-                {
-                    Path.GetFullPath("Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/BuildConfig~"),
-                    Path.GetFullPath("Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/BuildConfig~"),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/BuildConfig~")
-                };
+            string[] possiblePaths = AITPackagePathResolver.GetCandidatePaths(
+                "WebGLTemplates/AITTemplate/BuildConfig~", typeof(AITConvertCore));
 
             foreach (string path in possiblePaths)
             {
@@ -1113,19 +1102,8 @@ namespace AppsInToss.Editor
                 return _cachedSdkRuntimePath;
             }
 
-            string sdkPath = AITPackagePathResolver.GetSDKResolvedPath();
-            string[] possiblePaths = sdkPath != null
-                ? new string[]
-                {
-                    Path.Combine(sdkPath, "WebGLTemplates/AITTemplate/Runtime"),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/Runtime")
-                }
-                : new string[]
-                {
-                    Path.Combine(Directory.GetParent(Application.dataPath).FullName, "Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/Runtime"),
-                    Path.Combine(Directory.GetParent(Application.dataPath).FullName, "Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/Runtime"),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/Runtime")
-                };
+            string[] possiblePaths = AITPackagePathResolver.GetCandidatePaths(
+                "WebGLTemplates/AITTemplate/Runtime", typeof(AITConvertCore));
 
             foreach (string path in possiblePaths)
             {

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -1074,17 +1074,12 @@ namespace AppsInToss.Editor
             }
 
             // 경로 검색
-            string[] possiblePaths = AITPackagePathResolver.GetCandidatePaths(
-                "WebGLTemplates/AITTemplate/BuildConfig~", typeof(AITConvertCore));
-
-            foreach (string path in possiblePaths)
+            if (AITPackagePathResolver.TryResolveDirectory(
+                "WebGLTemplates/AITTemplate/BuildConfig~", out string found, typeof(AITConvertCore)))
             {
-                if (Directory.Exists(path))
-                {
-                    _cachedSdkBuildConfigPath = path;
-                    Debug.Log($"[AIT] SDK BuildConfig 경로 캐싱: {path}");
-                    return path;
-                }
+                _cachedSdkBuildConfigPath = found;
+                Debug.Log($"[AIT] SDK BuildConfig 경로 캐싱: {found}");
+                return found;
             }
 
             return null;
@@ -1102,18 +1097,14 @@ namespace AppsInToss.Editor
                 return _cachedSdkRuntimePath;
             }
 
-            string[] possiblePaths = AITPackagePathResolver.GetCandidatePaths(
-                "WebGLTemplates/AITTemplate/Runtime", typeof(AITConvertCore));
-
-            foreach (string path in possiblePaths)
+            if (AITPackagePathResolver.TryResolveDirectory(
+                "WebGLTemplates/AITTemplate/Runtime", out string found, typeof(AITConvertCore)))
             {
-                if (Directory.Exists(path))
-                {
-                    _cachedSdkRuntimePath = path;
-                    Debug.Log($"[AIT] SDK Runtime 경로 캐싱: {path}");
-                    return path;
-                }
+                _cachedSdkRuntimePath = found;
+                Debug.Log($"[AIT] SDK Runtime 경로 캐싱: {found}");
+                return found;
             }
+
             return null;
         }
 

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -1074,12 +1074,19 @@ namespace AppsInToss.Editor
             }
 
             // 경로 검색
-            string[] possiblePaths = new string[]
-            {
-                Path.GetFullPath("Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/BuildConfig~"),
-                Path.GetFullPath("Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/BuildConfig~"),
-                Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/BuildConfig~")
-            };
+            string resolvedPath = AITPackagePathResolver.GetSDKResolvedPath();
+            string[] possiblePaths = resolvedPath != null
+                ? new string[]
+                {
+                    Path.Combine(resolvedPath, "WebGLTemplates/AITTemplate/BuildConfig~"),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/BuildConfig~")
+                }
+                : new string[]
+                {
+                    Path.GetFullPath("Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/BuildConfig~"),
+                    Path.GetFullPath("Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/BuildConfig~"),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/BuildConfig~")
+                };
 
             foreach (string path in possiblePaths)
             {
@@ -1106,13 +1113,19 @@ namespace AppsInToss.Editor
                 return _cachedSdkRuntimePath;
             }
 
-            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
-            string[] possiblePaths = new string[]
-            {
-                Path.Combine(projectRoot, "Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/Runtime"),
-                Path.Combine(projectRoot, "Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/Runtime"),
-                Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/Runtime")
-            };
+            string sdkPath = AITPackagePathResolver.GetSDKResolvedPath();
+            string[] possiblePaths = sdkPath != null
+                ? new string[]
+                {
+                    Path.Combine(sdkPath, "WebGLTemplates/AITTemplate/Runtime"),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/Runtime")
+                }
+                : new string[]
+                {
+                    Path.Combine(Directory.GetParent(Application.dataPath).FullName, "Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/Runtime"),
+                    Path.Combine(Directory.GetParent(Application.dataPath).FullName, "Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/Runtime"),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates/AITTemplate/Runtime")
+                };
 
             foreach (string path in possiblePaths)
             {

--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -116,12 +116,19 @@ namespace AppsInToss.Editor
         /// <returns>존재하는 템플릿 경로, 또는 찾지 못한 경우 null</returns>
         public static string GetSDKLoadingTemplatePath()
         {
-            string[] sdkLoadingPaths = new string[]
-            {
-                Path.GetFullPath("Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/loading.html"),
-                Path.GetFullPath("Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/loading.html"),
-                Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITPackageInitializer).Assembly.Location)), "WebGLTemplates/AITTemplate/loading.html")
-            };
+            string resolvedPath = AITPackagePathResolver.GetSDKResolvedPath();
+            string[] sdkLoadingPaths = resolvedPath != null
+                ? new string[]
+                {
+                    Path.Combine(resolvedPath, "WebGLTemplates/AITTemplate/loading.html"),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITPackageInitializer).Assembly.Location)), "WebGLTemplates/AITTemplate/loading.html")
+                }
+                : new string[]
+                {
+                    Path.GetFullPath("Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/loading.html"),
+                    Path.GetFullPath("Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/loading.html"),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITPackageInitializer).Assembly.Location)), "WebGLTemplates/AITTemplate/loading.html")
+                };
 
             foreach (string sdkPath in sdkLoadingPaths)
             {

--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -116,18 +116,10 @@ namespace AppsInToss.Editor
         /// <returns>존재하는 템플릿 경로, 또는 찾지 못한 경우 null</returns>
         public static string GetSDKLoadingTemplatePath()
         {
-            string[] sdkLoadingPaths = AITPackagePathResolver.GetCandidatePaths(
-                "WebGLTemplates/AITTemplate/loading.html", typeof(AITPackageInitializer));
-
-            foreach (string sdkPath in sdkLoadingPaths)
-            {
-                if (File.Exists(sdkPath))
-                {
-                    return sdkPath;
-                }
-            }
-
-            return null;
+            return AITPackagePathResolver.TryResolveFile(
+                "WebGLTemplates/AITTemplate/loading.html", out string path, typeof(AITPackageInitializer))
+                ? path
+                : null;
         }
 
         /// <summary>

--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -116,19 +116,8 @@ namespace AppsInToss.Editor
         /// <returns>존재하는 템플릿 경로, 또는 찾지 못한 경우 null</returns>
         public static string GetSDKLoadingTemplatePath()
         {
-            string resolvedPath = AITPackagePathResolver.GetSDKResolvedPath();
-            string[] sdkLoadingPaths = resolvedPath != null
-                ? new string[]
-                {
-                    Path.Combine(resolvedPath, "WebGLTemplates/AITTemplate/loading.html"),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITPackageInitializer).Assembly.Location)), "WebGLTemplates/AITTemplate/loading.html")
-                }
-                : new string[]
-                {
-                    Path.GetFullPath("Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/loading.html"),
-                    Path.GetFullPath("Packages/com.appsintoss.miniapp/WebGLTemplates/AITTemplate/loading.html"),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITPackageInitializer).Assembly.Location)), "WebGLTemplates/AITTemplate/loading.html")
-                };
+            string[] sdkLoadingPaths = AITPackagePathResolver.GetCandidatePaths(
+                "WebGLTemplates/AITTemplate/loading.html", typeof(AITPackageInitializer));
 
             foreach (string sdkPath in sdkLoadingPaths)
             {

--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -372,26 +372,18 @@ namespace AppsInToss.Editor
         /// </summary>
         private static string FindPackageJsonTemplate()
         {
-            // SDK 패키지 경로 찾기
-            var packageInfo = AITPackagePathResolver.FindSDKPackageInfo();
-            string packagePath;
-
-            if (packageInfo != null)
+            // SDK 패키지 경로 기반 탐색 (resolver + Assembly.Location 폴백 포함)
+            const string relativePath = "WebGLTemplates/AITTemplate/BuildConfig~/package.json";
+            if (AITPackagePathResolver.TryResolveFile(relativePath, out string found, typeof(AITPackageInitializer)))
             {
-                packagePath = packageInfo.resolvedPath;
-            }
-            else
-            {
-                // Fallback: Assets/AppsInToss 경로
-                packagePath = Path.Combine(Application.dataPath, "AppsInToss");
+                return found;
             }
 
-            // WebGLTemplates/AITTemplate/BuildConfig~/package.json (Unity는 ~ 접미사 폴더 무시)
-            string packageJsonPath = Path.Combine(packagePath, "WebGLTemplates", "AITTemplate", "BuildConfig~", "package.json");
-
-            if (File.Exists(packageJsonPath))
+            // 최종 폴백: Assets/AppsInToss 경로 (임베디드 개발 환경)
+            string legacyPath = Path.Combine(Application.dataPath, "AppsInToss", relativePath);
+            if (File.Exists(legacyPath))
             {
-                return packageJsonPath;
+                return legacyPath;
             }
 
             return null;

--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -385,7 +385,7 @@ namespace AppsInToss.Editor
         private static string FindPackageJsonTemplate()
         {
             // SDK 패키지 경로 찾기
-            var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath("Packages/im.toss.apps-in-toss-unity-sdk");
+            var packageInfo = AITPackagePathResolver.FindSDKPackageInfo();
             string packagePath;
 
             if (packageInfo != null)

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -1,0 +1,29 @@
+using UnityEditor.PackageManager;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// SDK 패키지 경로를 안정적으로 찾기 위한 유틸리티.
+    /// FindForAssetPath가 실패할 수 있는 Git UPM 패키지 환경에서 폴백을 제공합니다.
+    /// </summary>
+    internal static class AITPackagePathResolver
+    {
+        private const string PackageAssetPath = "Packages/im.toss.apps-in-toss-unity-sdk";
+
+        /// <summary>
+        /// SDK의 PackageInfo를 찾습니다.
+        /// FindForAssetPath 실패 시 FindForAssembly를 폴백으로 사용합니다.
+        /// </summary>
+        internal static PackageInfo FindSDKPackageInfo()
+        {
+            var info = PackageInfo.FindForAssetPath(PackageAssetPath);
+            if (info != null)
+            {
+                return info;
+            }
+
+            // 폴백: 어셈블리 기반 탐색 (Git UPM 패키지에서 경로가 다를 수 있음)
+            return PackageInfo.FindForAssembly(typeof(AITPackagePathResolver).Assembly);
+        }
+    }
+}

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEditor.PackageManager;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 namespace AppsInToss.Editor
 {
@@ -13,9 +14,6 @@ namespace AppsInToss.Editor
     /// </summary>
     internal static class AITPackagePathResolver
     {
-        private const string PackageAssetPath = "Packages/im.toss.apps-in-toss-unity-sdk";
-        private const string LegacyPackageAssetPath = "Packages/com.appsintoss.miniapp";
-
         private static PackageInfo _cachedInfo;
         private static bool _cacheInitialized;
 
@@ -25,8 +23,8 @@ namespace AppsInToss.Editor
         /// 성공한 결과만 도메인 리로드까지 캐싱됩니다.
         /// </summary>
         /// <remarks>
-        /// 폴백 체인(PackageAssetPath → LegacyPackageAssetPath → FindForAssembly)을
-        /// 변경할 경우 AITVersion.LoadVersionInfoEditor()도 동기화할 것.
+        /// 폴백 체인을 변경할 경우 AITVersion.LoadVersionInfoEditor()도 동기화할 것.
+        /// 패키지 ID 상수는 AITVersion.PackageAssetPath / LegacyPackageAssetPath를 참조.
         /// </remarks>
         internal static PackageInfo FindSDKPackageInfo()
         {
@@ -35,14 +33,18 @@ namespace AppsInToss.Editor
                 return _cachedInfo;
             }
 
-            var info = PackageInfo.FindForAssetPath(PackageAssetPath)
-                       ?? PackageInfo.FindForAssetPath(LegacyPackageAssetPath)
+            var info = PackageInfo.FindForAssetPath(AITVersion.PackageAssetPath)
+                       ?? PackageInfo.FindForAssetPath(AITVersion.LegacyPackageAssetPath)
                        ?? PackageInfo.FindForAssembly(typeof(AITPackagePathResolver).Assembly);
 
             if (info != null)
             {
                 _cachedInfo = info;
                 _cacheInitialized = true;
+            }
+            else
+            {
+                Debug.LogWarning("[AIT] SDK 패키지를 찾을 수 없습니다. 패키지 설치 상태를 확인하세요.");
             }
 
             return info;
@@ -76,8 +78,8 @@ namespace AppsInToss.Editor
             string projectRoot = Directory.GetParent(Application.dataPath).FullName;
             var paths = new List<string>
             {
-                Path.Combine(projectRoot, PackageAssetPath, relativePath),
-                Path.Combine(projectRoot, LegacyPackageAssetPath, relativePath)
+                Path.Combine(projectRoot, AITVersion.PackageAssetPath, relativePath),
+                Path.Combine(projectRoot, AITVersion.LegacyPackageAssetPath, relativePath)
             };
 
             if (assemblyAnchor != null)
@@ -85,6 +87,7 @@ namespace AppsInToss.Editor
                 string loc = assemblyAnchor.Assembly.Location;
                 if (!string.IsNullOrEmpty(loc))
                 {
+                    // Assembly DLL은 {package-root}/Editor/ 또는 유사 하위 폴더에 위치한다고 가정
                     paths.Add(Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(loc)), relativePath));
                 }
             }

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using UnityEditor.PackageManager;
 
@@ -7,6 +8,7 @@ namespace AppsInToss.Editor
     /// SDK 패키지 경로를 안정적으로 찾기 위한 유틸리티.
     /// FindForAssetPath가 실패할 수 있는 Git UPM 패키지 환경에서 폴백을 제공합니다.
     /// 캐시는 도메인 리로드(스크립트 재컴파일) 시 자동으로 무효화됩니다.
+    /// Unity Editor 메인 스레드에서만 호출되는 것을 전제로 합니다.
     /// </summary>
     internal static class AITPackagePathResolver
     {
@@ -46,47 +48,36 @@ namespace AppsInToss.Editor
 
         /// <summary>
         /// SDK 내부의 상대 경로에 대한 후보 경로 배열을 반환합니다.
-        /// resolver가 성공하면 resolvedPath 기반 경로를 우선 사용하고,
-        /// 실패 시 하드코딩된 경로들을 폴백으로 사용합니다.
+        /// resolver가 성공하면 resolvedPath 기반 단일 경로를 반환하고,
+        /// 실패 시 하드코딩된 경로들과 Assembly.Location 폴백을 반환합니다.
         /// </summary>
         /// <param name="relativePath">SDK 루트로부터의 상대 경로 (예: "WebGLTemplates/AITTemplate/Runtime")</param>
-        /// <param name="assemblyAnchor">Assembly.Location 폴백에 사용할 타입 (null이면 생략)</param>
+        /// <param name="assemblyAnchor">Assembly.Location 폴백에 사용할 타입 (resolver 실패 시에만 사용, null이면 생략)</param>
         internal static string[] GetCandidatePaths(string relativePath, System.Type assemblyAnchor = null)
         {
             string resolvedPath = GetSDKResolvedPath();
             if (resolvedPath != null)
             {
-                if (assemblyAnchor != null)
-                {
-                    return new string[]
-                    {
-                        Path.Combine(resolvedPath, relativePath),
-                        Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(assemblyAnchor.Assembly.Location)), relativePath)
-                    };
-                }
-
-                return new string[]
-                {
-                    Path.Combine(resolvedPath, relativePath)
-                };
+                return new string[] { Path.Combine(resolvedPath, relativePath) };
             }
 
             // 폴백: 하드코딩된 경로 사용
-            if (assemblyAnchor != null)
-            {
-                return new string[]
-                {
-                    Path.GetFullPath(Path.Combine(PackageAssetPath, relativePath)),
-                    Path.GetFullPath(Path.Combine(LegacyPackageAssetPath, relativePath)),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(assemblyAnchor.Assembly.Location)), relativePath)
-                };
-            }
-
-            return new string[]
+            var paths = new List<string>
             {
                 Path.GetFullPath(Path.Combine(PackageAssetPath, relativePath)),
                 Path.GetFullPath(Path.Combine(LegacyPackageAssetPath, relativePath))
             };
+
+            if (assemblyAnchor != null)
+            {
+                string loc = assemblyAnchor.Assembly.Location;
+                if (!string.IsNullOrEmpty(loc))
+                {
+                    paths.Add(Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(loc)), relativePath));
+                }
+            }
+
+            return paths.ToArray();
         }
     }
 }

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -23,6 +23,9 @@ namespace AppsInToss.Editor
         /// FindForAssetPath 실패 시 FindForAssembly를 폴백으로 사용합니다.
         /// 결과는 도메인 리로드까지 캐싱됩니다.
         /// </summary>
+        /// <remarks>
+        /// 폴백 체인을 변경할 경우 AITVersion.LoadVersionInfoEditor()도 동기화할 것.
+        /// </remarks>
         internal static PackageInfo FindSDKPackageInfo()
         {
             if (_cacheInitialized)

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -6,6 +6,7 @@ namespace AppsInToss.Editor
     /// <summary>
     /// SDK 패키지 경로를 안정적으로 찾기 위한 유틸리티.
     /// FindForAssetPath가 실패할 수 있는 Git UPM 패키지 환경에서 폴백을 제공합니다.
+    /// 캐시는 도메인 리로드(스크립트 재컴파일) 시 자동으로 무효화됩니다.
     /// </summary>
     internal static class AITPackagePathResolver
     {
@@ -18,7 +19,7 @@ namespace AppsInToss.Editor
         /// <summary>
         /// SDK의 PackageInfo를 찾습니다.
         /// FindForAssetPath 실패 시 FindForAssembly를 폴백으로 사용합니다.
-        /// 결과는 세션 내에서 캐싱됩니다.
+        /// 결과는 도메인 리로드까지 캐싱됩니다.
         /// </summary>
         internal static PackageInfo FindSDKPackageInfo()
         {
@@ -75,16 +76,16 @@ namespace AppsInToss.Editor
             {
                 return new string[]
                 {
-                    Path.GetFullPath(PackageAssetPath + "/" + relativePath),
-                    Path.GetFullPath(LegacyPackageAssetPath + "/" + relativePath),
+                    Path.GetFullPath(Path.Combine(PackageAssetPath, relativePath)),
+                    Path.GetFullPath(Path.Combine(LegacyPackageAssetPath, relativePath)),
                     Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(assemblyAnchor.Assembly.Location)), relativePath)
                 };
             }
 
             return new string[]
             {
-                Path.GetFullPath(PackageAssetPath + "/" + relativePath),
-                Path.GetFullPath(LegacyPackageAssetPath + "/" + relativePath)
+                Path.GetFullPath(Path.Combine(PackageAssetPath, relativePath)),
+                Path.GetFullPath(Path.Combine(LegacyPackageAssetPath, relativePath))
             };
         }
     }

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -95,7 +95,11 @@ namespace AppsInToss.Editor
                 if (!string.IsNullOrEmpty(loc))
                 {
                     // Assembly DLL은 {package-root}/Editor/ 또는 유사 하위 폴더에 위치한다고 가정
-                    paths.Add(Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(loc)), relativePath));
+                    string packageRoot = Path.GetDirectoryName(Path.GetDirectoryName(loc));
+                    if (!string.IsNullOrEmpty(packageRoot))
+                    {
+                        paths.Add(Path.Combine(packageRoot, relativePath));
+                    }
                 }
             }
 

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using UnityEditor.PackageManager;
 
 namespace AppsInToss.Editor
@@ -9,21 +10,28 @@ namespace AppsInToss.Editor
     internal static class AITPackagePathResolver
     {
         private const string PackageAssetPath = "Packages/im.toss.apps-in-toss-unity-sdk";
+        private const string LegacyPackageAssetPath = "Packages/com.appsintoss.miniapp";
+
+        private static PackageInfo _cachedInfo;
+        private static bool _cacheInitialized;
 
         /// <summary>
         /// SDK의 PackageInfo를 찾습니다.
         /// FindForAssetPath 실패 시 FindForAssembly를 폴백으로 사용합니다.
+        /// 결과는 세션 내에서 캐싱됩니다.
         /// </summary>
         internal static PackageInfo FindSDKPackageInfo()
         {
-            var info = PackageInfo.FindForAssetPath(PackageAssetPath);
-            if (info != null)
+            if (_cacheInitialized)
             {
-                return info;
+                return _cachedInfo;
             }
 
-            // 폴백: 어셈블리 기반 탐색 (Git UPM 패키지에서 경로가 다를 수 있음)
-            return PackageInfo.FindForAssembly(typeof(AITPackagePathResolver).Assembly);
+            _cacheInitialized = true;
+            _cachedInfo = PackageInfo.FindForAssetPath(PackageAssetPath)
+                          ?? PackageInfo.FindForAssetPath(LegacyPackageAssetPath)
+                          ?? PackageInfo.FindForAssembly(typeof(AITPackagePathResolver).Assembly);
+            return _cachedInfo;
         }
 
         /// <summary>
@@ -33,6 +41,51 @@ namespace AppsInToss.Editor
         internal static string GetSDKResolvedPath()
         {
             return FindSDKPackageInfo()?.resolvedPath;
+        }
+
+        /// <summary>
+        /// SDK 내부의 상대 경로에 대한 후보 경로 배열을 반환합니다.
+        /// resolver가 성공하면 resolvedPath 기반 경로를 우선 사용하고,
+        /// 실패 시 하드코딩된 경로들을 폴백으로 사용합니다.
+        /// </summary>
+        /// <param name="relativePath">SDK 루트로부터의 상대 경로 (예: "WebGLTemplates/AITTemplate/Runtime")</param>
+        /// <param name="assemblyAnchor">Assembly.Location 폴백에 사용할 타입 (null이면 생략)</param>
+        internal static string[] GetCandidatePaths(string relativePath, System.Type assemblyAnchor = null)
+        {
+            string resolvedPath = GetSDKResolvedPath();
+            if (resolvedPath != null)
+            {
+                if (assemblyAnchor != null)
+                {
+                    return new string[]
+                    {
+                        Path.Combine(resolvedPath, relativePath),
+                        Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(assemblyAnchor.Assembly.Location)), relativePath)
+                    };
+                }
+
+                return new string[]
+                {
+                    Path.Combine(resolvedPath, relativePath)
+                };
+            }
+
+            // 폴백: 하드코딩된 경로 사용
+            if (assemblyAnchor != null)
+            {
+                return new string[]
+                {
+                    Path.GetFullPath(PackageAssetPath + "/" + relativePath),
+                    Path.GetFullPath(LegacyPackageAssetPath + "/" + relativePath),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(assemblyAnchor.Assembly.Location)), relativePath)
+                };
+            }
+
+            return new string[]
+            {
+                Path.GetFullPath(PackageAssetPath + "/" + relativePath),
+                Path.GetFullPath(LegacyPackageAssetPath + "/" + relativePath)
+            };
         }
     }
 }

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -70,7 +70,8 @@ namespace AppsInToss.Editor
         /// 실패 시 프로젝트 루트 기준 경로들과 Assembly.Location 폴백을 반환합니다.
         /// </summary>
         /// <param name="relativePath">SDK 루트로부터의 상대 경로 (예: "WebGLTemplates/AITTemplate/Runtime")</param>
-        /// <param name="assemblyAnchor">Assembly.Location 폴백에 사용할 타입 (resolver 실패 시에만 사용, null이면 생략)</param>
+        /// <param name="assemblyAnchor">Assembly.Location 폴백에 사용할 타입 (resolver 실패 시에만 사용, null이면 생략).
+        /// 호출자와 같은 asmdef에 속한 타입을 전달해야 올바른 Assembly DLL 경로를 얻을 수 있음.</param>
         internal static string[] GetCandidatePaths(string relativePath, System.Type assemblyAnchor = null)
         {
             string resolvedPath = GetSDKResolvedPath();

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -16,6 +16,7 @@ namespace AppsInToss.Editor
     {
         private static PackageInfo _cachedInfo;
         private static bool _cacheInitialized;
+        private static bool _warningLogged;
 
         /// <summary>
         /// SDK의 PackageInfo를 찾습니다.
@@ -42,8 +43,9 @@ namespace AppsInToss.Editor
                 _cachedInfo = info;
                 _cacheInitialized = true;
             }
-            else
+            else if (!_warningLogged)
             {
+                _warningLogged = true;
                 Debug.LogWarning("[AIT] SDK 패키지를 찾을 수 없습니다. 패키지 설치 상태를 확인하세요.");
             }
 

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using UnityEditor.PackageManager;
+using UnityEngine;
 
 namespace AppsInToss.Editor
 {
@@ -21,10 +22,11 @@ namespace AppsInToss.Editor
         /// <summary>
         /// SDK의 PackageInfo를 찾습니다.
         /// FindForAssetPath 실패 시 FindForAssembly를 폴백으로 사용합니다.
-        /// 결과는 도메인 리로드까지 캐싱됩니다.
+        /// 성공한 결과만 도메인 리로드까지 캐싱됩니다.
         /// </summary>
         /// <remarks>
-        /// 폴백 체인을 변경할 경우 AITVersion.LoadVersionInfoEditor()도 동기화할 것.
+        /// 폴백 체인(PackageAssetPath → LegacyPackageAssetPath → FindForAssembly)을
+        /// 변경할 경우 AITVersion.LoadVersionInfoEditor()도 동기화할 것.
         /// </remarks>
         internal static PackageInfo FindSDKPackageInfo()
         {
@@ -33,11 +35,17 @@ namespace AppsInToss.Editor
                 return _cachedInfo;
             }
 
-            _cacheInitialized = true;
-            _cachedInfo = PackageInfo.FindForAssetPath(PackageAssetPath)
-                          ?? PackageInfo.FindForAssetPath(LegacyPackageAssetPath)
-                          ?? PackageInfo.FindForAssembly(typeof(AITPackagePathResolver).Assembly);
-            return _cachedInfo;
+            var info = PackageInfo.FindForAssetPath(PackageAssetPath)
+                       ?? PackageInfo.FindForAssetPath(LegacyPackageAssetPath)
+                       ?? PackageInfo.FindForAssembly(typeof(AITPackagePathResolver).Assembly);
+
+            if (info != null)
+            {
+                _cachedInfo = info;
+                _cacheInitialized = true;
+            }
+
+            return info;
         }
 
         /// <summary>
@@ -52,7 +60,7 @@ namespace AppsInToss.Editor
         /// <summary>
         /// SDK 내부의 상대 경로에 대한 후보 경로 배열을 반환합니다.
         /// resolver가 성공하면 resolvedPath 기반 단일 경로를 반환하고,
-        /// 실패 시 하드코딩된 경로들과 Assembly.Location 폴백을 반환합니다.
+        /// 실패 시 프로젝트 루트 기준 경로들과 Assembly.Location 폴백을 반환합니다.
         /// </summary>
         /// <param name="relativePath">SDK 루트로부터의 상대 경로 (예: "WebGLTemplates/AITTemplate/Runtime")</param>
         /// <param name="assemblyAnchor">Assembly.Location 폴백에 사용할 타입 (resolver 실패 시에만 사용, null이면 생략)</param>
@@ -64,11 +72,12 @@ namespace AppsInToss.Editor
                 return new string[] { Path.Combine(resolvedPath, relativePath) };
             }
 
-            // 폴백: 하드코딩된 경로 사용
+            // 폴백: 프로젝트 루트 기준 경로 사용
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
             var paths = new List<string>
             {
-                Path.GetFullPath(Path.Combine(PackageAssetPath, relativePath)),
-                Path.GetFullPath(Path.Combine(LegacyPackageAssetPath, relativePath))
+                Path.Combine(projectRoot, PackageAssetPath, relativePath),
+                Path.Combine(projectRoot, LegacyPackageAssetPath, relativePath)
             };
 
             if (assemblyAnchor != null)

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -48,7 +48,7 @@ namespace AppsInToss.Editor
                 _warningLogged = true;
                 Debug.LogWarning(
                     $"[AIT] SDK 패키지를 찾을 수 없습니다. " +
-                    $"시도한 경로: {AITVersion.PackageAssetPath}, {AITVersion.LegacyPackageAssetPath}. " +
+                    $"시도: FindForAssetPath({AITVersion.PackageAssetPath}, {AITVersion.LegacyPackageAssetPath}), FindForAssembly. " +
                     "패키지 설치 상태를 확인하세요.");
             }
 
@@ -83,7 +83,7 @@ namespace AppsInToss.Editor
             // Unity 가상 Packages/ 경로와 달리 실제 디스크 경로를 구성하므로
             // 로컬(file:) 또는 임베디드 패키지 개발 환경에서만 유효함.
             string projectRoot = Directory.GetParent(Application.dataPath).FullName;
-            var paths = new List<string>
+            var paths = new List<string>(3)
             {
                 Path.Combine(projectRoot, AITVersion.PackageAssetPath, relativePath),
                 Path.Combine(projectRoot, AITVersion.LegacyPackageAssetPath, relativePath)

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -46,7 +46,10 @@ namespace AppsInToss.Editor
             else if (!_warningLogged)
             {
                 _warningLogged = true;
-                Debug.LogWarning("[AIT] SDK 패키지를 찾을 수 없습니다. 패키지 설치 상태를 확인하세요.");
+                Debug.LogWarning(
+                    $"[AIT] SDK 패키지를 찾을 수 없습니다. " +
+                    $"시도한 경로: {AITVersion.PackageAssetPath}, {AITVersion.LegacyPackageAssetPath}. " +
+                    "패키지 설치 상태를 확인하세요.");
             }
 
             return info;
@@ -76,7 +79,9 @@ namespace AppsInToss.Editor
                 return new string[] { Path.Combine(resolvedPath, relativePath) };
             }
 
-            // 폴백: 프로젝트 루트 기준 경로 사용 (로컬/임베디드 패키지 개발 환경용)
+            // 폴백: 프로젝트 루트 기준 물리 경로 사용.
+            // Unity 가상 Packages/ 경로와 달리 실제 디스크 경로를 구성하므로
+            // 로컬(file:) 또는 임베디드 패키지 개발 환경에서만 유효함.
             string projectRoot = Directory.GetParent(Application.dataPath).FullName;
             var paths = new List<string>
             {
@@ -95,6 +100,42 @@ namespace AppsInToss.Editor
             }
 
             return paths.ToArray();
+        }
+
+        /// <summary>
+        /// GetCandidatePaths의 결과에서 존재하는 첫 번째 디렉토리를 반환합니다.
+        /// </summary>
+        internal static bool TryResolveDirectory(string relativePath, out string resolvedPath, System.Type assemblyAnchor = null)
+        {
+            foreach (string path in GetCandidatePaths(relativePath, assemblyAnchor))
+            {
+                if (Directory.Exists(path))
+                {
+                    resolvedPath = path;
+                    return true;
+                }
+            }
+
+            resolvedPath = null;
+            return false;
+        }
+
+        /// <summary>
+        /// GetCandidatePaths의 결과에서 존재하는 첫 번째 파일을 반환합니다.
+        /// </summary>
+        internal static bool TryResolveFile(string relativePath, out string resolvedPath, System.Type assemblyAnchor = null)
+        {
+            foreach (string path in GetCandidatePaths(relativePath, assemblyAnchor))
+            {
+                if (File.Exists(path))
+                {
+                    resolvedPath = path;
+                    return true;
+                }
+            }
+
+            resolvedPath = null;
+            return false;
         }
     }
 }

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -25,5 +25,14 @@ namespace AppsInToss.Editor
             // 폴백: 어셈블리 기반 탐색 (Git UPM 패키지에서 경로가 다를 수 있음)
             return PackageInfo.FindForAssembly(typeof(AITPackagePathResolver).Assembly);
         }
+
+        /// <summary>
+        /// SDK 패키지의 파일시스템 경로를 반환합니다.
+        /// PackageInfo를 찾지 못하면 null을 반환합니다.
+        /// </summary>
+        internal static string GetSDKResolvedPath()
+        {
+            return FindSDKPackageInfo()?.resolvedPath;
+        }
     }
 }

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -76,7 +76,7 @@ namespace AppsInToss.Editor
                 return new string[] { Path.Combine(resolvedPath, relativePath) };
             }
 
-            // 폴백: 프로젝트 루트 기준 경로 사용
+            // 폴백: 프로젝트 루트 기준 경로 사용 (로컬/임베디드 패키지 개발 환경용)
             string projectRoot = Directory.GetParent(Application.dataPath).FullName;
             var paths = new List<string>
             {

--- a/Editor/AITPackagePathResolver.cs.meta
+++ b/Editor/AITPackagePathResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28b121bf6ad546739fc62ec00416a81c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/AITTemplateManager.cs
+++ b/Editor/AITTemplateManager.cs
@@ -34,26 +34,8 @@ namespace AppsInToss.Editor
             // SDK 업데이트 시 새 템플릿이 적용되도록 함
 
             // SDK의 WebGLTemplates 경로 찾기 (여러 가능한 경로 시도)
-            string sdkResolvedPath = AITPackagePathResolver.GetSDKResolvedPath();
-            string[] possibleSdkPaths;
-            if (sdkResolvedPath != null)
-            {
-                possibleSdkPaths = new string[]
-                {
-                    Path.Combine(sdkResolvedPath, "WebGLTemplates"),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates")
-                };
-            }
-            else
-            {
-                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
-                possibleSdkPaths = new string[]
-                {
-                    Path.Combine(projectRoot, "Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates"),
-                    Path.Combine(projectRoot, "Packages/com.appsintoss.miniapp/WebGLTemplates"),
-                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates")
-                };
-            }
+            string[] possibleSdkPaths = AITPackagePathResolver.GetCandidatePaths(
+                "WebGLTemplates", typeof(AITConvertCore));
 
             string sdkTemplatesPath = null;
             foreach (string path in possibleSdkPaths)

--- a/Editor/AITTemplateManager.cs
+++ b/Editor/AITTemplateManager.cs
@@ -33,21 +33,9 @@ namespace AppsInToss.Editor
             // 항상 최신 SDK 템플릿으로 교체 (기존 조건 제거)
             // SDK 업데이트 시 새 템플릿이 적용되도록 함
 
-            // SDK의 WebGLTemplates 경로 찾기 (여러 가능한 경로 시도)
-            string[] possibleSdkPaths = AITPackagePathResolver.GetCandidatePaths(
-                "WebGLTemplates", typeof(AITConvertCore));
-
-            string sdkTemplatesPath = null;
-            foreach (string path in possibleSdkPaths)
-            {
-                if (Directory.Exists(path))
-                {
-                    sdkTemplatesPath = path;
-                    break;
-                }
-            }
-
-            if (sdkTemplatesPath == null)
+            // SDK의 WebGLTemplates 경로 찾기
+            if (!AITPackagePathResolver.TryResolveDirectory(
+                "WebGLTemplates", out string sdkTemplatesPath, typeof(AITConvertCore)))
             {
                 Debug.LogError($"[AIT] SDK WebGLTemplates 폴더를 찾을 수 없습니다.");
                 return false;

--- a/Editor/AITTemplateManager.cs
+++ b/Editor/AITTemplateManager.cs
@@ -34,15 +34,26 @@ namespace AppsInToss.Editor
             // SDK 업데이트 시 새 템플릿이 적용되도록 함
 
             // SDK의 WebGLTemplates 경로 찾기 (여러 가능한 경로 시도)
-            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
-            string[] possibleSdkPaths = new string[]
+            string sdkResolvedPath = AITPackagePathResolver.GetSDKResolvedPath();
+            string[] possibleSdkPaths;
+            if (sdkResolvedPath != null)
             {
-                // Package로 설치된 경우 (Unity 프로젝트 루트 기준)
-                Path.Combine(projectRoot, "Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates"),
-                Path.Combine(projectRoot, "Packages/com.appsintoss.miniapp/WebGLTemplates"),
-                // Assembly 경로 기반
-                Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates")
-            };
+                possibleSdkPaths = new string[]
+                {
+                    Path.Combine(sdkResolvedPath, "WebGLTemplates"),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates")
+                };
+            }
+            else
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                possibleSdkPaths = new string[]
+                {
+                    Path.Combine(projectRoot, "Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates"),
+                    Path.Combine(projectRoot, "Packages/com.appsintoss.miniapp/WebGLTemplates"),
+                    Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(typeof(AITConvertCore).Assembly.Location)), "WebGLTemplates")
+                };
+            }
 
             string sdkTemplatesPath = null;
             foreach (string path in possibleSdkPaths)

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -128,7 +128,8 @@ namespace AppsInToss
             foreach (var package in args.removed)
             {
                 // 이 SDK 패키지가 제거되었는지 확인
-                if (package.name == "im.toss.apps-in-toss-unity-sdk")
+                if (package.name == AITVersion.PackageName ||
+                    package.name == AITVersion.LegacyPackageName)
                 {
                     Debug.Log("[AIT] SDK 패키지가 제거됨 - 서버 프로세스 정리 중...");
 

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -479,9 +479,12 @@ namespace AppsInToss.Editor.ErrorTracker
             return "Exception";
         }
 
-        private const string SdkPackagePath = "Packages/im.toss.apps-in-toss-unity-sdk/";
-        private const string SdkPackageCachePath = "Library/PackageCache/im.toss.apps-in-toss-unity-sdk@";
-        private const string SdkPackageCachePathNoVersion = "Library/PackageCache/im.toss.apps-in-toss-unity-sdk/";
+        private const string SdkPackagePath = AITVersion.PackageAssetPath + "/";
+        private const string SdkPackageCachePath = "Library/PackageCache/" + AITVersion.PackageName + "@";
+        private const string SdkPackageCachePathNoVersion = "Library/PackageCache/" + AITVersion.PackageName + "/";
+        private const string LegacySdkPackagePath = AITVersion.LegacyPackageAssetPath + "/";
+        private const string LegacySdkPackageCachePath = "Library/PackageCache/" + AITVersion.LegacyPackageName + "@";
+        private const string LegacySdkPackageCachePathNoVersion = "Library/PackageCache/" + AITVersion.LegacyPackageName + "/";
         private const string UserProjectPathPrefix = "Assets/";
 
         /// <summary>
@@ -506,7 +509,10 @@ namespace AppsInToss.Editor.ErrorTracker
 
                         if (filename.StartsWith(SdkPackagePath, StringComparison.Ordinal) ||
                             filename.StartsWith(SdkPackageCachePath, StringComparison.Ordinal) ||
-                            filename.StartsWith(SdkPackageCachePathNoVersion, StringComparison.Ordinal))
+                            filename.StartsWith(SdkPackageCachePathNoVersion, StringComparison.Ordinal) ||
+                            filename.StartsWith(LegacySdkPackagePath, StringComparison.Ordinal) ||
+                            filename.StartsWith(LegacySdkPackageCachePath, StringComparison.Ordinal) ||
+                            filename.StartsWith(LegacySdkPackageCachePathNoVersion, StringComparison.Ordinal))
                             return "sdk";
 
                         if (filename.StartsWith(UserProjectPathPrefix, StringComparison.Ordinal))

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -16,8 +16,10 @@ namespace AppsInToss
     [Preserve]
     public static class AITVersion
     {
-        internal const string PackageAssetPath = "Packages/im.toss.apps-in-toss-unity-sdk";
-        internal const string LegacyPackageAssetPath = "Packages/com.appsintoss.miniapp";
+        internal const string PackageName = "im.toss.apps-in-toss-unity-sdk";
+        internal const string LegacyPackageName = "com.appsintoss.miniapp";
+        internal const string PackageAssetPath = "Packages/" + PackageName;
+        internal const string LegacyPackageAssetPath = "Packages/" + LegacyPackageName;
 
         private static bool _loaded;
         private static string _version = "unknown";

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -16,8 +16,8 @@ namespace AppsInToss
     [Preserve]
     public static class AITVersion
     {
-        private const string PackageAssetPath = "Packages/im.toss.apps-in-toss-unity-sdk";
-        private const string LegacyPackageAssetPath = "Packages/com.appsintoss.miniapp";
+        internal const string PackageAssetPath = "Packages/im.toss.apps-in-toss-unity-sdk";
+        internal const string LegacyPackageAssetPath = "Packages/com.appsintoss.miniapp";
 
         private static bool _loaded;
         private static string _version = "unknown";

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -83,6 +83,7 @@ namespace AppsInToss
 #if UNITY_EDITOR
         private static void LoadVersionInfoEditor()
         {
+            // Keep in sync with AITPackagePathResolver.PackageAssetPath (Editor assembly)
             var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
                 "Packages/im.toss.apps-in-toss-unity-sdk"
             );

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -86,6 +86,13 @@ namespace AppsInToss
             var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
                 "Packages/im.toss.apps-in-toss-unity-sdk"
             );
+            // 폴백: Git UPM 패키지에서 경로가 다를 수 있으므로 어셈블리 기반 탐색
+            if (packageInfo == null)
+            {
+                packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(
+                    typeof(AITVersion).Assembly
+                );
+            }
             if (packageInfo != null)
             {
                 Version = packageInfo.version;

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -83,11 +83,18 @@ namespace AppsInToss
 #if UNITY_EDITOR
         private static void LoadVersionInfoEditor()
         {
-            // Keep in sync with AITPackagePathResolver.PackageAssetPath (Editor assembly)
+            // Keep in sync with AITPackagePathResolver (Editor assembly)
             var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
                 "Packages/im.toss.apps-in-toss-unity-sdk"
             );
-            // 폴백: Git UPM 패키지에서 경로가 다를 수 있으므로 어셈블리 기반 탐색
+            // 레거시 패키지 ID 폴백
+            if (packageInfo == null)
+            {
+                packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
+                    "Packages/com.appsintoss.miniapp"
+                );
+            }
+            // 어셈블리 기반 폴백 (Git UPM 패키지에서 경로가 다를 수 있음)
             if (packageInfo == null)
             {
                 packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -86,7 +86,8 @@ namespace AppsInToss
 #if UNITY_EDITOR
         private static void LoadVersionInfoEditor()
         {
-            // Keep in sync with AITPackagePathResolver.FindSDKPackageInfo() (Editor assembly)
+            // AITPackagePathResolver (Editor assembly)와 동일한 폴백 체인을 인라인으로 구현.
+            // Runtime asmdef에서 Editor assembly를 참조할 수 없으므로 직접 호출 불가.
             // 폴백 체인: PackageAssetPath → LegacyPackageAssetPath → FindForAssembly
             var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
                 PackageAssetPath

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -16,6 +16,9 @@ namespace AppsInToss
     [Preserve]
     public static class AITVersion
     {
+        private const string PackageAssetPath = "Packages/im.toss.apps-in-toss-unity-sdk";
+        private const string LegacyPackageAssetPath = "Packages/com.appsintoss.miniapp";
+
         private static bool _loaded;
         private static string _version = "unknown";
         private static string _releaseDateTime;
@@ -83,15 +86,15 @@ namespace AppsInToss
 #if UNITY_EDITOR
         private static void LoadVersionInfoEditor()
         {
-            // Keep in sync with AITPackagePathResolver (Editor assembly)
+            // Keep in sync with AITPackagePathResolver.FindSDKPackageInfo() (Editor assembly)
             var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
-                "Packages/im.toss.apps-in-toss-unity-sdk"
+                PackageAssetPath
             );
             // 레거시 패키지 ID 폴백
             if (packageInfo == null)
             {
                 packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
-                    "Packages/com.appsintoss.miniapp"
+                    LegacyPackageAssetPath
                 );
             }
             // 어셈블리 기반 폴백 (Git UPM 패키지에서 경로가 다를 수 있음)

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -86,8 +86,8 @@ namespace AppsInToss
 #if UNITY_EDITOR
         private static void LoadVersionInfoEditor()
         {
-            // AITPackagePathResolver (Editor assembly)와 동일한 폴백 체인을 인라인으로 구현.
-            // Runtime asmdef에서 Editor assembly를 참조할 수 없으므로 직접 호출 불가.
+            // AITPackagePathResolver.FindSDKPackageInfo()의 null-coalescing 체인과 동일한 로직.
+            // Runtime asmdef에서 Editor assembly를 참조할 수 없으므로 인라인 if-null 형태로 구현.
             // 폴백 체인: PackageAssetPath → LegacyPackageAssetPath → FindForAssembly
             var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
                 PackageAssetPath

--- a/Runtime/Helpers/AITVersion.cs
+++ b/Runtime/Helpers/AITVersion.cs
@@ -87,6 +87,7 @@ namespace AppsInToss
         private static void LoadVersionInfoEditor()
         {
             // Keep in sync with AITPackagePathResolver.FindSDKPackageInfo() (Editor assembly)
+            // 폴백 체인: PackageAssetPath → LegacyPackageAssetPath → FindForAssembly
             var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(
                 PackageAssetPath
             );

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:29:03Z
+// Updated at: 2026-04-16T04:31:59Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0429";
-        public const string CommitHash = "1e47155";
+        public const string ReleaseDateTime = "20260416_0431";
+        public const string CommitHash = "0d760c0";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:36:00Z
+// Updated at: 2026-04-16T04:38:19Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0436";
-        public const string CommitHash = "a4bf2ad";
+        public const string ReleaseDateTime = "20260416_0438";
+        public const string CommitHash = "967b5d1";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T06:25:30Z
+// Updated at: 2026-04-16T06:27:39Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0625";
-        public const string CommitHash = "77723c2";
+        public const string ReleaseDateTime = "20260416_0627";
+        public const string CommitHash = "bd58fd3";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:33:57Z
+// Updated at: 2026-04-16T04:36:00Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0433";
-        public const string CommitHash = "75824d2";
+        public const string ReleaseDateTime = "20260416_0436";
+        public const string CommitHash = "a4bf2ad";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:31:59Z
+// Updated at: 2026-04-16T04:33:57Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0431";
-        public const string CommitHash = "0d760c0";
+        public const string ReleaseDateTime = "20260416_0433";
+        public const string CommitHash = "75824d2";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:48:09Z
+// Updated at: 2026-04-16T06:19:13Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0448";
-        public const string CommitHash = "72f322a";
+        public const string ReleaseDateTime = "20260416_0619";
+        public const string CommitHash = "43ed15d";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:43:14Z
+// Updated at: 2026-04-16T04:45:49Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0443";
-        public const string CommitHash = "fb1ab70";
+        public const string ReleaseDateTime = "20260416_0445";
+        public const string CommitHash = "fb6e56b";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:38:19Z
+// Updated at: 2026-04-16T04:41:05Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0438";
-        public const string CommitHash = "967b5d1";
+        public const string ReleaseDateTime = "20260416_0441";
+        public const string CommitHash = "f405197";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T06:27:39Z
+// Updated at: 2026-04-16T06:31:42Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0627";
-        public const string CommitHash = "bd58fd3";
+        public const string ReleaseDateTime = "20260416_0631";
+        public const string CommitHash = "d8fa5da";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T06:22:43Z
+// Updated at: 2026-04-16T06:25:30Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0622";
-        public const string CommitHash = "9b8d7e5";
+        public const string ReleaseDateTime = "20260416_0625";
+        public const string CommitHash = "77723c2";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:41:05Z
+// Updated at: 2026-04-16T04:43:14Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0441";
-        public const string CommitHash = "f405197";
+        public const string ReleaseDateTime = "20260416_0443";
+        public const string CommitHash = "fb1ab70";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:26:23Z
+// Updated at: 2026-04-16T04:29:03Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0426";
-        public const string CommitHash = "dc8736c";
+        public const string ReleaseDateTime = "20260416_0429";
+        public const string CommitHash = "1e47155";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T04:45:49Z
+// Updated at: 2026-04-16T04:48:09Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0445";
-        public const string CommitHash = "fb6e56b";
+        public const string ReleaseDateTime = "20260416_0448";
+        public const string CommitHash = "72f322a";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T06:26:38Z
+// Updated at: 2026-04-16T04:26:23Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0626";
+        public const string ReleaseDateTime = "20260416_0426";
         public const string CommitHash = "dc8736c";
     }
 }

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,11 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T06:19:13Z
+// Updated at: 2026-04-16T06:22:43Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0619";
-        public const string CommitHash = "43ed15d";
+        public const string ReleaseDateTime = "20260416_0622";
+        public const string CommitHash = "9b8d7e5";
     }
 }


### PR DESCRIPTION
## Summary

- Git URL로 설치된 UPM 패키지에서 `FindForAssetPath("Packages/im.toss.apps-in-toss-unity-sdk")`가 `null`을 반환하는 문제 수정
- `AITPackagePathResolver` 유틸리티 클래스를 신규 생성하여 패키지 경로 탐색 로직을 중앙화
- 3단계 폴백 체인: `FindForAssetPath(primary)` → `FindForAssetPath(legacy)` → `FindForAssembly`
- 기존 6개 호출 사이트를 모두 resolver로 마이그레이션
- 레거시 패키지 ID(`com.appsintoss.miniapp`) 지원을 ErrorTracker, AppsInTossMenu에도 확장

## Changes

- **`Editor/AITPackagePathResolver.cs` (신규)**: 세션 캐싱, 경고 중복 방지, `TryResolveDirectory`/`TryResolveFile` 편의 메서드 제공
- **`Runtime/Helpers/AITVersion.cs`**: `PackageName`/`LegacyPackageName` 상수 추출, 인라인 폴백 추가 (Runtime에서 Editor assembly 참조 불가)
- **`Editor/AITAutoUpdater.cs`**: `FindSDKPackageInfo()` 사용
- **`Editor/AITPackageBuilder.cs`**: `TryResolveDirectory` 사용 (2곳)
- **`Editor/AITPackageInitializer.cs`**: `TryResolveFile` 사용 (2곳)
- **`Editor/AITTemplateManager.cs`**: `TryResolveDirectory` 사용
- **`Editor/AppsInTossMenu.cs`**: 패키지 제거 이벤트에 레거시 ID 체크 추가
- **`Editor/ErrorTracker/AITEditorErrorTracker.cs`**: 스택트레이스 분류에 레거시 패키지 경로 추가

## Test plan

- [ ] Git URL로 설치된 프로젝트에서 SDK 패키지가 정상 인식되는지 확인
- [ ] 로컬(file:) 경로로 설치된 프로젝트에서 기존 동작 유지 확인
- [ ] EditMode 테스트 통과 확인
- [ ] E2E 테스트 통과 확인