### PR TITLE
수정: Sprite atlas 경고가 Sentry로 유입되는 문제 해결

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorSourceTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorSourceTests.cs
@@ -213,8 +213,13 @@ public class ErrorSourceTests
     [Test]
     public void Message_SpriteAtlasWarning_NoAitInStack_ReturnsUnknown()
     {
-        // 스택이 있더라도 AIT 경로가 없으면 SDK가 아님
-        string stackTrace = "at UnityEngine.Sprite.GetBuiltinAtlas () [0x00000]";
+        // 프레임이 파일명까지 파싱되지만(in <path>:<line> 절 포함) SDK/사용자 경로 prefix와
+        // 일치하지 않는 경우 — 파일명 prefix 매칭 루프(AITEditorErrorTracker.cs:609-619)가
+        // 실제로 실행되어 어느 경로에도 매칭 안 되는지 검증. 이후 메시지에도 SDK 키워드가
+        // 없으므로 최종 fallback으로 "unknown"이 반환되어야 함.
+        string stackTrace =
+            "at UnityEngine.Sprite.GetBuiltinAtlas () [0x00000] in <unknown>:0\n" +
+            "at UnityEngine.CoreModule.Sprites.LoadAtlas () [0x00000] in /build/UnityCsReference/sprites.cs:42";
         Assert.AreEqual("unknown", AITEditorErrorTracker.DetermineErrorSource(
             stackTrace,
             "Sprite cloud matches more than one built-in atlases. Default to use the first available atlas."));

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorSourceTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorSourceTests.cs
@@ -198,6 +198,30 @@ public class ErrorSourceTests
 
     #endregion
 
+    #region Non-SDK 메시지 분류 회귀 테스트
+
+    [Test]
+    public void Message_SpriteAtlasWarning_NoStack_ReturnsUnknown()
+    {
+        // Sprite atlas 중복 경고는 Unity 내부 메시지 — SDK로 분류되면 안 됨.
+        // Sentry 관찰 이벤트에서도 error_source: unknown으로 태그되어 있음 (APPS-IN-TOSS-UNITY-SDK-DW).
+        Assert.AreEqual("unknown", AITEditorErrorTracker.DetermineErrorSource(
+            null,
+            "Sprite object_19_01 matches more than one built-in atlases. Default to use the first available atlas."));
+    }
+
+    [Test]
+    public void Message_SpriteAtlasWarning_NoAitInStack_ReturnsUnknown()
+    {
+        // 스택이 있더라도 AIT 경로가 없으면 SDK가 아님
+        string stackTrace = "at UnityEngine.Sprite.GetBuiltinAtlas () [0x00000]";
+        Assert.AreEqual("unknown", AITEditorErrorTracker.DetermineErrorSource(
+            stackTrace,
+            "Sprite cloud matches more than one built-in atlases. Default to use the first available atlas."));
+    }
+
+    #endregion
+
     #region AITLog sentryCapture=false 회귀 테스트
 
     [Test]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -156,20 +156,27 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void SpriteAtlasDuplicate_FullSentryMessage_ReturnsTrue()
     {
-        // Sentry에서 실제 관찰된 원문 — 마침표와 "Default to use..." 후행 문구 포함
-        // 리그레션 방지: 패턴이 끝부분 변화에 영향받지 않는지 검증
+        // Sentry APPS-IN-TOSS-UNITY-SDK-DW에서 실제 관찰된 원문 fixture.
+        // 현재 필터는 IndexOf 부분 매칭이라 후행 문구 유무는 결과에 영향 없지만,
+        // 실제 입력 예시를 테스트로 박아두면 향후 필터가 anchored/regex로 바뀔 때
+        // 이 실측 메시지를 놓치지 않도록 방어한다.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Sprite object_19_01 matches more than one built-in atlases. Default to use the first available atlas."));
     }
 
-    [TestCase("object_04_02")]
-    [TestCase("cloud")]
-    [TestCase("BG-main_01")]
-    [TestCase("player idle frame")]
-    public void SpriteAtlasDuplicate_VariousSpriteNames_ReturnsTrue(string spriteName)
+    // 필터가 향후 anchored/regex로 tightening되어도 실제 Unity 출력 변형을 놓치지 않도록
+    // 구조적으로 서로 다른 리스크 프로파일의 변형만 선별해 검증 (단순 이름 swap은 제외).
+    [TestCase(
+        "Sprite object_04_02 matches more than one built-in atlases. Default to use the first available atlas.",
+        TestName = "SpriteAtlas_StandardLayout_ReturnsTrue")]
+    [TestCase(
+        "[Warn]  Sprite cloud matches more than one built-in atlases.",
+        TestName = "SpriteAtlas_WithPrefixAndWhitespace_ReturnsTrue")]
+    [TestCase(
+        "Sprite 'player idle frame' matches more than one built-in atlases (fallback applied).",
+        TestName = "SpriteAtlas_QuotedNameAndTrailingParen_ReturnsTrue")]
+    public void SpriteAtlasDuplicate_RealisticVariants_ReturnsTrue(string message)
     {
-        // Sprite 이름 변형(숫자, 하이픈, 공백)에 관계없이 핵심 문구가 매칭되는지 검증
-        string message = $"Sprite {spriteName} matches more than one built-in atlases. Default to use the first available atlas.";
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(message));
     }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -154,6 +154,26 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void SpriteAtlasDuplicate_FullSentryMessage_ReturnsTrue()
