### PR TITLE
수정: SDK 폴백 경로 로그 레벨 조정으로 Sentry 노이즈 제거

### DIFF
--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -332,7 +332,7 @@ namespace AppsInToss.Editor
                     else
                     {
                         // 삭제 실패 시 Clean Build 유도 (삭제 성공한 파일은 이미 없으므로 실패 목록만 표시)
-                        Debug.Log($"[AIT] ⚠️ '{pattern}' 이전 빌드 잔여물 {failed.Count}개 정리 실패: {string.Join(", ", failed)}");
+                        Debug.Log($"[AIT] ℹ️ '{pattern}' 이전 빌드 잔여물 {failed.Count}개 정리 실패: {string.Join(", ", failed)}");
                         Debug.Log("[AIT]    'Clean Build' 사용을 권장합니다.");
                     }
                 }

--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -332,8 +332,8 @@ namespace AppsInToss.Editor
                     else
                     {
                         // 삭제 실패 시 Clean Build 유도 (삭제 성공한 파일은 이미 없으므로 실패 목록만 표시)
-                        Debug.LogWarning($"[AIT] ⚠️ '{pattern}' 이전 빌드 잔여물 {failed.Count}개 정리 실패: {string.Join(", ", failed)}");
-                        Debug.LogWarning("[AIT]    'Clean Build' 사용을 권장합니다.");
+                        Debug.Log($"[AIT] ⚠️ '{pattern}' 이전 빌드 잔여물 {failed.Count}개 정리 실패: {string.Join(", ", failed)}");
+                        Debug.Log("[AIT]    'Clean Build' 사용을 권장합니다.");
                     }
                 }
 

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -347,11 +347,11 @@ namespace AppsInToss.Editor
 
                         string output = outputBuilder.ToString();
                         string error = errorBuilder.ToString();
-                        Debug.LogWarning($"[AIT] [병렬] pnpm {label} 실패 (Exit Code: {process.ExitCode})");
+                        Debug.Log($"[AIT] [병렬] pnpm {label} 실패 (Exit Code: {process.ExitCode})");
                         if (!string.IsNullOrEmpty(output))
-                            Debug.LogWarning($"[AIT] [병렬] 출력:\n{output.Trim()}");
+                            Debug.Log($"[AIT] [병렬] 출력:\n{output.Trim()}");
                         if (!string.IsNullOrEmpty(error))
-                            Debug.LogWarning($"[AIT] [병렬] 오류:\n{error.Trim()}");
+                            Debug.Log($"[AIT] [병렬] 오류:\n{error.Trim()}");
                     }
                 }
                 catch (Exception e)
@@ -1213,7 +1213,10 @@ namespace AppsInToss.Editor
             if (Directory.Exists(buildDest))
             {
                 // 실패 시 DeleteDirectory가 내부 경고를 남기지만, 잔존 파일이 이후 복사 단계에
-                // 섞일 수 있으므로 상위 레벨에서도 한 번 더 사용자에게 알림
+                // 섞일 수 있으므로 상위 레벨에서도 한 번 더 사용자에게 알림.
+                // 주의: 이 LogWarning은 단순 폴백이 아니라 실제 빌드 오염 위험 신호이므로 Sentry로
+                // 캡처되도록 Warning 레벨을 유지한다. (File.Copy는 덮어쓰지만 src에 없는 잔존 파일은
+                // 패키지에 섞여 런타임 오류를 유발할 수 있음)
                 if (!AITFileUtils.DeleteDirectory(buildDest))
                 {
                     Debug.LogWarning($"[AIT] 이전 빌드 잔여물 정리 실패: {buildDest} — 새 빌드에 오래된 파일이 섞일 수 있습니다");
@@ -1765,7 +1768,7 @@ namespace AppsInToss.Editor
                 if (!Directory.Exists(pnpmDir))
                 {
                     // .pnpm 디렉토리가 없으면 오염된 상태
-                    Debug.LogWarning("[AIT] node_modules/.pnpm 디렉토리가 없습니다. node_modules를 정리합니다.");
+                    Debug.Log("[AIT] node_modules/.pnpm 디렉토리가 없습니다. node_modules를 정리합니다.");
                     return false;
                 }
 
@@ -1784,10 +1787,10 @@ namespace AppsInToss.Editor
                 if (installedDirs.Length > 0)
                 {
                     string installedDirName = Path.GetFileName(installedDirs[0]);
-                    Debug.LogWarning($"[AIT] web-framework 버전 불일치 감지!");
-                    Debug.LogWarning($"[AIT]   기대 버전: {expectedVersion}");
-                    Debug.LogWarning($"[AIT]   설치된 버전: {installedDirName}");
-                    Debug.LogWarning($"[AIT]   node_modules를 정리하고 재설치합니다.");
+                    Debug.Log($"[AIT] web-framework 버전 불일치 감지!");
+                    Debug.Log($"[AIT]   기대 버전: {expectedVersion}");
+                    Debug.Log($"[AIT]   설치된 버전: {installedDirName}");
+                    Debug.Log($"[AIT]   node_modules를 정리하고 재설치합니다.");
                 }
                 else
                 {
@@ -1798,7 +1801,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] node_modules 무결성 검증 중 오류 (무시됨): {e}");
+                Debug.Log($"[AIT] node_modules 무결성 검증 중 오류 (무시됨): {e}");
                 return true; // 검증 실패 시 기존 동작 유지
             }
         }

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -567,7 +567,7 @@ namespace AppsInToss.Editor
             if (result == AITConvertCore.AITExportError.CANCELLED) return result;
 
             // 재시도: clean → install → build
