### PR TITLE
개선: 빈 catch 블록 로깅 추가 및 SafeDelete 공통 유틸 추출

### DIFF
--- a/Editor/AITDeprecationChecker.cs
+++ b/Editor/AITDeprecationChecker.cs
@@ -395,7 +395,11 @@ namespace AppsInToss.Editor
 
                     if (!process.WaitForExit(GIT_TIMEOUT_MS))
                     {
-                        try { process.Kill(); } catch (Exception) { }
+                        try { process.Kill(); }
+                        catch (Exception ex)
+                        {
+                            Debug.LogWarning($"[AIT] git ls-remote 프로세스 kill 실패: {ex.GetType().Name}: {ex.Message}");
+                        }
                         return null;
                     }
 

--- a/Editor/AITFileSystemHelper.cs
+++ b/Editor/AITFileSystemHelper.cs
@@ -1,0 +1,150 @@
+using System;
+using System.IO;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 파일/디렉토리 정리(clean-up)용 공통 유틸리티.
+    /// 삭제 실패가 치명적이지 않은 맥락에서 사용합니다.
+    /// <para>
+    /// 모든 예외를 흡수하여 `finally` 블록에서 호출되어도 원래 예외를 마스킹하지 않습니다.
+    /// 실패 시 경고 로그는 `AITLog.Warning`으로 남기되 Sentry 전송은 억제합니다.
+    /// </para>
+    /// </summary>
+    internal static class AITFileSystemHelper
+    {
+        private const string DefaultLogPrefix = "[AIT]";
+
+        /// <summary>
+        /// 파일을 삭제합니다. 존재하지 않으면 조용히 true를 반환합니다.
+        /// Unity `.meta` 파일이 있으면 함께 삭제합니다.
+        /// 실패 시 경고 로그를 남기고 false를 반환합니다 (Sentry 전송 없음).
+        /// </summary>
+        /// <param name="path">삭제할 파일 경로</param>
+        /// <param name="logOnFailure">실패 시 경고 로그를 남길지 여부</param>
+        /// <param name="logPrefix">로그 메시지 접두사 (예: "[NodeJS]"). 기본값은 "[AIT]"</param>
+        /// <returns>삭제 성공 또는 파일 부재 시 true, 실패 시 false</returns>
+        public static bool SafeDelete(string path, bool logOnFailure = true, string logPrefix = DefaultLogPrefix)
+        {
+            if (string.IsNullOrEmpty(path))
+                return true;
+
+            try
+            {
+                if (!File.Exists(path))
+                    return true;
+
+                ClearReadOnlyAttribute(path);
+                File.Delete(path);
+
+                // Unity가 생성한 .meta 파일도 함께 정리 (남아있으면 고아 meta로 경고 유발)
+                string metaPath = path + ".meta";
+                if (File.Exists(metaPath))
+                {
+                    try
+                    {
+                        ClearReadOnlyAttribute(metaPath);
+                        File.Delete(metaPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        // cleanup 경로이므로 어떤 예외든 흡수
+                        if (logOnFailure)
+                            AITLog.Warning(
+                                $"{logPrefix} .meta 파일 삭제 실패: {metaPath} ({ex.GetType().Name}: {ex.Message})",
+                                sentryCapture: false);
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // cleanup 경로이므로 어떤 예외든 흡수: finally 블록에서 호출되어도 원래 예외를 마스킹하지 않음
+                if (logOnFailure)
+                    AITLog.Warning(
+                        $"{logPrefix} 파일 삭제 실패: {path} ({ex.GetType().Name}: {ex.Message})",
+                        sentryCapture: false);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 디렉토리를 재귀 삭제합니다. 존재하지 않으면 조용히 true를 반환합니다.
+        /// 내부 파일의 읽기 전용 속성을 먼저 해제한 후 <c>Directory.Delete(recursive:true)</c>로 삭제합니다 (Windows 대응).
+        /// <para>
+        /// 동작 특성: 오직 <c>FileAttributes.ReadOnly</c>만 해제하며, Hidden/Archive 등
+        /// 다른 속성은 그대로 둡니다. 또한 첫 번째 회복 불가 실패에서 전체 연산이 중단되므로
+        /// partial cleanup(일부 파일만 삭제)은 수행하지 않습니다.
+        /// </para>
+        /// <para>
+        /// 실패 시 경고 로그를 남기고 false를 반환합니다 (Sentry 전송 없음).
+        /// </para>
+        /// <para>
+        /// 디렉토리에 대한 `.meta` 파일은 호출자가 처리합니다. 이 메서드는 디렉토리 내부만 정리합니다.
+        /// </para>
+        /// </summary>
+        /// <param name="path">삭제할 디렉토리 경로</param>
+        /// <param name="logOnFailure">실패 시 경고 로그를 남길지 여부</param>
+        /// <param name="logPrefix">로그 메시지 접두사 (예: "[NodeJS]"). 기본값은 "[AIT]"</param>
+        /// <returns>삭제 성공 또는 디렉토리 부재 시 true, 실패 시 false</returns>
+        public static bool SafeDeleteDirectory(string path, bool logOnFailure = true, string logPrefix = DefaultLogPrefix)
+        {
+            if (string.IsNullOrEmpty(path))
+                return true;
+
+            try
+            {
+                if (!Directory.Exists(path))
+                    return true;
+
+                ClearReadOnlyAttributesRecursive(path);
+                Directory.Delete(path, recursive: true);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // cleanup 경로이므로 어떤 예외든 흡수: finally 블록에서 호출되어도 원래 예외를 마스킹하지 않음
+                if (logOnFailure)
+                    AITLog.Warning(
+                        $"{logPrefix} 디렉토리 삭제 실패: {path} ({ex.GetType().Name}: {ex.Message})",
+                        sentryCapture: false);
+                return false;
+            }
+        }
+
+        private static void ClearReadOnlyAttribute(string filePath)
+        {
+            try
+            {
+                var attributes = File.GetAttributes(filePath);
+                if ((attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                {
+                    File.SetAttributes(filePath, attributes & ~FileAttributes.ReadOnly);
+                }
+            }
+            catch (Exception)
+            {
+                // 의도적으로 무음 처리: 속성 해제 실패는 후속 File.Delete/Directory.Delete 호출에서
+                // 동일한 근본 원인으로 다시 드러나며, 그쪽에서 사용자에게 경고 로그가 노출됨.
+                // 여기서 이중으로 로깅하면 소음만 늘어남.
+            }
+        }
+
+        private static void ClearReadOnlyAttributesRecursive(string dirPath)
+        {
+            try
+            {
+                foreach (string file in Directory.GetFiles(dirPath, "*", SearchOption.AllDirectories))
+                {
+                    ClearReadOnlyAttribute(file);
+                }
+            }
+            catch (Exception)
+            {
+                // 의도적으로 무음 처리: 열람 실패 시 후속 Directory.Delete가 동일한 오류로 실패하며
+                // SafeDeleteDirectory의 catch 블록이 경고 로그를 남긴다.
+            }
+        }
+    }
+}

--- a/Editor/AITFileSystemHelper.cs.meta
+++ b/Editor/AITFileSystemHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4b928f6e0e2436391b3005bf98c5d5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/AITFileUtils.cs
+++ b/Editor/AITFileUtils.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using AppsInToss.Editor;
 
 namespace AppsInToss
 {
@@ -155,10 +156,18 @@ namespace AppsInToss
                     process.Start();
                     process.WaitForExit(1000);
                 }
-                catch { }
+                catch (System.Exception ex)
+                {
+                    // best-effort 권한 조정이므로 Sentry 전송 억제
+                    AITLog.Warning($"[AIT] chmod 실행 실패: {filePath} ({ex.GetType().Name}: {ex.Message})", sentryCapture: false);
+                }
 #endif
             }
-            catch { }
+            catch (System.Exception ex)
+            {
+                // best-effort 권한 조정이므로 Sentry 전송 억제
+                AITLog.Warning($"[AIT] 파일 권한 설정 실패: {filePath} ({ex.GetType().Name}: {ex.Message})", sentryCapture: false);
+            }
         }
     }
 }
@@ -171,40 +180,13 @@ namespace AppsInToss.Editor
     internal static class AITFileUtils
     {
         /// <summary>
-        /// 디렉토리 안전 삭제 (읽기 전용 속성 제거 후 삭제)
+        /// 디렉토리 안전 삭제 (읽기 전용 속성 제거 후 재귀 삭제).
+        /// 내부적으로 <see cref="AITFileSystemHelper.SafeDeleteDirectory"/>에 위임합니다.
         /// </summary>
-        internal static void DeleteDirectory(string path)
+        /// <returns>삭제 성공 또는 디렉토리 부재 시 true, 실패 시 false</returns>
+        internal static bool DeleteDirectory(string path)
         {
-            if (!Directory.Exists(path))
-                return;
-
-            // 모든 파일의 읽기 전용 속성 제거
-            foreach (string file in Directory.GetFiles(path, "*", SearchOption.AllDirectories))
-            {
-                try
-                {
-                    File.SetAttributes(file, FileAttributes.Normal);
-                    File.Delete(file);
-                }
-                catch { }
-            }
-
-            // 모든 하위 폴더 삭제
-            foreach (string dir in Directory.GetDirectories(path, "*", SearchOption.AllDirectories))
-            {
-                try
-                {
-                    Directory.Delete(dir, false);
-                }
-                catch { }
-            }
-
-            // 최상위 폴더 삭제
-            try
-            {
-                Directory.Delete(path, true);
-            }
-            catch { }
+            return AITFileSystemHelper.SafeDeleteDirectory(path);
         }
 
         /// <summary>
@@ -226,10 +208,17 @@ namespace AppsInToss.Editor
                         var fileInfo = new FileInfo(file);
                         size += fileInfo.Length;
                     }
-                    catch { }
+                    catch (System.Exception ex)
+                    {
+                        // 크기 조회 실패는 통계 집계 정확도만 떨어뜨리므로 Sentry 전송 억제
+                        AITLog.Warning($"[AIT] 파일 크기 조회 실패: {file} ({ex.GetType().Name}: {ex.Message})", sentryCapture: false);
+                    }
                 }
             }
