### PR TITLE
문서: Verification Commands 규약 섹션 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,16 @@ self-hosted runner에서만 재현되는 Brotli 크래시를 로컬에서 좁히
 | E2E만 | `./run-local-tests.sh --e2e` |
 | CI 트리거 (E2E) | `docs/claude/github-actions.md` 참조 |
 
+## Verification Commands
+
+review-fix-loop 등 자동화 skill이 파싱하는 규약 섹션. 각 항목은 실제 명령 또는 `none` 리터럴.
+
+- **Typecheck**: `./run-local-tests.sh --validate`
+- **Test**: none
+- **Lint**: none
+
+`--validate`(~30초)는 파일 구조 검증 + Playwright 설정 + SDK 유닛 테스트(vitest invariants 포함)를 묶어서 실행하므로 별도 Test 항목을 두지 않는다. Unity E2E(`--all`)는 비용이 크고 매 패스 실행에 부적합해 제외한다 — 변경이 E2E에 영향을 주면 `./run-local-tests.sh --e2e`를 수동 호출한다. Lint(`.meta` 체크, 포맷 등)는 GitHub Actions `lint` 워크플로우가 담당한다.
+
 ## 상세 문서
 
 필요할 때 Read로 가져가서 참조:


### PR DESCRIPTION
## 요약

Claude Code `review-fix-loop` skill이 파싱할 `## Verification Commands` 규약 섹션을 CLAUDE.md에 추가.

## 배경

개인 환경의 `~/.claude/skills/review-fix-loop`가 Step 5에서 각 레포 CLAUDE.md의 `## Verification Commands` 섹션을 읽어 typecheck/test/lint를 실행하도록 개정됨 (dave-environment `c3803b6`). 섹션이 없으면 skill이 halt한다.

## 변경 내용

`## 빠른 참조: 주요 명령어` 테이블(빠른 조회용)과 `## 상세 문서` 인덱스 사이에 skill용 규약 섹션을 삽입. 슬림화된 CLAUDE.md 구조는 유지.

- **Typecheck**: `./run-local-tests.sh --validate` — ~30초, SDK 유닛 테스트(vitest invariants) 포함
- **Test**: none — 유닛이 이미 --validate에 포함, Unity E2E는 비용 크고 매 패스 실행 부적합
- **Lint**: none — `.meta` 체크·포맷은 GitHub Actions `lint` 워크플로우 담당

## Test plan

- [x] `./run-local-tests.sh --validate` 로컬 실행 통과 (3 passed, 0 failed)