### PR TITLE
수정: Bulk Release Windows 빌드의 shell:bash temp path 깨짐 해결

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -378,7 +378,7 @@ jobs:
           }
 
           if ($successCount -eq 0) {
-            Write-Host "::warning::Windows Defender 제외 설정 실패 - 빌드 성능 저하 가능"
+            Write-Host "::warning::Failed to configure Windows Defender exclusions - build performance may degrade"
           } else {
             Write-Host "Defender exclusions configured: $successCount/$($paths.Count) paths"
           }
@@ -506,36 +506,51 @@ jobs:
 
       # =====================================================
       # BuildConfig 버전 업데이트 (선택적)
+      #
+      # 주의: shell: bash 는 Windows 러너에서 WSL bash(C:\WINDOWS\system32\bash.EXE)
+      # 또는 Git-bash 중 PATH 해석에 따라 달라짐. WSL bash 가 선택되면 Windows
+      # temp 스크립트 파일 경로가 백슬래시 이스케이프로 깨져 실패함
+      # (예: "/bin/bash: C:Users...work_temp...sh: No such file or directory").
+      # 따라서 node 로 직접 파일을 조작하여 shell 의존성을 완전히 제거한다.
+      # node 는 setup-node 없이도 self-hosted 러너에 이미 존재함.
       # =====================================================
       - name: Update BuildConfig SDK Version
         if: inputs.web-framework-version != ''
-        shell: bash
+        shell: node {0}
+        env:
+          WEB_FRAMEWORK_VERSION: ${{ inputs.web-framework-version }}
         run: |
-          VERSION="${{ inputs.web-framework-version }}"
-          BUILD_CONFIG_DIR="WebGLTemplates/AITTemplate/BuildConfig~"
-          BUILD_CONFIG="${BUILD_CONFIG_DIR}/package.json"
-          LOCK_FILE="${BUILD_CONFIG_DIR}/pnpm-lock.yaml"
+          const fs = require('fs');
+          const path = require('path');
+          const { execFileSync } = require('child_process');
 
-          echo "Updating @apps-in-toss/web-framework to ${VERSION}"
+          const version = process.env.WEB_FRAMEWORK_VERSION;
+          const buildConfigDir = 'WebGLTemplates/AITTemplate/BuildConfig~';
+          const buildConfig = path.join(buildConfigDir, 'package.json');
+          const lockFile = path.join(buildConfigDir, 'pnpm-lock.yaml');
 
-          # sed로 버전 업데이트 (macOS/Windows 호환)
-          if [ "${{ inputs.os }}" = "macos" ]; then
-            sed -i '' 's/"@apps-in-toss\/web-framework": "[^"]*"/"@apps-in-toss\/web-framework": "'"$VERSION"'"/' "$BUILD_CONFIG"
-            sed -i '' 's/"@apps-in-toss\/web-analytics": "[^"]*"/"@apps-in-toss\/web-analytics": "'"$VERSION"'"/' "$BUILD_CONFIG"
-          else
-            sed -i 's/"@apps-in-toss\/web-framework": "[^"]*"/"@apps-in-toss\/web-framework": "'"$VERSION"'"/' "$BUILD_CONFIG"
-            sed -i 's/"@apps-in-toss\/web-analytics": "[^"]*"/"@apps-in-toss\/web-analytics": "'"$VERSION"'"/' "$BUILD_CONFIG"
-          fi
+          console.log(`Updating @apps-in-toss/web-framework to ${version}`);
 
-          echo "Updated BuildConfig:"
-          cat "$BUILD_CONFIG"
+          const pkg = JSON.parse(fs.readFileSync(buildConfig, 'utf8'));
+          for (const section of ['dependencies', 'devDependencies']) {
+            if (!pkg[section]) continue;
+            for (const name of ['@apps-in-toss/web-framework', '@apps-in-toss/web-analytics']) {
+              if (pkg[section][name]) pkg[section][name] = version;
+            }
+          }
+          fs.writeFileSync(buildConfig, JSON.stringify(pkg, null, 2) + '\n');
 