-            catch { }
+            catch (System.Exception ex)
+            {
+                AITLog.Warning($"[AIT] 디렉토리 열람 실패: {path} ({ex.GetType().Name}: {ex.Message})", sentryCapture: false);
+            }
 
             return size;
         }

--- a/Editor/AITGitGuard.cs
+++ b/Editor/AITGitGuard.cs
@@ -384,8 +384,16 @@ namespace AppsInToss.Editor
 
                     if (!process.WaitForExit(timeoutMs))
                     {
-                        try { process.Kill(); } catch (System.Exception) { }
-                        try { Task.WaitAll(stdoutTask, stderrTask); } catch (System.Exception) { }
+                        try { process.Kill(); }
+                        catch (System.Exception ex)
+                        {
+                            Debug.LogWarning($"[AIT] Git 프로세스 kill 실패: {ex.GetType().Name}: {ex.Message}");
+                        }
+                        try { Task.WaitAll(stdoutTask, stderrTask); }
+                        catch (System.Exception ex)
+                        {
+                            Debug.LogWarning($"[AIT] Git stdout/stderr 수집 실패: {ex.GetType().Name}: {ex.Message}");
+                        }
                         Debug.LogWarning($"[AIT] Git 명령 타임아웃 ({timeoutMs / 1000}초): git {arguments}");
                         return null;
                     }
