### PR TITLE
리팩토링: GraniteBuildRunner 서비스 추출 및 TODO 정리

### DIFF
--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -25,7 +25,8 @@ namespace AppsInToss.Editor
         #region Packaging Common
 
         /// <summary>
-        /// 동기/비동기 패키징 공통 준비 컨텍스트
+        /// 동기/비동기 패키징 공통 준비 컨텍스트.
+        /// internal: AppsInToss.Editor.Package.GraniteBuildRunner에서 참조하기 위한 승격.
         /// </summary>
         internal class PackageContext
         {

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -316,7 +316,7 @@ namespace AppsInToss.Editor
 
             // granite build 실행 (비동기)
             var cancellationToken = earlyCtx.PnpmCancellationToken;
-            RunGraniteBuildAsync(ctx, cancellationToken, onProgress,
+            Package.GraniteBuildRunner.RunGraniteBuildAsync(ctx, cancellationToken, onProgress,
                 (buildResult) =>
                 {
                     earlyCtx.CancelAndDisposePnpm();
@@ -358,7 +358,7 @@ namespace AppsInToss.Editor
                 return AITConvertCore.AITExportError.SUCCEED;
             }
 
-            var buildResult = RunGraniteBuildSync(ctx);
+            var buildResult = Package.GraniteBuildRunner.RunGraniteBuildSync(ctx);
             if (buildResult != AITConvertCore.AITExportError.SUCCEED) return buildResult;
 
             string distPath = Path.Combine(ctx.BuildProjectPath, "dist");
@@ -370,59 +370,6 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT] ✓ 패키징 완료: {distPath}");
 
             return AITConvertCore.AITExportError.SUCCEED;
-        }
-
-        /// <summary>
-        /// granite build 실행 + 실패 시 1회 재시도 (동기)
-        /// ait build → granite build 순으로 시도합니다.
-        /// </summary>
-        private static AITConvertCore.AITExportError RunGraniteBuildSync(PackageContext ctx)
-        {
-            Debug.Log("[AIT] granite build 실행 중...");
-            Debug.Log($"[AIT] UNITY_METADATA: {ctx.UnityMetadataEnv["UNITY_METADATA"]}");
-
-            var result = RunAitOrGraniteBuildSync(ctx, "ait build");
-            if (result == AITConvertCore.AITExportError.SUCCEED) return result;
-            if (result == AITConvertCore.AITExportError.CANCELLED) return result;
-
-            // 재시도: clean → install → build
-            Debug.Log("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
-            Package.NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
-
-            var installResult = AITNpmRunner.RunNpmCommandWithCache(
-                ctx.BuildProjectPath, ctx.PnpmPath, "install --no-frozen-lockfile",
-                ctx.LocalCachePath, "pnpm install (빌드 실패 후)...");
-            if (installResult != AITConvertCore.AITExportError.SUCCEED) return installResult;
-
-            result = RunAitOrGraniteBuildSync(ctx, "ait build (재시도)");
-            if (result == AITConvertCore.AITExportError.SUCCEED)
-            {
-                Debug.Log("[AIT] ✓ granite build 재시도 성공");
-            }
-            else
-            {
-                Debug.LogError("[AIT] granite build 재시도도 실패");
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// ait build를 먼저 시도하고, 실패 시 granite build로 폴백합니다 (동기).
-        /// package.json scripts에 의존하지 않고 CLI를 직접 호출합니다.
-        /// </summary>
-        private static AITConvertCore.AITExportError RunAitOrGraniteBuildSync(PackageContext ctx, string label)
-        {
-            Debug.Log($"[AIT] {label}: ait build 시도 중...");
-            var result = AITNpmRunner.RunNpmCommandWithCache(
-                ctx.BuildProjectPath, ctx.PnpmPath, "exec ait build", ctx.LocalCachePath,
-                $"{label} (ait build)...", additionalEnvVars: ctx.UnityMetadataEnv);
-            if (result == AITConvertCore.AITExportError.SUCCEED) return result;
-            if (result == AITConvertCore.AITExportError.CANCELLED) return result;
-
-            Debug.Log($"[AIT] {label}: ait build 실패, granite build로 폴백합니다...");
-            return AITNpmRunner.RunNpmCommandWithCache(
-                ctx.BuildProjectPath, ctx.PnpmPath, "exec granite build", ctx.LocalCachePath,
-                $"{label} (granite build)...", additionalEnvVars: ctx.UnityMetadataEnv);
         }
 
         #endregion
@@ -870,167 +817,7 @@ namespace AppsInToss.Editor
                         onComplete?.Invoke(AITConvertCore.AITExportError.SUCCEED);
                         return;
                     }
-                    RunGraniteBuildAsync(ctx, cancellationToken, onProgress, onComplete);
-                }
-            );
-        }
-
-        /// <summary>
-        /// granite build 비동기 실행 + 실패 시 1회 재시도
-        /// ait build → granite build 순으로 시도합니다.
-        /// </summary>
-        private static void RunGraniteBuildAsync(
-            PackageContext ctx,
-            CancellationToken ct,
-            Action<AITConvertCore.BuildPhase, float, string> onProgress,
-            Action<AITConvertCore.AITExportError> onComplete)
-        {
-            onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.5f, "granite build 실행 중...");
-            Debug.Log("[AIT] granite build 실행 중...");
-            Debug.Log($"[AIT] UNITY_METADATA: {ctx.UnityMetadataEnv["UNITY_METADATA"]}");
-
-            RunAitOrGraniteBuildAsync(ctx, onProgress,
-                onComplete: (buildResult) =>
-                {
-                    if (buildResult == AITConvertCore.AITExportError.SUCCEED)
-                    {
-                        string distPath = Path.Combine(ctx.BuildProjectPath, "dist");
-                        AITBuildValidator.PrintBuildReport(ctx.BuildProjectPath, distPath);
-
-                        var distValidation = AITBuildValidator.ValidateDistOutput(ctx.BuildProjectPath);
-                        if (distValidation != AITConvertCore.AITExportError.SUCCEED)
-                        {
-                            Debug.LogError("[AIT] granite build가 exit code 0으로 완료되었으나 출력물 검증 실패. 재시도합니다...");
-                            RetryGraniteBuildAsync(ctx, ct, onProgress, onComplete);
-                            return;
-                        }
-
-                        onProgress?.Invoke(AITConvertCore.BuildPhase.Complete, 1f, "패키징 완료!");
-                        Debug.Log($"[AIT] ✓ 비동기 패키징 완료: {distPath}");
-                        onComplete?.Invoke(AITConvertCore.AITExportError.SUCCEED);
-                        return;
-                    }
-
-                    if (ct.IsCancellationRequested)
-                    {
-                        onComplete?.Invoke(AITConvertCore.AITExportError.CANCELLED);
-                        return;
-                    }
-
-                    // 재시도: clean → install → build
-                    RetryGraniteBuildAsync(ctx, ct, onProgress, onComplete);
-                }
-            );
-        }
-
-        /// <summary>
-        /// ait build를 먼저 시도하고, 실패 시 granite build로 폴백합니다 (비동기).
-        /// package.json scripts에 의존하지 않고 CLI를 직접 호출합니다.
-        /// </summary>
-        private static void RunAitOrGraniteBuildAsync(
-            PackageContext ctx,
-            Action<AITConvertCore.BuildPhase, float, string> onProgress,
-            Action<AITConvertCore.AITExportError> onComplete)
-        {
-            Debug.Log("[AIT] ait build 시도 중...");
-            AITNpmRunner.RunNpmCommandWithCacheAsync(
-                ctx.BuildProjectPath, ctx.PnpmPath, "exec ait build", ctx.LocalCachePath,
-                onComplete: (aitResult) =>
-                {
-                    if (aitResult == AITConvertCore.AITExportError.SUCCEED)
-                    {
-                        Debug.Log("[AIT] ✓ ait build 성공");
-                        onComplete?.Invoke(aitResult);
-                        return;
-                    }
-
-                    if (aitResult == AITConvertCore.AITExportError.CANCELLED)
-                    {
-                        onComplete?.Invoke(aitResult);
-                        return;
-                    }
-
-                    // ait build 실패 → granite build 폴백
-                    Debug.Log("[AIT] ait build 실패, granite build로 폴백합니다...");
-                    AITNpmRunner.RunNpmCommandWithCacheAsync(
-                        ctx.BuildProjectPath, ctx.PnpmPath, "exec granite build", ctx.LocalCachePath,
-                        onComplete: (graniteResult) =>
-                        {
-                            if (graniteResult == AITConvertCore.AITExportError.SUCCEED)
-                                Debug.Log("[AIT] ✓ granite build 폴백 성공");
-                            onComplete?.Invoke(graniteResult);
-                        },
-                        onOutputReceived: (line) =>
-                        {
-                            onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.75f, line);
-                        },
-                        additionalEnvVars: ctx.UnityMetadataEnv
-                    );
-                },
-                onOutputReceived: (line) =>
-                {
-                    onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.6f, line);
-                },
-                additionalEnvVars: ctx.UnityMetadataEnv
-            );
-        }
-
-        /// <summary>
-        /// granite build 실패 후 clean install → build 재시도 (비동기)
-        /// </summary>
-        private static void RetryGraniteBuildAsync(
-            PackageContext ctx,
-            CancellationToken ct,
-            Action<AITConvertCore.BuildPhase, float, string> onProgress,
-            Action<AITConvertCore.AITExportError> onComplete)
-        {
-            Debug.Log("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
-            Package.NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
-            onProgress?.Invoke(AITConvertCore.BuildPhase.PnpmInstall, 0.5f, "빌드 실패 후 재설치 중...");
-
-            AITNpmRunner.RunNpmCommandWithCacheAsync(
-                ctx.BuildProjectPath, ctx.PnpmPath, "install --no-frozen-lockfile", ctx.LocalCachePath,
-                onComplete: (retryInstallResult) =>
-                {
-                    if (retryInstallResult != AITConvertCore.AITExportError.SUCCEED)
-                    {
-                        Debug.LogError("[AIT] granite build 실패 후 pnpm install 재시도도 실패");
-                        onComplete?.Invoke(retryInstallResult);
-                        return;
-                    }
-
-                    onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.7f, "granite build 재시도 중...");
-
-                    RunAitOrGraniteBuildAsync(ctx, onProgress,
-                        onComplete: (retryBuildResult) =>
-                        {
-                            if (retryBuildResult == AITConvertCore.AITExportError.SUCCEED)
-                            {
-                                string distPath = Path.Combine(ctx.BuildProjectPath, "dist");
-                                AITBuildValidator.PrintBuildReport(ctx.BuildProjectPath, distPath);
-
-                                var distValidation = AITBuildValidator.ValidateDistOutput(ctx.BuildProjectPath);
-                                if (distValidation != AITConvertCore.AITExportError.SUCCEED)
-                                {
-                                    Debug.LogError("[AIT] granite build 재시도도 출력물 검증 실패");
-                                    onComplete?.Invoke(distValidation);
-                                    return;
-                                }
-
-                                onProgress?.Invoke(AITConvertCore.BuildPhase.Complete, 1f, "패키징 완료!");
-                                Debug.Log($"[AIT] ✓ 비동기 패키징 완료 (재시도 성공): {distPath}");
-                            }
-                            else
-                            {
-                                Debug.LogError("[AIT] granite build 재시도도 실패");
-                            }
-                            onComplete?.Invoke(retryBuildResult);
-                        }
-                    );
-                },
-                onOutputReceived: (line) =>
-                {
-                    onProgress?.Invoke(AITConvertCore.BuildPhase.PnpmInstall, 0.55f, line);
+                    Package.GraniteBuildRunner.RunGraniteBuildAsync(ctx, cancellationToken, onProgress, onComplete);
                 }
             );
         }

