### PR TITLE
수정: EditMode 회귀 — 와일드카드 패턴이 .meta 매칭, TestCase 인자 불일치

### DIFF
--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -284,7 +284,11 @@ namespace AppsInToss.Editor
                 return "";
             }
 
-            var files = Directory.GetFiles(buildPath, pattern);
+            // *.data* 같은 와일드카드 꼬리 패턴은 *.data.meta 도 매칭하므로 .meta 는 제외해야 한다.
+            // 그렇지 않으면 LastWriteTime 정렬 결과 .meta 가 최신으로 선택되어 잘못된 파일명을 반환한다.
+            var files = Array.FindAll(
+                Directory.GetFiles(buildPath, pattern),
+                p => !p.EndsWith(".meta", StringComparison.Ordinal));
             if (files.Length > 0)
             {
                 // 중복 파일 감지 시 최신 파일만 남기고 오래된 잔여물 자동 삭제

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
@@ -48,9 +48,9 @@ public class BuildOutputValidatorTests
     // 다른 타입은 Contains 매칭이라는 비대칭성을 고정
     // =====================================================
 
-    [TestCase("build.loader.js.br", "other")]
-    [TestCase("build.loader.js.gz", "other")]
-    [TestCase("build.loader.js.unityweb", "other")]
+    [TestCase("build.loader.js.br")]
+    [TestCase("build.loader.js.gz")]
+    [TestCase("build.loader.js.unityweb")]
     public void DetectFileType_CompressedLoader_ReturnsOther(string fileName)
     {
         Assert.AreEqual("other", BuildOutputValidator.DetectFileType(fileName));


### PR DESCRIPTION
## 요약

main HEAD (e6f6a14) 에서 트리거한 E2E (run 24795388675) 의 EditMode 단계가 모든 OS×Unity 버전 (9개 잡) 에서 동일한 두 회귀로 실패해 PR/Build 흐름 전체가 막힘.

## 회귀 원인과 수정

1. `BuildFileSelectionTests.FindFileInBuild_AllProductPatterns_DuplicateCleanup` (12 case 실패)
   - `*.data*` 같은 꼬리 와일드카드가 `*.data.meta` 도 매칭
   - 테스트가 `.meta` 를 새로 만들면 LastWriteTime 이 가장 최신 → 정렬 결과 첫 위치 → 잘못된 파일명 반환
   - 출력 증거: `자동 정리: new_hash.data, old_hash.data (남김: old_hash.data.meta)` ← .meta 가 'kept' 가 됨
   - **수정**: `Editor/AITBuildValidator.cs` `FindFileInBuild` 에서 `Directory.GetFiles` 결과의 `.meta` 항목을 명시적으로 제외

2. `BuildOutputValidatorTests.DetectFileType_CompressedLoader_ReturnsOther` (3 case 실패)
   - `[TestCase("...", "other")]` 로 인자 2개 선언했는데 메소드는 `(string fileName)` 1개만 받음
   - NUnit 이 `Too many arguments provided, provide at most 1 arguments.` 로 NotRunnable 처리
   - **수정**: TestCase 두 번째 인자(`"other"`) 제거 — 메소드 본문에서 expected="other" 가 하드코딩되어 있음

## 영향 범위

- `Editor/AITBuildValidator.cs` 의 변경은 production 동작도 바로잡음. `.meta` 파일은 빌드 산출물 검색 결과에 포함되면 안 됨.
- `BuildOutputValidatorTests.cs` 는 테스트 자체 버그라 production 코드는 무영향.

## 검증 계획

- [ ] PR 머지 후 main 에서 E2E 워크플로우 재트리거
- [ ] 9개 OS×Unity 잡 EditMode 단계 통과 확인
- [ ] Playwright E2E 까지 포함한 전체 흐름 success 확인