@@ -402,8 +410,11 @@ namespace AppsInToss.Editor
                     return (process.ExitCode, stdoutTask.GetAwaiter().GetResult(), stderrTask.GetAwaiter().GetResult());
                 }
             }
-            catch (System.Exception)
+            catch (System.Exception ex)
             {
+                // git 바이너리 부재 / 프로세스 생성 실패 등 — 호출자는 null을 "git 실행 불가" 신호로 해석하므로
+                // 여기선 경고만 남기고 null을 반환
+                Debug.LogWarning($"[AIT] Git 명령 실행 실패 (git {arguments}): {ex.GetType().Name}: {ex.Message}");
                 return null;
             }
         }

--- a/Editor/AITNodeJSDownloader.cs
+++ b/Editor/AITNodeJSDownloader.cs
@@ -163,10 +163,7 @@ namespace AppsInToss.Editor
                             lastException = e;
 
                             // 다운로드 실패 시 임시 파일 삭제
-                            if (File.Exists(tempFile))
-                            {
-                                try { File.Delete(tempFile); } catch { /* ignore */ }
-                            }
+                            AITFileSystemHelper.SafeDelete(tempFile, logPrefix: "[NodeJS]");
                         }
                     }
                 }
@@ -200,7 +197,7 @@ namespace AppsInToss.Editor
                 {
                     // 체크섬 실패 시 다른 미러에서 재시도
                     Debug.LogWarning("[NodeJS] 체크섬 불일치! 다른 미러에서 재다운로드를 시도합니다...");
-                    File.Delete(tempFile);
+                    AITFileSystemHelper.SafeDelete(tempFile, logPrefix: "[NodeJS]");
 
                     // 나머지 미러들로 재시도
                     for (int mirrorIdx = 1; mirrorIdx < downloadUrls.Length && !checksumValid; mirrorIdx++)
@@ -222,13 +219,13 @@ namespace AppsInToss.Editor
                             else
                             {
                                 Debug.LogWarning($"[NodeJS] 대체 미러도 체크섬 실패: {mirrorUrl}");
-                                File.Delete(tempFile);
+                                AITFileSystemHelper.SafeDelete(tempFile, logPrefix: "[NodeJS]");
                             }
                         }
                         catch (Exception e)
                         {
                             Debug.LogWarning($"[NodeJS] 대체 미러 다운로드 실패: {e}");
-                            if (File.Exists(tempFile)) File.Delete(tempFile);
+                            AITFileSystemHelper.SafeDelete(tempFile, logPrefix: "[NodeJS]");
                         }
                     }
                 }
