### PR TITLE
수정: pre-commit 훅에서 CommitHash/ReleaseDateTime 갱신 제거하여 머지 충돌 방지

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,22 +1,25 @@
 #!/usr/bin/env sh
 
-# AITVersionConstants.cs 업데이트
-DATETIME=$(date -u +"%Y%m%d_%H%M")
+# AITVersionConstants.cs - Version만 package.json과 동기화
+# CommitHash, ReleaseDateTime은 빌드 시점(AITConvertCore)과 릴리즈 시점(release.yml)에서 주입됨
 VERSION=$(cat package.json | grep '"version"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
-COMMIT_HASH=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "dev")
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Failed to extract version from package.json"
+  exit 1
+fi
 
 CONSTANTS_FILE="Runtime/Helpers/AITVersionConstants.cs"
 
 cat > "$CONSTANTS_FILE" << EOF
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "${VERSION}";
-        public const string ReleaseDateTime = "${DATETIME}";
-        public const string CommitHash = "${COMMIT_HASH}";
+        public const string ReleaseDateTime = null;
+        public const string CommitHash = null;
     }
 }
 EOF

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEditor;
 #if UNITY_6000_0_OR_NEWER
@@ -829,7 +830,19 @@ namespace AppsInToss
 #endif
             };
 
-            var result = BuildPipeline.BuildPlayer(buildPlayerOptions);
+            // 빌드 직전: AITVersionConstants.cs에 CommitHash, ReleaseDateTime 주입
+            string originalConstants = InjectVersionConstants();
+
+            UnityEditor.Build.Reporting.BuildReport result;
+            try
+            {
+                result = BuildPipeline.BuildPlayer(buildPlayerOptions);
+            }
+            finally
+            {
+                // 빌드 완료 후 (성공/실패 무관) 원본으로 복원
+                RestoreVersionConstants(originalConstants);
+            }
 
             // 빌드 리포트를 에러 리포터에 저장 (Issue 신고 시 사용)
             AITErrorReporter.SetBuildReport(result);
@@ -911,6 +924,113 @@ namespace AppsInToss
             }
 
             return AITExportError.SUCCEED;
