### PR TITLE
수정: SDK-8A/8B Sentry 설정 자동 적용

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -128,6 +128,15 @@ namespace AppsInToss.Editor
             PlayerSettings.SetScriptingBackend(BuildTargetGroup.WebGL, ScriptingImplementation.IL2CPP);
 #endif
 
+            // ===== WebGL Stack Trace Log Type =====
+            // 경고 방지: "The 'Method Name, File Name, and Line Number' option for IL2CPP stack traces is not supported on WebGL."
+            // WebGL에서는 Full(Method Name/File Name/Line Number)이 지원되지 않음. ScriptOnly로 설정.
+            PlayerSettings.SetStackTraceLogType(LogType.Error,     StackTraceLogType.ScriptOnly);
+            PlayerSettings.SetStackTraceLogType(LogType.Assert,    StackTraceLogType.ScriptOnly);
+            PlayerSettings.SetStackTraceLogType(LogType.Warning,   StackTraceLogType.ScriptOnly);
+            PlayerSettings.SetStackTraceLogType(LogType.Log,       StackTraceLogType.ScriptOnly);
+            PlayerSettings.SetStackTraceLogType(LogType.Exception, StackTraceLogType.ScriptOnly);
+
             PlayerSettings.stripEngineCode = editorConfig.stripEngineCode;
 
             // ===== Managed Stripping Level (프로필 → 자동) =====
