### PR TITLE
수정: EditMode 테스트 로그의 Sentry 캡처 억제 + manifest 폴백 로그 레벨 조정

### DIFF
--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -465,8 +465,10 @@ namespace AppsInToss.Editor
                 // 이 경고를 방지할 수 있음.
                 if (!UpdateManifestAndResolve(packageName, addUrl))
                 {
-                    // manifest.json 수정 실패 시 기존 방식으로 폴백
-                    Debug.LogWarning("[AIT] manifest.json 수정에 실패하여 기존 방식으로 업데이트합니다.");
+                    // URL이 동일하거나 manifest 구조가 달라지면 정상적으로 폴백됩니다.
+                    // 실제 오류는 UpdateManifestAndResolve 내부에서 LogWarning으로 이미 기록되므로
+                    // 호출부는 정보성 로그로만 남깁니다.
+                    Debug.Log("[AIT] PackageManager.Client.Add로 업데이트합니다.");
                     UnityEditor.PackageManager.Client.Add(addUrl);
                 }
             }

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -266,6 +266,11 @@ namespace AppsInToss.Editor.ErrorTracker
             if (_suppressLogCaptureCount > 0)
                 return;
 
+            // EditMode 테스트가 SUT를 호출하며 발생시키는 의도된 LogWarning/LogError는 Sentry에서 제외
+            // (테스트는 invalid input을 일부러 주입하므로 그 로그는 프로덕션 에러가 아님)
+            if (IsInvokedFromTestRunner(stackTrace))
+                return;
+
             // Dev/Production Server 프로세스에서 리디렉션된 로그는 Sentry에서 제외
             // (granite dev의 stdout/stderr가 Debug.Log/LogError/LogWarning으로 전달된 것)
             if (IsServerRedirectedLog(message))
