### PR TITLE
문서: main 브랜치 머지 방식을 squash merge 전용으로 명시

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,12 @@
 ### 브랜치 보호 규칙
 - **main 브랜치에 직접 push 불가** — 반드시 PR을 통해 머지
 - main 브랜치 규칙 (Repository Rulesets):
-  - PR 필수 (승인 없이 머지 가능, merge 방식만 허용)
+  - PR 필수 (승인 없이 머지 가능)
+  - **머지 방식: squash merge만 허용** (merge commit, rebase 불가)
   - 커밋 서명 필수 (`required_signatures`)
   - 삭제 불가, force push 불가
   - bypass 권한자 없음 (`current_user_can_bypass: never`)
-- **작업 시**: 항상 feature 브랜치 생성 → PR 제출
+- **작업 시**: 항상 feature 브랜치 생성 → PR 제출 → squash merge로 병합
 
 ### Git 커밋 가이드라인
 - **모든 커밋 메시지는 반드시 한국어로 작성**


### PR DESCRIPTION
## 변경 이유
레포 정책이 **squash merge만 허용**하도록 변경되어, CLAUDE.md의 main 브랜치 규칙 섹션을 이에 맞게 업데이트.

## 변경 사항
- `CLAUDE.md` 브랜치 보호 규칙에 머지 방식 명시 (squash merge 전용)
- 작업 플로우 설명에 squash merge 병합 과정 추가

## 테스트 계획
- [x] 문서 변경만 있어 추가 테스트 불필요