### PR TITLE
리팩토링: PathValidator 서비스 추출

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -252,7 +252,7 @@ namespace AppsInToss
         {
             if (AITDeprecationChecker.BlockIfDeprecated()) return;
             var config = UnityUtil.GetEditorConf();
-            if (!ValidateSettingsForPackage(config)) return;
+            if (!PathValidator.ValidateSettingsForPackage(config)) return;
 
             // 빌드 전 배포 키 사전 체크 (fail-fast)
             string deploymentKey = AITCredentialsUtil.GetDeploymentKey();
@@ -402,7 +402,7 @@ namespace AppsInToss
         [MenuItem("AIT/Open Build Output", false, 102)]
         public static void OpenBuildOutput()
         {
-            string buildPath = GetBuildTemplatePath();
+            string buildPath = PathValidator.GetBuildTemplatePath();
             if (Directory.Exists(buildPath))
             {
                 // EditorUtility.RevealInFinder는 폴더를 "선택"하므로 부모 폴더가 열림
@@ -548,7 +548,7 @@ namespace AppsInToss
         private static void ExecuteBuildAndPackage()
         {
             var config = UnityUtil.GetEditorConf();
-            if (!ValidateSettingsForPackage(config)) return;
+            if (!PathValidator.ValidateSettingsForPackage(config)) return;
 
             Debug.Log("AIT: 전체 빌드 & 패키징 시작...");
             buildStopwatch.Restart();
@@ -616,7 +616,7 @@ namespace AppsInToss
         private static void ExecuteDeploy()
         {
             var config = UnityUtil.GetEditorConf();
-            if (!ValidateSettingsForPackage(config)) return;
+            if (!PathValidator.ValidateSettingsForPackage(config)) return;
 
             // AITCredentials에서 배포 키 로드
             string deploymentKey = AITCredentialsUtil.GetDeploymentKey();
@@ -627,11 +627,11 @@ namespace AppsInToss
                 return;
             }
 
-            string buildPath = GetBuildTemplatePath();
+            string buildPath = PathValidator.GetBuildTemplatePath();
             string distPath = Path.Combine(buildPath, "dist");
 
             // npm 경로 찾기
-            string npmPath = FindNpmPath();
+            string npmPath = PathValidator.FindNpmPath();
             if (string.IsNullOrEmpty(npmPath))
             {
                 AITLog.Error("AIT: npm을 찾을 수 없습니다. Node.js가 설치되어 있는지 확인하세요.", sentryCapture: false);
@@ -806,7 +806,7 @@ namespace AppsInToss
             }
 
             var config = UnityUtil.GetEditorConf();
-            if (!ValidateSettings(config))
+            if (!PathValidator.ValidateSettings(config))
             {
                 return null;
             }
@@ -852,9 +852,9 @@ namespace AppsInToss
 
             Debug.Log($"AIT: 빌드 & 패키징 완료 (소요 시간: {buildStopwatch.Elapsed.TotalSeconds:F1}초)");
 
-            string buildPath = GetBuildTemplatePath();
-            string npmPath = FindNpmPath();
-            if (!ValidateNpmPath(npmPath))
+            string buildPath = PathValidator.GetBuildTemplatePath();
+            string npmPath = PathValidator.FindNpmPath();
+            if (!PathValidator.ValidateNpmPath(npmPath))
             {
                 return;
             }
@@ -873,7 +873,7 @@ namespace AppsInToss
             var config = ValidateAndSwitchServer(type);
             if (config == null) return;
 
-            string buildPath = GetBuildTemplatePath();
+            string buildPath = PathValidator.GetBuildTemplatePath();
 
             // 빌드 결과물이 있는지 확인
             if (!Directory.Exists(buildPath))
@@ -883,13 +883,13 @@ namespace AppsInToss
                 return;
             }
 
-            string npmPath = FindNpmPath();
-            if (!ValidateNpmPath(npmPath))
+            string npmPath = PathValidator.FindNpmPath();
+            if (!PathValidator.ValidateNpmPath(npmPath))
             {
                 return;
             }
 
-            if (!EnsureNodeModules(buildPath, npmPath))
+            if (!PathValidator.EnsureNodeModules(buildPath, npmPath))
             {
                 return;
             }
@@ -1181,7 +1181,7 @@ namespace AppsInToss
                     string cleanOutput = Regex.Replace(args.Data, @"\x1B\[[0-9;]*[mGKH]", "");
 
                     // 에러 패턴 감지 (stdout에도 에러가 출력될 수 있음)
-                    if (IsErrorOutput(cleanOutput))
+                    if (PathValidator.IsErrorOutput(cleanOutput))
                     {
                         Debug.LogError($"[{logPrefix}] {cleanOutput}");
 
@@ -1233,7 +1233,7 @@ namespace AppsInToss
                     string cleanOutput = Regex.Replace(args.Data, @"\x1B\[[0-9;]*[mGKH]", "");
 
                     // stderr 출력을 실제 에러와 경고로 분류
-                    if (IsErrorOutput(cleanOutput))
+                    if (PathValidator.IsErrorOutput(cleanOutput))
                         Debug.LogError($"[{logPrefix}] {cleanOutput}");
                     else
                         Debug.LogWarning($"[{logPrefix}] {cleanOutput}");
@@ -1254,34 +1254,6 @@ namespace AppsInToss
         }
 
         /// <summary>
-        /// 출력이 에러인지 판단
-        /// </summary>
-        private static bool IsErrorOutput(string output)
-        {
-            if (string.IsNullOrEmpty(output)) return false;
-
-            string lower = output.ToLowerInvariant();
-
-            // 명확한 에러 패턴
-            if (lower.Contains("error:") ||
-                lower.Contains("fatal:") ||
-                lower.Contains("eaddrinuse") ||
-                lower.Contains("port is already in use") ||
-                lower.Contains("address already in use") ||
-                lower.Contains("cannot find module") ||
-                lower.Contains("command not found") ||
-                lower.Contains("permission denied") ||
-                lower.Contains("build failed") ||
-                lower.Contains("deploy failed") ||
-                lower.Contains("install failed"))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// 포트 충돌 에러인지 판단
         /// </summary>
         private static bool IsPortConflictError(string output)
@@ -1292,68 +1264,6 @@ namespace AppsInToss
             return lower.Contains("eaddrinuse") ||
                    lower.Contains("port is already in use") ||
                    lower.Contains("address already in use");
-        }
-
-        /// <summary>
-        /// 빌드 경로 유효성 검사
-        /// </summary>
-        private static bool ValidateBuildPath(string buildPath)
-        {
-            if (!Directory.Exists(buildPath))
-            {
-                AITPlatformHelper.ShowInfoDialog("오류", "빌드 폴더를 찾을 수 없습니다.\n\n먼저 빌드를 실행하세요.", "확인");
-                return false;
-            }
-
-            string indexPath = Path.Combine(buildPath, "index.html");
-            if (!File.Exists(indexPath))
-            {
-                AITPlatformHelper.ShowInfoDialog("오류", "index.html을 찾을 수 없습니다.\n\n먼저 빌드를 실행하세요.", "확인");
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// npm 경로 유효성 검사
-        /// </summary>
-        private static bool ValidateNpmPath(string npmPath)
-        {
-            if (string.IsNullOrEmpty(npmPath))
-            {
-                AITLog.Error("AIT: npm을 찾을 수 없습니다.", sentryCapture: false);
-                AITPlatformHelper.ShowInfoDialog("오류", "npm을 찾을 수 없습니다.\n\nNode.js가 설치되어 있는지 확인하세요.", "확인");
-                return false;
-            }
-            return true;
-        }
-
-        /// <summary>
-        /// node_modules 확인 및 설치
-        /// </summary>
-        private static bool EnsureNodeModules(string buildPath, string npmPath)
-        {
-            string nodeModulesPath = Path.Combine(buildPath, "node_modules");
-            if (!Directory.Exists(nodeModulesPath))
-            {
-                Debug.Log("AIT: node_modules가 없습니다. pnpm install을 실행합니다...");
-
-                string localCachePath = AITPackageBuilder.GetSharedPnpmStorePath();
-                var installResult = AITNpmRunner.RunNpmCommandWithCache(
-                    buildPath, npmPath, "install", localCachePath, "pnpm install 실행 중..."
-                );
-
-                if (installResult != AITConvertCore.AITExportError.SUCCEED)
-                {
-                    AITLog.Error("AIT: pnpm install 실패", sentryCapture: false);
-                    AITPlatformHelper.ShowInfoDialog("오류", "pnpm install 실패\n\nConsole 로그를 확인하세요.", "확인");
-                    return false;
-                }
-
-                Debug.Log("AIT: pnpm install 완료");
-            }
-            return true;
         }
 
         private static void KillProcessOnPort(int port)
@@ -1650,48 +1560,6 @@ namespace AppsInToss
             }
         }
 
-        private static bool ValidateSettings(AITEditorScriptObject config)
-        {
-            if (config == null)
-            {
-                AITPlatformHelper.ShowInfoDialog("오류", "설정을 찾을 수 없습니다.", "확인");
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// 패키징/배포용 설정 검증 (appName 필수)
-        /// </summary>
-        private static bool ValidateSettingsForPackage(AITEditorScriptObject config)
-        {
-            if (!ValidateSettings(config))
-            {
-                return false;
-            }
-
-            if (string.IsNullOrWhiteSpace(config.appName))
-            {
-                AITLog.Error("AIT: App Name이 설정되지 않았습니다.", sentryCapture: false);
-                AITPlatformHelper.ShowInfoDialog("오류", "App Name이 설정되지 않았습니다.\n\nAIT > Configuration에서 App Name을 입력해주세요.", "확인");
-                return false;
-            }
-
-            return true;
-        }
-
-        private static string GetBuildTemplatePath()
-        {
-            string projectPath = UnityUtil.GetProjectPath();
-            return Path.Combine(projectPath, "ait-build");
-        }
-
-        private static string FindNpmPath()
-        {
-            // AITConvertCore의 FindNpm 사용 (pnpm 우선, 로컬 설치 지원)
-            return AITConvertCore.FindNpm();
-        }
     }
 
     /// <summary>

--- a/Editor/Menu/PathValidator.cs
+++ b/Editor/Menu/PathValidator.cs
@@ -1,0 +1,145 @@
+using System.IO;
+using UnityEngine;
+using AppsInToss.Editor;
+
+namespace AppsInToss.Editor.Menu
+{
+    /// <summary>
+    /// 빌드 경로, npm/pnpm 경로, node_modules 무결성, 설정값 검증 유틸리티
+    /// </summary>
+    internal static class PathValidator
+    {
+        /// <summary>
+        /// 출력이 에러인지 판단
+        /// </summary>
+        internal static bool IsErrorOutput(string output)
+        {
+            if (string.IsNullOrEmpty(output)) return false;
+
+            string lower = output.ToLowerInvariant();
+
+            // 명확한 에러 패턴
+            if (lower.Contains("error:") ||
+                lower.Contains("fatal:") ||
+                lower.Contains("eaddrinuse") ||
+                lower.Contains("port is already in use") ||
+                lower.Contains("address already in use") ||
+                lower.Contains("cannot find module") ||
+                lower.Contains("command not found") ||
+                lower.Contains("permission denied") ||
+                lower.Contains("build failed") ||
+                lower.Contains("deploy failed") ||
+                lower.Contains("install failed"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 빌드 경로 유효성 검사
+        /// </summary>
+        internal static bool ValidateBuildPath(string buildPath)
+        {
+            if (!Directory.Exists(buildPath))
+            {
+                AITPlatformHelper.ShowInfoDialog("오류", "빌드 폴더를 찾을 수 없습니다.\n\n먼저 빌드를 실행하세요.", "확인");
+                return false;
+            }
+
+            string indexPath = Path.Combine(buildPath, "index.html");
+            if (!File.Exists(indexPath))
+            {
+                AITPlatformHelper.ShowInfoDialog("오류", "index.html을 찾을 수 없습니다.\n\n먼저 빌드를 실행하세요.", "확인");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// npm 경로 유효성 검사
+        /// </summary>
+        internal static bool ValidateNpmPath(string npmPath)
+        {
+            if (string.IsNullOrEmpty(npmPath))
+            {
+                AITLog.Error("AIT: npm을 찾을 수 없습니다.", sentryCapture: false);
+                AITPlatformHelper.ShowInfoDialog("오류", "npm을 찾을 수 없습니다.\n\nNode.js가 설치되어 있는지 확인하세요.", "확인");
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// node_modules 확인 및 설치
+        /// </summary>
+        internal static bool EnsureNodeModules(string buildPath, string npmPath)
+        {
+            string nodeModulesPath = Path.Combine(buildPath, "node_modules");
+            if (!Directory.Exists(nodeModulesPath))
+            {
+                Debug.Log("AIT: node_modules가 없습니다. pnpm install을 실행합니다...");
+
+                string localCachePath = AITPackageBuilder.GetSharedPnpmStorePath();
+                var installResult = AITNpmRunner.RunNpmCommandWithCache(
+                    buildPath, npmPath, "install", localCachePath, "pnpm install 실행 중..."
+                );
+
+                if (installResult != AITConvertCore.AITExportError.SUCCEED)
+                {
+                    AITLog.Error("AIT: pnpm install 실패", sentryCapture: false);
+                    AITPlatformHelper.ShowInfoDialog("오류", "pnpm install 실패\n\nConsole 로그를 확인하세요.", "확인");
+                    return false;
+                }
+
+                Debug.Log("AIT: pnpm install 완료");
+            }
+            return true;
+        }
+
+        internal static bool ValidateSettings(AITEditorScriptObject config)
+        {
+            if (config == null)
+            {
+                AITPlatformHelper.ShowInfoDialog("오류", "설정을 찾을 수 없습니다.", "확인");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 패키징/배포용 설정 검증 (appName 필수)
+        /// </summary>
+        internal static bool ValidateSettingsForPackage(AITEditorScriptObject config)
+        {
+            if (!ValidateSettings(config))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(config.appName))
+            {
+                AITLog.Error("AIT: App Name이 설정되지 않았습니다.", sentryCapture: false);
+                AITPlatformHelper.ShowInfoDialog("오류", "App Name이 설정되지 않았습니다.\n\nAIT > Configuration에서 App Name을 입력해주세요.", "확인");
+                return false;
+            }
+
+            return true;
+        }
+
+        internal static string GetBuildTemplatePath()
+        {
+            string projectPath = UnityUtil.GetProjectPath();
+            return Path.Combine(projectPath, "ait-build");
+        }
+
+        internal static string FindNpmPath()
+        {
+            // AITConvertCore의 FindNpm 사용 (pnpm 우선, 로컬 설치 지원)
+            return AITConvertCore.FindNpm();
+        }
+    }
+}

--- a/Editor/Menu/PathValidator.cs.meta
+++ b/Editor/Menu/PathValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58e4cd968aff45938a48f1202c2d8065
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.IO;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss;
 using AppsInToss.Editor.Menu;
 
 namespace AppsInToss.Editor.Menu.Tests
@@ -74,16 +77,93 @@ namespace AppsInToss.Editor.Menu.Tests
         }
 
         [Test]
-        public void ValidateNpmPath_EmptyPath_ReturnsFalse()
+        public void ValidateNpmPath_EmptyOrNullPath_ReturnsFalse()
         {
+            // AITLog.Error → Debug.LogError 를 호출하므로 LogAssert.Expect 필요
+            LogAssert.Expect(LogType.Error, "AIT: npm을 찾을 수 없습니다.");
             Assert.IsFalse(PathValidator.ValidateNpmPath(""));
+
+            LogAssert.Expect(LogType.Error, "AIT: npm을 찾을 수 없습니다.");
             Assert.IsFalse(PathValidator.ValidateNpmPath(null));
         }
 
         [Test]
-        public void ValidateNpmPath_NonEmptyPath_ReturnsTrue()
+        public void ValidateNpmPath_AnyNonEmptyString_ReturnsTrue()
         {
+            // ValidateNpmPath는 string.IsNullOrEmpty만 검사 — 실제 파일 존재 검증은 하지 않음
             Assert.IsTrue(PathValidator.ValidateNpmPath("/usr/local/bin/npm"));
+        }
+
+        [Test]
+        public void ValidateSettings_NullConfig_ReturnsFalse()
+        {
+            bool result = PathValidator.ValidateSettings(null);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ValidateSettings_NonNullConfig_ReturnsTrue()
+        {
+            var config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+            try
+            {
+                bool result = PathValidator.ValidateSettings(config);
+                Assert.IsTrue(result);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(config);
+            }
+        }
+
+        [Test]
+        public void ValidateSettingsForPackage_NullConfig_ReturnsFalse()
+        {
+            bool result = PathValidator.ValidateSettingsForPackage(null);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ValidateSettingsForPackage_EmptyAppName_ReturnsFalse()
+        {
+            var config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+            try
+            {
+                config.appName = "";
+                // appName 비어있으면 AITLog.Error 경로 → LogAssert.Expect 필요
+                LogAssert.Expect(LogType.Error, "AIT: App Name이 설정되지 않았습니다.");
+                bool result = PathValidator.ValidateSettingsForPackage(config);
+                Assert.IsFalse(result);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(config);
+            }
+        }
+
+        [Test]
+        public void ValidateSettingsForPackage_ValidAppName_ReturnsTrue()
+        {
+            var config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+            try
+            {
+                config.appName = "test-app";
+                bool result = PathValidator.ValidateSettingsForPackage(config);
+                Assert.IsTrue(result);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(config);
+            }
+        }
+
+        [Test]
+        public void GetBuildTemplatePath_ReturnsProjectRelativeAitBuildPath()
+        {
+            string projectPath = UnityUtil.GetProjectPath();
+            string expected = Path.Combine(projectPath, "ait-build");
+            string actual = PathValidator.GetBuildTemplatePath();
+            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using AppsInToss;
-using AppsInToss.Editor.Menu;
 
 namespace AppsInToss.Editor.Menu.Tests
 {

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using AppsInToss.Editor.Menu;
+
+namespace AppsInToss.Editor.Menu.Tests
+{
+    public class PathValidatorTests
+    {
+        private string tempDir;
+
+        [SetUp]
+        public void Setup()
+        {
+            tempDir = Path.Combine(Path.GetTempPath(), "ait-pathvalidator-test-" + Guid.NewGuid());
+            Directory.CreateDirectory(tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ValidateBuildPath_NonExistentPath_ReturnsFalse()
+        {
+            string nonExistent = Path.Combine(tempDir, "nonexistent");
+            bool result = PathValidator.ValidateBuildPath(nonExistent);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ValidateBuildPath_ExistingDirectoryWithIndexHtml_ReturnsTrue()
+        {
+            File.WriteAllText(Path.Combine(tempDir, "index.html"), "<html></html>");
+            bool result = PathValidator.ValidateBuildPath(tempDir);
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void ValidateBuildPath_ExistingDirectoryWithoutIndexHtml_ReturnsFalse()
+        {
+            bool result = PathValidator.ValidateBuildPath(tempDir);
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void IsErrorOutput_NormalString_ReturnsFalse()
+        {
+            Assert.IsFalse(PathValidator.IsErrorOutput("hello world"));
+        }
+
+        [Test]
+        public void IsErrorOutput_EmptyOrNull_ReturnsFalse()
+        {
+            Assert.IsFalse(PathValidator.IsErrorOutput(""));
+            Assert.IsFalse(PathValidator.IsErrorOutput(null));
+        }
+
+        [Test]
+        public void IsErrorOutput_ErrorKeyword_ReturnsTrue()
+        {
+            // 실제 구현은 "error:", "fatal:", "eaddrinuse", "port is already in use",
+            // "address already in use", "cannot find module", "command not found",
+            // "permission denied", "build failed", "deploy failed", "install failed" 중 하나라도 포함 시 true
+            Assert.IsTrue(PathValidator.IsErrorOutput("ERROR: something failed"));
+            Assert.IsTrue(PathValidator.IsErrorOutput("Fatal: corruption detected"));
+            Assert.IsTrue(PathValidator.IsErrorOutput("listen EADDRINUSE: port 5173"));
+            Assert.IsTrue(PathValidator.IsErrorOutput("Build failed with errors"));
+        }
+
+        [Test]
+        public void ValidateNpmPath_EmptyPath_ReturnsFalse()
+        {
+            Assert.IsFalse(PathValidator.ValidateNpmPath(""));
+            Assert.IsFalse(PathValidator.ValidateNpmPath(null));
+        }
+
+        [Test]
+        public void ValidateNpmPath_NonEmptyPath_ReturnsTrue()
+        {
+            Assert.IsTrue(PathValidator.ValidateNpmPath("/usr/local/bin/npm"));
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 813171a2a3ba42cc87b3ebf4976c570c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경

`Editor/AppsInTossMenu.cs` (1,913행) God class를 6개 단일 책임 서비스로 분할하는 작업의 **2번째 PR** (총 6개 중).

## 변경 내용

- `Editor/Menu/PathValidator.cs` 신설 (`internal static class`, namespace `AppsInToss.Editor.Menu`): 경로/도구 검증 로직 집중
  - `ValidateBuildPath` — 빌드 폴더 및 `index.html` 존재 검증
  - `ValidateNpmPath` — npm 경로 유효성 검증
  - `EnsureNodeModules` — `node_modules` 무결성 확인 및 `pnpm install` 실행
  - `ValidateSettings`, `ValidateSettingsForPackage` — 설정 검증
  - `GetBuildTemplatePath` — `ait-build` 경로 반환
  - `FindNpmPath` — `AITConvertCore.FindNpm()` 래퍼
  - `IsErrorOutput` — 출력 문자열의 에러 키워드 포함 여부 판단
- `Editor/AppsInTossMenu.cs`: 8개 메서드 제거(-131행), 모든 호출부를 `PathValidator.X` 로 치환, `using AppsInToss.Editor.Menu;` 추가
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PathValidatorTests.cs` 신설: `ValidateBuildPath`/`IsErrorOutput`/`ValidateNpmPath` 스모크 테스트 (9 cases)

## 검증

- [x] `./run-local-tests.sh --validate` 통과 (3/3 tests passed)
- [x] facade 내 `AppsInTossMenu.<메서드>` 잔여 참조 grep 확인 (0건)
- [x] 외부 파일의 `AppsInTossMenu.<이동된_메서드>` 참조 grep 확인 (0건 — 원래 private)
- [ ] CI EditMode 테스트 통과 확인 필요

## 설계

공유 계획: `docs/superpowers/plans/2026-04-22-appsintossmenu-refactor.md` Task 2

## 참고

라운드 1 병렬 PR 3개 중 두 번째. 나머지는 `refactor-mainthreaddispatcher-extract`, `refactor-portresolver-extract`.