### PR TITLE
수정: jslib TypeScript 타입 검사 ts-morph v28 호환

### DIFF
--- a/Runtime/Helpers/AITVersionConstants.cs
+++ b/Runtime/Helpers/AITVersionConstants.cs
@@ -3,7 +3,7 @@ namespace AppsInToss
 {
     internal static class AITVersionConstants
     {
-        public const string Version = "2.4.6";
+        public const string Version = "2.4.7";
         public const string ReleaseDateTime = null;
         public const string CommitHash = null;
     }

--- a/sdk-runtime-generator~/src/generators/jslib-compiler.ts
+++ b/sdk-runtime-generator~/src/generators/jslib-compiler.ts
@@ -104,8 +104,8 @@ export async function typeCheckBridgeCode(
     const tsconfigContent = {
       compilerOptions: {
         target: 'ES2020',
-        module: 'ES2020',
-        moduleResolution: 'node',
+        module: 'ESNext',
+        moduleResolution: 'bundler',
         strict: true,
         noEmit: true,
         skipLibCheck: true,
@@ -144,7 +144,7 @@ export async function typeCheckBridgeCode(
     }
 
     // tsc 실행 (ts-morph 사용)
-    const { Project } = await import('ts-morph');
+    const { Project, ts } = await import('ts-morph');
 
     const project = new Project({
       tsConfigFilePath: tsconfigPath,
@@ -169,11 +169,19 @@ export async function typeCheckBridgeCode(
         file = path.basename(sourceFile.getFilePath());
       }
 
+      // getMessageText()는 string 또는 DiagnosticMessageChain을 반환.
+      // chain일 때 toString()은 "[object Object]"가 되므로 flattenDiagnosticMessageText로 풀어냄.
+      const rawMessage = diagnostic.getMessageText();
+      const message =
+        typeof rawMessage === 'string'
+          ? rawMessage
+          : ts.flattenDiagnosticMessageText(diagnostic.compilerObject.messageText, '\n');
+
       errors.push({
         file,
         line,
         column,
-        message: diagnostic.getMessageText().toString(),
+        message,
         code: diagnostic.getCode(),
       });
     }


### PR DESCRIPTION
## Summary

- Bulk Release 실패 원인 수정: ts-morph v28 (TypeScript 6.0)에서 `moduleResolution: 'node'`가 deprecated 되어 TS5107로 검사 실패
- `moduleResolution: 'bundler'` + `module: 'ESNext'`로 변경 (Unity WebGL jslib 번들러 환경에 적합)
- diagnostic 메시지가 `DiagnosticMessageChain`일 때 `.toString()`이 `"[object Object]"`로 출력되던 버그 수정 (`flattenDiagnosticMessageText` 사용)
- pre-commit hook에 의해 `AITVersionConstants.cs` 버전 동기화 포함 (2.4.6 → 2.4.7)

## Context

이전 Bulk Release (run 24654860590)에서 7개 버전 (2.4.1 ~ 2.4.7) 전부 "SDK Runtime 재생성" step에서 실패했음. 원인 추적 결과 PR #415 (ts-morph v27 → v28) 머지 후 `jslib-compiler.ts`가 생성하는 tsconfig가 TS 6에서 거부되는 것으로 확인.

로컬에서 재현 성공 → 실제 에러 메시지(`moduleResolution=node10 is deprecated and will stop functioning in TypeScript 7.0`)를 확보한 뒤 수정.

## Test plan

- [x] `pnpm generate` 로컬 통과 (2.5s)
- [x] `pnpm run test:tier2` 로컬 통과 (18/18)
- [ ] CI: Validate (SDK Generator Unit Tests + Unity .meta)
- [ ] CI: E2E Tests (수동 트리거)
- [ ] Bulk Release 재시도 전 E2E로 실환경 검증