### PR TITLE
리팩토링: MainThreadDispatcher 서비스 추출

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -9,6 +8,7 @@ using UnityEditor;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 using AppsInToss.Editor;
+using AppsInToss.Editor.Menu;
 
 namespace AppsInToss
 {
@@ -23,11 +23,6 @@ namespace AppsInToss
         private static AITServerStateManager prodServerState;
         private static Stopwatch buildStopwatch = new Stopwatch();
 
-        // 스레드 안전한 메인 스레드 작업 큐
-        // ThreadPool에서 EditorApplication.update에 직접 접근하는 대신 이 큐를 사용
-        private static readonly ConcurrentQueue<Action> mainThreadActionQueue = new ConcurrentQueue<Action>();
-        private static int isMainThreadQueueProcessorRegistered = 0;
-
         /// <summary>
         /// 도메인 리로드 시 기존 서버 프로세스 복원 및 종료 이벤트 등록
         /// </summary>
@@ -40,63 +35,13 @@ namespace AppsInToss
             // 즉시 실제 상태 검증 (domain reload 후 복원)
             devServerState.ValidateState();
             prodServerState.ValidateState();
-
-            // 메인 스레드 작업 큐 프로세서 등록
-            EnsureMainThreadQueueProcessorRegistered();
-
-            EditorApplication.quitting += OnEditorQuitting;
-            UnityEditor.PackageManager.Events.registeredPackages += OnPackagesChanged;
-        }
-
-        /// <summary>
-        /// 메인 스레드 작업 큐 프로세서가 등록되어 있는지 확인하고, 없으면 등록
-        /// Domain reload 후에도 재등록됨
-        /// </summary>
-        private static void EnsureMainThreadQueueProcessorRegistered()
-        {
-            if (Interlocked.CompareExchange(ref isMainThreadQueueProcessorRegistered, 1, 0) == 0)
-            {
-                EditorApplication.update += ProcessMainThreadActionQueue;
-            }
-        }
-
-        /// <summary>
-        /// 메인 스레드 작업 큐를 처리
-        /// EditorApplication.update에서 매 프레임 호출됨
-        /// </summary>
-        private static void ProcessMainThreadActionQueue()
-        {
-            // 한 프레임에 최대 10개 작업 처리 (에디터 응답성 유지)
-            int processedCount = 0;
-            while (processedCount < 10 && mainThreadActionQueue.TryDequeue(out var action))
-            {
-                try
-                {
-                    action?.Invoke();
-                }
-                catch (Exception e)
-                {
-                    Debug.LogException(e);
-                }
-                processedCount++;
-            }
-        }
-
-        /// <summary>
-        /// 메인 스레드에서 실행할 작업을 큐에 추가
-        /// ThreadPool 스레드에서 안전하게 호출 가능
-        /// </summary>
-        /// <param name="action">메인 스레드에서 실행할 작업</param>
-        private static void EnqueueMainThreadAction(Action action)
-        {
-            if (action == null) return;
-            mainThreadActionQueue.Enqueue(action);
         }
 
         /// <summary>
         /// Unity Editor 종료 시 모든 서버 프로세스 정리
+        /// MainThreadDispatcher의 EditorApplication.quitting 구독을 통해 호출됨.
         /// </summary>