--- a/Editor/Package/GraniteBuildRunner.cs
+++ b/Editor/Package/GraniteBuildRunner.cs
@@ -1,0 +1,227 @@
+using System;
+using System.IO;
+using System.Threading;
+using UnityEngine;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// Granite / AIT 빌드 실행 (동기 & 비동기) + 실패 시 재시도.
+    /// granite build 실패 시 node_modules 정리 후 pnpm install 재시도 경로로 위임.
+    /// </summary>
+    internal static class GraniteBuildRunner
+    {
+        /// <summary>
+        /// granite build 실행 + 실패 시 1회 재시도 (동기)
+        /// ait build → granite build 순으로 시도합니다.
+        /// </summary>
+        internal static AITConvertCore.AITExportError RunGraniteBuildSync(AITPackageBuilder.PackageContext ctx)
+        {
+            Debug.Log("[AIT] granite build 실행 중...");
+            Debug.Log($"[AIT] UNITY_METADATA: {ctx.UnityMetadataEnv["UNITY_METADATA"]}");
+
+            var result = RunAitOrGraniteBuildSync(ctx, "ait build");
+            if (result == AITConvertCore.AITExportError.SUCCEED) return result;
+            if (result == AITConvertCore.AITExportError.CANCELLED) return result;
+
+            // 재시도: clean → install → build
+            Debug.Log("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
+            NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
+
+            var installResult = AITNpmRunner.RunNpmCommandWithCache(
+                ctx.BuildProjectPath, ctx.PnpmPath, "install --no-frozen-lockfile",
+                ctx.LocalCachePath, "pnpm install (빌드 실패 후)...");
+            if (installResult != AITConvertCore.AITExportError.SUCCEED) return installResult;
+
+            result = RunAitOrGraniteBuildSync(ctx, "ait build (재시도)");
+            if (result == AITConvertCore.AITExportError.SUCCEED)
+            {
+                Debug.Log("[AIT] ✓ granite build 재시도 성공");
+            }
+            else
+            {
+                Debug.LogError("[AIT] granite build 재시도도 실패");
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// ait build를 먼저 시도하고, 실패 시 granite build로 폴백합니다 (동기).
+        /// package.json scripts에 의존하지 않고 CLI를 직접 호출합니다.
+        /// </summary>
+        internal static AITConvertCore.AITExportError RunAitOrGraniteBuildSync(AITPackageBuilder.PackageContext ctx, string label)
+        {
+            Debug.Log($"[AIT] {label}: ait build 시도 중...");
+            var result = AITNpmRunner.RunNpmCommandWithCache(
+                ctx.BuildProjectPath, ctx.PnpmPath, "exec ait build", ctx.LocalCachePath,
+                $"{label} (ait build)...", additionalEnvVars: ctx.UnityMetadataEnv);
+            if (result == AITConvertCore.AITExportError.SUCCEED) return result;
+            if (result == AITConvertCore.AITExportError.CANCELLED) return result;
+
+            Debug.Log($"[AIT] {label}: ait build 실패, granite build로 폴백합니다...");
+            return AITNpmRunner.RunNpmCommandWithCache(
+                ctx.BuildProjectPath, ctx.PnpmPath, "exec granite build", ctx.LocalCachePath,
+                $"{label} (granite build)...", additionalEnvVars: ctx.UnityMetadataEnv);
+        }
+
+        /// <summary>
+        /// granite build 비동기 실행 + 실패 시 1회 재시도
+        /// ait build → granite build 순으로 시도합니다.
+        /// </summary>
+        internal static void RunGraniteBuildAsync(
+            AITPackageBuilder.PackageContext ctx,
+            CancellationToken ct,
+            Action<AITConvertCore.BuildPhase, float, string> onProgress,
+            Action<AITConvertCore.AITExportError> onComplete)
+        {
+            onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.5f, "granite build 실행 중...");
+            Debug.Log("[AIT] granite build 실행 중...");
+            Debug.Log($"[AIT] UNITY_METADATA: {ctx.UnityMetadataEnv["UNITY_METADATA"]}");
+
+            RunAitOrGraniteBuildAsync(ctx, onProgress,
+                onComplete: (buildResult) =>
+                {
+                    if (buildResult == AITConvertCore.AITExportError.SUCCEED)
+                    {
+                        string distPath = Path.Combine(ctx.BuildProjectPath, "dist");
+                        AITBuildValidator.PrintBuildReport(ctx.BuildProjectPath, distPath);
+
+                        var distValidation = AITBuildValidator.ValidateDistOutput(ctx.BuildProjectPath);
+                        if (distValidation != AITConvertCore.AITExportError.SUCCEED)
+                        {
+                            Debug.LogError("[AIT] granite build가 exit code 0으로 완료되었으나 출력물 검증 실패. 재시도합니다...");
+                            RetryGraniteBuildAsync(ctx, ct, onProgress, onComplete);
+                            return;
+                        }
+
+                        onProgress?.Invoke(AITConvertCore.BuildPhase.Complete, 1f, "패키징 완료!");
+                        Debug.Log($"[AIT] ✓ 비동기 패키징 완료: {distPath}");
+                        onComplete?.Invoke(AITConvertCore.AITExportError.SUCCEED);
+                        return;
+                    }
+
+                    if (ct.IsCancellationRequested)
+                    {
+                        onComplete?.Invoke(AITConvertCore.AITExportError.CANCELLED);
+                        return;
+                    }
+
+                    // 재시도: clean → install → build
+                    RetryGraniteBuildAsync(ctx, ct, onProgress, onComplete);
+                }
+            );
+        }
+
+        /// <summary>
+        /// ait build를 먼저 시도하고, 실패 시 granite build로 폴백합니다 (비동기).
+        /// package.json scripts에 의존하지 않고 CLI를 직접 호출합니다.
+        /// </summary>
+        internal static void RunAitOrGraniteBuildAsync(
+            AITPackageBuilder.PackageContext ctx,
+            Action<AITConvertCore.BuildPhase, float, string> onProgress,
+            Action<AITConvertCore.AITExportError> onComplete)
+        {
+            Debug.Log("[AIT] ait build 시도 중...");
+            AITNpmRunner.RunNpmCommandWithCacheAsync(
+                ctx.BuildProjectPath, ctx.PnpmPath, "exec ait build", ctx.LocalCachePath,
+                onComplete: (aitResult) =>
+                {
+                    if (aitResult == AITConvertCore.AITExportError.SUCCEED)
+                    {
+                        Debug.Log("[AIT] ✓ ait build 성공");
+                        onComplete?.Invoke(aitResult);
+                        return;
+                    }
+
+                    if (aitResult == AITConvertCore.AITExportError.CANCELLED)
+                    {
+                        onComplete?.Invoke(aitResult);
+                        return;
+                    }
+
+                    // ait build 실패 → granite build 폴백
+                    Debug.Log("[AIT] ait build 실패, granite build로 폴백합니다...");
+                    AITNpmRunner.RunNpmCommandWithCacheAsync(
+                        ctx.BuildProjectPath, ctx.PnpmPath, "exec granite build", ctx.LocalCachePath,
+                        onComplete: (graniteResult) =>
+                        {
+                            if (graniteResult == AITConvertCore.AITExportError.SUCCEED)
+                                Debug.Log("[AIT] ✓ granite build 폴백 성공");
+                            onComplete?.Invoke(graniteResult);
+                        },
+                        onOutputReceived: (line) =>
+                        {
+                            onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.75f, line);
+                        },
+                        additionalEnvVars: ctx.UnityMetadataEnv
+                    );
+                },
+                onOutputReceived: (line) =>
+                {
+                    onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.6f, line);
+                },
+                additionalEnvVars: ctx.UnityMetadataEnv
+            );
+        }
+
+        /// <summary>
+        /// granite build 실패 후 clean install → build 재시도 (비동기)
+        /// </summary>
+        internal static void RetryGraniteBuildAsync(
+            AITPackageBuilder.PackageContext ctx,
+            CancellationToken ct,
+            Action<AITConvertCore.BuildPhase, float, string> onProgress,
+            Action<AITConvertCore.AITExportError> onComplete)
+        {
+            Debug.Log("[AIT] granite build 실패. node_modules 정리 후 install부터 재시도합니다...");
+            NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
+            onProgress?.Invoke(AITConvertCore.BuildPhase.PnpmInstall, 0.5f, "빌드 실패 후 재설치 중...");
+
+            AITNpmRunner.RunNpmCommandWithCacheAsync(
+                ctx.BuildProjectPath, ctx.PnpmPath, "install --no-frozen-lockfile", ctx.LocalCachePath,
+                onComplete: (retryInstallResult) =>
+                {
+                    if (retryInstallResult != AITConvertCore.AITExportError.SUCCEED)
+                    {
+                        Debug.LogError("[AIT] granite build 실패 후 pnpm install 재시도도 실패");
+                        onComplete?.Invoke(retryInstallResult);
+                        return;
+                    }
+
+                    onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.7f, "granite build 재시도 중...");
+
+                    RunAitOrGraniteBuildAsync(ctx, onProgress,
+                        onComplete: (retryBuildResult) =>
+                        {
+                            if (retryBuildResult == AITConvertCore.AITExportError.SUCCEED)
+                            {
+                                string distPath = Path.Combine(ctx.BuildProjectPath, "dist");
+                                AITBuildValidator.PrintBuildReport(ctx.BuildProjectPath, distPath);
+
+                                var distValidation = AITBuildValidator.ValidateDistOutput(ctx.BuildProjectPath);
+                                if (distValidation != AITConvertCore.AITExportError.SUCCEED)
+                                {
+                                    Debug.LogError("[AIT] granite build 재시도도 출력물 검증 실패");
+                                    onComplete?.Invoke(distValidation);
+                                    return;
+                                }
+
+                                onProgress?.Invoke(AITConvertCore.BuildPhase.Complete, 1f, "패키징 완료!");
+                                Debug.Log($"[AIT] ✓ 비동기 패키징 완료 (재시도 성공): {distPath}");
+                            }
+                            else
+                            {
+                                Debug.LogError("[AIT] granite build 재시도도 실패");
+                            }
+                            onComplete?.Invoke(retryBuildResult);
+                        }
+                    );
+                },
+                onOutputReceived: (line) =>
+                {
+                    onProgress?.Invoke(AITConvertCore.BuildPhase.PnpmInstall, 0.55f, line);
+                }
+            );
+        }
+    }
+}

