### PR TITLE
수정: loader.js 중복 파일 자동 정리로 Sentry 노이즈 제거

### DIFF
--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -298,6 +298,7 @@ namespace AppsInToss.Editor
                         return byTime != 0 ? byTime : string.CompareOrdinal(b, a);
                     });
 
+                    string kept = Path.GetFileName(files[0]);
                     var deleted = new List<string>();
                     var failed = new List<string>();
                     for (int i = 1; i < files.Length; i++)
@@ -321,11 +322,16 @@ namespace AppsInToss.Editor
                         {
                             failed.Add(Path.GetFileName(stalePath));
                         }
+                        catch (Exception)
+                        {
+                            // PathTooLongException 등 플랫폼별 예외도 fallback 처리
+                            failed.Add(Path.GetFileName(stalePath));
+                        }
                     }
 
                     if (failed.Count == 0)
                     {
-                        Debug.Log($"[AIT] ✓ '{pattern}' 이전 빌드 잔여물 {deleted.Count}개 자동 정리: {string.Join(", ", deleted)}");
+                        Debug.Log($"[AIT] ✓ '{pattern}' 이전 빌드 잔여물 {deleted.Count}개 자동 정리: {string.Join(", ", deleted)} (남김: {kept})");
                     }
                     else
                     {

--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -314,17 +314,13 @@ namespace AppsInToss.Editor
                             }
                             deleted.Add(Path.GetFileName(stalePath));
                         }
-                        catch (IOException)
+                        catch (Exception ex) when (
+                            ex is IOException ||
+                            ex is UnauthorizedAccessException ||
+                            ex is PathTooLongException ||
+                            ex is NotSupportedException ||
+                            ex is System.Security.SecurityException)
                         {
-                            failed.Add(Path.GetFileName(stalePath));
-                        }
-                        catch (UnauthorizedAccessException)
-                        {
-                            failed.Add(Path.GetFileName(stalePath));
-                        }
-                        catch (Exception)
-                        {
-                            // PathTooLongException 등 플랫폼별 예외도 fallback 처리
                             failed.Add(Path.GetFileName(stalePath));
                         }
                     }
@@ -336,8 +332,8 @@ namespace AppsInToss.Editor
                     else
                     {
                         // 삭제 실패 시 Clean Build 유도 (삭제 성공한 파일은 이미 없으므로 실패 목록만 표시)
-                        Debug.LogWarning($"[AIT] ⚠️ '{pattern}' 중복 파일 {failed.Count}개 정리 실패: {string.Join(", ", failed)}");
-                        Debug.LogWarning("[AIT]    이전 빌드 잔여물일 수 있습니다. 'Clean Build' 사용을 권장합니다.");
+                        Debug.LogWarning($"[AIT] ⚠️ '{pattern}' 이전 빌드 잔여물 {failed.Count}개 정리 실패: {string.Join(", ", failed)}");
+                        Debug.LogWarning("[AIT]    'Clean Build' 사용을 권장합니다.");
                     }
                 }
 