+        }
+
+        private const string VersionConstantsRelativePath = "Runtime/Helpers/AITVersionConstants.cs";
+
+        /// <summary>
+        /// 빌드 직전 AITVersionConstants.cs에 CommitHash와 ReleaseDateTime을 주입합니다.
+        /// </summary>
+        /// <returns>복원용 원본 파일 내용 (null이면 복원 불필요)</returns>
+        private static string InjectVersionConstants()
+        {
+            try
+            {
+                if (!AITPackagePathResolver.TryResolveFile(VersionConstantsRelativePath, out string constantsPath))
+                {
+                    Debug.LogWarning("[AIT] AITVersionConstants.cs를 찾을 수 없어 버전 상수 주입을 건너뜁니다.");
+                    return null;
+                }
+
+                string original = File.ReadAllText(constantsPath);
+
+                string commitHash = GetGitCommitHash();
+                string releaseDateTime = DateTime.UtcNow.ToString("yyyyMMdd_HHmm");
+
+                string injected = original;
+                injected = Regex.Replace(
+                    injected,
+                    @"public const string CommitHash = [^;]+;",
+                    $"public const string CommitHash = \"{commitHash}\";");
+                injected = Regex.Replace(
+                    injected,
+                    @"public const string ReleaseDateTime = [^;]+;",
+                    $"public const string ReleaseDateTime = \"{releaseDateTime}\";");
+
+                if (injected != original)
+                {
+                    File.WriteAllText(constantsPath, injected);
+                    EditorApplication.LockReloadAssemblies();
+                    try { AssetDatabase.Refresh(); }
+                    finally { EditorApplication.UnlockReloadAssemblies(); }
+                    Debug.Log($"[AIT] 버전 상수 주입 완료: CommitHash={commitHash}, ReleaseDateTime={releaseDateTime}");
+                }
+
+                return original;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] 버전 상수 주입 실패 (무시됨): {e.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 빌드 후 AITVersionConstants.cs를 원본으로 복원합니다.
+        /// </summary>
+        private static void RestoreVersionConstants(string originalContent)
+        {
+            if (originalContent == null) return;
+
+            try
+            {
+                if (!AITPackagePathResolver.TryResolveFile(VersionConstantsRelativePath, out string constantsPath))
+                    return;
+
+                File.WriteAllText(constantsPath, originalContent);
+                EditorApplication.LockReloadAssemblies();
+                try { AssetDatabase.Refresh(); }
+                finally { EditorApplication.UnlockReloadAssemblies(); }
+                Debug.Log("[AIT] 버전 상수 복원 완료");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] 버전 상수 복원 실패: {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// git rev-parse --short=7 HEAD로 현재 커밋 해시를 가져옵니다.
+        /// Unity 프로젝트 루트에서 실행하여 프로젝트 커밋 해시를 반환합니다.
+        /// (SDK가 UPM git 패키지로 설치된 경우에도 프로젝트의 커밋 해시를 사용)
+        /// </summary>
+        private static string GetGitCommitHash()
+        {
+            try
+            {
+                using (var process = new System.Diagnostics.Process
+                {
+                    StartInfo = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = "git",
+                        Arguments = "rev-parse --short=7 HEAD",
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        CreateNoWindow = true,
+                        WorkingDirectory = UnityUtil.GetProjectPath()
+                    }
+                })
+                {
+                    process.Start();
+                    string output = process.StandardOutput.ReadToEnd().Trim();
+                    bool exited = process.WaitForExit(5000);
+                    return exited && process.ExitCode == 0 && !string.IsNullOrEmpty(output) ? output : "unknown";
+                }
+            }
+            catch
+            {
+                return "unknown";
+            }
         }
 
         #endregion

--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -1,11 +1,10 @@
 // Auto-generated - DO NOT EDIT MANUALLY
-// Updated at: 2026-04-16T06:31:42Z
 namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
         public const string Version = "2.4.6";
-        public const string ReleaseDateTime = "20260416_0631";
-        public const string CommitHash = "d8fa5da";
+        public const string ReleaseDateTime = null;
+        public const string CommitHash = null;
     }
 }


### PR DESCRIPTION
## Summary
- AITVersionConstants.cs가 매 커밋마다 타임스탬프/해시로 재생성되어 브랜치 머지 시 항상 충돌이 발생하던 문제 해결
- pre-commit 훅에서 Version만 동기화, CommitHash/ReleaseDateTime은 null 유지
- WebGL 빌드 직전에 AITConvertCore에서 CommitHash/ReleaseDateTime 주입 후 빌드 완료 시 복원

## 변경 파일
- `.husky/pre-commit` — Version만 동기화, VERSION 추출 실패 가드 추가
- `Runtime/Helpers/AITVersionConstants.cs` — CommitHash/ReleaseDateTime을 null로 변경
- `Editor/AITConvertCore.cs` — 빌드 시점 버전 상수 주입/복원 로직 추가

## 동작 흐름
| 시점 | Version | CommitHash | ReleaseDateTime |
|------|---------|------------|------------------|
| 커밋 시 (pre-commit) | package.json 동기화 | null | null |
| 빌드 시 (WebGL) | 그대로 | git hash 주입 → 빌드 후 복원 | UTC 시간 주입 → 빌드 후 복원 |
| 릴리즈 시 (release.yml) | 릴리즈 버전 | 릴리즈 커밋 해시 | 릴리즈 시간 |

## Test plan
- [ ] pre-commit 훅 실행 시 AITVersionConstants.cs에 Version만 갱신되고 CommitHash/ReleaseDateTime은 null인지 확인
- [ ] Unity WebGL 빌드 시 CommitHash/ReleaseDateTime이 주입되는지 확인
- [ ] 빌드 완료 후 AITVersionConstants.cs가 원본(null 값)으로 복원되는지 확인
- [ ] 빌드 실패 시에도 파일이 복원되는지 확인
- [ ] release.yml 워크플로우의 기존 동작에 영향 없는지 확인