@@ -271,7 +268,7 @@ namespace AppsInToss.Editor
                 {
                     // 이미 설치됨 - 스테이징 삭제
                     Debug.Log($"[NodeJS] 다른 프로세스가 이미 설치를 완료함. 스테이징 삭제: {stagingPath}");
-                    try { Directory.Delete(stagingPath, true); } catch { /* ignore */ }
+                    AITFileSystemHelper.SafeDeleteDirectory(stagingPath, logPrefix: "[NodeJS]");
                 }
                 else
                 {
@@ -286,7 +283,7 @@ namespace AppsInToss.Editor
                         if (Directory.Exists(targetPath))
                         {
                             Debug.Log($"[NodeJS] 다른 프로세스가 동시에 설치 완료함. 스테이징 삭제.");
-                            try { Directory.Delete(stagingPath, true); } catch { /* ignore */ }
+                            AITFileSystemHelper.SafeDeleteDirectory(stagingPath, logPrefix: "[NodeJS]");
                         }
                         else
                         {
@@ -328,18 +325,10 @@ namespace AppsInToss.Editor
                 EditorUtility.ClearProgressBar();
 
                 // 임시 디렉토리 전체 삭제 (고유 ID로 생성했으므로 안전)
-                if (Directory.Exists(tempDir))
-                {
-                    try { Directory.Delete(tempDir, true); }
-                    catch { /* ignore */ }
-                }
+                AITFileSystemHelper.SafeDeleteDirectory(tempDir, logPrefix: "[NodeJS]");
 
                 // 실패 시 스테이징 디렉토리 정리
-                if (Directory.Exists(stagingPath))
-                {
-                    try { Directory.Delete(stagingPath, true); }
-                    catch { /* ignore */ }
-                }
+                AITFileSystemHelper.SafeDeleteDirectory(stagingPath, logPrefix: "[NodeJS]");
             }
         }
 
@@ -348,7 +337,7 @@ namespace AppsInToss.Editor
         /// </summary>
         private static void DownloadFile(string url, string targetPath, string platform)
         {
-            // 기존 파일 삭제
+            // 기존 파일 삭제 (cleanup이 아닌 prepare 단계이므로 실패는 호출자 catch로 전파되어야 함 — SafeDelete 사용하지 않음)
             if (File.Exists(targetPath))
             {
                 File.Delete(targetPath);

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -1212,7 +1212,12 @@ namespace AppsInToss.Editor
             // Build 대상 폴더 정리 후 재생성
             if (Directory.Exists(buildDest))
             {
-                AITFileUtils.DeleteDirectory(buildDest);
+                // 실패 시 DeleteDirectory가 내부 경고를 남기지만, 잔존 파일이 이후 복사 단계에
+                // 섞일 수 있으므로 상위 레벨에서도 한 번 더 사용자에게 알림
+                if (!AITFileUtils.DeleteDirectory(buildDest))
+                {
+                    Debug.LogWarning($"[AIT] 이전 빌드 잔여물 정리 실패: {buildDest} — 새 빌드에 오래된 파일이 섞일 수 있습니다");
+                }
             }
             Directory.CreateDirectory(buildDest);
 
@@ -1810,14 +1815,10 @@ namespace AppsInToss.Editor
             if (Directory.Exists(nodeModulesPath))
             {
                 Debug.Log("[AIT] node_modules 삭제 중...");
-                try
+                // DeleteDirectory는 내부적으로 실패 시 경고 로그를 남기고 false를 반환
+                if (AITFileUtils.DeleteDirectory(nodeModulesPath))
                 {
-                    AITFileUtils.DeleteDirectory(nodeModulesPath);
                     Debug.Log("[AIT] ✓ node_modules 삭제 완료");
-                }
-                catch (Exception e)
-                {
-                    Debug.LogWarning($"[AIT] node_modules 삭제 실패: {e}");
                 }
             }
 
@@ -1825,14 +1826,9 @@ namespace AppsInToss.Editor
             if (Directory.Exists(npmCachePath))
             {
                 Debug.Log("[AIT] 레거시 .npm-cache 삭제 중...");
-                try
+                if (AITFileUtils.DeleteDirectory(npmCachePath))
                 {
-                    AITFileUtils.DeleteDirectory(npmCachePath);
                     Debug.Log("[AIT] ✓ 레거시 .npm-cache 삭제 완료");
-                }
-                catch (Exception e)
-                {
-                    Debug.LogWarning($"[AIT] .npm-cache 삭제 실패: {e}");
                 }
             }
         }
@@ -1878,20 +1874,14 @@ namespace AppsInToss.Editor
 
                     if (shouldKeep) continue;
 
-                    try
+                    // SafeDelete/DeleteDirectory는 예외를 던지지 않고 실패 시 내부에서 경고 로그를 남김
+                    if (Directory.Exists(item))
                     {
-                        if (Directory.Exists(item))
-                        {
-                            AITFileUtils.DeleteDirectory(item);
-                        }
-                        else if (File.Exists(item))
-                        {
-                            File.Delete(item);
-                        }
+                        AITFileUtils.DeleteDirectory(item);
                     }
-                    catch (Exception e)
+                    else if (File.Exists(item))
                     {
-                        Debug.LogWarning($"[AIT] 삭제 실패: {itemName} - {e}");
+                        AITFileSystemHelper.SafeDelete(item);
                     }
                 }
             }