--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -291,17 +291,22 @@ namespace AppsInToss.Editor
                 // (경고 로그만으로는 매 빌드마다 반복 발생 → Sentry 노이즈 누적)
                 if (files.Length > 1)
                 {
-                    Array.Sort(files, (a, b) => File.GetLastWriteTime(b).CompareTo(File.GetLastWriteTime(a)));
+                    // LastWriteTime 동률 시 파일명 내림차순으로 고정(Array.Sort는 불안정)
+                    Array.Sort(files, (a, b) =>
+                    {
+                        int byTime = File.GetLastWriteTime(b).CompareTo(File.GetLastWriteTime(a));
+                        return byTime != 0 ? byTime : string.CompareOrdinal(b, a);
+                    });
 
                     var deleted = new List<string>();
                     var failed = new List<string>();
                     for (int i = 1; i < files.Length; i++)
                     {
-                        var stalePath = files[i];
+                        string stalePath = files[i];
                         try
                         {
                             File.Delete(stalePath);
-                            var metaPath = stalePath + ".meta";
+                            string metaPath = stalePath + ".meta";
                             if (File.Exists(metaPath))
                             {
                                 File.Delete(metaPath);
@@ -320,18 +325,12 @@ namespace AppsInToss.Editor
 
                     if (failed.Count == 0)
                     {
-                        Debug.Log($"[AIT] ✓ '{pattern}' 중복 {deleted.Count}개 자동 정리: {string.Join(", ", deleted.ToArray())}");
+                        Debug.Log($"[AIT] ✓ '{pattern}' 이전 빌드 잔여물 {deleted.Count}개 자동 정리: {string.Join(", ", deleted)}");
                     }
                     else
                     {
-                        // 삭제 실패 시에만 기존 경고 로그 유지 (수동 Clean Build 유도)
-                        Debug.LogWarning($"[AIT] ⚠️ '{pattern}'에 {files.Length}개 파일이 일치합니다. 최신 파일을 사용합니다.");
-                        foreach (var file in files)
-                        {
-                            var time = File.GetLastWriteTime(file);
-                            var selected = file == files[0] ? " ← 선택됨" : "";
-                            Debug.LogWarning($"[AIT]    - {Path.GetFileName(file)} ({time:yyyy-MM-dd HH:mm:ss}){selected}");
-                        }
+                        // 삭제 실패 시 Clean Build 유도 (삭제 성공한 파일은 이미 없으므로 실패 목록만 표시)
+                        Debug.LogWarning($"[AIT] ⚠️ '{pattern}' 중복 파일 {failed.Count}개 정리 실패: {string.Join(", ", failed)}");
                         Debug.LogWarning("[AIT]    이전 빌드 잔여물일 수 있습니다. 'Clean Build' 사용을 권장합니다.");
                     }
                 }

--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -287,18 +287,53 @@ namespace AppsInToss.Editor
             var files = Directory.GetFiles(buildPath, pattern);
             if (files.Length > 0)
             {
-                // 중복 파일 감지 시 경고 + 최신 파일 우선 선택
+                // 중복 파일 감지 시 최신 파일만 남기고 오래된 잔여물 자동 삭제
+                // (경고 로그만으로는 매 빌드마다 반복 발생 → Sentry 노이즈 누적)
                 if (files.Length > 1)
                 {
-                    Debug.LogWarning($"[AIT] ⚠️ '{pattern}'에 {files.Length}개 파일이 일치합니다. 최신 파일을 사용합니다.");
                     Array.Sort(files, (a, b) => File.GetLastWriteTime(b).CompareTo(File.GetLastWriteTime(a)));
-                    foreach (var file in files)
+
+                    var deleted = new List<string>();
+                    var failed = new List<string>();
+                    for (int i = 1; i < files.Length; i++)
                     {
-                        var time = File.GetLastWriteTime(file);
-                        var selected = file == files[0] ? " ← 선택됨" : "";
-                        Debug.LogWarning($"[AIT]    - {Path.GetFileName(file)} ({time:yyyy-MM-dd HH:mm:ss}){selected}");
+                        var stalePath = files[i];
+                        try
+                        {
+                            File.Delete(stalePath);
+                            var metaPath = stalePath + ".meta";
+                            if (File.Exists(metaPath))
+                            {
+                                File.Delete(metaPath);
+                            }
+                            deleted.Add(Path.GetFileName(stalePath));
+                        }
+                        catch (IOException)
+                        {
+                            failed.Add(Path.GetFileName(stalePath));
+                        }
+                        catch (UnauthorizedAccessException)
+                        {
+                            failed.Add(Path.GetFileName(stalePath));
+                        }
                     }
-                    Debug.LogWarning("[AIT]    이전 빌드 잔여물일 수 있습니다. 'Clean Build' 사용을 권장합니다.");
+
+                    if (failed.Count == 0)
+                    {
+                        Debug.Log($"[AIT] ✓ '{pattern}' 중복 {deleted.Count}개 자동 정리: {string.Join(", ", deleted.ToArray())}");
+                    }
+                    else
+                    {
+                        // 삭제 실패 시에만 기존 경고 로그 유지 (수동 Clean Build 유도)
+                        Debug.LogWarning($"[AIT] ⚠️ '{pattern}'에 {files.Length}개 파일이 일치합니다. 최신 파일을 사용합니다.");
+                        foreach (var file in files)
+                        {
+                            var time = File.GetLastWriteTime(file);
+                            var selected = file == files[0] ? " ← 선택됨" : "";
+                            Debug.LogWarning($"[AIT]    - {Path.GetFileName(file)} ({time:yyyy-MM-dd HH:mm:ss}){selected}");
+                        }
+                        Debug.LogWarning("[AIT]    이전 빌드 잔여물일 수 있습니다. 'Clean Build' 사용을 권장합니다.");
+                    }
                 }
 
                 string fileName = Path.GetFileName(files[0]);

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -6,6 +6,9 @@
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
 using AppsInToss.Editor;
 
 [TestFixture]
@@ -275,5 +278,120 @@ public class BuildFileSelectionTests
         Assert.AreEqual("build.loader.js", result);
         Assert.IsTrue(File.Exists(file),
             "Single match should never be deleted");
+    }
+
+    // =====================================================
+    // LastWriteTime 동률 — 파일명 내림차순 타이브레이크로 결정적 선택
+    // Array.Sort가 불안정하므로 명시적 이차 정렬 키가 필요
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_SameTimestamp_DeterministicByName()
+    {
+        var time = new DateTime(2026, 1, 1, 12, 0, 0);
+
+        string fileA = Path.Combine(tempDir, "aaa.loader.js");
+        File.WriteAllText(fileA, "// a");
+        File.SetLastWriteTime(fileA, time);
+
+        string fileZ = Path.Combine(tempDir, "zzz.loader.js");
+        File.WriteAllText(fileZ, "// z");
+        File.SetLastWriteTime(fileZ, time);
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+        // CompareOrdinal 내림차순 → "zzz" > "aaa" → zzz 선택
+        Assert.AreEqual("zzz.loader.js", result,
+            "Tie on LastWriteTime should break deterministically by filename (descending)");
+        Assert.IsFalse(File.Exists(fileA), "Tie loser should be deleted");
+        Assert.IsTrue(File.Exists(fileZ), "Tie winner should remain");
+    }
+
+    // =====================================================
+    // 로그 레벨 검증 — 자동 정리 성공 시 Warning 없이 Log 1줄
+    // Sentry 노이즈 제거의 핵심 목적 회귀 방지
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_DuplicateCleanup_EmitsInfoLogNotWarning()
+    {
+        string oldFile = Path.Combine(tempDir, "old.loader.js");
+        File.WriteAllText(oldFile, "// old");
+        File.SetLastWriteTime(oldFile, new DateTime(2025, 1, 1));
+
+        string newFile = Path.Combine(tempDir, "new.loader.js");
+        File.WriteAllText(newFile, "// new");
+        File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
+
+        LogAssert.Expect(LogType.Log, new Regex(@"\[AIT\] ✓ .+ 이전 빌드 잔여물 1개 자동 정리"));
+
+        AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+        // NoUnexpectedReceived가 Warning/Error가 같이 찍히지 않았음을 보장
+        LogAssert.NoUnexpectedReceived();
+    }
+
+    // =====================================================
+    // Fallback 경로 검증 — 삭제 실패 시에도 최신 파일 반환 + 경고
+    // 부모 디렉토리 권한 제어로 UnauthorizedAccessException 유도 (Unix 계열)
+    // Windows는 POSIX 권한 모델과 달라 동일하게 실패하지 않으므로 스킵
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_DeleteFails_FallsBackToWarning()
+    {
+        Assume.That(Application.platform != RuntimePlatform.WindowsEditor,
+            "Unix-only: chmod-based directory permission manipulation");
+
+        string oldFile = Path.Combine(tempDir, "old.loader.js");
+        File.WriteAllText(oldFile, "// old");
+        File.SetLastWriteTime(oldFile, new DateTime(2025, 1, 1));
+
+        string newFile = Path.Combine(tempDir, "new.loader.js");
+        File.WriteAllText(newFile, "// new");
+        File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
+
+        // 부모 디렉토리를 r-xr-xr-x(0555)로 변경 — 삭제 불가 → UnauthorizedAccessException
+        var originalAttrs = File.GetAttributes(tempDir);
+        try
+        {
+            Syscall_Chmod(tempDir, "0555");
+
+            LogAssert.Expect(LogType.Warning, new Regex(@"중복 파일 1개 정리 실패"));
+            LogAssert.Expect(LogType.Warning, new Regex(@"Clean Build"));
+
+            string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+            Assert.AreEqual("new.loader.js", result,
+                "Even when cleanup fails, newest file must still be returned");
+            Assert.IsTrue(File.Exists(oldFile),
+                "Delete should have failed, file must still exist");
+        }
+        finally
+        {
+            // TearDown이 tempDir을 지우려면 쓰기 권한 복구 필요
+            Syscall_Chmod(tempDir, "0755");
+            File.SetAttributes(tempDir, originalAttrs);
+        }
+    }
+
+    private static void Syscall_Chmod(string path, string mode)
+    {
+        var psi = new System.Diagnostics.ProcessStartInfo("chmod", $"{mode} \"{path}\"")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        using (var proc = System.Diagnostics.Process.Start(psi))
+        {
+            proc.WaitForExit(3000);
+            if (proc.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"chmod {mode} {path} failed: {proc.StandardError.ReadToEnd()}");
+            }
+        }
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -320,7 +320,7 @@ public class BuildFileSelectionTests
     }
 
     // =====================================================
-    // 로그 레벨 검증 — 자동 정리 성공 시 Warning/Error 0건
+    // 로그 레벨 검증 — 성공 시 Debug.Log 1건만 발생, Warning/Error 없음
     // Sentry 노이즈 제거의 핵심 목적 회귀 방지.
     // LogAssert.NoUnexpectedReceived는 Error/Assert/Exception만 감시하므로
     // Warning까지 확실히 막으려면 logMessageReceived 훅으로 직접 수집.
@@ -337,12 +337,24 @@ public class BuildFileSelectionTests
         File.WriteAllText(newFile, "// new");
         File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
 
-        var noisy = CollectNoisyLogs(() =>
+        var logs = CollectLogs(() =>
             AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js"));
 
+        // 양성 검증: 성공 메시지가 실제로 발생해야 함 (기능이 조용히 사라지지 않도록)
+        bool emittedSuccess = logs.Exists(l =>
+            l.type == LogType.Log &&
+            Regex.IsMatch(l.message, @"이전 빌드 잔여물 \d+개 자동 정리"));
+        Assert.IsTrue(emittedSuccess,
+            "성공 경로에서 자동 정리 확인 Debug.Log가 발생해야 함: " +
+            string.Join(" | ", logs.ConvertAll(l => $"[{l.type}] {l.message}")));
+
+        // 음성 검증: Warning/Error/Exception/Assert 없음 (Sentry 노이즈 방지)
+        var noisy = logs.FindAll(l =>
+            l.type == LogType.Warning || l.type == LogType.Error ||
+            l.type == LogType.Exception || l.type == LogType.Assert);
         Assert.IsEmpty(noisy,
             "성공 경로는 Warning/Error 로그를 발생시키면 안 됨: " +
-            string.Join(" | ", noisy));
+            string.Join(" | ", noisy.ConvertAll(l => $"[{l.type}] {l.message}")));
     }
 
     // =====================================================
@@ -373,7 +385,7 @@ public class BuildFileSelectionTests
             Assume.That(IsDirectoryWriteBlocked(tempDir),
                 "현재 사용자는 0555 디렉토리에도 쓸 수 있음 (root?) — 테스트 의미 없음");
 
-            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+중복 파일 \d+개 정리 실패"));
+            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+이전 빌드 잔여물 \d+개 정리 실패"));
             LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+Clean Build"));
 
             string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
@@ -386,7 +398,16 @@ public class BuildFileSelectionTests
         finally
         {
             // TearDown이 tempDir을 지우려면 쓰기 권한 복구 필요
-            try { Syscall_Chmod(tempDir, "0755"); } catch { /* best-effort */ }
+            try
+            {
+                Syscall_Chmod(tempDir, "0755");
+            }
+            catch (Exception ex)
+            {
+                // 진단 정보는 TestContext.Error로 — Debug.LogError는 AITEditorErrorTracker
+                // 가 다시 Sentry로 보낼 수 있어 회귀 방지 목적에 역행
+                TestContext.Error.WriteLine($"chmod 0755 restore failed: {ex.Message}");
+            }
         }
     }
 
@@ -410,39 +431,44 @@ public class BuildFileSelectionTests
         File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
 
         // Windows에서 FileShare.Read로 열면 다른 프로세스의 Delete가 sharing violation 발생
+        string result;
         using (File.Open(oldFile, FileMode.Open, FileAccess.Read, FileShare.Read))
         {
-            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+중복 파일 \d+개 정리 실패"));
+            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+이전 빌드 잔여물 \d+개 정리 실패"));
             LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+Clean Build"));
 
-            string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+            result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
 
-            Assert.AreEqual("new.loader.js", result,
-                "삭제 실패 시에도 최신 파일명은 정상 반환되어야 함");
             Assert.IsTrue(File.Exists(oldFile),
-                "파일이 열려있어 삭제 실패 → oldFile은 남아있어야 함");
+                "락이 걸려있는 동안 oldFile은 남아있어야 함");
         }
