### PR TITLE
수정: Changelog 자동 PR의 머지 방식을 squash로 변경

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -64,7 +64,7 @@ jobs:
             for attempt in 1 2 3; do
               sleep 3
               echo "머지 시도 ${attempt}/3..."
-              if gh pr merge --merge --delete-branch; then
+              if gh pr merge --squash --delete-branch; then
                 MERGED=true
                 break
               fi


### PR DESCRIPTION
## 배경

저장소 main 브랜치 ruleset이 **squash merge만 허용**하는데, `update-changelog.yml` 워크플로우는 `gh pr merge --merge`로 merge-commit 방식을 시도하고 있었다. 이 때문에 자동 머지 3번 재시도가 모두 실패하고 `::warning::자동 머지 실패` 로그만 남긴 채 PR이 누적되어 왔다.

현재 쌓여있는 Changelog PR: #464, #473

## 변경

- `.github/workflows/update-changelog.yml`의 `gh pr merge --merge --delete-branch`를 `--squash --delete-branch`로 교체 (1글자 변경)

## 검증

- `git diff`로 변경 최소화 확인 (1 insertion, 1 deletion)
- 쌓여있는 기존 PR(#464, #473)은 이 PR이 머지된 뒤 수동으로 squash 머지하거나 다음 Changelog 실행에서 새 PR로 대체하면 됨

## 참고

- CLAUDE.md에 명시된 저장소 규칙: "머지 방식: squash merge만 허용 (merge commit, rebase 불가)"
- 워크플로우는 `push: main` 트리거라서 본 PR 머지 직후 바로 다음 Changelog 실행에서 수정이 검증된다.