@@ -532,6 +537,35 @@ namespace AppsInToss.Editor.ErrorTracker
             for (int i = 0; i < AitKeywords.Length; i++)
             {
                 if (message.IndexOf(AitKeywords[i], StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+            return false;
+        }
+
+        // Unity EditMode 테스트 러너 실행을 감지하는 스택트레이스 마커.
+        // NUnit 프레임워크 호출부 또는 Unity가 주입한 TestTools/TestRunner 프레임이
+        // 스택에 포함되면 테스트 실행 컨텍스트로 간주합니다.
+        // 메시지 본문이 아닌 stackTrace 인자만 검사하여 사용자 프로젝트에 'NUnit' 문자열이
+        // 포함된 로그가 잘못 필터링되는 것을 방지합니다.
+        private static readonly string[] TestRunnerStackMarkers =
+        {
+            "NUnit.Framework.",
+            "UnityEngine.TestRunner.",
+            "UnityEditor.TestTools."
+        };
+
+        /// <summary>
+        /// 호출 스택이 Unity 테스트 러너 내부에서 비롯된 것인지 판별합니다.
+        /// true일 경우 해당 로그는 Sentry 캡처 대상에서 제외됩니다.
+        /// </summary>
+        internal static bool IsInvokedFromTestRunner(string stackTrace)
+        {
+            if (string.IsNullOrEmpty(stackTrace))
+                return false;
+
+            for (int i = 0; i < TestRunnerStackMarkers.Length; i++)
+            {
+                if (stackTrace.IndexOf(TestRunnerStackMarkers[i], StringComparison.Ordinal) >= 0)
                     return true;
             }
             return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsInvokedFromTestRunnerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsInvokedFromTestRunnerTests.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// IsInvokedFromTestRunnerTests.cs - 테스트 러너 스택 감지 단위 테스트
+// EditMode 테스트가 발생시키는 Debug.LogWarning을 Sentry에서 제외하기 위한
+// 호출 스택 기반 가드의 정상/예외 케이스를 검증.
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+[Category("Unit")]
+public class IsInvokedFromTestRunnerTests
+{
+    [Test]
+    public void NullStack_ReturnsFalse()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsInvokedFromTestRunner(null));
+    }
+
+    [Test]
+    public void EmptyStack_ReturnsFalse()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsInvokedFromTestRunner(""));
+    }
+
+    [Test]
+    public void PureSdkStack_ReturnsFalse()
+    {
+        string stack =
+            "AppsInToss.Editor.AITDeprecationChecker.ParseMinVersionFromJson (System.String json) (at Editor/AITDeprecationChecker.cs:150)\n" +
+            "AppsInToss.Editor.AITDeprecationChecker.FetchMinVersion () (at Editor/AITDeprecationChecker.cs:131)\n";
+        Assert.IsFalse(AITEditorErrorTracker.IsInvokedFromTestRunner(stack));
+    }
+
+    [Test]
+    public void NUnitFrameworkInStack_ReturnsTrue()
+    {
+        // NUnit.Framework가 호출 스택에 나타나면 테스트 실행 중으로 판단
+        string stack =
+            "AppsInToss.Editor.AITDeprecationChecker.ParseMinVersionFromJson (System.String json) (at Editor/AITDeprecationChecker.cs:150)\n" +
+            "DeprecationCheckerTests.ParseMinVersionFromJson_EmptyJson_ReturnsNull () (at Tests~/.../DeprecationCheckerTests.cs:198)\n" +
+            "NUnit.Framework.Internal.Reflect.InvokeMethod (System.Reflection.MethodInfo method, System.Object instance)\n";
+        Assert.IsTrue(AITEditorErrorTracker.IsInvokedFromTestRunner(stack));
+    }
+
+    [Test]
+    public void UnityTestRunnerInStack_ReturnsTrue()
+    {
+        // Unity의 TestRunner 내부 네임스페이스가 있으면 테스트 실행 중으로 판단
+        string stack =
+            "AppsInToss.Editor.Foo.Bar () (at Editor/Foo.cs:10)\n" +
+            "UnityEngine.TestRunner.NUnitExtensions.Runner.EnumerableTestMethodCommand+<ExecuteEnumerable>d__3.MoveNext ()\n";
+        Assert.IsTrue(AITEditorErrorTracker.IsInvokedFromTestRunner(stack));
+    }
+
+    [Test]
+    public void UnityEditorTestToolsInStack_ReturnsTrue()
+    {
+        string stack =
+            "AppsInToss.Editor.Foo.Bar () (at Editor/Foo.cs:10)\n" +
+            "UnityEditor.TestTools.TestRunner.EditModeLauncher+<DoRunSomeTests>d__4.MoveNext ()\n";
+        Assert.IsTrue(AITEditorErrorTracker.IsInvokedFromTestRunner(stack));
+    }
+
+    [Test]
+    public void MessageMentioningNunitText_ReturnsFalse()
+    {
+        // 메시지 본문에 'NUnit' 문자열이 있을 수 있으나 stackTrace 인자에 없으면 false
+        // (stackTrace 기반 판정이라는 불변 조건 확인)
+        string stack = "AppsInToss.Editor.Foo.Bar () (at Editor/Foo.cs:10)";
+        Assert.IsFalse(AITEditorErrorTracker.IsInvokedFromTestRunner(stack));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsInvokedFromTestRunnerTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsInvokedFromTestRunnerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c590a697dbd3496eadf3f5c794bebce8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- `AITEditorErrorTracker.OnLogMessageReceived`에 **스택트레이스 기반 테스트 러너 감지 가드**를 추가해 EditMode 테스트가 SUT를 invalid 입력으로 호출하며 발생시키는 정상 `Debug.LogWarning`/`LogError`가 Sentry(`editor` 환경)로 흘러들어가던 문제를 막음.
- `AITAutoUpdater`의 manifest.json 폴백 로그 레벨을 `LogWarning` → `Log`로 낮춰 정상 폴백 경로가 Sentry 이슈로 올라오던 문제 해결.
- `IsInvokedFromTestRunner` 단위 테스트 7건 추가.

## Root cause

Sentry 대시보드에서 최근 10시간 내 `APPS-IN-TOSS-UNITY-SDK-H6~H9/HD/HE`가 각 57~59건씩 동시 급증했는데, 이벤트 분포를 분석한 결과 **두 명의 개발자가 로컬에서 5개 Unity 버전으로 EditMode 테스트를 돌리는 패턴**과 정확히 일치함.

구체적으로 `DeprecationCheckerTests.cs`의 다음 케이스들이 SUT(`AITDeprecationChecker.ParseMinVersionFromJson`)의 `Debug.LogWarning`을 그대로 트리거하고 있었음:

- `ParseMinVersionFromJson_EmptyJson_ReturnsNull` → `sdk-policy.json이 비어 있습니다` (SDK-H6)
- `ParseMinVersionFromJson_MalformedJson_ReturnsNull` → `JSON parse error` (SDK-H7)
- `ParseMinVersionFromJson_InvalidVersionString_ReturnsNull` → `minVersion 파싱 실패: not-a-version` (SDK-H8)
- `ParseMinVersionFromJson_MissingMinVersion_ReturnsNull` / `NullJson_ReturnsNull` / `MissingSchemaVersion_ReturnsNull` → `minVersion이 없습니다` (SDK-H9)
- `ParseMinVersionFromJson_UnreasonablyHighVersion_ReturnsNull` → `minVersion 11.0.0이 비정상적으로 높습니다` (SDK-HD)
- `ParseMinVersionFromJson_UnsupportedSchemaVersion_ReturnsNull` → `schemaVersion 2 (지원: 1)` (SDK-HE)

`AITEditorErrorTracker`는 `_suppressLogCaptureCount` 기반의 명시적 suppress만 알고 있었고, 테스트 실행 컨텍스트 자체를 감지하지 못했음. 이번 가드는 모든 NUnit/Unity 테스트 러너 호출에 대해 자동 방어막 역할을 함.

그리고 `AITAutoUpdater.UpdateManifestAndResolve`가 'URL이 동일한 정상 폴백' 케이스에서도 호출부가 `LogWarning`을 찍어 SDK-K4 이슈가 지속적으로 발생. 실제 실패는 `UpdateManifestAndResolve` 내부에서 이미 로깅되므로 호출부는 `Log`로 낮춤.

## Test plan

- [ ] CI EditMode 테스트에서 `IsInvokedFromTestRunnerTests` 7건 모두 통과 (Unity 2021.3 / 2022.3 / 6000.0 / 6000.2 / 6000.3)
- [ ] CI EditMode에서 기존 `DeprecationCheckerTests` 통과 + Sentry에 새 이벤트 유입 없음
- [ ] 머지 후 24시간 내 SDK-H6~H9/HD/HE에 신규 이벤트 유입 중단 확인
- [ ] 머지 후 24시간 내 SDK-K4 이벤트 유입 중단 확인