+
+        Assert.AreEqual("new.loader.js", result,
+            "삭제 실패 시에도 최신 파일명은 정상 반환되어야 함");
     }
 
     // -----------------------------------------------------------------
-    // 유틸리티: 동작 중 Warning/Error 로그를 수집 (LogAssert 보강)
+    // 유틸리티: 동작 중 발생한 모든 로그를 타입과 함께 수집
+    // LogAssert.NoUnexpectedReceived가 Warning을 감시하지 않는 한계 보완.
     // -----------------------------------------------------------------
-    private static List<string> CollectNoisyLogs(Action action)
+    private struct LogEntry
     {
-        var noisy = new List<string>();
+        public LogType type;
+        public string message;
+    }
+
+    private static List<LogEntry> CollectLogs(Action action)
+    {
+        var logs = new List<LogEntry>();
         Application.LogCallback handler = null;
         handler = (msg, _, type) =>
         {
-            if (type == LogType.Warning || type == LogType.Error ||
-                type == LogType.Exception || type == LogType.Assert)
-            {
-                noisy.Add($"[{type}] {msg}");
-            }
+            logs.Add(new LogEntry { type = type, message = msg });
         };
         Application.logMessageReceived += handler;
         try { action(); }
         finally { Application.logMessageReceived -= handler; }
-        return noisy;
+        return logs;
     }
 
     private static bool IsDirectoryWriteBlocked(string dir)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -190,4 +190,90 @@ public class BuildFileSelectionTests
         Assert.AreEqual("ccc.data", result,
             "FindFileInBuild should select the newest among 3+ matching files");
     }
