### PR TITLE
문서: Windows Unity 경로 재발 방지 경고 주석 추가

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -432,6 +432,15 @@ jobs:
 
       # =====================================================
       # Unity 설치 감지
+      #
+      # 주의: Windows Unity 경로(C:\Program Files\...)는 반드시 shell: cmd 또는
+      # shell: powershell 스텝에서만 소비할 것. shell: bash 스텝에서 GitHub Actions
+      # 표현식으로 보간하면 Git-bash가 백슬래시를 이스케이프 문자로 해석해
+      # 임시 스크립트 파일 경로 자체가 깨지며 실패함
+      # (예: "/bin/bash: C:Users...work_temp...sh: No such file or directory").
+      # 예전 "Set Unity Outputs" 어댑터 스텝이 이 문제로 제거됨.
+      # 후속 스텝은 OS별로 steps.unity-macos의 outputs 또는
+      # steps.unity-windows의 outputs를 직접 참조할 것.
       # =====================================================
       - name: Detect Unity Installation (macOS)
         if: inputs.os == 'macos'


### PR DESCRIPTION
## 배경

#458 에서 `shell: bash` 스텝에 Windows Unity 경로(`C:\Program Files\...`)를 GitHub Actions 표현식으로 보간하면 Git-bash가 백슬래시를 이스케이프로 해석해 임시 스크립트 파일 경로 자체가 깨지는 문제를 수정했음 (예: `/bin/bash: C:Users...work_temp...sh: No such file or directory`).

당시엔 어댑터 스텝(`Set Unity Outputs`)만 제거하고 워크플로우 동작을 복구했지만, 이후에 누군가 같은 패턴을 무심코 재도입할 위험이 남아있음.

## 변경

`Unity 설치 감지` 섹션 헤더 아래에 9줄짜리 경고 주석 추가:

- Windows 경로는 `shell: cmd` 또는 `shell: powershell` 스텝에서만 소비할 것
- 실패 시 로그 예시 포함
- 후속 스텝은 `steps.unity-macos.*` / `steps.unity-windows.*` outputs를 직접 참조할 것

## 동작 변경

**없음.** 주석만 추가되는 문서성 변경.

## 검증

- 워크플로우 로직 변화 없음
- `.github/workflows/unity-build.yml` 단 1개 파일 9줄 추가