### PR TITLE
수정: 빌드 마커 생성 시 부모 디렉토리 자동 생성

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -283,6 +283,23 @@ namespace AppsInToss
             }
         }
 
+        /// <summary>
+        /// 빌드 마커 파일을 지정된 디렉토리에 생성합니다.
+        /// 부모 디렉토리가 없으면 자동 생성합니다 (Sentry SDK-DC 대응).
+        /// </summary>
+        internal static void WriteBuildMarker(string webglPath, AITBuildInfo buildInfo)
+        {
+            string markerPath = Path.Combine(webglPath, BUILD_MARKER_FILENAME);
+            string markerDir = Path.GetDirectoryName(markerPath);
+            if (!string.IsNullOrEmpty(markerDir) && !Directory.Exists(markerDir))
+            {
+                Directory.CreateDirectory(markerDir);
+                Debug.Log($"[AIT] 빌드 마커 디렉토리 생성: {markerDir}");
+            }
+            File.WriteAllText(markerPath, JsonUtility.ToJson(buildInfo, true));
+            Debug.Log($"[AIT] 빌드 마커 생성: {markerPath}");
+        }
+
         #endregion
 
         #region Public Static Fields
@@ -914,14 +931,7 @@ namespace AppsInToss
                     profileName = profile?.developmentBuild == true ? "Development" : "Production",
                     unityVersion = Application.unityVersion
                 };
-                string markerPath = Path.Combine(outputPath, BUILD_MARKER_FILENAME);
-                var markerDir = Path.GetDirectoryName(markerPath);
-                if (!string.IsNullOrEmpty(markerDir))
-                {
-                    Directory.CreateDirectory(markerDir);
-                }
-                File.WriteAllText(markerPath, JsonUtility.ToJson(buildInfo, true));
-                Debug.Log($"[AIT] 빌드 마커 생성: {markerPath}");
+                WriteBuildMarker(outputPath, buildInfo);
             }
             catch (Exception e)
             {

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -915,6 +915,11 @@ namespace AppsInToss
                     unityVersion = Application.unityVersion
                 };
                 string markerPath = Path.Combine(outputPath, BUILD_MARKER_FILENAME);
+                var markerDir = Path.GetDirectoryName(markerPath);
+                if (!string.IsNullOrEmpty(markerDir))
+                {
+                    Directory.CreateDirectory(markerDir);
+                }
                 File.WriteAllText(markerPath, JsonUtility.ToJson(buildInfo, true));
                 Debug.Log($"[AIT] 빌드 마커 생성: {markerPath}");
             }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildMarkerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildMarkerTests.cs