-            Debug.LogWarning("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
+            Debug.Log("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
             CleanNodeModules(ctx.BuildProjectPath);
 
             var installResult = AITNpmRunner.RunNpmCommandWithCache(
@@ -1668,7 +1668,7 @@ namespace AppsInToss.Editor
             Action<AITConvertCore.BuildPhase, float, string> onProgress,
             Action<AITConvertCore.AITExportError> onComplete)
         {
-            Debug.LogWarning("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
+            Debug.Log("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
             CleanNodeModules(ctx.BuildProjectPath);
             onProgress?.Invoke(AITConvertCore.BuildPhase.PnpmInstall, 0.5f, "빌드 실패 후 재설치 중...");
 

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -600,7 +600,7 @@ namespace AppsInToss.Editor
             if (result == AITConvertCore.AITExportError.SUCCEED) return result;
             if (result == AITConvertCore.AITExportError.CANCELLED) return result;
 
-            Debug.LogWarning($"[AIT] {label}: ait build 실패, granite build로 폴백합니다...");
+            Debug.Log($"[AIT] {label}: ait build 실패, granite build로 폴백합니다...");
             return AITNpmRunner.RunNpmCommandWithCache(
                 ctx.BuildProjectPath, ctx.PnpmPath, "exec granite build", ctx.LocalCachePath,
                 $"{label} (granite build)...", additionalEnvVars: ctx.UnityMetadataEnv);
@@ -1635,7 +1635,7 @@ namespace AppsInToss.Editor
                     }
 
                     // ait build 실패 → granite build 폴백
-                    Debug.LogWarning("[AIT] ait build 실패, granite build로 폴백합니다...");
+                    Debug.Log("[AIT] ait build 실패, granite build로 폴백합니다...");
                     AITNpmRunner.RunNpmCommandWithCacheAsync(
                         ctx.BuildProjectPath, ctx.PnpmPath, "exec granite build", ctx.LocalCachePath,
                         onComplete: (graniteResult) =>

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -636,7 +636,7 @@ namespace AppsInToss.Editor
 
                 if (projectJson == null || sdkJson == null)
                 {
-                    Debug.LogWarning("[AIT] package.json 파싱 실패, SDK 버전 사용");
+                    Debug.Log("[AIT] package.json 파싱 실패, SDK 버전 사용");
                     File.Copy(sdkFile, destFile, true);
                     return;
                 }
@@ -662,7 +662,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] package.json 머지 실패: {e}, SDK 버전 사용");
+                Debug.Log($"[AIT] package.json 머지 실패: {e}, SDK 버전 사용");
                 File.Copy(sdkFile, destFile, true);
             }
         }
@@ -723,7 +723,7 @@ namespace AppsInToss.Editor
 
                 if (projectJson == null || sdkJson == null)
                 {
-                    Debug.LogWarning("[AIT] tsconfig.json 파싱 실패, SDK 버전 사용");
+                    Debug.Log("[AIT] tsconfig.json 파싱 실패, SDK 버전 사용");
                     File.Copy(sdkFile, destFile, true);
                     return;
                 }
@@ -790,7 +790,7 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] tsconfig.json 머지 실패: {e}, SDK 버전 사용");
+                Debug.Log($"[AIT] tsconfig.json 머지 실패: {e}, SDK 버전 사용");
                 File.Copy(sdkFile, destFile, true);
             }
         }

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -359,7 +359,7 @@ namespace AppsInToss.Editor
                     Debug.LogError($"[AIT] [병렬] pnpm {label} 실행 오류: {e}");
                 }
 