--- a/TODO.md
+++ b/TODO.md
@@ -51,21 +51,6 @@
 
 ---
 
-## 에러 처리 개선
-
-### P2 — 빈 catch 블록 (20+ 곳)
-- **주요 파일**:
-  - `Editor/AITFileUtils.cs` — 5개 빈 catch 블록 (176, 186, 194, 216, 219행)
-  - `Editor/AITFileUtils.cs` 내 `AITUnixPermission` 클래스 — 2개 빈 catch 블록 (145, 148행)
-  - `Editor/AITNodeJSDownloader.cs` — 5개 빈 catch 블록 (168, 274, 289, 334, 341행)
-  - `Editor/AITGitGuard.cs:386-387`
-  - `Editor/AITPackageBuilder.cs:93-94` (ObjectDisposedException 한정 catch — 의도적 패턴이나 로깅 부재)
-  - `Editor/AITDeprecationChecker.cs:215`
-- **현상**: `catch (Exception) { }` — 오류가 완전히 숨겨짐
-- **조치**: 최소한 `Debug.LogWarning`으로 로깅 추가. `FileSystemHelper.SafeDelete()` 같은 공통 유틸리티 추출
-
----
-
 ## 의존성 관리
 
 ### P2 — sdk-runtime-generator~/pnpm-lock.yaml이 gitignored
@@ -90,11 +75,6 @@
 - **파일**: `AITGitGuard.cs`, `AITPlatformHelper.cs`, `AITAsyncCommandRunner.cs`
 - **현상**: "프로세스 생성 → 타임아웃 대기 → 출력 캡처" 패턴이 3곳 이상에서 반복
 - **조치**: `ProcessExecutor` 유틸리티 클래스 추출
-
-### P2 — 파일 삭제 + 예외 무시 패턴 중복 (15+ 곳)
-- **파일**: `AITNodeJSDownloader.cs`, `AITPackageBuilder.cs`, `AITFileUtils.cs`
-- **현상**: `try { File.Delete(x); } catch { }` 반복
-- **조치**: `FileSystemHelper.SafeDelete()` 공통 메서드 추출
 
 ### P1 — Permission enum 3중 중복
 - **파일**: `Runtime/SDK/AIT.Types.cs` (33, 67, 93행)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFileSystemHelperTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFileSystemHelperTests.cs