-        private static void OnEditorQuitting()
+        internal static void HandleEditorQuitting()
         {
             var devState = devServerState?.GetCachedState() ?? ServerState.NotRunning;
             var prodState = prodServerState?.GetCachedState() ?? ServerState.NotRunning;
@@ -122,8 +67,9 @@ namespace AppsInToss
 
         /// <summary>
         /// 패키지 등록 변경 시 SDK 패키지 제거 감지
+        /// MainThreadDispatcher의 PackageManager.Events.registeredPackages 구독을 통해 호출됨.
         /// </summary>
-        private static void OnPackagesChanged(UnityEditor.PackageManager.PackageRegistrationEventArgs args)
+        internal static void HandlePackagesChanged(UnityEditor.PackageManager.PackageRegistrationEventArgs args)
         {
             foreach (var package in args.removed)
             {
@@ -1219,7 +1165,7 @@ namespace AppsInToss
                     }
 
                     // 스레드 안전한 메인 스레드 큐를 통해 콜백 실행
-                    EnqueueMainThreadAction(() =>
+                    MainThreadDispatcher.Enqueue(() =>
                     {
                         EditorApplication.update -= timeoutCheck;
                         Debug.LogError($"[{logPrefix}] 서버 시작 실패: {reason}");
@@ -1269,7 +1215,7 @@ namespace AppsInToss
                             if (Interlocked.CompareExchange(ref serverStartedFlag, 1, 0) == 0)
                             {
                                 // 스레드 안전한 메인 스레드 큐를 통해 콜백 실행
-                                EnqueueMainThreadAction(() =>
+                                MainThreadDispatcher.Enqueue(() =>
                                 {
                                     EditorApplication.update -= timeoutCheck;
                                     onServerStarted?.Invoke(port);

--- a/Editor/Menu.meta
+++ b/Editor/Menu.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffc4841164964382812a22ff9fa25357
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Menu/MainThreadDispatcher.cs
+++ b/Editor/Menu/MainThreadDispatcher.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using Debug = UnityEngine.Debug;
+
+namespace AppsInToss.Editor.Menu
+{
+    /// <summary>
+    /// ThreadPool 스레드에서 Editor 메인 스레드로 작업을 디스패치하는 큐.
+    /// EditorApplication.update에 직접 접근할 수 없는 백그라운드 스레드가
+    /// 안전하게 메인 스레드 작업을 예약하기 위해 사용한다.
+    /// </summary>
+    [InitializeOnLoad]
+    internal static class MainThreadDispatcher
+    {
+        private static readonly ConcurrentQueue<Action> mainThreadActionQueue = new ConcurrentQueue<Action>();
+        private static int isMainThreadQueueProcessorRegistered = 0;
+
+        static MainThreadDispatcher()
+        {
+            EnsureRegistered();
+
+            EditorApplication.quitting += OnEditorQuitting;
+            Events.registeredPackages += OnPackagesChanged;
+        }
+
+        /// <summary>
+        /// 메인 스레드 작업 큐 프로세서가 등록되어 있는지 확인하고, 없으면 등록
+        /// Domain reload 후에도 재등록됨
+        /// </summary>
+        public static void EnsureRegistered()
+        {
+            if (Interlocked.CompareExchange(ref isMainThreadQueueProcessorRegistered, 1, 0) == 0)
+            {
+                EditorApplication.update += ProcessQueue;
+            }
+        }
+
+        /// <summary>
+        /// 메인 스레드에서 실행할 작업을 큐에 추가
+        /// ThreadPool 스레드에서 안전하게 호출 가능
+        /// </summary>
+        /// <param name="action">메인 스레드에서 실행할 작업</param>
+        public static void Enqueue(Action action)
+        {
+            if (action == null) return;
+            mainThreadActionQueue.Enqueue(action);
+        }
+
+        /// <summary>
+        /// 메인 스레드 작업 큐를 처리
+        /// EditorApplication.update에서 매 프레임 호출됨
+        /// </summary>
+        private static void ProcessQueue()
+        {
+            // 한 프레임에 최대 10개 작업 처리 (에디터 응답성 유지)
+            int processedCount = 0;
+            while (processedCount < 10 && mainThreadActionQueue.TryDequeue(out var action))
+            {
+                try
+                {
+                    action?.Invoke();
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
+                processedCount++;
+            }
+        }
+
+        private static void OnEditorQuitting()
+        {
+            AppsInTossMenu.HandleEditorQuitting();
+        }
+
+        private static void OnPackagesChanged(PackageRegistrationEventArgs args)
+        {
+            AppsInTossMenu.HandlePackagesChanged(args);
+        }
+    }
+}

--- a/Editor/Menu/MainThreadDispatcher.cs.meta
+++ b/Editor/Menu/MainThreadDispatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcf21a3ee6484831a3390528cdc8f80e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33fa9cecfd2d4b44a9f6f58c37f2ffb8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/MainThreadDispatcherTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/MainThreadDispatcherTests.cs
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------
+// MainThreadDispatcherTests.cs - MainThreadDispatcher 단위 테스트
+// Level 0: EditorApplication.update 의존 없이 순수 C# 로직만 검증
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.Menu;
+
+namespace AppsInToss.Editor.Menu.Tests
+{
+    [TestFixture]
+    public class MainThreadDispatcherTests
+    {
+        [Test]
+        public void Enqueue_NullAction_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => MainThreadDispatcher.Enqueue(null));
+        }
+
+        [Test]
+        public void EnsureRegistered_CalledTwice_RegistersOnlyOnce()
+        {
+            // static 생성자에서 이미 한 번 등록된 상태. 두 번 더 호출해도
+            // Interlocked.CompareExchange 가드로 인해 추가 등록 없이 안전해야 함.
+            Assert.DoesNotThrow(() =>
+            {
+                MainThreadDispatcher.EnsureRegistered();
+                MainThreadDispatcher.EnsureRegistered();
+            });
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/MainThreadDispatcherTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/MainThreadDispatcherTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 270734b171504538ace57f8de83cbf5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경

`AppsInTossMenu` 파일(현재 1900+ 줄)을 책임별로 분할하는 6개 PR 시리즈 중 **1번째** 작업입니다. 메인 스레드 작업 디스패치 책임을 독립 서비스로 분리하여 메뉴 facade의 크기를 축소하고, 후속 서비스(ServerManager 등) 분리의 토대를 마련합니다.

## 변경 내용

### 신설
- `Editor/Menu/MainThreadDispatcher.cs` (`internal static` + `[InitializeOnLoad]`)
  - `Enqueue(Action)` — ThreadPool 스레드에서 메인 스레드로 작업 예약
  - `EnsureRegistered()` — `EditorApplication.update` 프로세서 등록(도메인 리로드 안전)
  - `ProcessQueue()` — 프레임당 최대 10개 작업 처리 (에디터 응답성 유지)
  - static 생성자에서 `EditorApplication.quitting`, `PackageManager.Events.registeredPackages` 구독

### AppsInTossMenu.cs 변경
- 제거: `mainThreadActionQueue`, `isMainThreadQueueProcessorRegistered` 필드
- 제거: `EnsureMainThreadQueueProcessorRegistered`, `ProcessMainThreadActionQueue`, `EnqueueMainThreadAction` 메서드
- `OnEditorQuitting` → `HandleEditorQuitting` (internal, 코드 1:1 유지)
- `OnPackagesChanged` → `HandlePackagesChanged` (internal, 코드 1:1 유지) — 후속 Task(ServerManager 분리)에서 자연스럽게 이동 예정
- `EnqueueMainThreadAction(...)` 호출부 2곳 → `MainThreadDispatcher.Enqueue(...)`
- 정적 생성자에서 `EditorApplication.quitting` / `registeredPackages` 구독 제거 (MainThreadDispatcher가 담당)

### 테스트
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/MainThreadDispatcherTests.cs`
  - `Enqueue_NullAction_DoesNotThrow`
  - `EnsureRegistered_CalledTwice_RegistersOnlyOnce`
  - (FIFO 순서 테스트는 `EditorApplication.update` 의존으로 EditMode에서 재현 어렵기에 스킵)

## 검증 체크리스트
- [x] `./run-local-tests.sh --validate` 통과 (3/3 passed)
- [x] `grep -rn "mainThreadActionQueue|isMainThreadQueueProcessorRegistered|EnqueueMainThreadAction|EnsureMainThreadQueueProcessorRegistered|ProcessMainThreadActionQueue" Editor/` 결과가 신규 `MainThreadDispatcher.cs` 내부로만 한정됨
- [x] 신규 `.meta` 파일 생성 (Menu 폴더 2개 + .cs 파일 2개)
- [x] `AppsInTossSDKEditor.Editor` 어셈블리의 `InternalsVisibleTo("AppsInTossEditModeTests")` 로 테스트에서 `MainThreadDispatcher` 접근 가능

## 후속 PR 예고
- 2/6: TBD (플랜 참조)
- ...
- 6/6: TODO.md 최신화 + 전체 마무리
