### PR TITLE
수정: symbols.json.unityweb 파일을 허용 빌드 산출물로 분류

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
+++ b/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
@@ -218,7 +218,7 @@ public static class BuildOutputValidator
         return "disabled";
     }
 
-    internal static string DetectFileType(string fileName)
+    public static string DetectFileType(string fileName)
     {
         if (fileName.Contains(".symbols.json")) return "symbols";
         if (fileName.Contains(".wasm")) return "wasm";

--- a/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
+++ b/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
@@ -220,6 +220,7 @@ public static class BuildOutputValidator
 
     private static string DetectFileType(string fileName)
     {
+        if (fileName.Contains(".symbols.json")) return "symbols";
         if (fileName.Contains(".wasm")) return "wasm";
         if (fileName.Contains(".data")) return "data";
         if (fileName.Contains(".framework.js")) return "framework";

--- a/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
+++ b/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
@@ -218,7 +218,7 @@ public static class BuildOutputValidator
         return "disabled";
     }
 
-    private static string DetectFileType(string fileName)
+    internal static string DetectFileType(string fileName)
     {
         if (fileName.Contains(".symbols.json")) return "symbols";
         if (fileName.Contains(".wasm")) return "wasm";

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AppsInTossEditModeTests.asmdef
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AppsInTossEditModeTests.asmdef
@@ -5,7 +5,8 @@
         "AppsInTossSDK",
         "AppsInTossSDKEditor",
         "AppsInToss.Helpers",
-        "AppsInTossTestScripts"
+        "AppsInTossTestScripts",
+        "AppsInTossTestScripts.Editor"
     ],
     "includePlatforms": [
         "Editor"

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
@@ -30,8 +30,10 @@ public class BuildOutputValidatorTests
     [TestCase("build.wasm.gz", "wasm")]
     [TestCase("build.wasm.unityweb", "wasm")]
     [TestCase("build.data.br", "data")]
+    [TestCase("build.data.gz", "data")]
     [TestCase("build.data.unityweb", "data")]
     [TestCase("build.framework.js.br", "framework")]
+    [TestCase("build.framework.js.gz", "framework")]
     [TestCase("build.framework.js.unityweb", "framework")]
     [TestCase("build.symbols.json.br", "symbols")]
     [TestCase("build.symbols.json.gz", "symbols")]
@@ -39,6 +41,19 @@ public class BuildOutputValidatorTests
     public void DetectFileType_CompressedArtifacts_Classified(string fileName, string expectedType)
     {
         Assert.AreEqual(expectedType, BuildOutputValidator.DetectFileType(fileName));
+    }
+
+    // =====================================================
+    // loader는 EndsWith 매칭이므로 압축 변형은 "other"
+    // 다른 타입은 Contains 매칭이라는 비대칭성을 고정
+    // =====================================================
+
+    [TestCase("build.loader.js.br", "other")]
+    [TestCase("build.loader.js.gz", "other")]
+    [TestCase("build.loader.js.unityweb", "other")]
+    public void DetectFileType_CompressedLoader_ReturnsOther(string fileName)
+    {
+        Assert.AreEqual("other", BuildOutputValidator.DetectFileType(fileName));
     }
 
     // =====================================================
@@ -51,5 +66,16 @@ public class BuildOutputValidatorTests
     public void DetectFileType_UnknownFiles_ReturnsOther(string fileName)
     {
         Assert.AreEqual("other", BuildOutputValidator.DetectFileType(fileName));
+    }
+
+    // =====================================================
+    // Contains 매칭 semantics 고정
+    // .symbols.json 부분 문자열이 있으면 "symbols"로 분류됨 (Unity가 생성하지 않는 파일명)
+    // =====================================================
+
+    [Test]
+    public void DetectFileType_SubstringMatch_DocumentsContainsSemantics()
+    {
+        Assert.AreEqual("symbols", BuildOutputValidator.DetectFileType("notes.symbols.json.backup"));
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// BuildOutputValidatorTests.cs - EditMode Build 산출물 분류 테스트
+// Level 0: DetectFileType 패턴 매칭 검증
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+
+[TestFixture]
+public class BuildOutputValidatorTests
+{
+    // =====================================================
+    // 기본 파일 타입 분류
+    // =====================================================
+
+    [TestCase("build.loader.js", "loader")]
+    [TestCase("build.wasm", "wasm")]
+    [TestCase("build.data", "data")]
+    [TestCase("build.framework.js", "framework")]
+    [TestCase("build.symbols.json", "symbols")]
+    public void DetectFileType_UncompressedArtifacts_Classified(string fileName, string expectedType)
+    {
+        Assert.AreEqual(expectedType, BuildOutputValidator.DetectFileType(fileName));
+    }
+
+    // =====================================================
+    // 압축 변형 (.br, .gz, .unityweb) — Contains 매칭으로 모두 허용 타입
+    // =====================================================
+
+    [TestCase("build.wasm.br", "wasm")]
+    [TestCase("build.wasm.gz", "wasm")]
+    [TestCase("build.wasm.unityweb", "wasm")]
+    [TestCase("build.data.br", "data")]
+    [TestCase("build.data.unityweb", "data")]
+    [TestCase("build.framework.js.br", "framework")]
+    [TestCase("build.framework.js.unityweb", "framework")]
+    [TestCase("build.symbols.json.br", "symbols")]
+    [TestCase("build.symbols.json.gz", "symbols")]
+    [TestCase("build.symbols.json.unityweb", "symbols")]
+    public void DetectFileType_CompressedArtifacts_Classified(string fileName, string expectedType)
+    {
+        Assert.AreEqual(expectedType, BuildOutputValidator.DetectFileType(fileName));
+    }
+
+    // =====================================================
+    // 알 수 없는 파일은 "other"
+    // =====================================================
+
+    [TestCase("index.html")]
+    [TestCase("README.txt")]
+    [TestCase("random.file")]
+    public void DetectFileType_UnknownFiles_ReturnsOther(string fileName)
+    {
+        Assert.AreEqual("other", BuildOutputValidator.DetectFileType(fileName));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4e9eef6399b44c49a1b26a77e7e56e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경
- Sentry SDK-7R (96건) `Unexpected file in Build/: *.symbols.json.unityweb` 경고가 반복 발생
- 이 파일은 development build의 정상 산출물이나 BuildOutputValidator가 "other"로 분류 중

## 변경
- `DetectFileType`에서 `.symbols.json(.unityweb)` 패턴을 명시적으로 인식

## 검증
- `./run-local-tests.sh --validate` 통과