### PR TITLE
수정: Windows Unity 빌드 스텝의 shell:bash 경로 깨짐 해결

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -103,7 +103,7 @@ jobs:
 
     outputs:
       artifact-name: ${{ steps.artifact.outputs.name }}
-      unity-version-full: ${{ steps.unity.outputs.UNITY_VERSION }}
+      unity-version-full: ${{ inputs.os == 'macos' && steps.unity-macos.outputs.UNITY_VERSION || steps.unity-windows.outputs.UNITY_VERSION }}
 
     steps:
       # =====================================================
@@ -504,18 +504,6 @@ jobs:
           echo UNITY_PATH=%UNITY_PATH%>> %GITHUB_OUTPUT%
           echo UNITY_VERSION=%DETECTED_VERSION%>> %GITHUB_OUTPUT%
 
-      - name: Set Unity Outputs
-        id: unity
-        shell: bash
-        run: |
-          if [ "${{ inputs.os }}" = "macos" ]; then
-            echo "UNITY_PATH=${{ steps.unity-macos.outputs.UNITY_PATH }}" >> $GITHUB_OUTPUT
-            echo "UNITY_VERSION=${{ steps.unity-macos.outputs.UNITY_VERSION }}" >> $GITHUB_OUTPUT
-          else
-            echo "UNITY_PATH=${{ steps.unity-windows.outputs.UNITY_PATH }}" >> $GITHUB_OUTPUT
-            echo "UNITY_VERSION=${{ steps.unity-windows.outputs.UNITY_VERSION }}" >> $GITHUB_OUTPUT
-          fi
-
       # =====================================================
       # BuildConfig 버전 업데이트 (선택적)
       # =====================================================
@@ -614,13 +602,13 @@ jobs:
       - name: Run EditMode Tests (macOS)
         if: inputs.os == 'macos' && inputs.run-e2e-test
         run: |
-          UNITY_PATH="${{ steps.unity.outputs.UNITY_PATH }}"
+          UNITY_PATH="${{ steps.unity-macos.outputs.UNITY_PATH }}"
           PROJECT_PATH="${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}"
           RESULTS_FILE="$PROJECT_PATH/editmode-results.xml"
           MAX_WAIT=600  # Unity 프로세스 최대 대기 시간 (10분)
 
           echo "Running EditMode Tests..."
-          echo "Unity Version: ${{ steps.unity.outputs.UNITY_VERSION }}"
+          echo "Unity Version: ${{ steps.unity-macos.outputs.UNITY_VERSION }}"
 
           "$UNITY_PATH" -batchmode -nographics \
             -projectPath "$PROJECT_PATH" \
@@ -673,13 +661,13 @@ jobs:
         if: inputs.os == 'windows' && inputs.run-e2e-test
         shell: powershell
         run: |
-          $unityPath = "${{ steps.unity.outputs.UNITY_PATH }}"
+          $unityPath = "${{ steps.unity-windows.outputs.UNITY_PATH }}"
           $projectPath = "${{ github.workspace }}\Tests~\E2E\SampleUnityProject-${{ inputs.unity-version }}"
           $resultsFile = "$projectPath\editmode-results.xml"
           $maxWaitSeconds = 600  # Unity 프로세스 최대 대기 시간 (10분)
 
           Write-Host "Running EditMode Tests..."
-          Write-Host "Unity Version: ${{ steps.unity.outputs.UNITY_VERSION }}"
+          Write-Host "Unity Version: ${{ steps.unity-windows.outputs.UNITY_VERSION }}"
 
           $logFile = "$env:TEMP\unity-editmode-${{ inputs.unity-version }}.log"
 
@@ -785,7 +773,7 @@ jobs:
         if: inputs.os == 'windows' && inputs.run-build && (inputs.test-level || '2') != '0'
         shell: powershell
         run: |
-          $currentVersion = "${{ steps.unity.outputs.UNITY_VERSION }}"
+          $currentVersion = "${{ steps.unity-windows.outputs.UNITY_VERSION }}"
           Write-Host "Current Unity version: $currentVersion"
           Write-Host "Checking for Licensing Client processes from other Unity versions..."
 
@@ -826,7 +814,7 @@ jobs:
         if: inputs.os == 'macos' && inputs.run-build && (inputs.test-level || '2') != '0'
         run: |
           UNITY_BASE="/Applications/Unity/Hub/Editor"
-          CURRENT_VERSION="${{ steps.unity.outputs.UNITY_VERSION }}"
+          CURRENT_VERSION="${{ steps.unity-macos.outputs.UNITY_VERSION }}"
           CURRENT_DIR="${UNITY_BASE}/${CURRENT_VERSION}"
 
           # LicensingClient.app 경로 탐색 (버전별로 위치가 다를 수 있음)
@@ -925,7 +913,7 @@ jobs:
       - name: Run Unity EditMode Tests (macOS)
         if: inputs.os == 'macos' && inputs.run-unit-test
         run: |
