### PR TITLE
수정: 사용자 프로젝트 기인 경고 패턴 NonSdkMessagePatterns에 추가

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -59,7 +59,7 @@ namespace AppsInToss.Editor.ErrorTracker
         //   3. 여기 NonSdkMessagePatterns에 메시지의 불변 핵심 문구를 부분 문자열로 추가
         //      (Unity 버전/환경 차이에 민감한 부분은 피할 것)
         //      단, 단일 부분 문자열이 SDK 자체 로그와 충돌할 위험이 있으면
-        //      IsKnownNonSdkMessage 하단에 composite AND 조건(예: "GUID [" && "conflicts with:")을 추가
+        //      IsKnownNonSdkMessage 내에 composite AND 조건(예: "GUID [" && "conflicts with:")을 추가
         //   4. IsKnownNonSdkMessageTests.cs에 positive/negative 테스트 추가
         //      (특히 AIT 키워드가 섞여도 필터링되지 않는지 negative 케이스 필수)
         private static readonly string[] NonSdkMessagePatterns =

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -58,6 +58,8 @@ namespace AppsInToss.Editor.ErrorTracker
         //   2. Sentry에서 해당 이슈를 ignored 처리
         //   3. 여기 NonSdkMessagePatterns에 메시지의 불변 핵심 문구를 부분 문자열로 추가
         //      (Unity 버전/환경 차이에 민감한 부분은 피할 것)
+        //      단, 단일 부분 문자열이 SDK 자체 로그와 충돌할 위험이 있으면
+        //      IsKnownNonSdkMessage 하단에 composite AND 조건(예: "GUID [" && "conflicts with:")을 추가
         //   4. IsKnownNonSdkMessageTests.cs에 positive/negative 테스트 추가
         //      (특히 AIT 키워드가 섞여도 필터링되지 않는지 negative 케이스 필수)
         private static readonly string[] NonSdkMessagePatterns =

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -86,6 +86,9 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // Unity URP 내부
             "exceeds previous array size",
+
+            // 사용자 Unity 설치에 WebGL 모듈 미설치 — SDK-DD
+            "Build target 'WebGL' not supported",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.
@@ -555,6 +558,12 @@ namespace AppsInToss.Editor.ErrorTracker
             if (message.IndexOf("Script attached to", StringComparison.Ordinal) >= 0
                 && message.IndexOf("is missing", StringComparison.Ordinal) >= 0
                 && message.IndexOf("Assets/", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // "GUID [...] ... conflicts with:" 패턴 — 사용자 프로젝트에 동일 GUID 에셋 잔존 (SDK-BQ)
+            // AITTemplate 경로가 포함되더라도 SDK가 제공한 파일을 사용자가 복사해둔 경우이므로 필터 대상
+            if (message.IndexOf("GUID [", StringComparison.Ordinal) >= 0
+                && message.IndexOf("conflicts with:", StringComparison.Ordinal) >= 0)
                 return true;
 
             return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -285,9 +285,11 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void GuidConflict_ReturnsTrue()
     {
-        // 사용자 프로젝트에 동일 GUID의 에셋이 남아있어 AITTemplate 파일과 충돌 — SDK-BQ
-        // 주의: AITTemplate 경로가 메시지에 등장하지만 AitKeywords(`[AIT`, `AIT:`, ...)와는 매칭되지 않으므로
-        // SDK 가드를 통과하지 않고 정상 필터링됨
+        // Sentry APPS-IN-TOSS-UNITY-SDK-BQ에서 실제 관찰된 메시지 형태를 반영한 fixture.
+        // 사용자 프로젝트에 동일 GUID의 에셋이 남아있어 AITTemplate 파일과 충돌.
+        // AITTemplate 경로가 메시지에 포함되어도 AitKeywords(`[AIT`, `AIT:` 등) 중 어느 것의 부분 문자열도 아니므로
+        // SDK 보호 가드가 발동하지 않아 일반 필터 흐름으로 내려가 정상 필터링됨.
+        // 필터가 향후 anchored/regex로 tightening되더라도 이 실측 경로를 놓치지 않도록 fixture로 박아둠.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "GUID [abc123def456] for asset 'Assets/WebGLTemplates/AITTemplate/TemplateData/diagnostics.css' conflicts with: 'Assets/OldCopy/diagnostics.css'"));
     }
@@ -303,7 +305,7 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void GuidWithoutConflictsWith_ReturnsFalse()
     {
-        // "GUID [" 만 있고 "conflicts with:" 가 없으면 다른 종류의 메시지일 수 있으므로 필터링 안 함
+        // "GUID ["만 있고 "conflicts with:"가 없으면 composite AND의 한쪽만 충족되어 필터링 안 됨
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "GUID [abc123] for asset 'Assets/Foo/bar.png' updated"));
     }
