### PR TITLE
리팩토링: NodeModulesValidator 서비스 추출

### DIFF
--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -156,10 +156,10 @@ namespace AppsInToss.Editor
 
             // node_modules 무결성 검증
             string storePath = GetSharedPnpmStorePath();
-            if (!ValidateNodeModulesIntegrity(buildProjectPath))
+            if (!Package.NodeModulesValidator.ValidateIntegrity(buildProjectPath))
             {
                 Debug.Log("[AIT] node_modules 무결성 검증 실패. 정리 후 재설치합니다.");
-                CleanNodeModules(buildProjectPath);
+                Package.NodeModulesValidator.CleanNodeModules(buildProjectPath);
             }
 
             return (new PackageContext
@@ -214,10 +214,10 @@ namespace AppsInToss.Editor
 
             // node_modules 무결성 검증
             string storePath = GetSharedPnpmStorePath();
-            if (!ValidateNodeModulesIntegrity(buildProjectPath))
+            if (!Package.NodeModulesValidator.ValidateIntegrity(buildProjectPath))
             {
                 Debug.Log("[AIT] [병렬] node_modules 무결성 검증 실패. 정리 후 재설치합니다.");
-                CleanNodeModules(buildProjectPath);
+                Package.NodeModulesValidator.CleanNodeModules(buildProjectPath);
             }
 
             return (new EarlyPackageContext
@@ -276,7 +276,7 @@ namespace AppsInToss.Editor
                 if (ct.IsCancellationRequested)
                     return AITConvertCore.AITExportError.CANCELLED;
 
-                if (cleanFirst) CleanNodeModules(earlyCtx.BuildProjectPath);
+                if (cleanFirst) Package.NodeModulesValidator.CleanNodeModules(earlyCtx.BuildProjectPath);
 
                 string fullArguments = AITNpmRunner.BuildFullArguments(args, earlyCtx.LocalCachePath);
                 string command = $"\"{earlyCtx.PnpmPath}\" {fullArguments}";
@@ -541,7 +541,7 @@ namespace AppsInToss.Editor
         {
             foreach (var (args, label, cleanFirst) in PnpmInstallStages)
             {
-                if (cleanFirst) CleanNodeModules(ctx.BuildProjectPath);
+                if (cleanFirst) Package.NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
                 var result = AITNpmRunner.RunNpmCommandWithCache(
                     ctx.BuildProjectPath, ctx.PnpmPath, args, ctx.LocalCachePath,
                     $"pnpm {label}...");
@@ -568,7 +568,7 @@ namespace AppsInToss.Editor
 
             // 재시도: clean → install → build
             Debug.Log("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
-            CleanNodeModules(ctx.BuildProjectPath);
+            Package.NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
 
             var installResult = AITNpmRunner.RunNpmCommandWithCache(
                 ctx.BuildProjectPath, ctx.PnpmPath, "install --no-frozen-lockfile",
@@ -1669,7 +1669,7 @@ namespace AppsInToss.Editor
             Action<AITConvertCore.AITExportError> onComplete)
         {
             Debug.Log("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
-            CleanNodeModules(ctx.BuildProjectPath);
+            Package.NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
             onProgress?.Invoke(AITConvertCore.BuildPhase.PnpmInstall, 0.5f, "빌드 실패 후 재설치 중...");
 
             AITNpmRunner.RunNpmCommandWithCacheAsync(
@@ -1720,121 +1720,6 @@ namespace AppsInToss.Editor
         }
 
         #endregion
-
-        /// <summary>
-        /// node_modules 무결성 검증
-        /// package.json의 @apps-in-toss/web-framework 버전과 node_modules 내 설치 버전이 일치하는지 확인합니다.
-        /// pnpm의 node_modules/.pnpm/@apps-in-toss+web-framework@{version} 디렉토리 존재 여부로 판단합니다.
-        /// </summary>
-        /// <param name="buildProjectPath">빌드 프로젝트 경로</param>
-        /// <returns>true: 무결성 확인됨 또는 node_modules 없음, false: 버전 불일치로 정리 필요</returns>
-        private static bool ValidateNodeModulesIntegrity(string buildProjectPath)
-        {
-            string nodeModulesPath = Path.Combine(buildProjectPath, "node_modules");
-            if (!Directory.Exists(nodeModulesPath))
-            {
-                // node_modules가 없으면 검증 불필요 (install 시 새로 생성됨)
-                return true;
-            }
-
-            // package.json에서 web-framework 버전 읽기
-            string packageJsonPath = Path.Combine(buildProjectPath, "package.json");
-            if (!File.Exists(packageJsonPath))
-            {
-                return true;
-            }
-
-            try
-            {
-                string packageJsonContent = File.ReadAllText(packageJsonPath);
-                var packageJson = MiniJson.Deserialize(packageJsonContent) as Dictionary<string, object>;
-                if (packageJson == null) return true;
-
-                var dependencies = packageJson.ContainsKey("dependencies")
-                    ? packageJson["dependencies"] as Dictionary<string, object>
-                    : null;
-                if (dependencies == null) return true;
-
-                if (!dependencies.ContainsKey("@apps-in-toss/web-framework")) return true;
-
-                string expectedVersion = dependencies["@apps-in-toss/web-framework"] as string;
-                if (string.IsNullOrEmpty(expectedVersion)) return true;
-
-                // ^ 또는 ~ 접두사 제거 (정확한 버전만 비교)
-                expectedVersion = expectedVersion.TrimStart('^', '~');
-
-                // pnpm의 node_modules/.pnpm/@apps-in-toss+web-framework@{version} 확인
-                string pnpmDir = Path.Combine(nodeModulesPath, ".pnpm");
-                if (!Directory.Exists(pnpmDir))
-                {
-                    // .pnpm 디렉토리가 없으면 오염된 상태
-                    Debug.Log("[AIT] node_modules/.pnpm 디렉토리가 없습니다. node_modules를 정리합니다.");
-                    return false;
-                }
-
-                // @apps-in-toss+web-framework@{version}으로 시작하는 디렉토리 검색
-                string expectedDirPrefix = $"@apps-in-toss+web-framework@{expectedVersion}";
-                string[] matchingDirs = Directory.GetDirectories(pnpmDir, $"{expectedDirPrefix}*");
-
-                if (matchingDirs.Length > 0)
-                {
-                    Debug.Log($"[AIT] ✓ node_modules 무결성 확인: web-framework@{expectedVersion}");
-                    return true;
-                }
-
-                // 현재 설치된 버전 찾기 (로그용)
-                string[] installedDirs = Directory.GetDirectories(pnpmDir, "@apps-in-toss+web-framework@*");
-                if (installedDirs.Length > 0)
-                {
-                    string installedDirName = Path.GetFileName(installedDirs[0]);
-                    Debug.Log($"[AIT] web-framework 버전 불일치 감지!");
-                    Debug.Log($"[AIT]   기대 버전: {expectedVersion}");
-                    Debug.Log($"[AIT]   설치된 버전: {installedDirName}");
-                    Debug.Log($"[AIT]   node_modules를 정리하고 재설치합니다.");
-                }
-                else
-                {
-                    Debug.Log($"[AIT] web-framework가 node_modules에 없습니다. node_modules를 정리합니다.");
-                }
-
-                return false;
-            }
-            catch (Exception e)
-            {
-                Debug.Log($"[AIT] node_modules 무결성 검증 중 오류 (무시됨): {e}");
-                return true; // 검증 실패 시 기존 동작 유지
-            }
-        }
-
-        /// <summary>
-        /// node_modules 및 캐시 정리
-        /// </summary>
-        /// <param name="buildProjectPath">빌드 프로젝트 경로</param>
-        private static void CleanNodeModules(string buildProjectPath)
-        {
-            string nodeModulesPath = Path.Combine(buildProjectPath, "node_modules");
-            string npmCachePath = Path.Combine(buildProjectPath, ".npm-cache");
-
-            if (Directory.Exists(nodeModulesPath))
-            {
-                Debug.Log("[AIT] node_modules 삭제 중...");
-                // DeleteDirectory는 내부적으로 실패 시 경고 로그를 남기고 false를 반환
-                if (AITFileUtils.DeleteDirectory(nodeModulesPath))
-                {
-                    Debug.Log("[AIT] ✓ node_modules 삭제 완료");
-                }
-            }
-
-            // 레거시 로컬 캐시 정리 (공유 store로 이전됨)
-            if (Directory.Exists(npmCachePath))
-            {
-                Debug.Log("[AIT] 레거시 .npm-cache 삭제 중...");
-                if (AITFileUtils.DeleteDirectory(npmCachePath))
-                {
-                    Debug.Log("[AIT] ✓ 레거시 .npm-cache 삭제 완료");
-                }
-            }
-        }
 
         /// <summary>
         /// ait-build 폴더 준비 (기존 결과물 정리)
@@ -1910,7 +1795,7 @@ namespace AppsInToss.Editor
             }
 
             var (args, label, cleanFirst) = PnpmInstallStages[stageIndex];
-            if (cleanFirst) CleanNodeModules(buildProjectPath);
+            if (cleanFirst) Package.NodeModulesValidator.CleanNodeModules(buildProjectPath);
 
             Debug.Log($"[AIT] pnpm {label} 실행 중...");
 

--- a/Editor/Package.meta
+++ b/Editor/Package.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f33405774e540e4bdfac66d671e5dff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/NodeModulesValidator.cs
+++ b/Editor/Package/NodeModulesValidator.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// 빌드 프로젝트의 node_modules 디렉토리 무결성 검증 및 정리.
+    /// pnpm이 설치한 web-framework 버전이 package.json 선언 버전과 일치하는지 확인한다.
+    /// </summary>
+    internal static class NodeModulesValidator
+    {
+        /// <summary>
+        /// node_modules 무결성 검증.
+        /// package.json의 @apps-in-toss/web-framework 버전과 node_modules 내 설치 버전이 일치하는지 확인한다.
+        /// pnpm의 node_modules/.pnpm/@apps-in-toss+web-framework@{version} 디렉토리 존재 여부로 판단.
+        /// </summary>
+        /// <param name="buildProjectPath">빌드 프로젝트 경로</param>
+        /// <returns>true: 무결성 확인됨 또는 node_modules 없음, false: 버전 불일치로 정리 필요</returns>
+        internal static bool ValidateIntegrity(string buildProjectPath)
+        {
+            string nodeModulesPath = Path.Combine(buildProjectPath, "node_modules");
+            if (!Directory.Exists(nodeModulesPath))
+            {
+                return true;
+            }
+
+            string packageJsonPath = Path.Combine(buildProjectPath, "package.json");
+            if (!File.Exists(packageJsonPath))
+            {
+                return true;
+            }
+
+            try
+            {
+                string packageJsonContent = File.ReadAllText(packageJsonPath);
+                var packageJson = MiniJson.Deserialize(packageJsonContent) as Dictionary<string, object>;
+                if (packageJson == null) return true;
+
+                var dependencies = packageJson.ContainsKey("dependencies")
+                    ? packageJson["dependencies"] as Dictionary<string, object>
+                    : null;
+                if (dependencies == null) return true;
+
+                if (!dependencies.ContainsKey("@apps-in-toss/web-framework")) return true;
+
+                string expectedVersion = dependencies["@apps-in-toss/web-framework"] as string;
+                if (string.IsNullOrEmpty(expectedVersion)) return true;
+
+                expectedVersion = expectedVersion.TrimStart('^', '~');
+
+                string pnpmDir = Path.Combine(nodeModulesPath, ".pnpm");
+                if (!Directory.Exists(pnpmDir))
+                {
+                    Debug.Log("[AIT] node_modules/.pnpm 디렉토리가 없습니다. node_modules를 정리합니다.");
+                    return false;
+                }
+
+                string expectedDirPrefix = $"@apps-in-toss+web-framework@{expectedVersion}";
+                string[] matchingDirs = Directory.GetDirectories(pnpmDir, $"{expectedDirPrefix}*");
+
+                if (matchingDirs.Length > 0)
+                {
+                    Debug.Log($"[AIT] ✓ node_modules 무결성 확인: web-framework@{expectedVersion}");
+                    return true;
+                }
+
+                string[] installedDirs = Directory.GetDirectories(pnpmDir, "@apps-in-toss+web-framework@*");
+                if (installedDirs.Length > 0)
+                {
+                    string installedDirName = Path.GetFileName(installedDirs[0]);
+                    Debug.Log($"[AIT] web-framework 버전 불일치 감지!");
+                    Debug.Log($"[AIT]   기대 버전: {expectedVersion}");
+                    Debug.Log($"[AIT]   설치된 버전: {installedDirName}");
+                    Debug.Log($"[AIT]   node_modules를 정리하고 재설치합니다.");
+                }
+                else
+                {
+                    Debug.Log($"[AIT] web-framework가 node_modules에 없습니다. node_modules를 정리합니다.");
+                }
+
+                return false;
+            }
+            catch (Exception e)
+            {
+                Debug.Log($"[AIT] node_modules 무결성 검증 중 오류 (무시됨): {e}");
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// node_modules 및 레거시 .npm-cache 디렉토리를 삭제한다.
+        /// </summary>
+        internal static void CleanNodeModules(string buildProjectPath)
+        {
+            string nodeModulesPath = Path.Combine(buildProjectPath, "node_modules");
+            string npmCachePath = Path.Combine(buildProjectPath, ".npm-cache");
+
+            if (Directory.Exists(nodeModulesPath))
+            {
+                Debug.Log("[AIT] node_modules 삭제 중...");
+                if (AITFileUtils.DeleteDirectory(nodeModulesPath))
+                {
+                    Debug.Log("[AIT] ✓ node_modules 삭제 완료");
+                }
+            }
+
+            if (Directory.Exists(npmCachePath))
+            {
+                Debug.Log("[AIT] 레거시 .npm-cache 삭제 중...");
+                if (AITFileUtils.DeleteDirectory(npmCachePath))
+                {
+                    Debug.Log("[AIT] ✓ 레거시 .npm-cache 삭제 완료");
+                }
+            }
+        }
+    }
+}

--- a/Editor/Package/NodeModulesValidator.cs
+++ b/Editor/Package/NodeModulesValidator.cs
@@ -8,6 +8,8 @@ namespace AppsInToss.Editor.Package
     /// <summary>
     /// 빌드 프로젝트의 node_modules 디렉토리 무결성 검증 및 정리.
     /// pnpm이 설치한 web-framework 버전이 package.json 선언 버전과 일치하는지 확인한다.
+    /// 검증은 best-effort: 판별이 불가능한 모든 케이스(파일 없음, 파싱 실패, 예외 등)는
+    /// true를 반환해 불필요한 재설치를 피한다. false는 "정리가 확실히 필요하다"고 판단될 때만 반환된다.
     /// </summary>
     internal static class NodeModulesValidator
     {

--- a/Editor/Package/NodeModulesValidator.cs.meta
+++ b/Editor/Package/NodeModulesValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19070c57225042288133cf0c79665e45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec8c90c5a96b466cbe1876eace9df106
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/NodeModulesValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/NodeModulesValidatorTests.cs
@@ -5,7 +5,6 @@
 
 using System.IO;
 using NUnit.Framework;
-using AppsInToss.Editor.Package;
 
 namespace AppsInToss.Editor.Package.Tests
 {
@@ -84,6 +83,55 @@ namespace AppsInToss.Editor.Package.Tests
             File.WriteAllText(Path.Combine(_tempDir, "package.json"),
                 "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"^2.4.7\"}}");
             Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_StripsTildePrefix_WhenComparingVersions()
+        {
+            string pnpmDir = Path.Combine(_tempDir, "node_modules", ".pnpm");
+            Directory.CreateDirectory(pnpmDir);
+            Directory.CreateDirectory(Path.Combine(pnpmDir, "@apps-in-toss+web-framework@2.4.7"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"~2.4.7\"}}");
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsTrue_WhenPackageJsonIsMalformed()
+        {
+            // MiniJson이 파싱 실패 시 null 반환 → 검증 불가이므로 true (기존 동작 유지)
+            Directory.CreateDirectory(Path.Combine(_tempDir, "node_modules"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"), "{ this is not json ");
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsTrue_WhenDependenciesKeyMissing()
+        {
+            Directory.CreateDirectory(Path.Combine(_tempDir, "node_modules"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"), "{\"name\":\"x\"}");
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsTrue_WhenVersionStringEmpty()
+        {
+            Directory.CreateDirectory(Path.Combine(_tempDir, "node_modules"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"\"}}");
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsFalse_WhenPnpmDirHasOtherPackagesOnly()
+        {
+            // .pnpm이 존재하지만 web-framework는 없음 → 정리 필요
+            string pnpmDir = Path.Combine(_tempDir, "node_modules", ".pnpm");
+            Directory.CreateDirectory(pnpmDir);
+            Directory.CreateDirectory(Path.Combine(pnpmDir, "some-other-pkg@1.0.0"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"2.4.7\"}}");
+            Assert.IsFalse(NodeModulesValidator.ValidateIntegrity(_tempDir));
         }
 
         [Test]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/NodeModulesValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/NodeModulesValidatorTests.cs
@@ -1,0 +1,121 @@
+// -----------------------------------------------------------------------
+// NodeModulesValidatorTests.cs - NodeModulesValidator 단위 테스트
+// Level 0: 임시 디렉토리 fixture로 검증 로직만 확인 (pnpm 실행 없음)
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+using AppsInToss.Editor.Package;
+
+namespace AppsInToss.Editor.Package.Tests
+{
+    [TestFixture]
+    public class NodeModulesValidatorTests
+    {
+        private string _tempDir;
+
+        [SetUp]
+        public void CreateTempDir()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "ait-nm-tests-" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TearDown]
+        public void CleanupTempDir()
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsTrue_WhenNodeModulesMissing()
+        {
+            // node_modules가 없으면 install로 새로 생성될 것이므로 검증 불필요 → true
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsTrue_WhenPackageJsonMissing()
+        {
+            Directory.CreateDirectory(Path.Combine(_tempDir, "node_modules"));
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsTrue_WhenWebFrameworkNotInDependencies()
+        {
+            Directory.CreateDirectory(Path.Combine(_tempDir, "node_modules"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"other-pkg\":\"1.0.0\"}}");
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsFalse_WhenPnpmDirMissing()
+        {
+            // node_modules는 있는데 .pnpm 디렉토리가 없으면 오염된 상태
+            Directory.CreateDirectory(Path.Combine(_tempDir, "node_modules"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"2.4.7\"}}");
+            Assert.IsFalse(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsTrue_WhenVersionMatches()
+        {
+            string pnpmDir = Path.Combine(_tempDir, "node_modules", ".pnpm");
+            Directory.CreateDirectory(pnpmDir);
+            Directory.CreateDirectory(Path.Combine(pnpmDir, "@apps-in-toss+web-framework@2.4.7"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"2.4.7\"}}");
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_StripsCaretPrefix_WhenComparingVersions()
+        {
+            // package.json에 "^2.4.7"로 적혀 있어도 설치 디렉토리가 2.4.7이면 matching
+            string pnpmDir = Path.Combine(_tempDir, "node_modules", ".pnpm");
+            Directory.CreateDirectory(pnpmDir);
+            Directory.CreateDirectory(Path.Combine(pnpmDir, "@apps-in-toss+web-framework@2.4.7"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"^2.4.7\"}}");
+            Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void ValidateIntegrity_ReturnsFalse_WhenVersionMismatch()
+        {
+            string pnpmDir = Path.Combine(_tempDir, "node_modules", ".pnpm");
+            Directory.CreateDirectory(pnpmDir);
+            Directory.CreateDirectory(Path.Combine(pnpmDir, "@apps-in-toss+web-framework@2.4.6"));
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"2.4.7\"}}");
+            Assert.IsFalse(NodeModulesValidator.ValidateIntegrity(_tempDir));
+        }
+
+        [Test]
+        public void CleanNodeModules_RemovesNodeModulesAndLegacyCache()
+        {
+            string nodeModules = Path.Combine(_tempDir, "node_modules");
+            string legacyCache = Path.Combine(_tempDir, ".npm-cache");
+            Directory.CreateDirectory(nodeModules);
+            Directory.CreateDirectory(legacyCache);
+            File.WriteAllText(Path.Combine(nodeModules, "dummy.txt"), "x");
+
+            NodeModulesValidator.CleanNodeModules(_tempDir);
+
+            Assert.IsFalse(Directory.Exists(nodeModules), "node_modules가 삭제되어야 함");
+            Assert.IsFalse(Directory.Exists(legacyCache), ".npm-cache가 삭제되어야 함");
+        }
+
+        [Test]
+        public void CleanNodeModules_DoesNotThrow_WhenDirectoriesMissing()
+        {
+            Assert.DoesNotThrow(() => NodeModulesValidator.CleanNodeModules(_tempDir));
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/NodeModulesValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/NodeModulesValidatorTests.cs
@@ -99,7 +99,7 @@ namespace AppsInToss.Editor.Package.Tests
         [Test]
         public void ValidateIntegrity_ReturnsTrue_WhenPackageJsonIsMalformed()
         {
-            // MiniJson이 파싱 실패 시 null 반환 → 검증 불가이므로 true (기존 동작 유지)
+            // 파싱 실패/부분 파싱/예외 어느 경로든 best-effort 계약에 따라 true를 반환해야 한다.
             Directory.CreateDirectory(Path.Combine(_tempDir, "node_modules"));
             File.WriteAllText(Path.Combine(_tempDir, "package.json"), "{ this is not json ");
             Assert.IsTrue(NodeModulesValidator.ValidateIntegrity(_tempDir));

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/NodeModulesValidatorTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/NodeModulesValidatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c93588ea71ef481f977f26db2e35a2fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경
AITPackageBuilder.cs 분할 라운드 1. node_modules 무결성 검증 및 정리 로직을 `Editor/Package/NodeModulesValidator.cs`로 추출.

## 변경
- 신규 `NodeModulesValidator` 서비스 (`ValidateIntegrity`, `CleanNodeModules`)
- `ValidateNodeModulesIntegrity` → `ValidateIntegrity` 이름 단축 (서비스 내부 맥락상 Node 접두사 중복)
- facade 내 모든 호출부를 서비스 호출로 치환
- EditMode 테스트 9건 추가 (node_modules 없음/오염/버전 match·mismatch/caret stripping)

## 검증
- `./run-local-tests.sh --validate` 통과
- 외부 파일 수정 없음 (두 메서드는 private이었으므로 외부 참조 없음)