### PR TITLE
수정: Set Artifact Name 스텝도 node shell로 전환

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1457,16 +1457,22 @@ jobs:
       # =====================================================
       # 아티팩트 업로드
       # =====================================================
+      # shell: bash 가 Windows 러너에서 WSL bash 로 해석되면 temp 스크립트 경로가
+      # 깨지므로(자세한 설명은 위 Update BuildConfig 주석 참고) node shell 사용.
       - name: Set Artifact Name
         id: artifact
-        shell: bash
+        shell: node {0}
+        env:
+          OS: ${{ inputs.os }}
+          UNITY_VERSION: ${{ inputs.unity-version }}
+          SDK_VERSION: ${{ inputs.sdk-version }}
         run: |
-          SDK_VERSION="${{ inputs.sdk-version }}"
-          if [ -n "$SDK_VERSION" ]; then
-            echo "name=ait-build-${{ inputs.os }}-${{ inputs.unity-version }}-v${SDK_VERSION}" >> $GITHUB_OUTPUT
-          else
-            echo "name=ait-build-${{ inputs.os }}-${{ inputs.unity-version }}" >> $GITHUB_OUTPUT
-          fi
+          const fs = require('fs');
+          const { OS, UNITY_VERSION, SDK_VERSION } = process.env;
+          const suffix = SDK_VERSION ? `-v${SDK_VERSION}` : '';
+          const name = `ait-build-${OS}-${UNITY_VERSION}${suffix}`;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\n`);
+          console.log(`Artifact name: ${name}`);
 
       - name: Upload AIT Build
         if: inputs.run-build && (inputs.test-level || '2') != '0'


### PR DESCRIPTION
## 현상

PR #460 머지 후 재트리거된 Bulk Release run `24791921658` 에서 v2.4.0 / v2.4.1 Windows 2021.3 잡이 동일 step `Set Artifact Name` 에서 같은 에러로 실패:

```
/bin/bash: C:Usersdaveactions-runner-2_work_temp3d23b70d-...sh: No such file or directory
##[error]Process completed with exit code 1.
```

## 원인

#460 에서 `Update BuildConfig SDK Version` 한 군데만 `shell: node {0}` 로 옮겼지만, **같은 패턴의 `shell: bash` 가 "Set Artifact Name" 스텝에도 남아 있었음**. Windows runner 에서 `shell: bash` 가 WSL bash(`C:\WINDOWS\system32\bash.EXE`) 로 해석되면 GitHub Actions 가 만든 temp 스크립트 경로(`C:\Users\...\_temp\....sh`)가 백슬래시 이스케이프로 깨져 실행 자체에 실패함.

## 수정

`Set Artifact Name` 스텝을 `shell: node {0}` 로 변환. inputs 는 env 로 전달하고 `GITHUB_OUTPUT` 에 `name=<artifact-name>` 한 줄을 append.

## 변경 파일

- `.github/workflows/unity-build.yml` 단 1개 (13 추가 / 7 삭제)

## 검증

- [x] `actionlint`: 신규 구조 에러 없음
- [x] `./run-local-tests.sh --validate`: 3 passed / 0 failed
- [ ] 머지 후 Bulk Release 재트리거하여 Windows 빌드 끝까지 통과 확인

## 후속

향후 워크플로우 작성 시 Windows runner 와 호환되어야 하는 스텝은 `shell: bash` 대신 `shell: node {0}` 또는 `shell: powershell` 을 사용할 것.