### PR TITLE
수정: 빌드 산출물 중복 자동 정리를 모든 파일 패턴으로 확장

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -300,6 +300,10 @@ public class BuildFileSelectionTests
     // 자동 정리를 받는지 명시적으로 고정한다.
     // 비압축(.data), Brotli(.wasm.br), Gzip(.framework.js.gz), decompressionFallback
     // (.data.unityweb, .symbols.json.unityweb) 케이스를 전부 포함.
+    //
+    // 비고: FindFileInBuild_CompressedExtensions_Matches(:108)는 단일 파일에 대한
+    // 패턴 매칭만 검증하지만, 이 테스트는 동일 조합에 '중복 시 자동 정리'와
+    // '반환값 = 최신 파일명' 계약을 추가로 고정한다.
     // =====================================================
 
     // pattern: AITBuildValidator.GetFilePatterns가 생성하는 실제 패턴
@@ -318,6 +322,7 @@ public class BuildFileSelectionTests
     [TestCase("*.wasm.unityweb", ".wasm.unityweb")]
     [TestCase("*.symbols.json*", ".symbols.json")]
     [TestCase("*.symbols.json*", ".symbols.json.br")]
+    [TestCase("*.symbols.json*", ".symbols.json.gz")]
     [TestCase("*.symbols.json.unityweb", ".symbols.json.unityweb")]
     public void FindFileInBuild_AllProductPatterns_DuplicateCleanup(string pattern, string suffix)
     {
@@ -332,9 +337,12 @@ public class BuildFileSelectionTests
         File.WriteAllText(newFile, "new");
         File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
 
+        string result = null;
         var logs = CollectLogs(() =>
-            AITBuildValidator.FindFileInBuild(tempDir, pattern));
+            result = AITBuildValidator.FindFileInBuild(tempDir, pattern));
 
+        Assert.AreEqual("new_hash" + suffix, result,
+            $"[{pattern} / {suffix}] 최신 파일명이 반환되어야 함");
         Assert.IsFalse(File.Exists(oldFile),
             $"[{pattern} / {suffix}] 이전 빌드 잔여물이 자동 삭제되어야 함");
         Assert.IsFalse(File.Exists(oldMeta),

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -293,6 +293,65 @@ public class BuildFileSelectionTests
     }
 
     // =====================================================
+    // 중복 자동 정리 — 모든 WebGL 산출물 패턴 회귀 방지
+    // Sentry SDK-7J(213ev), SDK-7T(3ev): loader.js 외 .data/.wasm/.framework.js/
+    // .symbols.json 파일에 대해서도 같은 "이전 빌드 잔여물" 경고가 반복 수집됨.
+    // FindFileInBuild는 패턴 독립적으로 동작하므로 호출부가 모든 패턴에 대해
+    // 자동 정리를 받는지 명시적으로 고정한다.
+    // 비압축(.data), Brotli(.wasm.br), Gzip(.framework.js.gz), decompressionFallback
+    // (.data.unityweb, .symbols.json.unityweb) 케이스를 전부 포함.
+    // =====================================================
+
+    // pattern: AITBuildValidator.GetFilePatterns가 생성하는 실제 패턴
+    // suffix: 생성할 파일 확장자 (pattern과 매칭되어야 함)
+    [TestCase("*.data*", ".data")]
+    [TestCase("*.data*", ".data.br")]
+    [TestCase("*.data*", ".data.gz")]
+    [TestCase("*.data.unityweb", ".data.unityweb")]
+    [TestCase("*.framework.js*", ".framework.js")]
+    [TestCase("*.framework.js*", ".framework.js.br")]
+    [TestCase("*.framework.js*", ".framework.js.gz")]
+    [TestCase("*.framework.js.unityweb", ".framework.js.unityweb")]
+    [TestCase("*.wasm*", ".wasm")]
+    [TestCase("*.wasm*", ".wasm.br")]
+    [TestCase("*.wasm*", ".wasm.gz")]
+    [TestCase("*.wasm.unityweb", ".wasm.unityweb")]
+    [TestCase("*.symbols.json*", ".symbols.json")]
+    [TestCase("*.symbols.json*", ".symbols.json.br")]
+    [TestCase("*.symbols.json.unityweb", ".symbols.json.unityweb")]
+    public void FindFileInBuild_AllProductPatterns_DuplicateCleanup(string pattern, string suffix)
+    {
+        string oldFile = Path.Combine(tempDir, "old_hash" + suffix);
+        File.WriteAllText(oldFile, "old");
+        File.SetLastWriteTime(oldFile, new DateTime(2025, 1, 1));
+
+        string oldMeta = oldFile + ".meta";
+        File.WriteAllText(oldMeta, "fileFormatVersion: 2\nguid: deadbeef\n");
+
+        string newFile = Path.Combine(tempDir, "new_hash" + suffix);
+        File.WriteAllText(newFile, "new");
+        File.SetLastWriteTime(newFile, new DateTime(2026, 2, 1));
+
+        var logs = CollectLogs(() =>
+            AITBuildValidator.FindFileInBuild(tempDir, pattern));
+
+        Assert.IsFalse(File.Exists(oldFile),
+            $"[{pattern} / {suffix}] 이전 빌드 잔여물이 자동 삭제되어야 함");
+        Assert.IsFalse(File.Exists(oldMeta),
+            $"[{pattern} / {suffix}] 잔여물의 .meta 파일도 함께 삭제되어야 함");
+        Assert.IsTrue(File.Exists(newFile),
+            $"[{pattern} / {suffix}] 최신 파일은 유지되어야 함");
+
+        // Sentry 노이즈 방지: 성공 경로에서는 Warning/Error 없이 Debug.Log만 발생
+        var noisy = logs.FindAll(l =>
+            l.type == LogType.Warning || l.type == LogType.Error ||
+            l.type == LogType.Exception || l.type == LogType.Assert);
+        Assert.IsEmpty(noisy,
+            $"[{pattern} / {suffix}] 정상 자동 정리는 Warning/Error를 발생시키면 안 됨: " +
+            string.Join(" | ", noisy.ConvertAll(l => $"[{l.type}] {l.message}")));
+    }
+
+    // =====================================================
     // LastWriteTime 동률 — 파일명 내림차순 타이브레이크로 결정적 선택
     // Array.Sort가 불안정하므로 명시적 이차 정렬 키가 필요
     // =====================================================