@@ -311,9 +313,25 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void ConflictsWithoutGuid_ReturnsFalse()
     {
-        // "conflicts with:" 만 있고 "GUID [" 가 없으면 SDK 자체 충돌 메시지일 수 있으므로 필터링 안 함
+        // "conflicts with:"만 있고 "GUID ["가 없으면 composite AND의 한쪽만 충족되어 필터링 안 됨
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Package version conflicts with: older version"));
+    }
+
+    [Test]
+    public void BuildTargetWebGLNotSupported_WithAitPrefix_NeverFiltered()
+    {
+        // AITKeyword 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Build target 'WebGL' not supported"));
+    }
+
+    [Test]
+    public void GuidConflict_WithAitPrefix_NeverFiltered()
+    {
+        // AITKeyword 가드 회귀 방지: [AIT] prefix가 붙은 GUID 충돌 메시지는 SDK가 직접 출력한 것으로 간주되어야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] GUID [abc123] for asset 'Assets/Foo/bar.png' conflicts with: 'Assets/Baz/bar.png'"));
     }
 
     #endregion

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -265,6 +265,59 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 사용자 환경 문제 (WebGL 모듈 미설치, GUID 충돌)
+
+    [Test]
+    public void BuildTargetWebGLNotSupported_ReturnsTrue()
+    {
+        // 사용자 Unity 설치에 WebGL 모듈이 없어서 발생 — SDK-DD
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Build target 'WebGL' not supported"));
+    }
+
+    [Test]
+    public void BuildTargetWebGLNotSupported_FullMessage_ReturnsTrue()
+    {
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Build target 'WebGL' not supported. Please install it via Unity Hub."));
+    }
+
+    [Test]
+    public void GuidConflict_ReturnsTrue()
+    {
+        // 사용자 프로젝트에 동일 GUID의 에셋이 남아있어 AITTemplate 파일과 충돌 — SDK-BQ
+        // 주의: AITTemplate 경로가 메시지에 등장하지만 AitKeywords(`[AIT`, `AIT:`, ...)와는 매칭되지 않으므로
+        // SDK 가드를 통과하지 않고 정상 필터링됨
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "GUID [abc123def456] for asset 'Assets/WebGLTemplates/AITTemplate/TemplateData/diagnostics.css' conflicts with: 'Assets/OldCopy/diagnostics.css'"));
+    }
+
+    [Test]
+    public void GuidConflict_WithoutAitTemplate_ReturnsTrue()
+    {
+        // AITTemplate 경로가 없어도 일반 GUID 충돌 메시지라면 사용자 프로젝트 문제
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "GUID [deadbeef] for asset 'Assets/Foo/bar.png' conflicts with: 'Assets/Baz/bar.png'"));
+    }
+
+    [Test]
+    public void GuidWithoutConflictsWith_ReturnsFalse()
+    {
+        // "GUID [" 만 있고 "conflicts with:" 가 없으면 다른 종류의 메시지일 수 있으므로 필터링 안 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "GUID [abc123] for asset 'Assets/Foo/bar.png' updated"));
+    }
+
+    [Test]
+    public void ConflictsWithoutGuid_ReturnsFalse()
+    {
+        // "conflicts with:" 만 있고 "GUID [" 가 없으면 SDK 자체 충돌 메시지일 수 있으므로 필터링 안 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Package version conflicts with: older version"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -225,7 +225,7 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
-    public void FieldsSerializedInSdkAssembly_NotFiltered()
+    public void FieldsSerializedInSdkAssembly_NeverFiltered()
     {
         // SDK 어셈블리(AppsInTossSDKEditor 등)의 직렬화 경고는 보호되어야 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
@@ -321,7 +321,7 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void BuildTargetWebGLNotSupported_WithAitPrefix_NeverFiltered()
     {
-        // AITKeyword 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AIT] Build target 'WebGL' not supported"));
     }
@@ -329,7 +329,7 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void GuidConflict_WithAitPrefix_NeverFiltered()
     {
-        // AITKeyword 가드 회귀 방지: [AIT] prefix가 붙은 GUID 충돌 메시지는 SDK가 직접 출력한 것으로 간주되어야 함
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 GUID 충돌 메시지는 SDK가 직접 출력한 것으로 간주되어야 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AIT] GUID [abc123] for asset 'Assets/Foo/bar.png' conflicts with: 'Assets/Baz/bar.png'"));
     }


### PR DESCRIPTION
## 배경

최근 7일간 Sentry에 사용자 프로젝트/Unity 환경 기인 경고가 대량 유입되고 있어, 해당 패턴들을 Editor Error Tracker의 `NonSdkMessagePatterns` 필터에 추가합니다.

## 변경 사항

### 1. 패턴 추가

**`Build target 'WebGL' not supported`** (SDK-DD, 7일 3건)
- 사용자 Unity 설치에 WebGL 모듈이 없을 때 발생
- 단순 부분 문자열 매칭으로 추가

**`GUID [...] ... conflicts with:`** (SDK-BQ, 7일 16건)
- 사용자 프로젝트에 동일 GUID 에셋이 잔존해 AITTemplate 파일과 충돌
- `Script attached to ... is missing ... Assets/` 와 동일한 방식으로 `GUID [` + `conflicts with:` 복합 조건으로 판정
- 이유: `GUID [` 또는 `conflicts with:` 각각만 매칭하면 SDK 자체 로그를 잘못 필터링할 위험이 있어 AND 조건 필요

### 2. AitKeywords 가드 검증

GUID 충돌 메시지에 `AITTemplate` 경로가 등장하지만 `AitKeywords`의 토큰(`[AIT`, `AIT:`, `AppsInToss`, `apps-in-toss`, `ait-build`, `AITConvertCore`, `AITPackageBuilder`, `AITNodeJS`, `AITNpmRunner`)과는 매칭되지 않습니다. 즉 SDK 보호 가드를 통과하지 않고 정상 필터링됩니다. `AITTemplate` 자체는 SDK가 제공한 파일이지만 사용자가 복사해둔 구 에셋과 GUID 충돌이 나는 상황이므로 **사용자 프로젝트 정리가 필요한 환경 문제**로 분류됩니다.

### 3. FORBIDDEN_ORIGIN / AIT_MOCK_OR_TIMEOUT (SDK-D3, D2)

스코프 외 처리 — 사유:
- 두 메시지의 원문(`[AIT Login] ...`)은 Unity SDK 저장소에 없음. 외부 `@apps-in-toss/web-framework` 런타임에서 출력되며 WebGL 브라우저 런타임 또는 Dev Server 프로세스 stdout 리디렉션을 통해서만 Editor에 전달 가능.
- 이 메시지는 개발자에게 Apps in Toss 관리자 페이지에서 origin을 등록해야 한다는 실질적인 정보를 제공하므로, Console에서 억제하지 않는 편이 좋음.
- Editor Sentry 캡처 측 로그 레벨 조정이 필요하면 별도 PR에서 진행 예정.

## 테스트

`IsKnownNonSdkMessageTests`에 6개 케이스 추가:
- `BuildTargetWebGLNotSupported_ReturnsTrue` / `_FullMessage_ReturnsTrue`
- `GuidConflict_ReturnsTrue` (AITTemplate 경로 포함)
- `GuidConflict_WithoutAitTemplate_ReturnsTrue`
- `GuidWithoutConflictsWith_ReturnsFalse` (SDK 자체 GUID 로그 보호)
- `ConflictsWithoutGuid_ReturnsFalse` (SDK 자체 conflict 로그 보호)

## 검증

- [x] `./run-local-tests.sh --validate` 통과 (E2E 구조 검증 + Playwright 설정 + SDK Generator 유닛 테스트 18개 pass)
- [ ] Unity EditMode 테스트: 로컬 Unity 미설치로 CI에서 검증 예정
- [x] AitKeywords 매칭 로직 수동 트레이스 완료 (SDK 자체 로그가 새 패턴에 의해 필터링되지 않음)

## 참고

- 파일: `Editor/ErrorTracker/AITEditorErrorTracker.cs`, `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`
- 관련 Sentry 이슈: SDK-DD, SDK-BQ
- `UnauthorizedAccessException: Access to the path 'gen-mapping' is denied.` (SDK-CA)는 실제 SDK 삭제 경로의 에러일 수 있어 이번 PR에서는 패턴 추가하지 않음 — 별도 조사 필요.