+
+    // =====================================================
+    // 중복 파일 자동 정리 — 최신 외 오래된 파일 삭제
+    // Sentry 이슈 SDK-7F/7G/7H/7J 대응:
+    // 중복 감지 시 경고만 출력 → 자동 삭제로 전환하여 반복 경고 제거
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_MultipleMatches_DeletesStaleFiles()
+    {
+        // 오래된 파일 (이전 빌드 잔여물)
+        string oldFile = Path.Combine(tempDir, "old_hash.loader.js");
+        File.WriteAllText(oldFile, "// old loader");
+        File.SetLastWriteTime(oldFile, new DateTime(2025, 1, 1, 0, 0, 0));
+
+        // 최신 파일 (현재 빌드)
+        string newFile = Path.Combine(tempDir, "new_hash.loader.js");
+        File.WriteAllText(newFile, "// new loader");
+        File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1, 0, 0, 0));
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+        Assert.AreEqual("new_hash.loader.js", result);
+        Assert.IsFalse(File.Exists(oldFile),
+            "Stale duplicate should be deleted to prevent repeated Sentry warnings");
+        Assert.IsTrue(File.Exists(newFile),
+            "Newest file must remain after cleanup");
+    }
+
+    [Test]
+    public void FindFileInBuild_MultipleMatches_DeletesMetaFiles()
+    {
+        // Unity .meta 파일도 함께 정리해야 중복 asset 경고 방지
+        string oldFile = Path.Combine(tempDir, "old_hash.loader.js");
+        File.WriteAllText(oldFile, "// old");
+        File.SetLastWriteTime(oldFile, new DateTime(2025, 1, 1));
+
+        string oldMeta = oldFile + ".meta";
+        File.WriteAllText(oldMeta, "fileFormatVersion: 2\nguid: deadbeef\n");
+
+        string newFile = Path.Combine(tempDir, "new_hash.loader.js");
+        File.WriteAllText(newFile, "// new");
+        File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
+
+        AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+        Assert.IsFalse(File.Exists(oldFile), "stale file should be deleted");
+        Assert.IsFalse(File.Exists(oldMeta), "stale .meta should be deleted");
+    }
+
+    [Test]
+    public void FindFileInBuild_ThreeMatches_DeletesAllButNewest()
+    {
+        string file1 = Path.Combine(tempDir, "aaa.data");
+        File.WriteAllText(file1, "old1");
+        File.SetLastWriteTime(file1, new DateTime(2025, 1, 1));
+
+        string file2 = Path.Combine(tempDir, "bbb.data");
+        File.WriteAllText(file2, "old2");
+        File.SetLastWriteTime(file2, new DateTime(2025, 6, 1));
+
+        string file3 = Path.Combine(tempDir, "ccc.data");
+        File.WriteAllText(file3, "newest");
+        File.SetLastWriteTime(file3, new DateTime(2026, 2, 1));
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, "*.data*");
+
+        Assert.AreEqual("ccc.data", result);
+        Assert.IsFalse(File.Exists(file1), "oldest should be deleted");
+        Assert.IsFalse(File.Exists(file2), "middle should be deleted");
+        Assert.IsTrue(File.Exists(file3), "newest should remain");
+    }
+
+    [Test]
+    public void FindFileInBuild_SingleFile_NotDeleted()
+    {
+        // 단일 파일은 삭제 로직을 거치지 않아야 함 (회귀 방지)
+        string file = Path.Combine(tempDir, "build.loader.js");
+        File.WriteAllText(file, "// only");
+
+        string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+        Assert.AreEqual("build.loader.js", result);
+        Assert.IsTrue(File.Exists(file),
+            "Single match should never be deleted");
+    }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -5,6 +5,7 @@
 
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using UnityEngine;
@@ -26,9 +27,20 @@ public class BuildFileSelectionTests
     [TearDown]
     public void TearDown()
     {
-        if (Directory.Exists(tempDir))
+        try
         {
-            Directory.Delete(tempDir, true);
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // fallback 테스트가 권한을 복구하지 못한 경우 임시 디렉토리 누수 허용
+        }
+        catch (IOException)
+        {
+            // 다른 테스트가 파일을 잡고 있는 경우 best-effort
         }
     }
 