-          # pnpm-lock.yaml 삭제 후 재생성 (frozen-lockfile 호환성 유지)
-          rm -f "$LOCK_FILE"
-          echo "Regenerating pnpm-lock.yaml..."
-          cd "$BUILD_CONFIG_DIR"
-          npx pnpm@10 install --lockfile-only
-          echo "pnpm-lock.yaml regenerated"
+          console.log('Updated BuildConfig:');
+          console.log(fs.readFileSync(buildConfig, 'utf8'));
+
+          if (fs.existsSync(lockFile)) fs.unlinkSync(lockFile);
+          console.log('Regenerating pnpm-lock.yaml...');
+          execFileSync('npx', ['pnpm@10', 'install', '--lockfile-only'], {
+            cwd: buildConfigDir,
+            stdio: 'inherit',
+            shell: process.platform === 'win32'
+          });
+          console.log('pnpm-lock.yaml regenerated');
 
       # =====================================================
       # 광고 ID 치환 (빌드 전)


### PR DESCRIPTION
## 현상

4/22 Bulk Release 워크플로우 (run `24789863648`) 의 Windows 2021.3 빌드 8건이 모두 동일한 에러로 실패:

```
/bin/bash: C:Usersdaveactions-runner-2_work_tempb52cf1a8-...sh: No such file or directory
##[error]Process completed with exit code 1.
```

실패 스텝: `Update BuildConfig SDK Version` (shell: bash)

## 원인

`shell: bash` 는 Windows 러너에서 PATH 해석에 따라 **WSL bash** (`C:\WINDOWS\system32\bash.EXE`) 또는 **Git-bash** (`C:\Program Files\Git\usr\bin\bash.EXE`) 중 하나를 선택함. WSL bash 가 선택되면 GitHub Actions 가 생성한 Windows 경로(`C:\Users\...\_temp\...sh`)를 그대로 전달하지만 WSL bash 는 POSIX 경로를 기대하므로 **백슬래시가 이스케이프로 해석되어 경로가 깨짐**.

4/14 성공한 Bulk Release 에서는 같은 러너에서 Git-bash 가 선택됐음. PATH 해석의 비결정성이 runner 환경 변화에 의해 노출된 케이스.

관련: #458 은 유사한 패턴의 다른 스텝(`Set Unity Outputs`) 을 제거했지만, `Update BuildConfig SDK Version` 은 여전히 `shell: bash` 로 남아있었음.

## 수정

`Update BuildConfig SDK Version` 스텝의 `shell: bash` 을 `shell: node {0}` 로 전환. node 는 setup-node 없이도 self-hosted 러너에 존재하며, temp 스크립트 파일 경로 전달에 shell 을 거치지 않으므로 OS 와 무관하게 안전함.

스크립트는 기존 `sed` 로직을 node 로 재작성:
- `package.json` 을 Node.js 로 파싱하여 `@apps-in-toss/web-framework`, `@apps-in-toss/web-analytics` 버전 치환
- `pnpm-lock.yaml` 삭제
- `npx pnpm@10 install --lockfile-only` 로 lockfile 재생성

부가: `Exclude Project from Windows Defender` 스텝의 한국어 Write-Host 리터럴이 Windows PowerShell v5 의 기본 코드페이지(CP949 등)에서 UTF-8 한글 바이트를 파싱 에러로 해석했었음. `continue-on-error: true` 덕에 치명적이지 않았으나, 로그 노이즈 제거 목적으로 영문 메시지로 교체.

## 변경 파일

- `.github/workflows/unity-build.yml` (42 추가 / 27 삭제)

## 검증

- [x] `actionlint`: 기존 shellcheck info 경고 외 신규 에러 없음
- [x] `./run-local-tests.sh --validate`: 3 passed / 0 failed
- [ ] 머지 후 Bulk Release 재트리거하여 v2.4.0~v2.4.7 Windows 빌드 성공 확인