@@ -184,6 +193,7 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - 스레딩: {threadsSupport}{(editorConfig.threadsSupport < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - 데이터 캐싱: {dataCaching}{(editorConfig.dataCaching < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - 예외 처리: {exceptionSupport}{(editorConfig.exceptionSupport < 0 ? " (자동)" : "")}");
+            Debug.Log($"[AIT]   - Stack Trace Log Type: ScriptOnly (WebGL 자동)");
             Debug.Log($"[AIT]   - Stripping Level: {strippingLevel}{(profile?.managedStrippingLevel < 0 || profile == null ? " (자동)" : " (프로필)")}");
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -100,10 +100,10 @@ namespace AppsInToss.Editor
 
             // ===== 예외 처리 (사용자 지정 또는 자동) =====
             // 출처: UnityVersion.md:393, 431
+            // 실제 적용은 아래 ApplySentryFriendlyWebGLSettings에서 수행 (stack trace와 함께 관리)
             WebGLExceptionSupport exceptionSupport = editorConfig.exceptionSupport >= 0
                 ? (WebGLExceptionSupport)editorConfig.exceptionSupport
                 : AITDefaultSettings.GetDefaultExceptionSupport();
-            PlayerSettings.WebGL.exceptionSupport = exceptionSupport;
 
             // ===== 파일 해싱 =====
             // Unity 2021.3에서 nameFilesAsHashes = true 시 Bee 빌드 루프 버그 발생
@@ -128,14 +128,9 @@ namespace AppsInToss.Editor
             PlayerSettings.SetScriptingBackend(BuildTargetGroup.WebGL, ScriptingImplementation.IL2CPP);
 #endif
 
-            // ===== WebGL Stack Trace Log Type =====
-            // 경고 방지: "The 'Method Name, File Name, and Line Number' option for IL2CPP stack traces is not supported on WebGL."
-            // WebGL에서는 Full(Method Name/File Name/Line Number)이 지원되지 않음. ScriptOnly로 설정.
-            PlayerSettings.SetStackTraceLogType(LogType.Error,     StackTraceLogType.ScriptOnly);
-            PlayerSettings.SetStackTraceLogType(LogType.Assert,    StackTraceLogType.ScriptOnly);
-            PlayerSettings.SetStackTraceLogType(LogType.Warning,   StackTraceLogType.ScriptOnly);
-            PlayerSettings.SetStackTraceLogType(LogType.Log,       StackTraceLogType.ScriptOnly);
-            PlayerSettings.SetStackTraceLogType(LogType.Exception, StackTraceLogType.ScriptOnly);
+            // ===== Sentry 친화 설정 (WebGL exception support + stack trace) =====
+            // Capture() 스냅샷이 반드시 이보다 먼저 찍혀야 Restore()가 의미 있음 (DoExport 참조).
+            ApplySentryFriendlyWebGLSettings(exceptionSupport);
 
             PlayerSettings.stripEngineCode = editorConfig.stripEngineCode;
 
@@ -193,7 +188,7 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - 스레딩: {threadsSupport}{(editorConfig.threadsSupport < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - 데이터 캐싱: {dataCaching}{(editorConfig.dataCaching < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - 예외 처리: {exceptionSupport}{(editorConfig.exceptionSupport < 0 ? " (자동)" : "")}");
-            Debug.Log($"[AIT]   - Stack Trace Log Type: ScriptOnly (WebGL 자동)");
+            Debug.Log($"[AIT]   - Stack Trace Log Type (Error/Assert/Warning/Log/Exception): {PlayerSettings.GetStackTraceLogType(LogType.Error)} (WebGL 자동)");
             Debug.Log($"[AIT]   - Stripping Level: {strippingLevel}{(profile?.managedStrippingLevel < 0 || profile == null ? " (자동)" : " (프로필)")}");
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
@@ -204,6 +199,28 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - WASM Streaming: {editorConfig.wasmStreaming}");
 #endif
 #endif
+        }
+
+        /// <summary>
+        /// Sentry/에러 추적 SDK가 요구하는 WebGL 설정을 적용한다.
+        /// - WebGL exceptionSupport를 지정 값으로 설정 (기본 FullWithStacktrace — stack trace 캡처 가능)
+        /// - Stack Trace Log Type은 WebGL에서 지원되는 ScriptOnly로 고정 (Full은 IL2CPP/WebGL 조합 미지원)
+        ///
+        /// 주의: PlayerSettings.SetStackTraceLogType은 플랫폼별이 아닌 프로젝트 전역 설정이다.
+        /// 사용자 PlayerSettings가 영구 변경되지 않도록, 호출 직전에 AITPlayerSettingsBackup.Capture()가
+        /// 실행되어 있어야 한다 (AITConvertCore.DoExport 참조). 이 메서드는 Init() 외부에서도
+        /// 테스트가 부수 효과(AssetDatabase.Refresh 등) 없이 설정만 검증할 수 있도록 분리되었다.
+        /// </summary>
+        internal static void ApplySentryFriendlyWebGLSettings(WebGLExceptionSupport exceptionSupport)
+        {
+            PlayerSettings.WebGL.exceptionSupport = exceptionSupport;
+
+            // 경고 방지: "The 'Method Name, File Name, and Line Number' option for IL2CPP stack traces is not supported on WebGL."
+            PlayerSettings.SetStackTraceLogType(LogType.Error, StackTraceLogType.ScriptOnly);
+            PlayerSettings.SetStackTraceLogType(LogType.Assert, StackTraceLogType.ScriptOnly);
+            PlayerSettings.SetStackTraceLogType(LogType.Warning, StackTraceLogType.ScriptOnly);
+            PlayerSettings.SetStackTraceLogType(LogType.Log, StackTraceLogType.ScriptOnly);
+            PlayerSettings.SetStackTraceLogType(LogType.Exception, StackTraceLogType.ScriptOnly);
         }
 
         /// <summary>

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -203,6 +203,7 @@ namespace AppsInToss.Editor
 
         /// <summary>
         /// Sentry/에러 추적 SDK가 요구하는 WebGL 설정을 적용한다.
+        /// 호출 위치: <see cref="Init"/> 내 IL2CPP 설정 직후 (Init이 이 메서드에 위임).
         /// - WebGL exceptionSupport를 지정 값으로 설정 (기본 FullWithStacktrace — stack trace 캡처 가능)
         /// - Stack Trace Log Type은 WebGL에서 지원되는 ScriptOnly로 고정 (Full은 IL2CPP/WebGL 조합 미지원)
         ///

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -806,10 +806,10 @@ namespace AppsInToss.Editor
             DrawModifiedIndicator(isModified);
 
             string label = config.exceptionSupport < 0
-                ? $"예외 처리 모드 (자동: ExplicitlyThrown)"
+                ? $"예외 처리 모드 (자동: {defaultValue})"
                 : "예외 처리 모드";
 
-            string[] options = { "자동 (ExplicitlyThrown)", "None", "ExplicitlyThrownOnly", "FullWithStacktrace", "FullWithoutStacktrace" };
+            string[] options = { $"자동 ({defaultValue})", "None", "ExplicitlyThrownOnly", "FullWithStacktrace", "FullWithoutStacktrace" };
             int currentIndex = config.exceptionSupport < 0 ? 0 : config.exceptionSupport + 1;
             int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
             config.exceptionSupport = newIndex == 0 ? -1 : newIndex - 1;

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -187,7 +187,7 @@ namespace AppsInToss
         public bool wasmStreaming = true;
 
         [Header("고급 설정 (주의: 변경 시 호환성 문제 발생 가능)")]
-        [Tooltip("-1 = 자동 (ExplicitlyThrownExceptionsOnly)")]
+        [Tooltip("-1 = 자동 (FullWithStacktrace, Sentry 경고 방지)")]
         public int exceptionSupport = -1;
 
         [Tooltip("-1 = 자동 (false), Unity Pro 라이선스 필요")]
@@ -421,7 +421,9 @@ namespace AppsInToss
         /// </summary>
         public static WebGLExceptionSupport GetDefaultExceptionSupport()
         {
-            return WebGLExceptionSupport.ExplicitlyThrownExceptionsOnly;
+            // Sentry/에러 추적 SDK가 stack trace를 캡처하려면 FullWithStacktrace 필요.
+            // Unity 기본값(ExplicitlyThrownExceptionsOnly)을 올려서 Sentry의 런타임 경고 제거.
+            return WebGLExceptionSupport.FullWithStacktrace;
         }
 
         /// <summary>

--- a/Editor/AITPlayerSettingsBackup.cs
+++ b/Editor/AITPlayerSettingsBackup.cs
@@ -34,6 +34,13 @@ namespace AppsInToss.Editor
         public ManagedStrippingLevel managedStrippingLevel;
         public Il2CppCompilerConfiguration il2cppCompilerConfiguration;
 
+        // Stack Trace Log Type (LogType별)
+        public StackTraceLogType stackTraceLogTypeError;
+        public StackTraceLogType stackTraceLogTypeAssert;
+        public StackTraceLogType stackTraceLogTypeWarning;
+        public StackTraceLogType stackTraceLogTypeLog;
+        public StackTraceLogType stackTraceLogTypeException;
+
 #if UNITY_2022_3_OR_NEWER
         public WebGLDebugSymbolMode debugSymbolMode;
 #endif
@@ -80,6 +87,13 @@ namespace AppsInToss.Editor
                 managedStrippingLevel = PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.WebGL),
                 il2cppCompilerConfiguration = PlayerSettings.GetIl2CppCompilerConfiguration(BuildTargetGroup.WebGL),
 #endif
+
+                // Stack Trace Log Type (LogType별)
+                stackTraceLogTypeError     = PlayerSettings.GetStackTraceLogType(LogType.Error),
+                stackTraceLogTypeAssert    = PlayerSettings.GetStackTraceLogType(LogType.Assert),
+                stackTraceLogTypeWarning   = PlayerSettings.GetStackTraceLogType(LogType.Warning),
+                stackTraceLogTypeLog       = PlayerSettings.GetStackTraceLogType(LogType.Log),
+                stackTraceLogTypeException = PlayerSettings.GetStackTraceLogType(LogType.Exception),
             };
 
 #if UNITY_2022_3_OR_NEWER
@@ -149,6 +163,13 @@ namespace AppsInToss.Editor
             PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL, managedStrippingLevel);
             PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.WebGL, il2cppCompilerConfiguration);
 #endif
+
+            // Stack Trace Log Type (LogType별)
+            PlayerSettings.SetStackTraceLogType(LogType.Error,     stackTraceLogTypeError);
+            PlayerSettings.SetStackTraceLogType(LogType.Assert,    stackTraceLogTypeAssert);
+            PlayerSettings.SetStackTraceLogType(LogType.Warning,   stackTraceLogTypeWarning);
+            PlayerSettings.SetStackTraceLogType(LogType.Log,       stackTraceLogTypeLog);
+            PlayerSettings.SetStackTraceLogType(LogType.Exception, stackTraceLogTypeException);
 
 #if UNITY_2022_3_OR_NEWER
             PlayerSettings.WebGL.debugSymbolMode = debugSymbolMode;

--- a/TODO.md
+++ b/TODO.md
@@ -161,11 +161,6 @@
 
 ## Sentry / ErrorTracker 개선 (2026-04-18 Sentry 이슈 전수 조사 기반)
 
-### P1 — SDK 설정 경고를 자동 적용으로 전환
-- **이슈**: SDK-8A (Sentry Exception Support 설정 필요, 31건), SDK-8B (IL2CPP stack traces WebGL 미지원, 19건)
-- **현상**: SDK가 매 빌드마다 경고만 출력하고, 사용자가 수동으로 설정해야 함
-- **조치**: `AITBuildInitializer.Init()`에서 해당 설정을 자동으로 적용하도록 변경 (Graphics API 변경과 동일 패턴)
-
 ### P2 — 사용자 SDK API 변경으로 인한 컴파일 에러 모니터링
 - **이슈**: SDK-80, 81 (AppsInTossMenu.Build/Package 정의 없음), SDK-7Z (namespace AppsInToss not found)
 - **현상**: SDK 업데이트 후 API 변경으로 사용자 프로젝트에서 컴파일 에러 발생. SDK breaking change의 영향을 파악할 수 있는 귀중한 데이터

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerSettingsTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerSettingsTests.cs
@@ -97,6 +97,11 @@ public class AITBuildInitializerSettingsTests
         PlayerSettings.SetStackTraceLogType(LogType.Error, StackTraceLogType.ScriptOnly);
         PlayerSettings.SetStackTraceLogType(LogType.Log, StackTraceLogType.ScriptOnly);
 
+        // 덮어쓰기가 실제로 snapshot 값과 다른지 확인해 Restore가 fixed-point가 아니라 round-trip임을 보장
+        Assert.AreNotEqual(StackTraceLogType.Full,
+            PlayerSettings.GetStackTraceLogType(LogType.Error),
+            "Sanity: overwrite must actually change LogType.Error value before Restore");
+
         snapshot.Restore();
 
         Assert.AreEqual(StackTraceLogType.Full,

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerSettingsTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerSettingsTests.cs
@@ -1,0 +1,109 @@
+// -----------------------------------------------------------------------
+// AITBuildInitializerSettingsTests.cs - Sentry/Stack Trace 설정 자동 적용 검증
+// Level 0: GetDefaultExceptionSupport, Init()가 적용하는 WebGL Stack Trace 설정 검증
+// Sentry 이슈 APPS-IN-TOSS-UNITY-SDK-8A / 8B 재발 방지용 회귀 테스트
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITBuildInitializerSettingsTests
+{
+    private AITPlayerSettingsBackup backup;
+
+    [SetUp]
+    public void Setup()
+    {
+        // 테스트 실행 중 PlayerSettings를 변경하므로 미리 백업
+        backup = AITPlayerSettingsBackup.Capture();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // 테스트 종료 후 원래 PlayerSettings로 복원
+        backup.Restore();
+    }
+
+    // =====================================================
+    // 기본값 검증 (SDK-8A 회귀 방지)
+    // =====================================================
+
+    [Test]
+    public void GetDefaultExceptionSupport_Returns_FullWithStacktrace()
+    {
+        // Sentry가 stack trace를 캡처하려면 FullWithStacktrace 필요
+        // 이 값이 낮아지면 Sentry에서 SDK-8A 경고가 재발생함
+        var result = AITDefaultSettings.GetDefaultExceptionSupport();
+        Assert.AreEqual(WebGLExceptionSupport.FullWithStacktrace, result,
+            "Default exception support must be FullWithStacktrace to avoid Sentry SDK-8A warning");
+    }
+
+    // =====================================================
+    // Init() 동작 검증 (SDK-8A 회귀 방지)
+    // =====================================================
+
+    [Test]
+    public void Init_Sets_WebGLExceptionSupport_FullWithStacktrace()
+    {
+        // 초기 상태를 낮춰놓고 Init()가 올려주는지 확인
+        PlayerSettings.WebGL.exceptionSupport = WebGLExceptionSupport.None;
+
+        AITBuildInitializer.Init();
+
+        Assert.AreEqual(WebGLExceptionSupport.FullWithStacktrace,
+            PlayerSettings.WebGL.exceptionSupport,
+            "Init() must set WebGL exceptionSupport to FullWithStacktrace");
+    }
+
+    // =====================================================
+    // Init() Stack Trace 설정 검증 (SDK-8B 회귀 방지)
+    // =====================================================
+
+    [TestCase(LogType.Error)]
+    [TestCase(LogType.Assert)]
+    [TestCase(LogType.Warning)]
+    [TestCase(LogType.Log)]
+    [TestCase(LogType.Exception)]
+    public void Init_Sets_StackTraceLogType_ScriptOnly_For_All_LogTypes(LogType logType)
+    {
+        // WebGL에서 지원되지 않는 Full로 먼저 설정 → Init()가 ScriptOnly로 내려야 함
+        PlayerSettings.SetStackTraceLogType(logType, StackTraceLogType.Full);
+
+        AITBuildInitializer.Init();
+
+        Assert.AreEqual(StackTraceLogType.ScriptOnly,
+            PlayerSettings.GetStackTraceLogType(logType),
+            $"Init() must set stack trace log type for {logType} to ScriptOnly (WebGL does not support Full)");
+    }
+
+    // =====================================================
+    // Backup/Restore가 Stack Trace 설정을 보존하는지 확인
+    // =====================================================
+
+    [Test]
+    public void PlayerSettingsBackup_RoundTrips_StackTraceLogType()
+    {
+        // 사용자 설정 시뮬레이션: Full로 지정
+        PlayerSettings.SetStackTraceLogType(LogType.Error, StackTraceLogType.Full);
+        PlayerSettings.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
+
+        var snapshot = AITPlayerSettingsBackup.Capture();
+
+        // SDK가 값을 덮어씀
+        PlayerSettings.SetStackTraceLogType(LogType.Error, StackTraceLogType.ScriptOnly);
+        PlayerSettings.SetStackTraceLogType(LogType.Log, StackTraceLogType.ScriptOnly);
+
+        snapshot.Restore();
+
+        Assert.AreEqual(StackTraceLogType.Full,
+            PlayerSettings.GetStackTraceLogType(LogType.Error),
+            "Restore must return LogType.Error stack trace to pre-build user value");
+        Assert.AreEqual(StackTraceLogType.None,
+            PlayerSettings.GetStackTraceLogType(LogType.Log),
+            "Restore must return LogType.Log stack trace to pre-build user value");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerSettingsTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerSettingsTests.cs
@@ -1,12 +1,13 @@
 // -----------------------------------------------------------------------
 // AITBuildInitializerSettingsTests.cs - Sentry/Stack Trace 설정 자동 적용 검증
-// Level 0: GetDefaultExceptionSupport, Init()가 적용하는 WebGL Stack Trace 설정 검증
+// Level 0: AITBuildInitializer.ApplySentryFriendlyWebGLSettings 및 백업/복원 순수 로직 검증
 // Sentry 이슈 APPS-IN-TOSS-UNITY-SDK-8A / 8B 재발 방지용 회귀 테스트
 // -----------------------------------------------------------------------
 
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
+using AppsInToss;
 using AppsInToss.Editor;
 
 [TestFixture]
@@ -43,24 +44,23 @@ public class AITBuildInitializerSettingsTests
     }
 
     // =====================================================
-    // Init() 동작 검증 (SDK-8A 회귀 방지)
+    // ApplySentryFriendlyWebGLSettings 동작 검증 (SDK-8A 회귀 방지)
     // =====================================================
 
     [Test]
-    public void Init_Sets_WebGLExceptionSupport_FullWithStacktrace()
+    public void ApplySentryFriendlyWebGLSettings_Sets_ExceptionSupport()
     {
-        // 초기 상태를 낮춰놓고 Init()가 올려주는지 확인
         PlayerSettings.WebGL.exceptionSupport = WebGLExceptionSupport.None;
 
-        AITBuildInitializer.Init();
+        AITBuildInitializer.ApplySentryFriendlyWebGLSettings(WebGLExceptionSupport.FullWithStacktrace);
 
         Assert.AreEqual(WebGLExceptionSupport.FullWithStacktrace,
             PlayerSettings.WebGL.exceptionSupport,
-            "Init() must set WebGL exceptionSupport to FullWithStacktrace");
+            "ApplySentryFriendlyWebGLSettings must set WebGL exceptionSupport to the requested value");
     }
 
     // =====================================================
-    // Init() Stack Trace 설정 검증 (SDK-8B 회귀 방지)
+    // ApplySentryFriendlyWebGLSettings Stack Trace 설정 검증 (SDK-8B 회귀 방지)
     // =====================================================
 
     [TestCase(LogType.Error)]
@@ -68,16 +68,16 @@ public class AITBuildInitializerSettingsTests
     [TestCase(LogType.Warning)]
     [TestCase(LogType.Log)]
     [TestCase(LogType.Exception)]
-    public void Init_Sets_StackTraceLogType_ScriptOnly_For_All_LogTypes(LogType logType)
+    public void ApplySentryFriendlyWebGLSettings_Sets_StackTraceLogType_ScriptOnly(LogType logType)
     {
-        // WebGL에서 지원되지 않는 Full로 먼저 설정 → Init()가 ScriptOnly로 내려야 함
+        // WebGL에서 지원되지 않는 Full로 먼저 설정 → 헬퍼가 ScriptOnly로 내려야 함
         PlayerSettings.SetStackTraceLogType(logType, StackTraceLogType.Full);
 
-        AITBuildInitializer.Init();
+        AITBuildInitializer.ApplySentryFriendlyWebGLSettings(WebGLExceptionSupport.FullWithStacktrace);
 
         Assert.AreEqual(StackTraceLogType.ScriptOnly,
             PlayerSettings.GetStackTraceLogType(logType),
-            $"Init() must set stack trace log type for {logType} to ScriptOnly (WebGL does not support Full)");
+            $"ApplySentryFriendlyWebGLSettings must set stack trace log type for {logType} to ScriptOnly (WebGL does not support Full)");
     }
 
     // =====================================================

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerSettingsTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerSettingsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6c39e2d591e4ebdb99f229d58c83eb3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 변경 이유
Sentry 경고 APPS-IN-TOSS-UNITY-SDK-8A (97건) / SDK-8B (65건) 노이즈 제거.
SDK가 빌드 시점에 자동으로 Sentry 친화 설정을 적용하도록 변경.

## 변경 사항
- `AITEditorScriptObject.cs` — 기본 exceptionSupport를 FullWithStacktrace로
- `AITBuildInitializer.cs` — IL2CPP stack trace를 WebGL에서 지원되는 ScriptOnly로 설정
- `AITPlayerSettingsBackup.cs` — stack trace 설정 백업/복원 추가
- EditMode 테스트 추가

## 관련 이슈
- Sentry APPS-IN-TOSS-UNITY-SDK-8A
- Sentry APPS-IN-TOSS-UNITY-SDK-8B

## 테스트 계획
- [x] `./run-local-tests.sh --validate` 통과
- [x] EditMode 테스트 통과
- [ ] 실제 빌드 시 Sentry 경고 미발생 확인 (실제 빌드 환경에서)