@@ -308,8 +320,10 @@ public class BuildFileSelectionTests
     }
 
     // =====================================================
-    // 로그 레벨 검증 — 자동 정리 성공 시 Warning 없이 Log 1줄
-    // Sentry 노이즈 제거의 핵심 목적 회귀 방지
+    // 로그 레벨 검증 — 자동 정리 성공 시 Warning/Error 0건
+    // Sentry 노이즈 제거의 핵심 목적 회귀 방지.
+    // LogAssert.NoUnexpectedReceived는 Error/Assert/Exception만 감시하므로
+    // Warning까지 확실히 막으려면 logMessageReceived 훅으로 직접 수집.
     // =====================================================
 
     [Test]
@@ -323,22 +337,21 @@ public class BuildFileSelectionTests
         File.WriteAllText(newFile, "// new");
         File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
 
-        LogAssert.Expect(LogType.Log, new Regex(@"\[AIT\] ✓ .+ 이전 빌드 잔여물 1개 자동 정리"));
+        var noisy = CollectNoisyLogs(() =>
+            AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js"));
 
-        AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
-
-        // NoUnexpectedReceived가 Warning/Error가 같이 찍히지 않았음을 보장
-        LogAssert.NoUnexpectedReceived();
+        Assert.IsEmpty(noisy,
+            "성공 경로는 Warning/Error 로그를 발생시키면 안 됨: " +
+            string.Join(" | ", noisy));
     }
 
     // =====================================================