@@ -1,0 +1,145 @@
+// -----------------------------------------------------------------------
+// BuildMarkerTests.cs - 빌드 마커 파일 생성/읽기 회귀 테스트
+// Level 0: WriteBuildMarker가 부모 디렉토리 부재 시에도 성공하는지 검증 (Sentry SDK-DC)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Reflection;
+using AppsInToss;
+
+[TestFixture]
+public class BuildMarkerTests
+{
+    private string tempDir;
+    private MethodInfo writeMarkerMethod;
+    private MethodInfo readMarkerMethod;
+    private Type buildInfoType;
+
+    [SetUp]
+    public void Setup()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "ait-test-marker-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+
+        var convertType = typeof(AITConvertCore);
+        buildInfoType = convertType.Assembly.GetType("AppsInToss.AITBuildInfo");
+        Assert.IsNotNull(buildInfoType, "AITBuildInfo type should exist in assembly");
+
+        writeMarkerMethod = convertType.GetMethod("WriteBuildMarker",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(writeMarkerMethod, "WriteBuildMarker method should exist");
+
+        readMarkerMethod = convertType.GetMethod("ReadBuildMarker",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(readMarkerMethod, "ReadBuildMarker method should exist");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private object MakeBuildInfo()
+    {
+        var info = Activator.CreateInstance(buildInfoType);
+        buildInfoType.GetField("sdkVersion").SetValue(info, "test-version");
+        buildInfoType.GetField("buildTime").SetValue(info, "2026-01-01T00:00:00Z");
+        buildInfoType.GetField("compressionFormat").SetValue(info, 0);
+        buildInfoType.GetField("decompressionFallback").SetValue(info, false);
+        buildInfoType.GetField("profileName").SetValue(info, "Production");
+        buildInfoType.GetField("unityVersion").SetValue(info, "2021.3.45f2");
+        return info;
+    }
+
+    // =====================================================
+    // Sentry SDK-DC 회귀 테스트: 부모 디렉토리가 없어도 마커 생성 성공
+    // =====================================================
+
+    [Test]
+    public void WriteBuildMarker_CreatesParentDirectory_WhenMissing()
+    {
+        string missingOutputPath = Path.Combine(tempDir, "webgl");
+        Assert.IsFalse(Directory.Exists(missingOutputPath),
+            "Precondition: webgl/ should not exist");
+
+        var buildInfo = MakeBuildInfo();
+
+        // DirectoryNotFoundException이 발생하지 않아야 함
+        Assert.DoesNotThrow(() =>
+        {
+            writeMarkerMethod.Invoke(null, new object[] { missingOutputPath, buildInfo });
+        }, "WriteBuildMarker should not throw when parent directory is missing");
+
+        string markerPath = Path.Combine(missingOutputPath, AITConvertCore.BUILD_MARKER_FILENAME);
+        Assert.IsTrue(File.Exists(markerPath),
+            "Marker file should be written at the expected path");
+    }
+
+    // =====================================================
+    // 기존 디렉토리가 있을 때도 정상 동작
+    // =====================================================
+
+    [Test]
+    public void WriteBuildMarker_Succeeds_WhenParentExists()
+    {
+        string existingOutputPath = Path.Combine(tempDir, "webgl");
+        Directory.CreateDirectory(existingOutputPath);
+
+        var buildInfo = MakeBuildInfo();
+        writeMarkerMethod.Invoke(null, new object[] { existingOutputPath, buildInfo });
+
+        string markerPath = Path.Combine(existingOutputPath, AITConvertCore.BUILD_MARKER_FILENAME);
+        Assert.IsTrue(File.Exists(markerPath),
+            "Marker file should be written when parent directory exists");
+    }
+
+    // =====================================================
+    // 쓰기 후 ReadBuildMarker로 왕복 검증
+    // =====================================================
+
+    [Test]
+    public void WriteBuildMarker_RoundTripsThroughReadBuildMarker()
+    {
+        string outputPath = Path.Combine(tempDir, "webgl");
+        var written = MakeBuildInfo();
+
+        writeMarkerMethod.Invoke(null, new object[] { outputPath, written });
+
+        object read = readMarkerMethod.Invoke(null, new object[] { outputPath });
+        Assert.IsNotNull(read, "ReadBuildMarker should return a value after WriteBuildMarker");
+
+        Assert.AreEqual("test-version",
+            buildInfoType.GetField("sdkVersion").GetValue(read),
+            "sdkVersion should round-trip");
+        Assert.AreEqual("Production",
+            buildInfoType.GetField("profileName").GetValue(read),
+            "profileName should round-trip");
+    }
+
+    // =====================================================
+    // 멱등성: 같은 경로에 두 번 써도 마지막 값이 남음
+    // =====================================================
+
+    [Test]
+    public void WriteBuildMarker_IsIdempotent_WhenCalledTwice()
+    {
+        string outputPath = Path.Combine(tempDir, "webgl");
+
+        var first = MakeBuildInfo();
+        writeMarkerMethod.Invoke(null, new object[] { outputPath, first });
+
+        var second = MakeBuildInfo();
+        buildInfoType.GetField("sdkVersion").SetValue(second, "second-version");
+        writeMarkerMethod.Invoke(null, new object[] { outputPath, second });
+
+        object read = readMarkerMethod.Invoke(null, new object[] { outputPath });
+        Assert.AreEqual("second-version",
+            buildInfoType.GetField("sdkVersion").GetValue(read),
+            "Second WriteBuildMarker should overwrite the first");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildMarkerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildMarkerTests.cs
@@ -6,33 +6,17 @@
 using NUnit.Framework;
 using System;
 using System.IO;
-using System.Reflection;
 using AppsInToss;
 
 [TestFixture]
 public class BuildMarkerTests
 {
     private string tempDir;
-    private MethodInfo writeMarkerMethod;
-    private MethodInfo readMarkerMethod;
-    private Type buildInfoType;
 
     [SetUp]
     public void Setup()
     {
         tempDir = Path.Combine(Path.GetTempPath(), "ait-test-marker-" + Guid.NewGuid().ToString("N").Substring(0, 8));
-
-        var convertType = typeof(AITConvertCore);
-        buildInfoType = convertType.Assembly.GetType("AppsInToss.AITBuildInfo");
-        Assert.IsNotNull(buildInfoType, "AITBuildInfo type should exist in assembly");
-
-        writeMarkerMethod = convertType.GetMethod("WriteBuildMarker",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.IsNotNull(writeMarkerMethod, "WriteBuildMarker method should exist");
-
-        readMarkerMethod = convertType.GetMethod("ReadBuildMarker",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.IsNotNull(readMarkerMethod, "ReadBuildMarker method should exist");
     }
 
     [TearDown]
@@ -44,16 +28,17 @@ public class BuildMarkerTests
         }
     }
 
-    private object MakeBuildInfo()
+    private static AITBuildInfo MakeBuildInfo(string sdkVersion = "test-version")
     {
-        var info = Activator.CreateInstance(buildInfoType);
-        buildInfoType.GetField("sdkVersion").SetValue(info, "test-version");
-        buildInfoType.GetField("buildTime").SetValue(info, "2026-01-01T00:00:00Z");
-        buildInfoType.GetField("compressionFormat").SetValue(info, 0);
-        buildInfoType.GetField("decompressionFallback").SetValue(info, false);
-        buildInfoType.GetField("profileName").SetValue(info, "Production");
-        buildInfoType.GetField("unityVersion").SetValue(info, "2021.3.45f2");
-        return info;
+        return new AITBuildInfo
+        {
+            sdkVersion = sdkVersion,
+            buildTime = "2026-01-01T00:00:00Z",
+            compressionFormat = 0,
+            decompressionFallback = false,
+            profileName = "Production",
+            unityVersion = "2021.3.45f2"
+        };
     }
 
     // =====================================================
@@ -67,12 +52,10 @@ public class BuildMarkerTests
         Assert.IsFalse(Directory.Exists(missingOutputPath),
             "Precondition: webgl/ should not exist");
 
-        var buildInfo = MakeBuildInfo();
-
         // DirectoryNotFoundException이 발생하지 않아야 함
         Assert.DoesNotThrow(() =>
         {
-            writeMarkerMethod.Invoke(null, new object[] { missingOutputPath, buildInfo });
+            AITConvertCore.WriteBuildMarker(missingOutputPath, MakeBuildInfo());
         }, "WriteBuildMarker should not throw when parent directory is missing");
 
         string markerPath = Path.Combine(missingOutputPath, AITConvertCore.BUILD_MARKER_FILENAME);
@@ -90,8 +73,7 @@ public class BuildMarkerTests
         string existingOutputPath = Path.Combine(tempDir, "webgl");
         Directory.CreateDirectory(existingOutputPath);
 
-        var buildInfo = MakeBuildInfo();
-        writeMarkerMethod.Invoke(null, new object[] { existingOutputPath, buildInfo });
+        AITConvertCore.WriteBuildMarker(existingOutputPath, MakeBuildInfo());
 
         string markerPath = Path.Combine(existingOutputPath, AITConvertCore.BUILD_MARKER_FILENAME);
         Assert.IsTrue(File.Exists(markerPath),
@@ -106,19 +88,13 @@ public class BuildMarkerTests
     public void WriteBuildMarker_RoundTripsThroughReadBuildMarker()
     {
         string outputPath = Path.Combine(tempDir, "webgl");
-        var written = MakeBuildInfo();
 
-        writeMarkerMethod.Invoke(null, new object[] { outputPath, written });
+        AITConvertCore.WriteBuildMarker(outputPath, MakeBuildInfo());
 
-        object read = readMarkerMethod.Invoke(null, new object[] { outputPath });
+        AITBuildInfo read = AITConvertCore.ReadBuildMarker(outputPath);
         Assert.IsNotNull(read, "ReadBuildMarker should return a value after WriteBuildMarker");
-
-        Assert.AreEqual("test-version",
-            buildInfoType.GetField("sdkVersion").GetValue(read),
-            "sdkVersion should round-trip");
-        Assert.AreEqual("Production",
-            buildInfoType.GetField("profileName").GetValue(read),
-            "profileName should round-trip");
+        Assert.AreEqual("test-version", read.sdkVersion, "sdkVersion should round-trip");
+        Assert.AreEqual("Production", read.profileName, "profileName should round-trip");
     }
 
     // =====================================================
@@ -130,16 +106,12 @@ public class BuildMarkerTests
     {
         string outputPath = Path.Combine(tempDir, "webgl");
 
-        var first = MakeBuildInfo();
-        writeMarkerMethod.Invoke(null, new object[] { outputPath, first });
+        AITConvertCore.WriteBuildMarker(outputPath, MakeBuildInfo("first-version"));
+        AITConvertCore.WriteBuildMarker(outputPath, MakeBuildInfo("second-version"));
 
-        var second = MakeBuildInfo();
-        buildInfoType.GetField("sdkVersion").SetValue(second, "second-version");
-        writeMarkerMethod.Invoke(null, new object[] { outputPath, second });
-
-        object read = readMarkerMethod.Invoke(null, new object[] { outputPath });
-        Assert.AreEqual("second-version",
-            buildInfoType.GetField("sdkVersion").GetValue(read),
+        AITBuildInfo read = AITConvertCore.ReadBuildMarker(outputPath);
+        Assert.IsNotNull(read);
+        Assert.AreEqual("second-version", read.sdkVersion,
             "Second WriteBuildMarker should overwrite the first");
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildMarkerTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildMarkerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e9f8c32fca54efa8f436f824dcb3a3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 변경 이유
Sentry APPS-IN-TOSS-UNITY-SDK-DC: `.ait-build-info.json` 생성 시 부모 디렉토리 부재로 DirectoryNotFoundException 발생.

## 변경 사항
`AITConvertCore.BuildWebGL()`에서 마커 파일 쓰기 전에 `Directory.CreateDirectory()` 호출 추가.

## 테스트 계획
- [x] `./run-local-tests.sh --validate` 통과