### PR TITLE
문서: CLAUDE.md에 Push 직전 체크리스트 및 Brotli flaky 로컬 재현 가이드 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,38 @@
   - 추가 안전망: "Filter by error message" → `[AIT-TEST]` prefix 포함 메시지 차단
 - 이 필터 설정 없이는 CI에서 통합 테스트가 돌 때마다 프로덕션 Sentry에 이벤트가 유입됨
 
+### Push 직전 검증 체크리스트
+
+SDK 생성기 작업을 포함하는 변경사항을 커밋/푸시하기 전, **순서대로** 확인:
+
+1. **생성물 상태 확인**: `sdk-runtime-generator~/` 또는 `Runtime/SDK/` 근처를 수정했다면 먼저
+   ```bash
+   cd sdk-runtime-generator~ && pnpm generate && cd ..
+   git status --short
+   ```
+   `Runtime/SDK/` 하위에 예상치 못한 변경이 보이면 생성기 수정 의도와 맞는지 확인. 의도하지 않은 산출물은 커밋 전 조치.
+2. **.gitignore 적용 확인**: `webgl/`, `ait-build/dist/`, `ait-build/node_modules/`, `Library/`, `Temp/`, `*.log` 등이 `git status`에 나타나면 `.gitignore`에 빠진 항목이 있는지 검토 (기존 `.gitignore` 참조).
+3. **로컬 검증 실행**: 빠른 경로는 `./run-local-tests.sh --validate` (~30초) — 파일 구조 + SDK 유닛 테스트. 생성기 변경에는 `--editmode`(~10초)도 병행 권장.
+4. **스테이지 최종 리뷰**: `git diff --cached`로 정확히 어떤 파일이 커밋되는지 한 번 더 확인. 특히 다음을 체크:
+   - 의도하지 않은 `Runtime/SDK/` 재생성 산출물 포함 여부
+   - `.meta` 파일 누락/추가 여부 (Lint 워크플로우에서 검출)
+   - 대용량 바이너리/빌드 산출물 혼입 여부
+
+### 로컬 CI 재현 (WebGL Brotli flaky)
+
+self-hosted runner에서만 재현되는 Brotli 크래시를 로컬에서 좁히려면 `run-local-tests.sh`의 `--compression`과 `--parallel`을 조합:
+
+```bash
+# Brotli 압축 강제로 빌드 (CI와 동일 경로)
+./run-local-tests.sh --unity-build --compression brotli --unity-version 6000.2
+
+# 동시 빌드로 리소스 경합 재현 (모든 버전 병렬)
+./run-local-tests.sh --unity-build --parallel --compression brotli
+```
+
+**압축 포맷 값**: `auto` | `disabled` | `gzip` | `brotli` (`run-local-tests.sh` 참조).
+**주의**: self-hosted runner의 리소스 경합 자체(CPU/메모리/디스크 경합)는 로컬 머신 스펙에 따라 재현이 보장되지 않음. 로컬에서 통과해도 CI flaky가 재현되지 않을 수 있으며, 이 경우 `rerun-failed-jobs` 경로를 사용 (위 "E2E 테스트 실패 대응" 참조).
+
 ## 빠른 참조: 주요 명령어
 
 | 작업 | 명령어 |


### PR DESCRIPTION
## 요약

- Push 직전 실수 방지를 위한 **4단계 순차 체크리스트**를 CLAUDE.md의 "자주 하는 실수 방지" 섹션에 추가 (생성물 확인 → gitignore 적용 → 로컬 검증 → `git diff --cached` 최종 리뷰).
- WebGL Brotli flaky를 로컬에서 격리 재현하는 방법을 문서화. `run-local-tests.sh` 스크립트에 이미 존재하는 `--compression brotli` / `--parallel` 옵션을 CLAUDE.md에 인용.

## 왜

기존 CLAUDE.md는 "자동 생성 코드 정책", "파일 위생" 같은 개별 규칙은 갖고 있지만 **커밋 직전에 실행할 순차 워크플로우**가 명시적으로 없음. 이전에 self-hosted runner Brotli crash + 자동 생성물 실수 커밋 패턴이 반복돼서 체크리스트화하는 편이 낫다고 판단.

## 근거 (실제 파일 경로)

- `run-local-tests.sh:13, 517` — `--compression brotli`, `--parallel` 플래그
- `sdk-runtime-generator~/package.json` — `generate` / `validate` / `test` script
- `.gitignore` — `webgl/`, `ait-build/dist/` 자동 생성 경로
- 기존 CLAUDE.md 581행 전체 확인 후 중복 없는 영역만 append

## Test plan

- [x] 인용된 모든 파일/경로/스크립트명 존재 확인
- [x] 기존 섹션 재구성 없이 append만
- Docs-only, CI 영향 없음

---

이전에 동일 내용의 PR(#476)이 있었으나 대규모 자동화 작업 흐름에서 정책 확인 전 빠른 close를 선택했음. 재확인 결과 docs-only 개선이고 내용이 유효해 재오픈.