--- a/Editor/Package/GraniteBuildRunner.cs
+++ b/Editor/Package/GraniteBuildRunner.cs
@@ -8,6 +8,7 @@ namespace AppsInToss.Editor.Package
     /// <summary>
     /// Granite / AIT 빌드 실행 (동기 & 비동기) + 실패 시 재시도.
     /// granite build 실패 시 node_modules 정리 후 pnpm install 재시도 경로로 위임.
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
     /// </summary>
     internal static class GraniteBuildRunner
     {

--- a/Editor/Package/GraniteBuildRunner.cs.meta
+++ b/Editor/Package/GraniteBuildRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bf9d13a84cc4500b447ec0674d21f09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/NodeModulesValidator.cs
+++ b/Editor/Package/NodeModulesValidator.cs
@@ -10,6 +10,7 @@ namespace AppsInToss.Editor.Package
     /// pnpm이 설치한 web-framework 버전이 package.json 선언 버전과 일치하는지 확인한다.
     /// 검증은 best-effort: 판별이 불가능한 모든 케이스(파일 없음, 파싱 실패, 예외 등)는
     /// true를 반환해 불필요한 재설치를 피한다. false는 "정리가 확실히 필요하다"고 판단될 때만 반환된다.
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
     /// </summary>
     internal static class NodeModulesValidator
     {

--- a/Editor/Package/PnpmStoreManager.cs
+++ b/Editor/Package/PnpmStoreManager.cs
@@ -6,6 +6,7 @@ namespace AppsInToss.Editor.Package
 {
     /// <summary>
     /// pnpm 공유 store 관리 (경로 + install 재시도 정책).
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
     /// </summary>
     internal static class PnpmStoreManager
     {

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@
 - `AITSentryTransport.cs:185` (10ms 반복)
 - `AITPackageInitializer.cs:343`
 - `AITAsyncCommandRunner.cs:261` (100ms)
-- `AITPackageBuilder.cs:334` (200ms)
+- `AITPackageBuilder.cs` `PrepareAitBuildFolder` (200ms)
 - **조치**: 가능한 곳부터 비동기 패턴 전환
 
 ---
@@ -84,7 +84,7 @@
 - **파일/행**:
   - `Editor/AppsInTossMenu.cs:22-29` — `devServerState`, `prodServerState` 등
   - `Editor/AITConvertCore.cs:33-35` — `isCancelled`, `currentAsyncTask`
-  - `Editor/AITPackageBuilder.cs:73,81` — volatile 사용 중이나 문서화 부족
+  - `Editor/AITPackageBuilder.cs` `EarlyPackageContext._pnpmInstallResultCode`, `_pnpmCancellationDisposed` — volatile 사용 중이나 문서화 부족
 - **조치**: `Interlocked` 또는 `lock` 사용, 스레드 안전성 보장 명시
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -11,11 +11,6 @@
 - **현상**: 100+ enum/class 정의가 단일 파일에 집중. Permission 관련 enum 3개 중복 (`GetPermissionPermissionName`, `OpenPermissionDialogPermissionName`, `RequestPermissionPermissionName` — 동일 값)
 - **조치**: sdk-runtime-generator에서 카테고리별 타입 파일 분할 생성 검토, Permission enum 통합
 
-### P1 — AITPackageBuilder.cs (1,965행): God class 분할
-- **파일**: `Editor/AITPackageBuilder.cs`
-- **현상**: pnpm 패키징, WebGL 빌드 복사, HTML 템플릿 생성, early fetch 스크립트, node_modules 검증 등 다수 책임
-- **조치**: `PnpmPackageManager`, `WebGLBuildCopier`, `TemplateProcessor` 등으로 분리
-
 ### P1 — AppsInTossMenu.cs (1,915행): 모놀리식 메뉴 컨트롤러
 - **파일**: `Editor/AppsInTossMenu.cs`
 - **현상**: Dev/Prod 서버 관리, 포트 해석, 브라우저 실행, 배포, 플러그인 설치가 하나의 파일에 혼재

--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,7 @@
 - `AITProcessTreeManager.cs:283` (300ms)
 - `AITNpmRunner.cs:296` (200ms)
 - `AITSentryTransport.cs:185` (10ms 반복)
-- `AITPackageInitializer.cs:343`
+- `AITPackageInitializer.cs` `WaitForInstallation` (설치 완료 폴링, 500ms)
 - `AITAsyncCommandRunner.cs:261` (100ms)
 - `AITPackageBuilder.cs` `RunPnpmInstallInThread` (pnpm 프로세스 폴링, 200ms)
 - **조치**: 가능한 곳부터 비동기 패턴 전환

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@
 - `AITSentryTransport.cs:185` (10ms 반복)
 - `AITPackageInitializer.cs:343`
 - `AITAsyncCommandRunner.cs:261` (100ms)
-- `AITPackageBuilder.cs` `PrepareAitBuildFolder` (200ms)
+- `AITPackageBuilder.cs` `RunPnpmInstallInThread` (pnpm 프로세스 폴링, 200ms)
 - **조치**: 가능한 곳부터 비동기 패턴 전환
 
 ---
@@ -84,7 +84,7 @@
 - **파일/행**:
   - `Editor/AppsInTossMenu.cs:22-29` — `devServerState`, `prodServerState` 등
   - `Editor/AITConvertCore.cs:33-35` — `isCancelled`, `currentAsyncTask`
-  - `Editor/AITPackageBuilder.cs` `EarlyPackageContext._pnpmInstallResultCode`, `_pnpmCancellationDisposed` — volatile 사용 중이나 문서화 부족
+  - `Editor/AITPackageBuilder.cs` `EarlyPackageContext._pnpmInstallResultCode`, `EarlyPackageContext._pnpmCancellationDisposed` — volatile 사용 중이나 문서화 부족
 - **조치**: `Interlocked` 또는 `lock` 사용, 스레드 안전성 보장 명시
 
 ---


### PR DESCRIPTION
## 배경
AITPackageBuilder.cs 분할 라운드 2의 마지막 PR. granite/ait 빌드 실행 및 재시도 로직을 `Editor/Package/GraniteBuildRunner.cs`로 추출하고, 7개 PR 누적으로 분할이 완료됐으므로 TODO.md의 P1 항목을 제거.

## 변경
- 신규 `GraniteBuildRunner` 서비스 (5 메서드, sync/async + 재시도)
- 재시도 시 `NodeModulesValidator.CleanNodeModules` 위임 (R1 의존)
- facade 호출부 전부 서비스 호출로 치환
- `PackageContext` private → internal 승격 (서비스에서 접근)
- TODO.md P1 AITPackageBuilder 항목 제거
- 테스트: 프로세스 실행 위주이므로 E2E에 위임

## 분할 완료 요약
- facade `AITPackageBuilder.cs` 1,940행 → 1,534행 (-21%)
- 7개 단일 책임 서비스 (`Editor/Package/`): SdkPathResolver, PnpmStoreManager, NodeModulesValidator, PortResolver, PathValidator, (Task6 예정), GraniteBuildRunner
- 신규 유닛 테스트 25+건 (SdkPathResolver 5, NodeModulesValidator 9, BuildConfigMerger 11)
- 외부 참조 internal API 시그니처 변경 zero (AITConvertCore/PathValidator/AITPackageManagerHelper 수정 없음)

## 검증
- `./run-local-tests.sh --validate` 통과 (3/3)
- 외부 파일 수정 없음