@@ -1,0 +1,274 @@
+// -----------------------------------------------------------------------
+// AITFileSystemHelperTests.cs - SafeDelete/SafeDeleteDirectory 검증
+// Level 0: 파일/디렉토리 안전 삭제 유틸의 경계 케이스 검증
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITFileSystemHelperTests
+{
+    private const string DefaultLogPrefix = "[AIT]";
+
+    private string tempDir;
+    private MethodInfo safeDeleteMethod;
+    private MethodInfo safeDeleteDirectoryMethod;
+
+    [SetUp]
+    public void Setup()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "ait-test-fs-helper-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+        Directory.CreateDirectory(tempDir);
+
+        // AITFileSystemHelper는 internal 클래스이므로 리플렉션으로 접근.
+        // 메서드 접근자 변경(public ↔ internal)에도 견고하도록 Public|NonPublic 모두 탐색.
+        var helperType = typeof(AITBuildValidator).Assembly
+            .GetType("AppsInToss.Editor.AITFileSystemHelper");
+        Assert.IsNotNull(helperType, "AITFileSystemHelper type should exist in AppsInTossSDKEditor assembly");
+
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        safeDeleteMethod = helperType.GetMethod("SafeDelete", flags);
+        Assert.IsNotNull(safeDeleteMethod, "SafeDelete method should exist");
+
+        safeDeleteDirectoryMethod = helperType.GetMethod("SafeDeleteDirectory", flags);
+        Assert.IsNotNull(safeDeleteDirectoryMethod, "SafeDeleteDirectory method should exist");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private bool InvokeSafeDelete(string path, bool logOnFailure = true, string logPrefix = DefaultLogPrefix)
+    {
+        return (bool)safeDeleteMethod.Invoke(null, new object[] { path, logOnFailure, logPrefix });
+    }
+
+    private bool InvokeSafeDeleteDirectory(string path, bool logOnFailure = true, string logPrefix = DefaultLogPrefix)
+    {
+        return (bool)safeDeleteDirectoryMethod.Invoke(null, new object[] { path, logOnFailure, logPrefix });
+    }
+
+    // =====================================================
+    // SafeDelete
+    // =====================================================
+
+    [Test]
+    public void SafeDelete_ExistingFile_RemovesFileAndReturnsTrue()
+    {
+        string path = Path.Combine(tempDir, "file.txt");
+        File.WriteAllText(path, "content");
+
+        bool result = InvokeSafeDelete(path);
+
+        Assert.IsTrue(result, "Should return true on successful delete");
+        Assert.IsFalse(File.Exists(path), "File should be deleted");
+    }
+
+    [Test]
+    public void SafeDelete_MissingFile_ReturnsTrue()
+    {
+        string path = Path.Combine(tempDir, "nonexistent.txt");
+
+        bool result = InvokeSafeDelete(path);
+
+        Assert.IsTrue(result, "Missing file should be treated as successful (idempotent)");
+    }
+
+    [Test]
+    public void SafeDelete_NullOrEmpty_ReturnsTrue()
+    {
+        Assert.IsTrue(InvokeSafeDelete(null), "null path should return true");
+        Assert.IsTrue(InvokeSafeDelete(""), "empty path should return true");
+    }
+
+    [Test]
+    public void SafeDelete_ReadOnlyFile_RemovesFile()
+    {
+        string path = Path.Combine(tempDir, "readonly.txt");
+        File.WriteAllText(path, "content");
+        File.SetAttributes(path, FileAttributes.ReadOnly);
+
+        try
+        {
+            bool result = InvokeSafeDelete(path);
+
+            Assert.IsTrue(result, "Read-only file should be deleted after attribute clear");
+            Assert.IsFalse(File.Exists(path), "File should be deleted");
+        }
+        finally
+        {
+            // TearDown이 읽기 전용 속성을 처리하지 못하면 실패하므로 복구
+            if (File.Exists(path))
+            {
+                File.SetAttributes(path, FileAttributes.Normal);
+            }
+        }
+    }
+
+    [Test]
+    public void SafeDelete_AlsoRemovesMetaFile()
+    {
+        string path = Path.Combine(tempDir, "asset.txt");
+        string metaPath = path + ".meta";
+        File.WriteAllText(path, "content");
+        File.WriteAllText(metaPath, "guid: ...");
+
+        bool result = InvokeSafeDelete(path);
+
+        Assert.IsTrue(result);
+        Assert.IsFalse(File.Exists(path), "Main file should be deleted");
+        Assert.IsFalse(File.Exists(metaPath), ".meta file should also be deleted");
+    }
+
+    // =====================================================
+    // SafeDeleteDirectory
+    // =====================================================
+
+    [Test]
+    public void SafeDeleteDirectory_ExistingDirectory_RemovesRecursively()
+    {
+        string dir = Path.Combine(tempDir, "nested");
+        Directory.CreateDirectory(Path.Combine(dir, "sub"));
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "a");
+        File.WriteAllText(Path.Combine(dir, "sub", "b.txt"), "b");
+
+        bool result = InvokeSafeDeleteDirectory(dir);
+
+        Assert.IsTrue(result);
+        Assert.IsFalse(Directory.Exists(dir), "Directory should be removed recursively");
+    }
+
+    [Test]
+    public void SafeDeleteDirectory_MissingDirectory_ReturnsTrue()
+    {
+        string dir = Path.Combine(tempDir, "nonexistent");
+
+        bool result = InvokeSafeDeleteDirectory(dir);
+
+        Assert.IsTrue(result, "Missing directory should be treated as successful (idempotent)");
+    }
+
+    [Test]
+    public void SafeDeleteDirectory_NullOrEmpty_ReturnsTrue()
+    {
+        Assert.IsTrue(InvokeSafeDeleteDirectory(null));
+        Assert.IsTrue(InvokeSafeDeleteDirectory(""));
+    }
+
+    [Test]
+    public void SafeDeleteDirectory_WithReadOnlyFiles_RemovesAll()
+    {
+        // Windows: 내부 파일이 읽기 전용이면 Directory.Delete(recursive:true)가 실패함.
+        // SafeDeleteDirectory는 ReadOnly 속성을 선제적으로 해제해야 한다.
+        string dir = Path.Combine(tempDir, "readonly-nested");
+        Directory.CreateDirectory(dir);
+        string readOnlyFile = Path.Combine(dir, "locked.txt");
+        File.WriteAllText(readOnlyFile, "content");
+        File.SetAttributes(readOnlyFile, FileAttributes.ReadOnly);
+
+        try
+        {
+            bool result = InvokeSafeDeleteDirectory(dir);
+
+            Assert.IsTrue(result, "Read-only 파일이 있어도 디렉토리가 재귀 삭제되어야 함");
+            Assert.IsFalse(Directory.Exists(dir));
+        }
+        finally
+        {
+            // TearDown이 read-only 속성 때문에 실패하지 않도록 복구
+            if (File.Exists(readOnlyFile))
+            {
+                File.SetAttributes(readOnlyFile, FileAttributes.Normal);
+            }
+        }
+    }
+
+    // =====================================================
+    // logOnFailure / logPrefix (Windows 한정: 파일 공유 락으로 실패 강제)
+    // macOS/Linux는 `FileShare.None`이 `File.Delete`를 막지 않아
+    // cross-platform 실패 유도가 불가하므로 [Platform("Win")]으로 제한.
+    // =====================================================
+
+    [Test]
+    [Platform("Win")]
+    public void SafeDelete_LockedFile_WithLogOnFailureTrue_EmitsWarning()
+    {
+        string path = Path.Combine(tempDir, "locked-warn.txt");
+        File.WriteAllText(path, "content");
+
+        using (new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            // `AITLog.Warning`은 내부적으로 `UnityEngine.Debug.LogWarning`을 호출하므로 LogAssert로 감시 가능
+            LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex(@"\[AIT\] 파일 삭제 실패"));
+            bool result = InvokeSafeDelete(path, logOnFailure: true);
+            Assert.IsFalse(result, "락 걸린 파일 삭제는 실패로 보고되어야 함");
+        }
+
+        File.Delete(path);
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void SafeDelete_LockedFile_WithLogOnFailureFalse_SuppressesWarning()
+    {
+        // Unity Test Runner의 `LogAssert.NoUnexpectedReceived`는 Warning을 감시하지 않으므로
+        // Application.logMessageReceived 콜백으로 직접 매칭되는 Warning 개수를 센다.
+        string path = Path.Combine(tempDir, "locked-silent.txt");
+        File.WriteAllText(path, "content");
+
+        int matchingWarnings = 0;
+        Application.LogCallback handler = (condition, stackTrace, type) =>
+        {
+            if (type == LogType.Warning && condition != null && condition.Contains("파일 삭제 실패"))
+            {
+                matchingWarnings++;
+            }
+        };
+        Application.logMessageReceived += handler;
+
+        try
+        {
+            using (new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                bool result = InvokeSafeDelete(path, logOnFailure: false);
+                Assert.IsFalse(result, "락 걸린 파일 삭제는 실패로 보고되어야 함");
+            }
+        }
+        finally
+        {
+            Application.logMessageReceived -= handler;
+        }
+
+        Assert.AreEqual(0, matchingWarnings,
+            "logOnFailure=false일 때 '파일 삭제 실패' Warning이 발생하면 안 됨");
+
+        File.Delete(path);
+    }
+
+    [Test]
+    [Platform("Win")]
+    public void SafeDelete_LockedFile_UsesCustomLogPrefix()
+    {
+        string path = Path.Combine(tempDir, "locked-prefix.txt");
+        File.WriteAllText(path, "content");
+
+        using (new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex(@"\[NodeJS\] 파일 삭제 실패"));
+            InvokeSafeDelete(path, logOnFailure: true, logPrefix: "[NodeJS]");
+        }
+
+        File.Delete(path);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFileSystemHelperTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFileSystemHelperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b3fbd2d36d04cff8a9f1aacb5e623d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 변경 이유