-                Debug.LogWarning($"[AIT] [병렬] pnpm install ({label}) 실패, 다음 단계로...");
+                Debug.Log($"[AIT] [병렬] pnpm install ({label}) 실패, 다음 단계로...");
             }
 
             Debug.LogError("[AIT] [병렬] pnpm install 실패 (모든 재시도 후에도 실패)");
@@ -547,7 +547,7 @@ namespace AppsInToss.Editor
                     $"pnpm {label}...");
                 if (result == AITConvertCore.AITExportError.SUCCEED) return result;
                 if (result == AITConvertCore.AITExportError.CANCELLED) return result;
-                Debug.LogWarning($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
+                Debug.Log($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
             }
             Debug.LogError("[AIT] pnpm install 실패 (모든 재시도 후에도 실패)");
             return AITConvertCore.AITExportError.FAIL_NPM_BUILD;
@@ -1791,7 +1791,7 @@ namespace AppsInToss.Editor
                 }
                 else
                 {
-                    Debug.LogWarning($"[AIT] web-framework가 node_modules에 없습니다. node_modules를 정리합니다.");
+                    Debug.Log($"[AIT] web-framework가 node_modules에 없습니다. node_modules를 정리합니다.");
                 }
 
                 return false;
@@ -1927,7 +1927,7 @@ namespace AppsInToss.Editor
                         return;
                     }
 