-          UNITY_PATH="${{ steps.unity.outputs.UNITY_PATH }}"
+          UNITY_PATH="${{ steps.unity-macos.outputs.UNITY_PATH }}"
           PROJECT_PATH="${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}"
           LOG_FILE="/tmp/unity-test-${{ inputs.unity-version }}.log"
           RESULTS_FILE="/tmp/unity-test-results-${{ inputs.unity-version }}.xml"
@@ -965,7 +953,7 @@ jobs:
         if: inputs.os == 'windows' && inputs.run-unit-test
         shell: powershell
         run: |
-          $unityPath = "${{ steps.unity.outputs.UNITY_PATH }}"
+          $unityPath = "${{ steps.unity-windows.outputs.UNITY_PATH }}"
           $projectPath = "${{ github.workspace }}\Tests~\E2E\SampleUnityProject-${{ inputs.unity-version }}"
           $logFile = "$env:TEMP\unity-test-${{ inputs.unity-version }}.log"
           $resultsFile = "$env:TEMP\unity-test-results-${{ inputs.unity-version }}.xml"
@@ -1116,7 +1104,7 @@ jobs:
             ATTEMPT_FILE="/tmp/retry-attempt-${{ inputs.unity-version }}"
             echo "0" > "$ATTEMPT_FILE"
 
-            UNITY_PATH="${{ steps.unity.outputs.UNITY_PATH }}"
+            UNITY_PATH="${{ steps.unity-macos.outputs.UNITY_PATH }}"
             PROJECT_PATH="${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}"
             LOG_FILE="/tmp/unity-build-${{ inputs.unity-version }}.log"
 
@@ -1130,7 +1118,7 @@ jobs:
             }
             trap cleanup_unity EXIT
 
-            echo "Unity Version: ${{ steps.unity.outputs.UNITY_VERSION }}"
+            echo "Unity Version: ${{ steps.unity-macos.outputs.UNITY_VERSION }}"
             echo "Unity Path: ${UNITY_PATH}"
             echo "Project Path: ${PROJECT_PATH}"
 
@@ -1259,10 +1247,10 @@ jobs:
               Set-Content -Path $attemptFile -Value "0"
             }
 
-            $unityPath = "${{ steps.unity.outputs.UNITY_PATH }}"
+            $unityPath = "${{ steps.unity-windows.outputs.UNITY_PATH }}"
             $projectPath = "${{ github.workspace }}\Tests~\E2E\SampleUnityProject-${{ inputs.unity-version }}"
 
-            Write-Host "Unity Version: ${{ steps.unity.outputs.UNITY_VERSION }}"
+            Write-Host "Unity Version: ${{ steps.unity-windows.outputs.UNITY_VERSION }}"
             Write-Host "Unity Path: $unityPath"
             Write-Host "Project Path: $projectPath"
 


### PR DESCRIPTION
## 원인

`unity-build.yml`의 **"Set Unity Outputs"** 스텝이 `shell: bash`로 동작하면서 `${{ steps.unity-windows.outputs.UNITY_PATH }}` 치환 결과인 Windows 경로(`C:\Program Files\Unity\Hub\Editor\<ver>\Editor\Unity.exe`)가 Git-bash의 임시 스크립트 파일에 그대로 삽입되는 과정에서, 백슬래시가 이스케이프 문자로 해석되어 **스크립트 파일 경로 자체가 깨지는** 문제가 발생함.

실패 로그:
```
/bin/bash: C:Usersdaveactions-runner-1_work_temp8d4fa705-....sh: No such file or directory
##[error]Process completed with exit code 1.
```

이로 인해 4/22 이후 **Release / Bulk Release 워크플로우의 Windows 빌드가 전멸**. (4/19 v2.4.7 Release는 성공, 코드 변경 없이 4/22부터 실패 시작)

## 수정

어댑터 역할만 하던 **"Set Unity Outputs"** 스텝을 제거하고, 후속 스텝들이 이미 OS별로 분리되어 있는 구조를 활용해 각자 자기 OS의 감지 스텝 id를 직접 참조하도록 변경:

- macOS 스텝(`shell: bash`) → `steps.unity-macos.outputs.*`
- Windows 스텝(`shell: powershell`) → `steps.unity-windows.outputs.*`
- job 레벨 출력 `unity-version-full` → `inputs.os` 기반 ternary 표현식으로 분기

### 효과
- **Windows 경로가 `shell: bash` 스크립트를 거치는 경로 자체가 사라짐** → 백슬래시 이스케이프 문제 원천 차단
- YAML 라인 수 감소 (25 deletions / 13 insertions)
- 불필요한 중간 스텝 제거로 워크플로우 단순화

## 변경 파일

- `.github/workflows/unity-build.yml` 단 1개

## 검증

- [x] `actionlint`: 워크플로우 구조/표현식 에러 0건 (기존 shellcheck info 경고만 존재, 이번 변경과 무관)
- [x] `./run-local-tests.sh --validate`: 3 passed, 0 failed
- [ ] Bulk Release 재트리거하여 Windows 빌드 통과 확인 (머지 후 수행)