### PR DESCRIPTION
## 배경

PR #432에서 `AITBuildValidator.FindFileInBuild()`가 중복 파일 감지 시 오래된 잔여물을 자동 삭제하도록 개선했다. 해당 로직은 **패턴 독립적**으로 구현되어 있어 이론적으로는 모든 WebGL 산출물 패턴에서 작동한다.

그러나 Sentry를 통해 수집된 이슈를 보면 `loader.js`가 아닌 다른 빌드 산출물에 대해서도 동일 계열의 "이전 빌드 잔여물일 수 있습니다" 경고가 반복 기록되고 있었다:

- **SDK-7J** — 213 events 누적
- **SDK-7T** — `.data.unityweb` 빌드 실패 관련 (3 events)

현재 회귀 테스트는 `*.loader.js`와 `*.data*`(일부)에만 집중되어 있어, 향후 리팩토링에서 특정 패턴만 누락되는 회귀를 방지하지 못한다.

## 변경 내용

프로덕션 코드(`AITBuildValidator`, `AITPackageBuilder`) 변경 없음. `FindFileInBuild`는 이미 패턴 독립적으로 중복 정리를 수행하고, `AITPackageBuilder`도 loader/data/framework/wasm/symbols 모두에 대해 이 메서드를 호출한다.

이 PR은 **모든 WebGL 산출물 패턴에 대해 중복 자동 정리가 작동함**을 고정하는 회귀 테스트만 추가한다:

- `Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs`에 파라미터화된 `FindFileInBuild_AllProductPatterns_DuplicateCleanup` 테스트 추가 (15개 TestCase)

### 커버하는 케이스

| 압축 | data | framework.js | wasm | symbols.json |
|------|------|--------------|------|--------------|
| 비압축 | ✓ | ✓ | ✓ | ✓ |
| Brotli | ✓ | ✓ | ✓ | ✓ |
| Gzip | ✓ | ✓ | ✓ | — |
| Decompression Fallback (`.unityweb`) | ✓ | ✓ | ✓ | ✓ |

각 케이스마다 다음을 모두 검증:
1. 오래된 잔여물 파일이 자동 삭제되는지
2. 잔여물의 `.meta` 파일이 동반 삭제되는지
3. 최신 파일은 유지되는지
4. 성공 경로에서 Warning/Error가 발생하지 않는지 (Sentry 노이즈 방지)

## PR #432와의 관계

PR #432(`dbe1670` + 리뷰 반영 커밋들)가 도입한 자동 정리 로직의 **검증 커버리지를 모든 Unity WebGL 산출물 패턴으로 확장**한다. 런타임 동작은 그대로이되, 향후 "loader만 자동 정리되고 다른 패턴은 경고만 유지"되는 회귀를 컴파일/CI 레벨에서 잡을 수 있게 된다.

## 검증

- [x] `./run-local-tests.sh --validate` 통과
- [ ] EditMode 테스트는 로컬에 Unity가 설치되지 않아 스킵됨 → CI에서 Level 0 테스트로 검증 필요
- [ ] 머지 후 Sentry SDK-7J의 `last_seen` 타임스탬프가 멈추는지 확인 (후속)

## 관련

- Related: #432 (`수정: loader.js 중복 파일 자동 정리로 Sentry 노이즈 제거`)
- Sentry: SDK-7J (213ev), SDK-7T
