### PR TITLE
정책: SDK 최소 지원 버전을 v2.4.0으로 내림

### DIFF
--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -57,7 +57,7 @@ jobs:
           POLICY_MIN_VERSION=$(jq -r '.minVersion // empty' sdk-policy.json 2>/dev/null || echo "")
           if [ -z "$POLICY_MIN_VERSION" ]; then
             # 이 값은 AITDeprecationChecker.cs의 FallbackDeprecationThreshold와 일치해야 합니다.
-            POLICY_MIN_VERSION="2.4.1"
+            POLICY_MIN_VERSION="2.4.0"
             echo "sdk-policy.json에서 minVersion을 읽지 못해 폴백 사용: ${POLICY_MIN_VERSION}"
           fi
 

--- a/Editor/AITDeprecationChecker.cs
+++ b/Editor/AITDeprecationChecker.cs
@@ -15,7 +15,7 @@ namespace AppsInToss.Editor
     [InitializeOnLoad]
     public static class AITDeprecationChecker
     {
-        private static readonly Version FallbackDeprecationThreshold = new Version(2, 4, 1);
+        private static readonly Version FallbackDeprecationThreshold = new Version(2, 4, 0);
         private const string GIT_REPO_URL = "https://github.com/toss/apps-in-toss-unity-sdk.git";
         // SDK는 main 브랜치의 sdk-policy.json을 런타임에 fetch합니다.
         // 로컬 패키지에도 같은 파일이 포함되어 있으나, 정책의 정본(source of truth)은 main 브랜치입니다.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeprecationCheckerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeprecationCheckerTests.cs
@@ -315,15 +315,15 @@ public class DeprecationCheckerTests
     // =====================================================
 
     [Test]
-    public void FallbackDeprecationThreshold_Is_v2_4_1()
+    public void FallbackDeprecationThreshold_Is_v2_4_0()
     {
         var field = checkerType.GetField("FallbackDeprecationThreshold",
             BindingFlags.NonPublic | BindingFlags.Static);
         Assert.IsNotNull(field, "FallbackDeprecationThreshold field should exist");
 
         var threshold = (Version)field.GetValue(null);
-        Assert.AreEqual(new Version(2, 4, 1), threshold,
-            "Fallback deprecation threshold should be 2.4.1");
+        Assert.AreEqual(new Version(2, 4, 0), threshold,
+            "Fallback deprecation threshold should be 2.4.0");
     }
 
     [Test]

--- a/sdk-policy.json
+++ b/sdk-policy.json
@@ -1,4 +1,4 @@
 {
   "schemaVersion": 1,
-  "minVersion": "2.4.1"
+  "minVersion": "2.4.0"
 }


### PR DESCRIPTION
## 변경 사항

- `sdk-policy.json` minVersion: `2.4.1` → `2.4.0`
- `AITDeprecationChecker.FallbackDeprecationThreshold`: `2.4.1` → `2.4.0`
- `.github/workflows/bulk-release.yml` 폴백: `2.4.1` → `2.4.0` (불변 조건 유지)
- `DeprecationCheckerTests` 테스트 업데이트

## 배경

v2.4.0 번들을 재배포할 필요가 생겨 최소 지원 버전을 한 단계 낮춤.

## 효과

- **Bulk Release**: 이후 실행부터 v2.4.0도 재배포 대상에 포함됨
- **기존 v2.4.0 미만 사용자**: `AITDeprecationChecker`가 `raw.githubusercontent.com`의 `sdk-policy.json`을 런타임 fetch하여 deprecation 다이얼로그 + 빌드 차단이 자동으로 작동 (이미 구현된 동적 로딩 활용)
- `FALLBACK_UPGRADE_TAG`는 `release/v2.4.1`을 유지 (불변 조건 `tag ≥ threshold` 충족)

## 검증 계획

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI Validate 통과 확인
- [ ] 머지 후 Bulk Release 재트리거하여 v2.4.0 포함 확인