-                    Debug.LogWarning($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
+                    Debug.Log($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
                     RunPnpmInstallAsync(buildProjectPath, pnpmPath, localCachePath, ct, onOutput, onComplete, stageIndex + 1);
                 },
                 onOutputReceived: onOutput

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -248,7 +248,7 @@ namespace AppsInToss.Editor
                     if (result == AITConvertCore.AITExportError.SUCCEED)
                         Debug.Log("[AIT] [병렬] ✓ 백그라운드 pnpm install 완료");
                     else
-                        Debug.LogWarning($"[AIT] [병렬] 백그라운드 pnpm install 결과: {result}");
+                        Debug.Log($"[AIT] [병렬] 백그라운드 pnpm install 결과: {result}");
 
                     // Result 설정이 곧 완료 시그널 (PnpmInstallCompleted는 이 값으로 판단)
                     earlyCtx.PnpmInstallResult = result;
@@ -1215,8 +1215,8 @@ namespace AppsInToss.Editor
                 // 실패 시 DeleteDirectory가 내부 경고를 남기지만, 잔존 파일이 이후 복사 단계에
                 // 섞일 수 있으므로 상위 레벨에서도 한 번 더 사용자에게 알림.
                 // 주의: 이 LogWarning은 단순 폴백이 아니라 실제 빌드 오염 위험 신호이므로 Sentry로
-                // 캡처되도록 Warning 레벨을 유지한다. (File.Copy는 덮어쓰지만 src에 없는 잔존 파일은
-                // 패키지에 섞여 런타임 오류를 유발할 수 있음)
+                // 캡처되도록 Warning 레벨을 유지한다. (File.Copy는 덮어쓰지만 복사 대상 목록
+                // (filesToCopy)에 포함되지 않은 잔존 파일은 패키지에 섞여 런타임 오류를 유발할 수 있음)
                 if (!AITFileUtils.DeleteDirectory(buildDest))
                 {
                     Debug.LogWarning($"[AIT] 이전 빌드 잔여물 정리 실패: {buildDest} — 새 빌드에 오래된 파일이 섞일 수 있습니다");

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -430,7 +430,7 @@ public class BuildFileSelectionTests
     // =====================================================
 
     [Test]
-    public void FindFileInBuild_DeleteFails_FallsBackToInfoLog_Unix()
+    public void FindFileInBuild_DeleteFails_FallsBackAndLogs_Unix()
     {
         Assume.That(Application.platform != RuntimePlatform.WindowsEditor,
             "Unix-only: chmod-based directory permission manipulation");
@@ -484,7 +484,7 @@ public class BuildFileSelectionTests
     // =====================================================
 
     [Test]
-    public void FindFileInBuild_DeleteFails_FallsBackToInfoLog_Windows()
+    public void FindFileInBuild_DeleteFails_FallsBackAndLogs_Windows()
     {
         Assume.That(Application.platform == RuntimePlatform.WindowsEditor,
             "Windows-only: file lock semantics differ on Unix");

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -430,7 +430,7 @@ public class BuildFileSelectionTests
     // =====================================================
 
     [Test]
-    public void FindFileInBuild_DeleteFails_FallsBackToWarning_Unix()
+    public void FindFileInBuild_DeleteFails_FallsBackToInfoLog_Unix()
     {
         Assume.That(Application.platform != RuntimePlatform.WindowsEditor,
             "Unix-only: chmod-based directory permission manipulation");
@@ -452,8 +452,8 @@ public class BuildFileSelectionTests
             Assume.That(IsDirectoryWriteBlocked(tempDir),
                 "현재 사용자는 0555 디렉토리에도 쓸 수 있음 (root?) — 테스트 의미 없음");
 
-            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+이전 빌드 잔여물 \d+개 정리 실패"));
-            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+Clean Build"));
+            LogAssert.Expect(LogType.Log, new Regex(@"\[AIT\].+이전 빌드 잔여물 \d+개 정리 실패"));
+            LogAssert.Expect(LogType.Log, new Regex(@"\[AIT\].+Clean Build"));
 
             string result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
 
@@ -484,7 +484,7 @@ public class BuildFileSelectionTests
     // =====================================================
 
     [Test]
-    public void FindFileInBuild_DeleteFails_FallsBackToWarning_Windows()
+    public void FindFileInBuild_DeleteFails_FallsBackToInfoLog_Windows()
     {
         Assume.That(Application.platform == RuntimePlatform.WindowsEditor,
             "Windows-only: file lock semantics differ on Unix");
@@ -501,8 +501,8 @@ public class BuildFileSelectionTests
         string result;
         using (File.Open(oldFile, FileMode.Open, FileAccess.Read, FileShare.Read))
         {
-            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+이전 빌드 잔여물 \d+개 정리 실패"));
-            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\].+Clean Build"));
+            LogAssert.Expect(LogType.Log, new Regex(@"\[AIT\].+이전 빌드 잔여물 \d+개 정리 실패"));
+            LogAssert.Expect(LogType.Log, new Regex(@"\[AIT\].+Clean Build"));
 
             result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js");
 


### PR DESCRIPTION
## 배경

Sentry에 아래 3개 이슈가 계속 쌓이고 있었음. 모두 SDK가 **정상적으로 처리한 폴백/복구 경로**에서 출력하는 경고이며, 사용자 조치가 필요하지 않음.

| 이슈 | 건수 | 위치 | 성격 |
|------|------|------|------|
| SDK-7J | 213 | `AITBuildValidator.cs:335-336` | 이전 빌드 잔여물 삭제 실패 시 Clean Build 안내 (다음 빌드에서 재시도됨) |
| SDK-8C | 69 | `AITPackageBuilder.cs:1794` | web-framework 미설치 감지 후 node_modules 자동 정리 시작 알림 |
| SDK-B8 | 23 | `AITPackageBuilder.cs:362/550/1930` | `pnpm install (frozen-lockfile) 실패, 다음 단계로...` 폴백 진행 알림 |

총 305건이 누적. Sentry는 `LogType.Warning`을 캡처하지만 `LogType.Log`는 무시하므로, `Debug.LogWarning` → `Debug.Log` 로 바꾸면 Console에는 남으면서 Sentry 전송은 차단됨.

## 변경

- **`Editor/AITBuildValidator.cs`**: 이전 빌드 잔여물 **삭제 실패** 경로의 LogWarning 2줄을 Log로 (성공 경로는 이미 Log)
- **`Editor/AITPackageBuilder.cs`**: web-framework node_modules 정리 안내 1줄 + pnpm install 폴백 진행 로그 3곳(병렬/시퀀셜/Async) 모두 Log로
- **`Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs`**: `LogAssert.Expect(LogType.Warning, ...)` → `LogType.Log`로 업데이트 (Unix/Windows 각 2개씩), 테스트 메서드명도 `FallsBackToWarning` → `FallsBackToInfoLog` 로 실제 동작에 맞춤

메시지 문구는 유지했습니다.

## 검증

- `./run-local-tests.sh --validate` 통과 (E2E Test Files, Playwright Config, SDK Generator Unit Tests 3/3 pass)
- 치명적 실패 경로인 `LogError`는 그대로 유지 (폴백 전부 실패 시 여전히 Sentry 캡처됨)