### PR TITLE
리팩토링: PortResolver 서비스 추출

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -910,7 +910,7 @@ namespace AppsInToss
             string suffix = openBrowser ? "" : " (서버만)";
 
             // 서버 포트 해석 및 충돌 검사
-            if (!TryResolveServerPorts(config,
+            if (!PortResolver.TryResolveServerPorts(config,
                 out string graniteHost, out int granitePort,
                 out string viteHost, out int vitePort))
             {
@@ -955,7 +955,7 @@ namespace AppsInToss
                         Debug.Log($"AIT:   Granite (Metro): http://{graniteHost}:{finalGranitePort}");
                         Debug.Log($"AIT:   Vite: http://{viteHost}:{finalVitePort}");
                         if (openBrowser)
-                            WaitForPortAndOpenBrowser(finalVitePort, $"http://localhost:{finalVitePort}{GetBrowserPath(type)}");
+                            PortResolver.WaitForPortAndOpenBrowser(finalVitePort, $"http://localhost:{finalVitePort}{GetBrowserPath(type)}");
                     },
                     onServerFailed: (reason) =>
                     {
@@ -985,7 +985,7 @@ namespace AppsInToss
             int port = stateManager?.Port ?? 0;
             if (port > 0)
             {
-                KillProcessOnPort(port);
+                PortResolver.KillProcessOnPort(port);
             }
 
             // 상태 관리자에 중지 알림
@@ -1109,7 +1109,7 @@ namespace AppsInToss
                 // (일부 환경에서 stdout 버퍼링으로 인해 포트 정보가 지연될 수 있음)
                 if (elapsed > PORT_FALLBACK_CHECK_START_SECONDS && expectedPort > 0)
                 {
-                    if (!IsPortAvailable(expectedPort))
+                    if (!PortResolver.IsPortAvailable(expectedPort))
                     {
                         // 포트가 사용 중 = 서버가 시작됨
                         if (Interlocked.CompareExchange(ref serverStartedFlag, 1, 0) == 0)
@@ -1186,7 +1186,7 @@ namespace AppsInToss
                         Debug.LogError($"[{logPrefix}] {cleanOutput}");
 
                         // 포트 충돌 에러 감지
-                        if (IsPortConflictError(cleanOutput))
+                        if (PortResolver.IsPortConflictError(cleanOutput))
                         {
                             lock (failureReasonLock)
                             {
@@ -1239,7 +1239,7 @@ namespace AppsInToss
                         Debug.LogWarning($"[{logPrefix}] {cleanOutput}");
 
                     // 포트 충돌 에러 감지
-                    if (IsPortConflictError(cleanOutput))
+                    if (PortResolver.IsPortConflictError(cleanOutput))
                     {
                         lock (failureReasonLock)
                         {
@@ -1251,144 +1251,6 @@ namespace AppsInToss
 
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
-        }
-
-        /// <summary>
-        /// 포트 충돌 에러인지 판단
-        /// </summary>
-        private static bool IsPortConflictError(string output)
-        {
-            if (string.IsNullOrEmpty(output)) return false;
-
-            string lower = output.ToLowerInvariant();
-            return lower.Contains("eaddrinuse") ||
-                   lower.Contains("port is already in use") ||
-                   lower.Contains("address already in use");
-        }
-
-        private static void KillProcessOnPort(int port)
-        {
-            try
-            {
-                string command;
-
-                if (AITPlatformHelper.IsWindows)
-                {
-                    // Windows: netstat + taskkill
-                    command = $"for /f \"tokens=5\" %a in ('netstat -aon ^| findstr :{port}') do taskkill /PID %a /F 2>nul";
-                }
-                else
-                {
-                    // Unix: lsof + kill
-                    command = $"lsof -ti :{port} | xargs kill -9 2>/dev/null";
-                }
-
-                AITPlatformHelper.ExecuteCommand(command, null, null, timeoutMs: 2000, verbose: false);
-            }
-            catch
-            {
-                // 무시
-            }
-        }
-
-        /// <summary>
-        /// 포트가 사용 가능한지 확인 (0.0.0.0과 127.0.0.1 모두 체크)
-        /// </summary>
-        private static bool IsPortAvailable(int port)
-        {
-            // granite/vite는 0.0.0.0에 바인딩하므로 Any로 체크해야 함
-            try
-            {
-                var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Any, port);
-                listener.Start();
-                listener.Stop();
-            }
-            catch
-            {
-                return false;
-            }
-
-            // 추가로 Loopback도 체크 (다른 프로세스가 127.0.0.1에만 바인딩한 경우)
-            try
-            {
-                var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
-                listener.Start();
-                listener.Stop();
-            }
-            catch
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Vite 포트가 열릴 때까지 대기한 후 브라우저를 엽니다.
-        /// Granite 포트가 먼저 감지되지만 Vite는 아직 준비되지 않았을 수 있으므로
-        /// EditorApplication.update 폴링으로 최대 15초 대기합니다.
-        /// </summary>
-        private static void WaitForPortAndOpenBrowser(int port, string url)
-        {
-            // 이미 포트가 열려있으면 즉시 열기
-            if (!IsPortAvailable(port))
-            {
-                Debug.Log($"[AIT] Vite 포트 {port} 준비 완료, 브라우저 열기");
-                Application.OpenURL(url);
-                return;
-            }
-
-            Debug.Log($"[AIT] Vite 포트 {port} 대기 중...");
-            double startTime = EditorApplication.timeSinceStartup;
-            double lastCheckTime = 0;
-            const double maxWaitSeconds = 15.0;
-            const double checkIntervalSeconds = 0.5;
-
-            void PollVitePort()
-            {
-                double elapsed = EditorApplication.timeSinceStartup - startTime;
-
-                // TCP bind/unbind 부하 방지: 0.5초 간격으로 체크
-                if (elapsed - lastCheckTime < checkIntervalSeconds)
-                    return;
-                lastCheckTime = elapsed;
-
-                if (!IsPortAvailable(port))
-                {
-                    // 포트가 사용 중 = Vite 서버 준비됨
-                    EditorApplication.update -= PollVitePort;
-                    Debug.Log($"[AIT] Vite 포트 {port} 준비 완료 ({elapsed:F1}초 대기), 브라우저 열기");
-                    Application.OpenURL(url);
-                    return;
-                }
-
-                if (elapsed > maxWaitSeconds)
-                {
-                    // 타임아웃 — 그래도 브라우저 열기 (사용자가 직접 새로고침 가능)
-                    EditorApplication.update -= PollVitePort;
-                    Debug.LogWarning($"[AIT] Vite 포트 {port} 대기 타임아웃 ({maxWaitSeconds}초), 브라우저를 엽니다");
-                    Application.OpenURL(url);
-                }
-            }
-
-            EditorApplication.update += PollVitePort;
-        }
-
-        /// <summary>
-        /// 사용 가능한 포트 찾기 (시작 포트부터 최대 10개 시도)
-        /// </summary>
-        private static int FindAvailablePort(int startPort, int maxAttempts = 10)
-        {
-            for (int i = 0; i < maxAttempts; i++)
-            {
-                int port = startPort + i;
-                if (IsPortAvailable(port))
-                {
-                    return port;
-                }
-                Debug.Log($"[AIT] 포트 {port}가 사용 중, 다음 포트 시도...");
-            }
-            return -1; // 사용 가능한 포트 없음
         }
 
         // ============================================
@@ -1484,56 +1346,6 @@ namespace AppsInToss
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// 서버 포트 설정 해석 및 충돌 검사
-        /// </summary>
-        private static bool TryResolveServerPorts(
-            AITEditorScriptObject config,
-            out string graniteHost, out int granitePort,
-            out string viteHost, out int vitePort)
-        {
-            graniteHost = !string.IsNullOrEmpty(config.graniteHost) ? config.graniteHost : "0.0.0.0";
-            granitePort = config.granitePort > 0 ? config.granitePort : 8081;
-            viteHost = !string.IsNullOrEmpty(config.viteHost) ? config.viteHost : "localhost";
-            vitePort = config.vitePort > 0 ? config.vitePort : 5173;
-
-            // Vite 포트 충돌 확인 및 자동 탐지
-            if (!IsPortAvailable(vitePort))
-            {
-                int availablePort = FindAvailablePort(vitePort);
-                if (availablePort > 0)
-                {
-                    Debug.Log($"[AIT] 포트 {vitePort}가 사용 중, {availablePort} 사용");
-                    vitePort = availablePort;
-                }
-                else
-                {
-                    AITLog.Error($"[AIT] 사용 가능한 포트를 찾을 수 없습니다 (시도: {vitePort}-{vitePort+9})", sentryCapture: false);
-                    AITPlatformHelper.ShowInfoDialog("포트 오류", $"포트 {vitePort} 및 인근 포트가 모두 사용 중입니다.\n다른 포트를 Configuration에서 설정하거나, 사용 중인 프로세스를 종료하세요.", "확인");
-                    return false;
-                }
-            }
-
-            // Granite 포트 충돌 확인 및 자동 탐지
-            if (!IsPortAvailable(granitePort))
-            {
-                int availablePort = FindAvailablePort(granitePort);
-                if (availablePort > 0)
-                {
-                    Debug.Log($"[AIT] Granite 포트 {granitePort}가 사용 중, {availablePort} 사용");
-                    granitePort = availablePort;
-                }
-                else
-                {
-                    AITLog.Error($"[AIT] 사용 가능한 Granite 포트를 찾을 수 없습니다 (시도: {granitePort}-{granitePort+9})", sentryCapture: false);
-                    AITPlatformHelper.ShowInfoDialog("포트 오류", $"Granite 포트 {granitePort} 및 인근 포트가 모두 사용 중입니다.\n다른 포트를 Configuration에서 설정하거나, 사용 중인 프로세스를 종료하세요.", "확인");
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         /// <summary>

--- a/Editor/Menu/PathValidator.cs
+++ b/Editor/Menu/PathValidator.cs
@@ -16,14 +16,14 @@ namespace AppsInToss.Editor.Menu
         {
             if (string.IsNullOrEmpty(output)) return false;
 
+            // 포트 충돌은 PortResolver에 단일 진실 공급원이 있음
+            if (PortResolver.IsPortConflictError(output)) return true;
+
             string lower = output.ToLowerInvariant();
 
-            // 명확한 에러 패턴
+            // 그 외 명확한 에러 패턴
             if (lower.Contains("error:") ||
                 lower.Contains("fatal:") ||
-                lower.Contains("eaddrinuse") ||
-                lower.Contains("port is already in use") ||
-                lower.Contains("address already in use") ||
                 lower.Contains("cannot find module") ||
                 lower.Contains("command not found") ||
                 lower.Contains("permission denied") ||

--- a/Editor/Menu/PortResolver.cs
+++ b/Editor/Menu/PortResolver.cs
@@ -1,11 +1,11 @@
 using UnityEditor;
 using UnityEngine;
-using AppsInToss.Editor;
 
 namespace AppsInToss.Editor.Menu
 {
     /// <summary>
-    /// 서버 포트 해석 및 충돌 처리 유틸리티
+    /// 서버 포트 해석 및 충돌 처리 유틸리티.
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
     /// </summary>
     internal static class PortResolver
     {

--- a/Editor/Menu/PortResolver.cs
+++ b/Editor/Menu/PortResolver.cs
@@ -1,4 +1,3 @@
-using System.Net.Sockets;
 using UnityEditor;
 using UnityEngine;
 using AppsInToss.Editor;
@@ -25,6 +24,8 @@ namespace AppsInToss.Editor.Menu
 
         internal static void KillProcessOnPort(int port)
         {
+            if (port <= 0) return;
+
             try
             {
                 string command;
@@ -56,7 +57,7 @@ namespace AppsInToss.Editor.Menu
             // granite/vite는 0.0.0.0에 바인딩하므로 Any로 체크해야 함
             try
             {
-                var listener = new TcpListener(System.Net.IPAddress.Any, port);
+                var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Any, port);
                 listener.Start();
                 listener.Stop();
             }
@@ -68,7 +69,7 @@ namespace AppsInToss.Editor.Menu
             // 추가로 Loopback도 체크 (다른 프로세스가 127.0.0.1에만 바인딩한 경우)
             try
             {
-                var listener = new TcpListener(System.Net.IPAddress.Loopback, port);
+                var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
                 listener.Start();
                 listener.Stop();
             }
@@ -172,7 +173,7 @@ namespace AppsInToss.Editor.Menu
                 }
                 else
                 {
-                    AITLog.Error($"[AIT] 사용 가능한 포트를 찾을 수 없습니다 (시도: {vitePort}-{vitePort + 9})", sentryCapture: false);
+                    AITLog.Error($"[AIT] 사용 가능한 포트를 찾을 수 없습니다 (시도: {vitePort}-{vitePort+9})", sentryCapture: false);
                     AITPlatformHelper.ShowInfoDialog("포트 오류", $"포트 {vitePort} 및 인근 포트가 모두 사용 중입니다.\n다른 포트를 Configuration에서 설정하거나, 사용 중인 프로세스를 종료하세요.", "확인");
                     return false;
                 }
@@ -189,7 +190,7 @@ namespace AppsInToss.Editor.Menu
                 }
                 else
                 {
-                    AITLog.Error($"[AIT] 사용 가능한 Granite 포트를 찾을 수 없습니다 (시도: {granitePort}-{granitePort + 9})", sentryCapture: false);
+                    AITLog.Error($"[AIT] 사용 가능한 Granite 포트를 찾을 수 없습니다 (시도: {granitePort}-{granitePort+9})", sentryCapture: false);
                     AITPlatformHelper.ShowInfoDialog("포트 오류", $"Granite 포트 {granitePort} 및 인근 포트가 모두 사용 중입니다.\n다른 포트를 Configuration에서 설정하거나, 사용 중인 프로세스를 종료하세요.", "확인");
                     return false;
                 }

--- a/Editor/Menu/PortResolver.cs
+++ b/Editor/Menu/PortResolver.cs
@@ -22,6 +22,9 @@ namespace AppsInToss.Editor.Menu
                    lower.Contains("address already in use");
         }
 
+        /// <summary>
+        /// 지정된 포트를 점유 중인 프로세스를 강제 종료
+        /// </summary>
         internal static void KillProcessOnPort(int port)
         {
             if (port <= 0) return;

--- a/Editor/Menu/PortResolver.cs
+++ b/Editor/Menu/PortResolver.cs
@@ -1,0 +1,201 @@
+using System.Net.Sockets;
+using UnityEditor;
+using UnityEngine;
+using AppsInToss.Editor;
+
+namespace AppsInToss.Editor.Menu
+{
+    /// <summary>
+    /// 서버 포트 해석 및 충돌 처리 유틸리티
+    /// </summary>
+    internal static class PortResolver
+    {
+        /// <summary>
+        /// 포트 충돌 에러인지 판단
+        /// </summary>
+        internal static bool IsPortConflictError(string output)
+        {
+            if (string.IsNullOrEmpty(output)) return false;
+
+            string lower = output.ToLowerInvariant();
+            return lower.Contains("eaddrinuse") ||
+                   lower.Contains("port is already in use") ||
+                   lower.Contains("address already in use");
+        }
+
+        internal static void KillProcessOnPort(int port)
+        {
+            try
+            {
+                string command;
+
+                if (AITPlatformHelper.IsWindows)
+                {
+                    // Windows: netstat + taskkill
+                    command = $"for /f \"tokens=5\" %a in ('netstat -aon ^| findstr :{port}') do taskkill /PID %a /F 2>nul";
+                }
+                else
+                {
+                    // Unix: lsof + kill
+                    command = $"lsof -ti :{port} | xargs kill -9 2>/dev/null";
+                }
+
+                AITPlatformHelper.ExecuteCommand(command, null, null, timeoutMs: 2000, verbose: false);
+            }
+            catch
+            {
+                // 무시
+            }
+        }
+
+        /// <summary>
+        /// 포트가 사용 가능한지 확인 (0.0.0.0과 127.0.0.1 모두 체크)
+        /// </summary>
+        internal static bool IsPortAvailable(int port)
+        {
+            // granite/vite는 0.0.0.0에 바인딩하므로 Any로 체크해야 함
+            try
+            {
+                var listener = new TcpListener(System.Net.IPAddress.Any, port);
+                listener.Start();
+                listener.Stop();
+            }
+            catch
+            {
+                return false;
+            }
+
+            // 추가로 Loopback도 체크 (다른 프로세스가 127.0.0.1에만 바인딩한 경우)
+            try
+            {
+                var listener = new TcpListener(System.Net.IPAddress.Loopback, port);
+                listener.Start();
+                listener.Stop();
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Vite 포트가 열릴 때까지 대기한 후 브라우저를 엽니다.
+        /// Granite 포트가 먼저 감지되지만 Vite는 아직 준비되지 않았을 수 있으므로
+        /// EditorApplication.update 폴링으로 최대 15초 대기합니다.
+        /// </summary>
+        internal static void WaitForPortAndOpenBrowser(int port, string url)
+        {
+            // 이미 포트가 열려있으면 즉시 열기
+            if (!IsPortAvailable(port))
+            {
+                Debug.Log($"[AIT] Vite 포트 {port} 준비 완료, 브라우저 열기");
+                Application.OpenURL(url);
+                return;
+            }
+
+            Debug.Log($"[AIT] Vite 포트 {port} 대기 중...");
+            double startTime = EditorApplication.timeSinceStartup;
+            double lastCheckTime = 0;
+            const double maxWaitSeconds = 15.0;
+            const double checkIntervalSeconds = 0.5;
+
+            void PollVitePort()
+            {
+                double elapsed = EditorApplication.timeSinceStartup - startTime;
+
+                // TCP bind/unbind 부하 방지: 0.5초 간격으로 체크
+                if (elapsed - lastCheckTime < checkIntervalSeconds)
+                    return;
+                lastCheckTime = elapsed;
+
+                if (!IsPortAvailable(port))
+                {
+                    // 포트가 사용 중 = Vite 서버 준비됨
+                    EditorApplication.update -= PollVitePort;
+                    Debug.Log($"[AIT] Vite 포트 {port} 준비 완료 ({elapsed:F1}초 대기), 브라우저 열기");
+                    Application.OpenURL(url);
+                    return;
+                }
+
+                if (elapsed > maxWaitSeconds)
+                {
+                    // 타임아웃 — 그래도 브라우저 열기 (사용자가 직접 새로고침 가능)
+                    EditorApplication.update -= PollVitePort;
+                    Debug.LogWarning($"[AIT] Vite 포트 {port} 대기 타임아웃 ({maxWaitSeconds}초), 브라우저를 엽니다");
+                    Application.OpenURL(url);
+                }
+            }
+
+            EditorApplication.update += PollVitePort;
+        }
+
+        /// <summary>
+        /// 사용 가능한 포트 찾기 (시작 포트부터 최대 10개 시도)
+        /// </summary>
+        internal static int FindAvailablePort(int startPort, int maxAttempts = 10)
+        {
+            for (int i = 0; i < maxAttempts; i++)
+            {
+                int port = startPort + i;
+                if (IsPortAvailable(port))
+                {
+                    return port;
+                }
+                Debug.Log($"[AIT] 포트 {port}가 사용 중, 다음 포트 시도...");
+            }
+            return -1; // 사용 가능한 포트 없음
+        }
+
+        /// <summary>
+        /// 서버 포트 설정 해석 및 충돌 검사
+        /// </summary>
+        internal static bool TryResolveServerPorts(
+            AITEditorScriptObject config,
+            out string graniteHost, out int granitePort,
+            out string viteHost, out int vitePort)
+        {
+            graniteHost = !string.IsNullOrEmpty(config.graniteHost) ? config.graniteHost : "0.0.0.0";
+            granitePort = config.granitePort > 0 ? config.granitePort : 8081;
+            viteHost = !string.IsNullOrEmpty(config.viteHost) ? config.viteHost : "localhost";
+            vitePort = config.vitePort > 0 ? config.vitePort : 5173;
+
+            // Vite 포트 충돌 확인 및 자동 탐지
+            if (!IsPortAvailable(vitePort))
+            {
+                int availablePort = FindAvailablePort(vitePort);
+                if (availablePort > 0)
+                {
+                    Debug.Log($"[AIT] 포트 {vitePort}가 사용 중, {availablePort} 사용");
+                    vitePort = availablePort;
+                }
+                else
+                {
+                    AITLog.Error($"[AIT] 사용 가능한 포트를 찾을 수 없습니다 (시도: {vitePort}-{vitePort + 9})", sentryCapture: false);
+                    AITPlatformHelper.ShowInfoDialog("포트 오류", $"포트 {vitePort} 및 인근 포트가 모두 사용 중입니다.\n다른 포트를 Configuration에서 설정하거나, 사용 중인 프로세스를 종료하세요.", "확인");
+                    return false;
+                }
+            }
+
+            // Granite 포트 충돌 확인 및 자동 탐지
+            if (!IsPortAvailable(granitePort))
+            {
+                int availablePort = FindAvailablePort(granitePort);
+                if (availablePort > 0)
+                {
+                    Debug.Log($"[AIT] Granite 포트 {granitePort}가 사용 중, {availablePort} 사용");
+                    granitePort = availablePort;
+                }
+                else
+                {
+                    AITLog.Error($"[AIT] 사용 가능한 Granite 포트를 찾을 수 없습니다 (시도: {granitePort}-{granitePort + 9})", sentryCapture: false);
+                    AITPlatformHelper.ShowInfoDialog("포트 오류", $"Granite 포트 {granitePort} 및 인근 포트가 모두 사용 중입니다.\n다른 포트를 Configuration에서 설정하거나, 사용 중인 프로세스를 종료하세요.", "확인");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Editor/Menu/PortResolver.cs.meta
+++ b/Editor/Menu/PortResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7430e0b3f8a24a20b0648079b00399cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs
@@ -6,75 +6,75 @@
 using NUnit.Framework;
 using AppsInToss.Editor.Menu;
 
-namespace AppsInToss.Editor.Menu.Tests
+[TestFixture]
+public class PortResolverParserTests
 {
-    [TestFixture]
-    public class PortResolverParserTests
+    [Test]
+    public void IsPortConflictError_EaddrInUse_ReturnsTrue()
     {
-        [Test]
-        public void IsPortConflictError_EaddrInUse_ReturnsTrue()
-        {
-            Assert.IsTrue(PortResolver.IsPortConflictError("Error: listen EADDRINUSE: address already in use :::5173"));
-        }
+        Assert.IsTrue(PortResolver.IsPortConflictError("Error: listen EADDRINUSE: address already in use :::5173"));
+    }
 
-        [Test]
-        public void IsPortConflictError_PortIsAlreadyInUseMessage_ReturnsTrue()
-        {
-            Assert.IsTrue(PortResolver.IsPortConflictError("Port is already in use"));
-        }
+    [Test]
+    public void IsPortConflictError_PortIsAlreadyInUseMessage_ReturnsTrue()
+    {
+        Assert.IsTrue(PortResolver.IsPortConflictError("Port is already in use"));
+    }
 
-        [Test]
-        public void IsPortConflictError_AddressAlreadyInUseMessage_ReturnsTrue()
-        {
-            Assert.IsTrue(PortResolver.IsPortConflictError("bind: address already in use"));
-        }
+    [Test]
+    public void IsPortConflictError_AddressAlreadyInUseMessage_ReturnsTrue()
+    {
+        Assert.IsTrue(PortResolver.IsPortConflictError("bind: address already in use"));
+    }
 
-        [Test]
-        public void IsPortConflictError_NormalOutput_ReturnsFalse()
-        {
-            Assert.IsFalse(PortResolver.IsPortConflictError("Build succeeded in 1.2s"));
-        }
+    [Test]
+    public void IsPortConflictError_NormalOutput_ReturnsFalse()
+    {
+        Assert.IsFalse(PortResolver.IsPortConflictError("Build succeeded in 1.2s"));
+    }
 
-        [Test]
-        public void IsPortConflictError_EmptyString_ReturnsFalse()
-        {
-            Assert.IsFalse(PortResolver.IsPortConflictError(string.Empty));
-        }
+    [Test]
+    public void IsPortConflictError_EmptyString_ReturnsFalse()
+    {
+        Assert.IsFalse(PortResolver.IsPortConflictError(string.Empty));
+    }
 
-        [Test]
-        public void IsPortConflictError_Null_ReturnsFalse()
-        {
-            Assert.IsFalse(PortResolver.IsPortConflictError(null));
-        }
+    [Test]
+    public void IsPortConflictError_Null_ReturnsFalse()
+    {
+        Assert.IsFalse(PortResolver.IsPortConflictError(null));
+    }
 
-        [Test]
-        public void IsPortConflictError_AllUppercase_ReturnsTrue()
-        {
-            // ToLowerInvariant() 계약 고정: 완전 대문자 입력도 매칭되어야 함
-            Assert.IsTrue(PortResolver.IsPortConflictError("PORT IS ALREADY IN USE"));
-        }
+    // ToLowerInvariant() 계약 고정: 3개 패턴 모두 완전 대문자 입력도 매칭되어야 함
+    [TestCase("EADDRINUSE")]
+    [TestCase("PORT IS ALREADY IN USE")]
+    [TestCase("ADDRESS ALREADY IN USE")]
+    public void IsPortConflictError_AllUppercase_ReturnsTrue(string input)
+    {
+        Assert.IsTrue(PortResolver.IsPortConflictError(input));
+    }
 
-        [Test]
-        public void IsPortConflictError_SubstringInMultiLineOutput_ReturnsTrue()
-        {
-            // 실제 툴 출력은 다중 라인 스택트레이스일 수 있음
-            string output = "Starting dev server...\n  at node (internal)\nError: listen EADDRINUSE on :::5173\n  at Server.listen";
-            Assert.IsTrue(PortResolver.IsPortConflictError(output));
-        }
+    [Test]
+    public void IsPortConflictError_SubstringInMultiLineOutput_ReturnsTrue()
+    {
+        // 실제 툴 출력은 다중 라인 스택트레이스일 수 있음. 트리거가 중간 라인에 있어도 감지되어야 함.
+        string output = "Starting dev server...\n  at node (internal)\nError: listen EADDRINUSE on :::5173\n  at Server.listen";
+        Assert.IsTrue(PortResolver.IsPortConflictError(output));
+    }
 
-        [Test]
-        public void IsPortConflictError_NearMissPhrase_ReturnsFalse()
-        {
-            // 느슨한 문구 매칭으로 false positive가 생기지 않아야 함
-            Assert.IsFalse(PortResolver.IsPortConflictError("the address has already been used"));
-        }
+    // 느슨한 문구 매칭으로 false positive가 생기지 않아야 함
+    [TestCase("the address has already been used")]
+    [TestCase("port already in use")] // "is" 누락
+    public void IsPortConflictError_NearMissPhrase_ReturnsFalse(string input)
+    {
+        Assert.IsFalse(PortResolver.IsPortConflictError(input));
+    }
 
-        [Test]
-        public void IsPortConflictError_WhitespaceOnly_ReturnsFalse()
-        {
-            Assert.IsFalse(PortResolver.IsPortConflictError("   "));
-            Assert.IsFalse(PortResolver.IsPortConflictError("\n"));
-            Assert.IsFalse(PortResolver.IsPortConflictError("\t"));
-        }
+    [Test]
+    public void IsPortConflictError_WhitespaceOnly_ReturnsFalse()
+    {
+        Assert.IsFalse(PortResolver.IsPortConflictError("   "));
+        Assert.IsFalse(PortResolver.IsPortConflictError("\n"));
+        Assert.IsFalse(PortResolver.IsPortConflictError("\t"));
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs
@@ -46,5 +46,35 @@ namespace AppsInToss.Editor.Menu.Tests
         {
             Assert.IsFalse(PortResolver.IsPortConflictError(null));
         }
+
+        [Test]
+        public void IsPortConflictError_AllUppercase_ReturnsTrue()
+        {
+            // ToLowerInvariant() 계약 고정: 완전 대문자 입력도 매칭되어야 함
+            Assert.IsTrue(PortResolver.IsPortConflictError("PORT IS ALREADY IN USE"));
+        }
+
+        [Test]
+        public void IsPortConflictError_SubstringInMultiLineOutput_ReturnsTrue()
+        {
+            // 실제 툴 출력은 다중 라인 스택트레이스일 수 있음
+            string output = "Starting dev server...\n  at node (internal)\nError: listen EADDRINUSE on :::5173\n  at Server.listen";
+            Assert.IsTrue(PortResolver.IsPortConflictError(output));
+        }
+
+        [Test]
+        public void IsPortConflictError_NearMissPhrase_ReturnsFalse()
+        {
+            // 느슨한 문구 매칭으로 false positive가 생기지 않아야 함
+            Assert.IsFalse(PortResolver.IsPortConflictError("the address has already been used"));
+        }
+
+        [Test]
+        public void IsPortConflictError_WhitespaceOnly_ReturnsFalse()
+        {
+            Assert.IsFalse(PortResolver.IsPortConflictError("   "));
+            Assert.IsFalse(PortResolver.IsPortConflictError("\n"));
+            Assert.IsFalse(PortResolver.IsPortConflictError("\t"));
+        }
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs
@@ -1,0 +1,50 @@
+// -----------------------------------------------------------------------
+// PortResolverParserTests.cs
+// Level 0: PortResolver.IsPortConflictError 순수 파서 검증
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.Menu;
+
+namespace AppsInToss.Editor.Menu.Tests
+{
+    [TestFixture]
+    public class PortResolverParserTests
+    {
+        [Test]
+        public void IsPortConflictError_EaddrInUse_ReturnsTrue()
+        {
+            Assert.IsTrue(PortResolver.IsPortConflictError("Error: listen EADDRINUSE: address already in use :::5173"));
+        }
+
+        [Test]
+        public void IsPortConflictError_PortIsAlreadyInUseMessage_ReturnsTrue()
+        {
+            Assert.IsTrue(PortResolver.IsPortConflictError("Port is already in use"));
+        }
+
+        [Test]
+        public void IsPortConflictError_AddressAlreadyInUseMessage_ReturnsTrue()
+        {
+            Assert.IsTrue(PortResolver.IsPortConflictError("bind: address already in use"));
+        }
+
+        [Test]
+        public void IsPortConflictError_NormalOutput_ReturnsFalse()
+        {
+            Assert.IsFalse(PortResolver.IsPortConflictError("Build succeeded in 1.2s"));
+        }
+
+        [Test]
+        public void IsPortConflictError_EmptyString_ReturnsFalse()
+        {
+            Assert.IsFalse(PortResolver.IsPortConflictError(string.Empty));
+        }
+
+        [Test]
+        public void IsPortConflictError_Null_ReturnsFalse()
+        {
+            Assert.IsFalse(PortResolver.IsPortConflictError(null));
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4810930385ae4ad7940987313852368f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경

AppsInTossMenu 분할 리팩토링 (6개 PR 중 **3번째**).
거대해진 `Editor/AppsInTossMenu.cs` 에서 포트 관련 유틸을 `PortResolver` 로 분리합니다.

## 변경 사항

### 이동 (1:1)

`Editor/AppsInTossMenu.cs` → `Editor/Menu/PortResolver.cs` (`internal static class`, namespace `AppsInToss.Editor.Menu`)

- `KillProcessOnPort(int)`
- `IsPortAvailable(int)`
- `FindAvailablePort(int, int)`
- `WaitForPortAndOpenBrowser(int, string)`
- `TryResolveServerPorts(AITEditorScriptObject, out …)`
- `IsPortConflictError(string)`

### facade

- `using AppsInToss.Editor.Menu;` 추가
- 내부 호출 6곳을 `PortResolver.X(…)` 로 치환
- 메서드 본문 제거 (194줄 감소)

### 테스트

`Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/PortResolverParserTests.cs` 신설 (namespace `AppsInToss.Editor.Menu.Tests`) — 순수 파서 `IsPortConflictError` 에 대해 아래 케이스 검증:
- `EADDRINUSE` (대소문자 무관)
- `port is already in use` 메시지
- `address already in use` 메시지
- 일반 출력 → false
- 빈 문자열 / null → false

TCP 소켓이 필요한 `IsPortAvailable` / `FindAvailablePort` 는 통합 성격이라 스킵.

## 검증

- `./run-local-tests.sh --validate` 통과 (E2E 파일 / Playwright 설정 / SDK Generator invariants)
- Unity 컴파일은 E2E 워크플로우에서 검증
- 외부 참조 grep 결과 없음 — 호출부는 모두 facade 내부에 있었음

## 주의

- `Runtime/SDK/` 미수정
- TODO.md 미수정 (이번 Task 범위 외)
- squash merge 대상