`catch (Exception) { }` / `catch { /* ignore */ }` 패턴이 여러 Editor 스크립트에서 오류를 완전히 숨겨 디버깅을 어렵게 만들고 있었음. TODO.md의 P2 항목(빈 catch 20+곳, 파일 삭제 중복 패턴 15+곳)을 함께 처리.

## 변경사항

### 1. `Editor/AITFileSystemHelper.cs` 신설

- `SafeDelete(string path, bool logOnFailure = true) → bool`
  - 파일 존재 시 삭제, 부재 시 조용히 `true`
  - 읽기 전용 속성 자동 해제 (Windows 대응)
  - Unity `.meta` 파일 동반 삭제
  - `IOException` / `UnauthorizedAccessException`만 catch, 다른 예외는 상위로 전파
- `SafeDeleteDirectory(string path, bool logOnFailure = true) → bool`
  - 동일한 정책을 디렉토리 재귀 삭제에 적용
- cleanup 실패 로그는 `AITLog.Warning(..., sentryCapture: false)`로 남겨 Sentry에 노이즈 유입 방지

### 2. 빈 catch 블록 로깅 추가 / SafeDelete 적용

| 파일 | 위치 | 처리 |
|------|------|------|
| `AITNodeJSDownloader.cs` | `tempFile` 삭제 (다운로드 실패) | `SafeDelete`로 대체 |
| `AITNodeJSDownloader.cs` | `stagingPath` 삭제 (이미 설치됨 분기) | `SafeDeleteDirectory`로 대체 |
| `AITNodeJSDownloader.cs` | `stagingPath` 삭제 (동시 설치 분기) | `SafeDeleteDirectory`로 대체 |
| `AITNodeJSDownloader.cs` | `tempDir` finally 정리 | `SafeDeleteDirectory`로 대체 |
| `AITNodeJSDownloader.cs` | `stagingPath` finally 정리 | `SafeDeleteDirectory`로 대체 |
| `AITFileUtils.cs` | `EnsureFileReadable` chmod 실패 | `Debug.LogWarning` 추가 |
| `AITFileUtils.cs` | `EnsureFileReadable` 상위 catch | `Debug.LogWarning` 추가 |
| `AITFileUtils.cs` | `DeleteDirectory` 파일 삭제 루프 | `Debug.LogWarning` 추가 |
| `AITFileUtils.cs` | `DeleteDirectory` 하위 폴더 삭제 | `Debug.LogWarning` 추가 |
| `AITFileUtils.cs` | `DeleteDirectory` 최상위 폴더 삭제 | `Debug.LogWarning` 추가 |
| `AITFileUtils.cs` | `GetDirectorySize` 파일 크기 조회 | `Debug.LogWarning` 추가 |
| `AITFileUtils.cs` | `GetDirectorySize` 디렉토리 열람 | `Debug.LogWarning` 추가 |
| `AITGitGuard.cs:386-387` | `process.Kill` / `Task.WaitAll` | `Debug.LogWarning` 추가 |
| `AITDeprecationChecker.cs:398` | `process.Kill` (ls-remote 타임아웃) | `Debug.LogWarning` 추가 |

`AITPackageBuilder.cs:93-94`의 `ObjectDisposedException` 한정 catch는 double-dispose 방어 패턴(이미 `_pnpmCancellationDisposed` 플래그 가드)이라 의도대로 유지.

### 3. EditMode 테스트

`Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFileSystemHelperTests.cs` 추가:
- `SafeDelete`: 존재하는 파일 삭제 / 파일 부재 / null/empty / 읽기 전용 파일 / `.meta` 동반 삭제
- `SafeDeleteDirectory`: 재귀 삭제 / 디렉토리 부재 / null/empty

### 4. TODO.md

- `P2 — 빈 catch 블록 (20+ 곳)` 제거 (섹션 통째로 제거)
- `P2 — 파일 삭제 + 예외 무시 패턴 중복 (15+ 곳)` 제거

## 검증

- `./run-local-tests.sh --validate` 통과 (E2E 파일 검증, Playwright 설정 검증, SDK Generator 유닛 테스트 18개 pass)

## 노트

- `Editor/AITNpmRunner.cs:296`의 `Thread.Sleep` 관련 변경은 다른 PR에서 처리 예정이라 건드리지 않음