-    // Fallback 경로 검증 — 삭제 실패 시에도 최신 파일 반환 + 경고
-    // 부모 디렉토리 권한 제어로 UnauthorizedAccessException 유도 (Unix 계열)
-    // Windows는 POSIX 권한 모델과 달라 동일하게 실패하지 않으므로 스킵
+    // Fallback 경로 검증 (Unix) — chmod로 삭제 실패 유도
+    // Windows는 POSIX 권한 모델이 달라 별도 테스트 (file lock)에서 커버
     // =====================================================
 
     [Test]
-    public void FindFileInBuild_DeleteFails_FallsBackToWarning()
+    public void FindFileInBuild_DeleteFails_FallsBackToWarning_Unix()
     {
         Assume.That(Application.platform != RuntimePlatform.WindowsEditor,
             "Unix-only: chmod-based directory permission manipulation");
@@ -351,28 +364,98 @@ public class BuildFileSelectionTests
         File.WriteAllText(newFile, "// new");
         File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
 
-        // 부모 디렉토리를 r-xr-xr-x(0555)로 변경 — 삭제 불가 → UnauthorizedAccessException
-        var originalAttrs = File.GetAttributes(tempDir);
         try
         {
             Syscall_Chmod(tempDir, "0555");
 
-            LogAssert.Expect(LogType.Warning, new Regex(@"중복 파일 1개 정리 실패"));
-            LogAssert.Expect(LogType.Warning, new Regex(@"Clean Build"));
+            // root 사용자면 0555가 무시되어 삭제가 성공 → false positive
+            // 실제로 쓰기 불가한지 선검증
+            Assume.That(IsDirectoryWriteBlocked(tempDir),
+                "현재 사용자는 0555 디렉토리에도 쓸 수 있음 (root?) — 테스트 의미 없음");
+
+            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+중복 파일 \d+개 정리 실패"));
+            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+Clean Build"));
 
             string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
 
             Assert.AreEqual("new.loader.js", result,
-                "Even when cleanup fails, newest file must still be returned");
+                "삭제 실패 시에도 최신 파일명은 정상 반환되어야 함");
             Assert.IsTrue(File.Exists(oldFile),
-                "Delete should have failed, file must still exist");
+                "chmod로 삭제를 막았으므로 oldFile은 남아있어야 함");
         }
         finally
         {
             // TearDown이 tempDir을 지우려면 쓰기 권한 복구 필요
-            Syscall_Chmod(tempDir, "0755");
-            File.SetAttributes(tempDir, originalAttrs);
+            try { Syscall_Chmod(tempDir, "0755"); } catch { /* best-effort */ }
         }
