### PR TITLE
리팩토링: .Result 블로킹 호출을 async/await로 전환

### DIFF
--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -368,6 +368,10 @@ namespace AppsInToss.Editor
         /// <summary>
         /// 원격 해시 결과 처리 (메인 스레드의 async 컨텍스트에서 await 기반으로 실행됨)
         /// </summary>
+        /// <remarks>
+        /// EditorApplication.delayCall의 async void 람다에서 await 됨.
+        /// 예외는 호출 측 try/catch에서 반드시 삼켜야 함 (async void 크래시 방지).
+        /// </remarks>
         private static async Task OnRemoteHashResolved(
             string remoteHash,
             string installedHash,

--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -162,7 +162,7 @@ namespace AppsInToss.Editor
 
             bool capturedIsManualCheck = isManualCheck;
 
-            System.Threading.Tasks.Task.Run(() =>
+            Task.Run(() =>
             {
                 try
                 {

--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -369,8 +369,10 @@ namespace AppsInToss.Editor
         /// 원격 해시 결과 처리 (메인 스레드의 async 컨텍스트에서 await 기반으로 실행됨)
         /// </summary>
         /// <remarks>
-        /// EditorApplication.delayCall의 async void 람다에서 await 됨.
-        /// 예외는 호출 측 try/catch에서 반드시 삼켜야 함 (async void 크래시 방지).
+        /// 이 메서드는 네트워크/Unity API 예외를 내부에서 삼키지 않고 throw할 수 있음.
+        /// EditorApplication.delayCall의 async void 람다에서 호출되므로 호출 측은
+        /// 반드시 try/catch로 예외를 삼켜야 함 (async void의 미처리 예외는
+        /// SynchronizationContext로 올라가 Editor를 크래시시킬 수 있음).
         /// </remarks>
         private static async Task OnRemoteHashResolved(
             string remoteHash,
@@ -519,7 +521,9 @@ namespace AppsInToss.Editor
             }
             catch (Exception)
             {
-                // API 호출 실패 시 무시
+                // API 호출 실패 시 무시 — 커밋 시간은 보조 정보이므로 실패해도
+                // 업데이트 체크 흐름 자체는 계속 진행되어야 함. 이 메서드는 null을
+                // 반환하고, 호출 측(OnRemoteHashResolved)은 short hash만 표시함.
             }
 
             return null;

--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
@@ -167,11 +168,11 @@ namespace AppsInToss.Editor
                 {
                     string remoteHash = GetRemoteCommitHash(capturedGitUrl, capturedFragment);
 
-                    EditorApplication.delayCall += () =>
+                    EditorApplication.delayCall += async () =>
                     {
                         try
                         {
-                            OnRemoteHashResolved(
+                            await OnRemoteHashResolved(
                                 remoteHash,
                                 capturedInstalledHash,
                                 capturedPackageId,
@@ -364,7 +365,7 @@ namespace AppsInToss.Editor
         /// <summary>
         /// 원격 해시 결과 처리 (메인 스레드에서 호출)
         /// </summary>
-        private static void OnRemoteHashResolved(
+        private static async Task OnRemoteHashResolved(
             string remoteHash,
             string installedHash,
             string packageId,
@@ -411,8 +412,8 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT] SDK 업데이트 발견: {shortInstalled} → {shortRemote}");
 
             // 커밋 시간 정보 가져오기 (GitHub API)
-            string installedTime = GetCommitTime(gitUrl, installedHash);
-            string remoteTime = GetCommitTime(gitUrl, remoteHash);
+            string installedTime = await GetCommitTime(gitUrl, installedHash);
+            string remoteTime = await GetCommitTime(gitUrl, remoteHash);
 
             // 다이얼로그 메시지 구성
             string installedInfo = string.IsNullOrEmpty(installedTime)
@@ -469,7 +470,7 @@ namespace AppsInToss.Editor
         /// <summary>
         /// GitHub API를 통해 커밋 시간 가져오기
         /// </summary>
-        private static string GetCommitTime(string gitUrl, string commitHash)
+        private static async Task<string> GetCommitTime(string gitUrl, string commitHash)
         {
             try
             {
@@ -492,7 +493,9 @@ namespace AppsInToss.Editor
                     client.DefaultRequestHeaders.Add("User-Agent", "Unity-AIT-SDK");
                     client.Timeout = TimeSpan.FromSeconds(5);
 
-                    var response = client.GetStringAsync(apiUrl).Result;
+                    // await 사용: 메인 스레드에서 .Result로 블로킹하면
+                    // Unity SynchronizationContext와 상호작용해 데드락 가능.
+                    string response = await client.GetStringAsync(apiUrl);
 
                     // 간단한 JSON 파싱으로 committer.date 추출
                     // "committer":{"name":"...","email":"...","date":"2026-02-02T12:34:56Z"}

--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -168,6 +168,9 @@ namespace AppsInToss.Editor
                 {
                     string remoteHash = GetRemoteCommitHash(capturedGitUrl, capturedFragment);
 
+                    // delayCall은 Action 델리게이트이므로 아래는 async void 람다로 추론됨.
+                    // 내부 예외는 반드시 이 try/catch에서 삼켜야 함
+                    // (async void의 throw는 SynchronizationContext로 올라가 Editor를 크래시시킬 수 있음).
                     EditorApplication.delayCall += async () =>
                     {
                         try
@@ -363,7 +366,7 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// 원격 해시 결과 처리 (메인 스레드에서 호출)
+        /// 원격 해시 결과 처리 (메인 스레드의 async 컨텍스트에서 await 기반으로 실행됨)
         /// </summary>
         private static async Task OnRemoteHashResolved(
             string remoteHash,

--- a/Editor/AITGitGuard.cs
+++ b/Editor/AITGitGuard.cs
@@ -3,6 +3,7 @@ using UnityEditor;
 using System.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Debug = UnityEngine.Debug;
 
 namespace AppsInToss.Editor
@@ -384,14 +385,16 @@ namespace AppsInToss.Editor
                     if (!process.WaitForExit(timeoutMs))
                     {
                         try { process.Kill(); } catch (System.Exception) { }
-                        try { System.Threading.Tasks.Task.WaitAll(stdoutTask, stderrTask); } catch (System.Exception) { }
+                        try { Task.WaitAll(stdoutTask, stderrTask); } catch (System.Exception) { }
                         Debug.LogWarning($"[AIT] Git 명령 타임아웃 ({timeoutMs / 1000}초): git {arguments}");
                         return null;
                     }
 
+                    // 타임아웃 강제(WaitForExit(int)) + 리더 drain 확정(WaitForExit())의 2단계 패턴.
                     // 타임아웃 오버로드 WaitForExit(int)은 stdout/stderr 비동기 리더 배수(drain)를
                     // 보장하지 않음. 파라미터 없는 오버로드를 한 번 더 호출해 리더 완료를 확정함.
-                    // (이 시점에서 프로세스는 이미 exit 상태이므로 리더가 EOF로 곧 완료됨.)
+                    // (이 시점에서 프로세스는 이미 exit 상태이므로 리더가 EOF로 곧 완료됨.
+                    //  둘 중 한 호출만 남기지 말 것 — 하나만 있으면 hang 또는 drain 누락 발생.)
                     process.WaitForExit();
 
                     // 이 시점에서 두 리더 Task는 완료 상태이므로 동기 접근에 데드락 위험 없음.

--- a/Editor/AITGitGuard.cs
+++ b/Editor/AITGitGuard.cs
@@ -389,7 +389,9 @@ namespace AppsInToss.Editor
                         return null;
                     }
 
-                    return (process.ExitCode, stdoutTask.Result, stderrTask.Result);
+                    // WaitForExit 이후 Task는 이미 완료된 상태이므로 동기 접근은 데드락 위험 없음.
+                    // .Result 대신 GetAwaiter().GetResult()를 사용해 예외 래핑(AggregateException)을 피함.
+                    return (process.ExitCode, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult());
                 }
             }
             catch (System.Exception)

--- a/Editor/AITGitGuard.cs
+++ b/Editor/AITGitGuard.cs
@@ -391,6 +391,7 @@ namespace AppsInToss.Editor
 
                     // 타임아웃 오버로드 WaitForExit(int)은 stdout/stderr 비동기 리더 배수(drain)를
                     // 보장하지 않음. 파라미터 없는 오버로드를 한 번 더 호출해 리더 완료를 확정함.
+                    // (이 시점에서 프로세스는 이미 exit 상태이므로 리더가 EOF로 곧 완료됨.)
                     process.WaitForExit();
 
                     // 이 시점에서 두 리더 Task는 완료 상태이므로 동기 접근에 데드락 위험 없음.

--- a/Editor/AITGitGuard.cs
+++ b/Editor/AITGitGuard.cs
@@ -389,7 +389,11 @@ namespace AppsInToss.Editor
                         return null;
                     }
 
-                    // WaitForExit 이후 Task는 이미 완료된 상태이므로 동기 접근은 데드락 위험 없음.
+                    // 타임아웃 오버로드 WaitForExit(int)은 stdout/stderr 비동기 리더 배수(drain)를
+                    // 보장하지 않음. 파라미터 없는 오버로드를 한 번 더 호출해 리더 완료를 확정함.
+                    process.WaitForExit();
+
+                    // 이 시점에서 두 리더 Task는 완료 상태이므로 동기 접근에 데드락 위험 없음.
                     // .Result 대신 GetAwaiter().GetResult()를 사용해 예외 래핑(AggregateException)을 피함.
                     return (process.ExitCode, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult());
                 }

--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -393,7 +393,11 @@ namespace AppsInToss.Editor
                         return result;
                     }
 
-                    // WaitForExit 이후 Task는 이미 완료된 상태이므로 동기 접근은 데드락 위험 없음.
+                    // 타임아웃 오버로드 WaitForExit(int)은 stdout/stderr 비동기 리더 배수(drain)를
+                    // 보장하지 않음. 파라미터 없는 오버로드를 한 번 더 호출해 리더 완료를 확정함.
+                    process.WaitForExit();
+
+                    // 이 시점에서 두 리더 Task는 완료 상태이므로 동기 접근에 데드락 위험 없음.
                     // .Result 대신 GetAwaiter().GetResult()를 사용해 예외 래핑(AggregateException)을 피함.
                     result.Output = StripAnsiCodes(outputTask.GetAwaiter().GetResult());
                     result.Error = StripAnsiCodes(errorTask.GetAwaiter().GetResult());

--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -395,6 +395,7 @@ namespace AppsInToss.Editor
 
                     // 타임아웃 오버로드 WaitForExit(int)은 stdout/stderr 비동기 리더 배수(drain)를
                     // 보장하지 않음. 파라미터 없는 오버로드를 한 번 더 호출해 리더 완료를 확정함.
+                    // (이 시점에서 프로세스는 이미 exit 상태이므로 리더가 EOF로 곧 완료됨.)
                     process.WaitForExit();
 
                     // 이 시점에서 두 리더 Task는 완료 상태이므로 동기 접근에 데드락 위험 없음.

--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -393,8 +393,10 @@ namespace AppsInToss.Editor
                         return result;
                     }
 
-                    result.Output = StripAnsiCodes(outputTask.Result);
-                    result.Error = StripAnsiCodes(errorTask.Result);
+                    // WaitForExit 이후 Task는 이미 완료된 상태이므로 동기 접근은 데드락 위험 없음.
+                    // .Result 대신 GetAwaiter().GetResult()를 사용해 예외 래핑(AggregateException)을 피함.
+                    result.Output = StripAnsiCodes(outputTask.GetAwaiter().GetResult());
+                    result.Error = StripAnsiCodes(errorTask.GetAwaiter().GetResult());
                     result.ExitCode = process.ExitCode;
                     result.Success = process.ExitCode == 0;
 

--- a/Editor/AITPlatformHelper.cs
+++ b/Editor/AITPlatformHelper.cs
@@ -393,9 +393,11 @@ namespace AppsInToss.Editor
                         return result;
                     }
 
+                    // 타임아웃 강제(WaitForExit(int)) + 리더 drain 확정(WaitForExit())의 2단계 패턴.
                     // 타임아웃 오버로드 WaitForExit(int)은 stdout/stderr 비동기 리더 배수(drain)를
                     // 보장하지 않음. 파라미터 없는 오버로드를 한 번 더 호출해 리더 완료를 확정함.
-                    // (이 시점에서 프로세스는 이미 exit 상태이므로 리더가 EOF로 곧 완료됨.)
+                    // (이 시점에서 프로세스는 이미 exit 상태이므로 리더가 EOF로 곧 완료됨.
+                    //  둘 중 한 호출만 남기지 말 것 — 하나만 있으면 hang 또는 drain 누락 발생.)
                     process.WaitForExit();
 
                     // 이 시점에서 두 리더 Task는 완료 상태이므로 동기 접근에 데드락 위험 없음.

--- a/TODO.md
+++ b/TODO.md
@@ -64,14 +64,6 @@
 - **현상**: `Thread.Sleep(1000 * retry)` — 최대 3초까지 블로킹 (호출 컨텍스트의 스레딩 모델 확인 필요)
 - **조치**: 메인 스레드 호출 확인 후, 필요 시 `Task.Delay()` + async/await 패턴으로 전환
 
-### P2 — .Result 동기 블로킹 호출
-- **파일/행**:
-  - `Editor/AITAutoUpdater.cs:485` — `client.GetStringAsync(apiUrl).Result`
-  - `Editor/AITGitGuard.cs:392` — `stdoutTask.Result`, `stderrTask.Result`
-  - `Editor/AITPlatformHelper.cs:396-397` — `outputTask.Result`, `errorTask.Result`
-- **현상**: `.Result` 호출은 데드락 가능성
-- **조치**: async/await 체인으로 리팩토링
-
 ### P2 — 기타 Thread.Sleep 호출 (6곳)
 - `AITProcessTreeManager.cs:283` (300ms)
 - `AITNpmRunner.cs:296` (200ms)


### PR DESCRIPTION
## 요약

TODO.md의 `P2 — .Result 동기 블로킹 호출` 항목을 해결합니다. 세 파일의 `.Result` 사용 패턴을 호출 컨텍스트에 맞게 전환해 데드락 위험을 제거했습니다.

## 파일별 변경 내용

### `Editor/AITAutoUpdater.cs` — 실질 데드락 위험 제거 (async/await 전파)

- 호출 체인: `Task.Run(...)` → `EditorApplication.delayCall` 람다(**메인 스레드**) → `OnRemoteHashResolved` → `GetCommitTime` → `HttpClient.GetStringAsync(apiUrl).Result`
- 메인 스레드의 `.Result` 블로킹은 Unity `SynchronizationContext`와 상호작용해 진짜 데드락을 일으킬 수 있음.
- 변경:
  - `GetCommitTime`: `string` → `async Task<string>` 반환. `.Result` → `await`.
  - `OnRemoteHashResolved`: `void` → `async Task` 반환. 내부 `GetCommitTime` 호출을 `await`.
  - `EditorApplication.delayCall` 람다: `async () => { ... }`로 변경 (try/catch로 예외 래핑 유지).
  - `using System.Threading.Tasks;` 추가.

### `Editor/AITGitGuard.cs:392`, `Editor/AITPlatformHelper.cs:396-397` — 최소 변경

- 두 지점 모두 `process.WaitForExit(timeoutMs)`가 `true`를 반환한 이후 호출되므로 Task는 이미 완료된 상태. 블로킹 데드락 위험은 사실상 없음.
- 호출자(`RunGit`, `ExecuteCommand`)는 `GitGuardIssue` 감지 루프, `[InitializeOnLoad]`, `[MenuItem]` 같은 **동기 Editor 진입점** 하위에서 호출되어 async 전파 비용이 큼(호출 체인 전체가 async로 바뀌어야 함).
- 따라서 `.Result` → `.GetAwaiter().GetResult()`로 **최소 변경**. `AggregateException` 래핑을 피하고 관용적 패턴에 맞춤. 이유는 주석으로 기록.

## 변환 범위 (부분 완료 사유)

| 파일 | 전환 방식 | 사유 |
|------|----------|------|
| `AITAutoUpdater.cs` | async/await 전파 | 메인 스레드 블로킹 호출 — 실질 데드락 위험 |
| `AITGitGuard.cs` | `GetAwaiter().GetResult()` | WaitForExit 이후 Task 완료 상태 — 데드락 위험 없음 |
| `AITPlatformHelper.cs` | `GetAwaiter().GetResult()` | 위와 동일 |

## 검증

- `./run-local-tests.sh --validate` 통과 (E2E 파일/Playwright config/SDK Generator unit tests, 18개 invariant).
- EditMode 테스트: 로컬에 Unity 미설치로 스킵됨 — CI에서 검증 예정.
- TODO.md의 해당 항목 제거.

## Test plan

- [ ] CI EditMode 테스트 (Level 0) 통과 확인
- [ ] Unity Editor에서 수동으로 `AIT/Check for Updates...` 메뉴 실행 → `GetCommitTime` 경로 리그레션 없음 확인
- [ ] Editor 재시작 시 `AITGitGuard` 자동 체크 동작 확인 (git 저장소 진입)
- [ ] `AITPlatformHelper.ExecuteCommand` 경로(`AITNpmRunner` 등)를 사용하는 빌드 파이프라인 동작 확인