+    {
+        // Sentry에서 실제 관찰된 원문 — 마침표와 "Default to use..." 후행 문구 포함
+        // 리그레션 방지: 패턴이 끝부분 변화에 영향받지 않는지 검증
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Sprite object_19_01 matches more than one built-in atlases. Default to use the first available atlas."));
+    }
+
+    [TestCase("object_04_02")]
+    [TestCase("cloud")]
+    [TestCase("BG-main_01")]
+    [TestCase("player idle frame")]
+    public void SpriteAtlasDuplicate_VariousSpriteNames_ReturnsTrue(string spriteName)
+    {
+        // Sprite 이름 변형(숫자, 하이픈, 공백)에 관계없이 핵심 문구가 매칭되는지 검증
+        string message = $"Sprite {spriteName} matches more than one built-in atlases. Default to use the first available atlas.";
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(message));
+    }
+
+    [Test]
     public void ScriptMissingInUserAssets_ReturnsTrue()
     {
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(


### PR DESCRIPTION
## 변경 이유
Sentry에 `APPS-IN-TOSS-UNITY-SDK-DW ~ E9` 범위로 60+ 개의 Sprite atlas 경고 이슈가 유입 중 (예: "Sprite object_19_01 matches more than one built-in atlases. Default to use the first available atlas.").

## 조사 결과
본 이슈는 **코드 버그가 아니라 유저의 SDK 버전 업그레이드 지연**에 의한 것임을 확인했다.

### 타임라인
- **v2.4.6 릴리즈**: 2026-04-16 12:09 UTC (`dcb687d`)
- **필터 추가 커밋 `a8a0d50`**: 2026-04-16 18:32 UTC — `NonSdkMessagePatterns`에 `"matches more than one built-in atlases"` 패턴 도입
- **v2.4.7 릴리즈**: 2026-04-19 20:20 UTC (`25de94e`) — 필터 포함된 최초 공식 릴리즈
- **Sentry 유입 이벤트**: 마지막 발생 2026-04-20 21:56, 모든 이벤트가 `release: apps-in-toss.unity@2.4.6` 태그 — 즉 **필터가 없는 구버전(v2.4.6)을 사용하는 유저 환경에서 발생**한 것

### 현재 필터 로직 검증
`AITEditorErrorTracker`의 경로는 이미 올바르게 동작한다:

1. `OnLogMessageReceived()` → `IsAitRelated(message, stackTrace)` 체크 (스택에 AIT 프레임 있으면 true)
2. true인 경우 `IsKnownNonSdkMessage(message)` 체크 (메시지 기반 필터)
3. `IsKnownNonSdkMessage`의 SDK 보호 가드는 **메시지만** 검사하므로, 스택에 AIT 프레임이 있더라도 메시지에 AIT 키워드가 없으면 `NonSdkMessagePatterns`와 매칭되어 필터링된다.

즉, v2.4.7 이상에서는 유사한 Sprite atlas 경고가 Sentry에 유입되지 않는다. 해당 유저가 업그레이드하면 자연 해결된다.

## 변경 사항
코드 로직은 이미 의도대로 작동하므로 **회귀 방지를 위한 테스트 커버리지만 보강**했다.

### `IsKnownNonSdkMessageTests.cs`
- `SpriteAtlasDuplicate_FullSentryMessage_ReturnsTrue`: Sentry 실제 관찰 원문(후행 문구 "Default to use the first available atlas." 포함)에 대한 명시적 검증
- `SpriteAtlasDuplicate_VariousSpriteNames_ReturnsTrue`: Sprite 이름 변형(숫자, 하이픈, 공백)에 관계없이 필터가 작동함을 파라미터라이즈 테스트로 보장

### `ErrorSourceTests.cs`
- `Message_SpriteAtlasWarning_NoStack_ReturnsUnknown`: Sprite atlas 경고가 SDK로 오분류되지 않고 `error_source=unknown`으로 분류됨을 보장 (실제 Sentry 태그와 일치)
- `Message_SpriteAtlasWarning_NoAitInStack_ReturnsUnknown`: 스택이 있더라도 AIT 경로가 없으면 SDK로 분류하지 않음을 보장

## 관련 Sentry 이슈
- APPS-IN-TOSS-UNITY-SDK-DW, E9 등 (60+ 개 Sprite 이름별 이슈)
- 모두 `release: apps-in-toss.unity@2.4.6` 태그 — v2.4.7 업그레이드 시 자연 해결

## 테스트 계획
- [x] EditMode 테스트 코드 추가
- [ ] CI에서 `./run-local-tests.sh --validate` 통과
- [ ] EditMode 테스트 (ErrorTracker 카테고리) 통과