+    }
+
+    // =====================================================
+    // Fallback 경로 검증 (Windows) — FileStream 락으로 IOException 유도
+    // Windows는 열린 파일을 다른 핸들에서 삭제 불가(sharing violation)
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_DeleteFails_FallsBackToWarning_Windows()
+    {
+        Assume.That(Application.platform == RuntimePlatform.WindowsEditor,
+            "Windows-only: file lock semantics differ on Unix");
+
+        string oldFile = Path.Combine(tempDir, "old.loader.js");
+        File.WriteAllText(oldFile, "// old");
+        File.SetLastWriteTime(oldFile, new DateTime(2025, 1, 1));
+
+        string newFile = Path.Combine(tempDir, "new.loader.js");
+        File.WriteAllText(newFile, "// new");
+        File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
+
+        // Windows에서 FileShare.Read로 열면 다른 프로세스의 Delete가 sharing violation 발생
+        using (File.Open(oldFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+중복 파일 \d+개 정리 실패"));
+            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+Clean Build"));
+
+            string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
+
+            Assert.AreEqual("new.loader.js", result,
+                "삭제 실패 시에도 최신 파일명은 정상 반환되어야 함");
+            Assert.IsTrue(File.Exists(oldFile),
+                "파일이 열려있어 삭제 실패 → oldFile은 남아있어야 함");
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // 유틸리티: 동작 중 Warning/Error 로그를 수집 (LogAssert 보강)
+    // -----------------------------------------------------------------
+    private static List<string> CollectNoisyLogs(Action action)
+    {
+        var noisy = new List<string>();
+        Application.LogCallback handler = null;
+        handler = (msg, _, type) =>
+        {
+            if (type == LogType.Warning || type == LogType.Error ||
+                type == LogType.Exception || type == LogType.Assert)
+            {
+                noisy.Add($"[{type}] {msg}");
+            }
+        };
+        Application.logMessageReceived += handler;
+        try { action(); }
+        finally { Application.logMessageReceived -= handler; }
+        return noisy;
+    }
+
+    private static bool IsDirectoryWriteBlocked(string dir)
+    {
+        string probe = Path.Combine(dir, "probe-" + Guid.NewGuid().ToString("N").Substring(0, 6));
+        try
+        {
+            File.WriteAllText(probe, "x");
+            File.Delete(probe);
+            return false;
+        }
+        catch (UnauthorizedAccessException) { return true; }
+        catch (IOException) { return true; }
     }
 
     private static void Syscall_Chmod(string path, string mode)
@@ -386,7 +469,11 @@ public class BuildFileSelectionTests
         };
         using (var proc = System.Diagnostics.Process.Start(psi))
         {
-            proc.WaitForExit(3000);
+            if (!proc.WaitForExit(3000))
+            {
+                try { proc.Kill(); } catch { /* best-effort */ }
+                throw new InvalidOperationException($"chmod {mode} {path} timed out");
+            }
             if (proc.ExitCode != 0)
             {
                 throw new InvalidOperationException(


### PR DESCRIPTION
## 변경 이유

Sentry 이슈 SDK-7F/7G/7H/7J가 660+ 이벤트 누적 중.
`AITBuildValidator.FindFileInBuild()`가 중복 파일 감지 시 경고만 출력하고
잔여물을 정리하지 않아 사용자가 Clean Build를 하지 않으면 매 빌드마다
같은 경고가 반복 발생 → Sentry 노이즈로 유입됨.

## 변경 사항

- 중복 감지 시 최신 파일 외 오래된 파일을 `.meta`와 함께 자동 삭제
- 삭제 실패(IOException/UnauthorizedAccess)한 경우에만 기존 경고 4줄 유지하여 Clean Build 유도
- 자동 정리 경로는 `Debug.Log` 한 줄로 축소하여 Sentry 노이즈 차단 (Warning → Log)

## 테스트 계획

- [x] `./run-local-tests.sh --validate` 통과 (3/3)
- [x] EditMode 테스트 4개 추가 (`BuildFileSelectionTests.cs`)
  - `FindFileInBuild_MultipleMatches_DeletesStaleFiles` — 오래된 파일 삭제 확인
  - `FindFileInBuild_MultipleMatches_DeletesMetaFiles` — `.meta` 함께 삭제 확인
  - `FindFileInBuild_ThreeMatches_DeletesAllButNewest` — 3개 이상 잔여물 처리
  - `FindFileInBuild_SingleFile_NotDeleted` — 단일 파일 회귀 방지
- [ ] CI: EditMode 테스트 통과 확인 필요