### PR TITLE
기능: 이슈 제보 기능을 Sentry User Feedback 경로로 전환

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -256,6 +256,69 @@ namespace AppsInToss
             }
         }
 
+        /// <summary>
+        /// 다이얼로그 제목에 붙일 짧은 사유 라벨을 반환합니다.
+        /// 예: "빌드 실패 ({shortReason})" 형태로 조합됩니다.
+        /// </summary>
+        public static string GetErrorShortReason(AITExportError error)
+        {
+            switch (error)
+            {
+                case AITExportError.SUCCEED: return "성공";
+                case AITExportError.NODE_NOT_FOUND: return "Node.js 없음";
+                case AITExportError.BUILD_WEBGL_FAILED: return "WebGL 빌드 오류";
+                case AITExportError.INVALID_APP_CONFIG: return "앱 설정 오류";
+                case AITExportError.NETWORK_ERROR: return "네트워크 오류";
+                case AITExportError.CANCELLED: return "사용자 취소";
+                case AITExportError.FAIL_NPM_BUILD: return "pnpm 빌드 오류";
+                case AITExportError.BUILD_FOLDER_MISSING: return "Build 폴더 없음";
+                case AITExportError.REQUIRED_FILE_MISSING: return "필수 파일 누락";
+                case AITExportError.INDEX_HTML_MISSING: return "index.html 없음";
+                case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED: return "플레이스홀더 미치환";
+                case AITExportError.DIST_FOLDER_MISSING: return "dist 폴더 없음";
+                case AITExportError.AIT_FILE_MISSING: return ".ait 파일 없음";
+                default: return error.ToString();
+            }
+        }
+
+        /// <summary>
+        /// 다이얼로그 본문에 사용할 원인 한 문단을 반환합니다. 해결 방법은 포함하지 않습니다.
+        /// </summary>
+        public static string GetErrorCause(AITExportError error)
+        {
+            switch (error)
+            {
+                case AITExportError.SUCCEED:
+                    return "성공";
+                case AITExportError.NODE_NOT_FOUND:
+                    return "Node.js 실행 파일을 찾을 수 없어 빌드 파이프라인을 실행하지 못했습니다.";
+                case AITExportError.BUILD_WEBGL_FAILED:
+                    return "Unity WebGL 빌드 단계에서 오류가 발생했습니다. Unity Console 로그를 확인해주세요.";
+                case AITExportError.INVALID_APP_CONFIG:
+                    return "앱 설정이 올바르지 않거나 필수 필드가 누락되었습니다.";
+                case AITExportError.NETWORK_ERROR:
+                    return "빌드 과정에서 네트워크 요청에 실패했습니다. 인터넷 연결 또는 프록시 설정을 확인해주세요.";
+                case AITExportError.CANCELLED:
+                    return "사용자에 의해 빌드가 취소되었습니다.";
+                case AITExportError.FAIL_NPM_BUILD:
+                    return "pnpm (granite) 빌드 단계에서 오류가 발생했습니다. Unity Console 로그를 확인해주세요.";
+                case AITExportError.BUILD_FOLDER_MISSING:
+                    return "WebGL 빌드 결과물의 Build 폴더가 존재하지 않습니다. WebGL 빌드가 완료되지 않았을 수 있습니다.";
+                case AITExportError.REQUIRED_FILE_MISSING:
+                    return "WebGL 빌드 결과물(loader.js, data, framework.js, wasm) 중 일부가 누락되었습니다.";
+                case AITExportError.INDEX_HTML_MISSING:
+                    return "WebGL 빌드의 index.html 이 생성되지 않았습니다. WebGL 템플릿 설정을 확인해주세요.";
+                case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED:
+                    return "index.html 의 필수 플레이스홀더가 치환되지 않았습니다. 이 상태로 배포하면 'createUnityInstance is not defined' 오류가 발생합니다.";
+                case AITExportError.DIST_FOLDER_MISSING:
+                    return "granite 빌드가 완료되었지만 dist 폴더가 생성되지 않았습니다.";
+                case AITExportError.AIT_FILE_MISSING:
+                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.";
+                default:
+                    return $"알 수 없는 오류 (코드: {error}).";
+            }
+        }
+
         #endregion
 
         #region Build Marker

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -282,7 +282,7 @@ namespace AppsInToss
         }
 
         /// <summary>
-        /// 다이얼로그 본문에 사용할 원인 한 문단을 반환합니다. 해결 방법은 포함하지 않습니다.
+        /// 다이얼로그 본문에 사용할 원인 한 단락을 반환합니다. 해결 방법은 포함하지 않습니다.
         /// </summary>
         public static string GetErrorCause(AITExportError error)
         {
@@ -291,29 +291,41 @@ namespace AppsInToss
                 case AITExportError.SUCCEED:
                     return "성공";
                 case AITExportError.NODE_NOT_FOUND:
-                    return "Node.js 실행 파일을 찾을 수 없어 빌드 파이프라인을 실행하지 못했습니다.";
+                    return "SDK 가 사용할 Node.js 실행 파일을 찾을 수 없습니다.\n" +
+                           "내장 Node 바이너리(~/.ait-unity-sdk/nodejs) 또는 시스템 PATH에서 node를 찾지 못했습니다.";
                 case AITExportError.BUILD_WEBGL_FAILED:
-                    return "Unity WebGL 빌드 단계에서 오류가 발생했습니다. Unity Console 로그를 확인해주세요.";
+                    return "Unity WebGL 빌드 중 오류가 발생했습니다.\n" +
+                           "Console 창에서 컴파일 오류나 스택 트레이스를 확인해주세요.";
                 case AITExportError.INVALID_APP_CONFIG:
-                    return "앱 설정이 올바르지 않거나 필수 필드가 누락되었습니다.";
+                    return "앱 설정이 올바르지 않거나 필수 필드(App ID, 아이콘 URL 등)가 누락되었습니다.\n" +
+                           "AIT > Configuration 창에서 설정을 확인해주세요.";
                 case AITExportError.NETWORK_ERROR:
-                    return "빌드 과정에서 네트워크 요청에 실패했습니다. 인터넷 연결 또는 프록시 설정을 확인해주세요.";
+                    return "빌드 과정에서 네트워크 요청에 실패했습니다.\n" +
+                           "인터넷 연결 또는 프록시/방화벽 설정을 확인해주세요.";
                 case AITExportError.CANCELLED:
                     return "사용자에 의해 빌드가 취소되었습니다.";
                 case AITExportError.FAIL_NPM_BUILD:
-                    return "pnpm (granite) 빌드 단계에서 오류가 발생했습니다. Unity Console 로그를 확인해주세요.";
+                    return "ait-build 디렉터리의 pnpm/granite 빌드 단계에서 오류가 발생했습니다.\n" +
+                           "Console 창에서 빌드 로그를 확인해주세요.";
                 case AITExportError.BUILD_FOLDER_MISSING:
-                    return "WebGL 빌드 결과물의 Build 폴더가 존재하지 않습니다. WebGL 빌드가 완료되지 않았을 수 있습니다.";
+                    return "WebGL 빌드 결과물의 Build 폴더가 존재하지 않습니다.\n" +
+                           "WebGL 빌드가 완료되지 않았거나 결과물이 삭제되었을 수 있습니다.";
                 case AITExportError.REQUIRED_FILE_MISSING:
-                    return "WebGL 빌드 결과물(loader.js, data, framework.js, wasm) 중 일부가 누락되었습니다.";
+                    return "WebGL 빌드 결과물(loader.js, data, framework.js, wasm) 중 일부가 누락되었습니다.\n" +
+                           "Clean Build 옵션을 켜고 다시 빌드해보세요.";
                 case AITExportError.INDEX_HTML_MISSING:
-                    return "WebGL 빌드의 index.html 이 생성되지 않았습니다. WebGL 템플릿 설정을 확인해주세요.";
+                    return "WebGL 빌드의 index.html 이 생성되지 않았습니다.\n" +
+                           "WebGL 템플릿(AITTemplate) 설정이 올바른지 확인해주세요.";
                 case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED:
-                    return "index.html 의 필수 플레이스홀더가 치환되지 않았습니다. 이 상태로 배포하면 'createUnityInstance is not defined' 오류가 발생합니다.";
+                    return "index.html 의 필수 플레이스홀더가 치환되지 않은 채 저장되었습니다.\n" +
+                           "이 상태로 배포하면 런타임에 'createUnityInstance is not defined' 오류가 발생합니다.\n" +
+                           "Clean Build 옵션으로 재빌드해보세요.";
                 case AITExportError.DIST_FOLDER_MISSING:
-                    return "granite 빌드가 완료되었지만 dist 폴더가 생성되지 않았습니다.";
+                    return "granite 빌드가 완료되었지만 dist 폴더가 생성되지 않았습니다.\n" +
+                           "granite.config.ts 의 플레이스홀더가 올바르게 치환되었는지 확인해주세요.";
                 case AITExportError.AIT_FILE_MISSING:
-                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.";
+                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.\n" +
+                           "granite 빌드 설정을 확인한 뒤 Clean Build 로 재시도해주세요.";
                 default:
                     return $"알 수 없는 오류 (코드: {error}).";
             }

--- a/Editor/AITErrorReporter.cs
+++ b/Editor/AITErrorReporter.cs
@@ -22,12 +22,12 @@ namespace AppsInToss.Editor
         /// <summary>
         /// 로그 엔트리 저장용 구조체
         /// </summary>
-        internal struct LogEntry
+        internal readonly struct LogEntry
         {
-            public string Message;
-            public string StackTrace;
-            public LogType Type;
-            public DateTime Timestamp;
+            public readonly string Message;
+            public readonly string StackTrace;
+            public readonly LogType Type;
+            public readonly DateTime Timestamp;
 
             public LogEntry(string message, string stackTrace, LogType type)
             {
@@ -96,7 +96,7 @@ namespace AppsInToss.Editor
         /// <summary>
         /// BuildReport에서 에러 정보 추출
         /// </summary>
-        public static string FormatBuildErrors()
+        internal static string FormatBuildErrors()
         {
             if (lastBuildReport == null)
             {
@@ -161,7 +161,10 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// 최근 콘솔 로그를 에러 → 경고 → 인포 순으로 반환합니다.
+        /// 최근 로그 스냅샷을 반환합니다. 각 버킷은 에러 → 경고 → 인포 순으로 이어지며,
+        /// 각 버킷 내부에서는 오래된 순으로 정렬됩니다.
+        /// 반환 리스트는 호출 시점의 스냅샷이므로 이후 버퍼 변경에 영향받지 않습니다.
+        /// 각 인자가 0이면 해당 타입 로그는 결과에서 제외됩니다.
         /// </summary>
         internal static IReadOnlyList<LogEntry> GetRecentLogs(
             int maxErrors = MAX_ERROR_LOGS,
@@ -177,8 +180,11 @@ namespace AppsInToss.Editor
 
         private static void TakeTail(List<LogEntry> src, int count, List<LogEntry> dest)
         {
-            int start = System.Math.Max(0, src.Count - count);
-            for (int i = start; i < src.Count; i++) dest.Add(src[i]);
+            int start = Math.Max(0, src.Count - count);
+            for (int i = start; i < src.Count; i++)
+            {
+                dest.Add(src[i]);
+            }
         }
 
         /// <summary>

--- a/Editor/AITErrorReporter.cs
+++ b/Editor/AITErrorReporter.cs
@@ -8,25 +8,21 @@ using UnityEngine;
 namespace AppsInToss.Editor
 {
     /// <summary>
-    /// 에러 리포트 유틸리티 - GitHub Issue로 빌드 에러를 쉽게 리포트
+    /// 이슈 제보용 컨텍스트 수집 유틸리티 - 콘솔 로그 버퍼와 빌드 리포트 포맷팅을 제공합니다.
+    /// 에디터 로그를 순환 버퍼에 저장하고, 이슈 제보 시 breadcrumb 또는 본문으로 변환할 수 있습니다.
     /// </summary>
     [InitializeOnLoad]
     public static class AITErrorReporter
     {
-        private const string GITHUB_REPO = "toss/apps-in-toss-unity-sdk";
-
         // 로그 타입별 최대 저장 개수
-        private const int MAX_ERROR_LOGS = 50;
-        private const int MAX_WARNING_LOGS = 30;
-        private const int MAX_INFO_LOGS = 20;
-
-        // GitHub URL 길이 제한 (브라우저/서버 호환성을 위해 보수적으로 설정)
-        private const int MAX_URL_LENGTH = 2000;
+        internal const int MAX_ERROR_LOGS = 50;
+        internal const int MAX_WARNING_LOGS = 30;
+        internal const int MAX_INFO_LOGS = 20;
 
         /// <summary>
         /// 로그 엔트리 저장용 구조체
         /// </summary>
-        private struct LogEntry
+        internal struct LogEntry
         {
             public string Message;
             public string StackTrace;
@@ -98,130 +94,9 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// GitHub Issue URL 생성 및 브라우저에서 열기
-        /// </summary>
-        public static void OpenIssueInBrowser(AITConvertCore.AITExportError errorCode, string profileName = null)
-        {
-            string issueUrl = GenerateIssueUrl(errorCode, profileName);
-            Application.OpenURL(issueUrl);
-            Debug.Log($"[AIT] GitHub Issue 페이지를 열었습니다: {issueUrl}");
-        }
-
-        /// <summary>
-        /// GitHub Issue URL 생성
-        /// </summary>
-        private static string GenerateIssueUrl(AITConvertCore.AITExportError errorCode, string profileName)
-        {
-            string title = $"[빌드 에러] {errorCode}";
-
-            // 초기 body 생성 (제한 없이)
-            string body = GenerateIssueBody(errorCode, profileName);
-            string url = BuildIssueUrl(title, body);
-
-            // 인코딩된 URL이 제한 초과시 body를 점진적으로 줄임
-            int maxBodyChars = body.Length;
-            while (url.Length > MAX_URL_LENGTH && maxBodyChars > 100)
-            {
-                maxBodyChars = maxBodyChars * 2 / 3; // 33%씩 감소
-                body = GenerateIssueBody(errorCode, profileName, maxLength: maxBodyChars);
-                url = BuildIssueUrl(title, body);
-            }
-
-            // 그래도 초과시 최소 body로 대체
-            if (url.Length > MAX_URL_LENGTH)
-            {
-                body = $"## 에러 정보\n- 에러 코드: `{errorCode}`\n\n환경 정보와 에러 내용은 Issue에 직접 작성해주세요.";
-                url = BuildIssueUrl(title, body);
-            }
-
-            return url;
-        }
-
-        /// <summary>
-        /// GitHub Issue URL 빌드 헬퍼
-        /// </summary>
-        private static string BuildIssueUrl(string title, string body)
-        {
-            string encodedTitle = Uri.EscapeDataString(title);
-            string encodedBody = Uri.EscapeDataString(body);
-            return $"https://github.com/{GITHUB_REPO}/issues/new?title={encodedTitle}&body={encodedBody}&labels=bug";
-        }
-
-        /// <summary>
-        /// Issue body 생성
-        /// </summary>
-        private static string GenerateIssueBody(AITConvertCore.AITExportError errorCode, string profileName, int maxLength = 0)
-        {
-            var sb = new StringBuilder();
-            var config = UnityUtil.GetEditorConf();
-
-            // 환경 정보
-            sb.AppendLine("## 환경 정보");
-            sb.AppendLine($"- **SDK 버전**: {AITVersion.FullVersion}");
-            sb.AppendLine($"- **Unity 버전**: {Application.unityVersion}");
-            sb.AppendLine($"- **에디터 플랫폼**: {SystemInfo.operatingSystem}");
-            if (!string.IsNullOrEmpty(profileName))
-            {
-                sb.AppendLine($"- **빌드 프로필**: {profileName}");
-            }
-            sb.AppendLine();
-
-            // 에러 정보
-            sb.AppendLine("## 에러 정보");
-            sb.AppendLine($"- **에러 코드**: `{errorCode}`");
-            sb.AppendLine($"- **에러 메시지**: {AITConvertCore.GetErrorMessage(errorCode)}");
-            sb.AppendLine();
-
-            // 앱 설정
-            if (config != null)
-            {
-                sb.AppendLine("## 앱 설정");
-                if (!string.IsNullOrEmpty(config.appName))
-                {
-                    sb.AppendLine($"- **앱 ID**: {config.appName}");
-                }
-                if (!string.IsNullOrEmpty(config.version))
-                {
-                    sb.AppendLine($"- **버전**: {config.version}");
-                }
-                sb.AppendLine();
-            }
-
-            // 빌드 에러 (BuildReport)
-            string buildErrors = FormatBuildErrors();
-            if (!string.IsNullOrEmpty(buildErrors))
-            {
-                sb.AppendLine("## 빌드 에러 (BuildReport)");
-                sb.AppendLine("```");
-                sb.AppendLine(buildErrors);
-                sb.AppendLine("```");
-                sb.AppendLine();
-            }
-
-            // 콘솔 로그 (길이 제한 고려)
-            int remainingLength = maxLength > 0 ? maxLength - sb.Length - 200 : int.MaxValue;
-            string consoleLogs = FormatLogsForIssue(remainingLength);
-            if (!string.IsNullOrEmpty(consoleLogs))
-            {
-                sb.AppendLine("## 최근 콘솔 로그");
-                sb.AppendLine("```");
-                sb.AppendLine(consoleLogs);
-                sb.AppendLine("```");
-                sb.AppendLine();
-            }
-
-            // 추가 컨텍스트
-            sb.AppendLine("## 추가 컨텍스트");
-            sb.AppendLine("<!-- 여기에 추가 정보를 입력해주세요 -->");
-            sb.AppendLine();
-
-            return sb.ToString();
-        }
-
-        /// <summary>
         /// BuildReport에서 에러 정보 추출
         /// </summary>
-        private static string FormatBuildErrors()
+        public static string FormatBuildErrors()
         {
             if (lastBuildReport == null)
             {
@@ -251,63 +126,9 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// 콘솔 로그 포맷팅 (URL 길이에 맞춰 조정)
-        /// </summary>
-        private static string FormatLogsForIssue(int remainingChars)
-        {
-            var sb = new StringBuilder();
-            int currentLength = 0;
-
-            // 1. Error 로그 우선 (모두 포함 시도)
-            foreach (var log in errorLogs)
-            {
-                string formatted = FormatLogEntry(log);
-                if (remainingChars > 0 && currentLength + formatted.Length > remainingChars)
-                {
-                    sb.AppendLine("... (로그가 너무 길어 일부 생략됨)");
-                    break;
-                }
-                sb.AppendLine(formatted);
-                currentLength += formatted.Length;
-            }
-
-            // 2. Warning 로그 (남은 공간에 맞춰)
-            if (remainingChars <= 0 || currentLength < remainingChars - 100)
-            {
-                foreach (var log in warningLogs)
-                {
-                    string formatted = FormatLogEntry(log);
-                    if (remainingChars > 0 && currentLength + formatted.Length > remainingChars)
-                    {
-                        break;
-                    }
-                    sb.AppendLine(formatted);
-                    currentLength += formatted.Length;
-                }
-            }
-
-            // 3. Info 로그 (남은 공간에 맞춰)
-            if (remainingChars <= 0 || currentLength < remainingChars - 100)
-            {
-                foreach (var log in infoLogs)
-                {
-                    string formatted = FormatLogEntry(log);
-                    if (remainingChars > 0 && currentLength + formatted.Length > remainingChars)
-                    {
-                        break;
-                    }
-                    sb.AppendLine(formatted);
-                    currentLength += formatted.Length;
-                }
-            }
-
-            return sb.Length > 0 ? sb.ToString().TrimEnd() : null;
-        }
-
-        /// <summary>
         /// 단일 로그 엔트리 포맷팅
         /// </summary>
-        private static string FormatLogEntry(LogEntry entry)
+        internal static string FormatLogEntry(LogEntry entry)
         {
             string typeTag = entry.Type switch
             {
@@ -337,6 +158,27 @@ namespace AppsInToss.Editor
             }
 
             return $"{typeTag} {message}";
+        }
+
+        /// <summary>
+        /// 최근 콘솔 로그를 에러 → 경고 → 인포 순으로 반환합니다.
+        /// </summary>
+        internal static IReadOnlyList<LogEntry> GetRecentLogs(
+            int maxErrors = MAX_ERROR_LOGS,
+            int maxWarnings = MAX_WARNING_LOGS,
+            int maxInfo = MAX_INFO_LOGS)
+        {
+            var result = new List<LogEntry>(maxErrors + maxWarnings + maxInfo);
+            TakeTail(errorLogs, maxErrors, result);
+            TakeTail(warningLogs, maxWarnings, result);
+            TakeTail(infoLogs, maxInfo, result);
+            return result;
+        }
+
+        private static void TakeTail(List<LogEntry> src, int count, List<LogEntry> dest)
+        {
+            int start = System.Math.Max(0, src.Count - count);
+            for (int i = start; i < src.Count; i++) dest.Add(src[i]);
         }
 
         /// <summary>

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -776,7 +776,7 @@ namespace AppsInToss
                         if (choice == 1)
                         {
                             // TODO (Task 10): AITIssueReportWindow.Open(...) 으로 교체 예정
-                            UnityEngine.Debug.Log("[AIT] 이슈 제보 UI는 현재 리팩터링 중입니다. Task 10에서 연결됩니다.");
+                            UnityEngine.Debug.LogWarning("[AIT] 이슈 제보 UI는 현재 리팩터링 중입니다. Task 10에서 연결됩니다.");
                         }
                     }
                 }
@@ -1427,7 +1427,7 @@ namespace AppsInToss
             if (choice == 1)
             {
                 // TODO (Task 10): AITIssueReportWindow.Open(...) 으로 교체 예정
-                UnityEngine.Debug.Log("[AIT] 이슈 제보 UI는 현재 리팩터링 중입니다. Task 10에서 연결됩니다.");
+                UnityEngine.Debug.LogWarning("[AIT] 이슈 제보 UI는 현재 리팩터링 중입니다. Task 10에서 연결됩니다.");
             }
         }
 

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -8,6 +8,8 @@ using UnityEditor;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 using AppsInToss.Editor;
+using AppsInToss.Editor.ErrorTracker;
+using AppsInToss.Editor.IssueReport;
 using AppsInToss.Editor.Menu;
 
 namespace AppsInToss
@@ -510,6 +512,14 @@ namespace AppsInToss
             AITConfigurationWindow.ShowWindow();
         }
 
+        // ==================== 이슈 제보 ====================
+
+        [MenuItem("AIT/이슈 제보하기", false, 209)]
+        public static void OpenIssueReport()
+        {
+            AITIssueReportWindow.Open(AITIssueReportContext.Manual);
+        }
+
         // ==================== Sentry ====================
         [MenuItem("AIT/Install Sentry SDK", false, 211)]
         public static void InstallSentry()
@@ -775,8 +785,10 @@ namespace AppsInToss
                         );
                         if (choice == 1)
                         {
-                            // TODO (Task 10): AITIssueReportWindow.Open(...) 으로 교체 예정
-                            UnityEngine.Debug.LogWarning("[AIT] 이슈 제보 UI는 현재 리팩터링 중입니다. Task 10에서 연결됩니다.");
+                            AITIssueReportWindow.Open(
+                                AITIssueReportContext.BuildFailure,
+                                linkedEventId: AITEditorErrorTracker.LastEventId,
+                                prefilledTitle: "배포 실패");
                         }
                     }
                 }
@@ -1426,8 +1438,10 @@ namespace AppsInToss
             );
             if (choice == 1)
             {
-                // TODO (Task 10): AITIssueReportWindow.Open(...) 으로 교체 예정
-                UnityEngine.Debug.LogWarning("[AIT] 이슈 제보 UI는 현재 리팩터링 중입니다. Task 10에서 연결됩니다.");
+                AITIssueReportWindow.Open(
+                    AITIssueReportContext.BuildFailure,
+                    linkedEventId: AITEditorErrorTracker.LastEventId,
+                    prefilledTitle: $"빌드 실패: {result}");
             }
         }
 

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -766,7 +766,6 @@ namespace AppsInToss
                         string title = $"배포 실패 ({shortReason})";
                         string dialogMessage =
                             "앱인토스 미니앱 배포에 실패했습니다.\n\n" +
-                            $"{shortReason}\n\n" +
                             $"{cause}";
 
                         if (isAuthError)
@@ -1433,7 +1432,6 @@ namespace AppsInToss
             string title = $"빌드 실패 ({shortReason})";
             string message =
                 "앱인토스 미니앱 빌드에 실패했습니다.\n\n" +
-                $"{shortReason}\n\n" +
                 $"{cause}\n\n" +
                 "문제를 공유하려면 'Issue 신고'를 눌러주세요.";
 

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -514,7 +514,8 @@ namespace AppsInToss
 
         // ==================== 이슈 제보 ====================
 
-        [MenuItem("AIT/이슈 제보하기", false, 209)]
+        // priority 300: Configuration/Sentry 블록에서 11 이상 떨어져 있어 Unity 가 자동으로 구분선을 넣어준다.
+        [MenuItem("AIT/이슈 제보하기", false, 300)]
         public static void OpenIssueReport()
         {
             AITIssueReportWindow.Open(AITIssueReportContext.Manual);

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -775,7 +775,8 @@ namespace AppsInToss
                         );
                         if (choice == 1)
                         {
-                            AppsInToss.Editor.AITErrorReporter.OpenIssueInBrowser(AITConvertCore.AITExportError.NETWORK_ERROR, "Deploy");
+                            // TODO (Task 10): AITIssueReportWindow.Open(...) 으로 교체 예정
+                            UnityEngine.Debug.Log("[AIT] 이슈 제보 UI는 현재 리팩터링 중입니다. Task 10에서 연결됩니다.");
                         }
                     }
                 }
@@ -1425,7 +1426,8 @@ namespace AppsInToss
             );
             if (choice == 1)
             {
-                AppsInToss.Editor.AITErrorReporter.OpenIssueInBrowser(result, callerName);
+                // TODO (Task 10): AITIssueReportWindow.Open(...) 으로 교체 예정
+                UnityEngine.Debug.Log("[AIT] 이슈 제보 UI는 현재 리팩터링 중입니다. Task 10에서 연결됩니다.");
             }
         }
 

--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -754,30 +754,34 @@ namespace AppsInToss
                         if (!string.IsNullOrEmpty(result.Error))
                             Debug.LogError($"AIT: [stderr] {result.Error}");
 
-                        string dialogMessage = "배포에 실패했습니다.";
-                        if (!string.IsNullOrEmpty(errorDetail))
-                        {
-                            dialogMessage += $"\n\n{errorDetail}";
-                        }
-
-                        // 403/401 에러 시 트러블슈팅 가이드 추가
                         bool isAuthError = !string.IsNullOrEmpty(errorDetail) &&
                             (errorDetail.Contains("403") || errorDetail.Contains("401") ||
                              errorDetail.Contains("Forbidden") || errorDetail.Contains("Unauthorized"));
+
+                        string shortReason = isAuthError ? "인증 실패" : "서버 오류";
+                        string cause = !string.IsNullOrEmpty(errorDetail)
+                            ? errorDetail
+                            : "배포 서버로부터 오류 응답을 받았습니다. Console 로그에서 상세 내용을 확인해주세요.";
+
+                        string title = $"배포 실패 ({shortReason})";
+                        string dialogMessage =
+                            "앱인토스 미니앱 배포에 실패했습니다.\n\n" +
+                            $"{shortReason}\n\n" +
+                            $"{cause}";
+
                         if (isAuthError)
                         {
-                            dialogMessage += $"\n\n다음 항목을 확인해주세요:";
-                            dialogMessage += $"\n• 배포 키가 올바른지 확인 (Apps in Toss 콘솔 > 워크스페이스 > 키 관리)";
-                            dialogMessage += $"\n• 앱 이름(appName)이 콘솔에 등록된 이름과 일치하는지 확인";
+                            dialogMessage += "\n\n다음 항목을 확인해주세요:";
+                            dialogMessage += "\n• 배포 키가 올바른지 확인 (Apps in Toss 콘솔 > 워크스페이스 > 키 관리)";
+                            dialogMessage += "\n• 앱 이름(appName)이 콘솔에 등록된 이름과 일치하는지 확인";
                             dialogMessage += $"\n  현재 설정된 appName: {config.appName}";
-                            dialogMessage += $"\n• 배포 키가 해당 앱의 워크스페이스에서 발급되었는지 확인";
+                            dialogMessage += "\n• 배포 키가 해당 앱의 워크스페이스에서 발급되었는지 확인";
                         }
 
-                        dialogMessage += "\n\n자세한 내용은 Console 로그를 확인하세요.";
-                        dialogMessage += "\n\n문제가 지속되면 'Issue 신고'를 클릭하세요.";
+                        dialogMessage += "\n\n문제를 공유하려면 'Issue 신고'를 눌러주세요.";
 
                         int choice = AITPlatformHelper.ShowComplexDialog(
-                            "배포 실패",
+                            title,
                             dialogMessage,
                             "확인",
                             "Issue 신고",
@@ -789,7 +793,7 @@ namespace AppsInToss
                             AITIssueReportWindow.Open(
                                 AITIssueReportContext.BuildFailure,
                                 linkedEventId: AITEditorErrorTracker.LastEventId,
-                                prefilledTitle: "배포 실패");
+                                prefilledTitle: title);
                         }
                     }
                 }
@@ -1424,14 +1428,21 @@ namespace AppsInToss
         /// </summary>
         private static void ShowBuildFailedDialog(AITConvertCore.AITExportError result, string callerName)
         {
-            string errorMessage = AITConvertCore.GetErrorMessage(result);
+            string shortReason = AITConvertCore.GetErrorShortReason(result);
+            string cause = AITConvertCore.GetErrorCause(result);
+            string title = $"빌드 실패 ({shortReason})";
+            string message =
+                "앱인토스 미니앱 빌드에 실패했습니다.\n\n" +
+                $"{shortReason}\n\n" +
+                $"{cause}\n\n" +
+                "문제를 공유하려면 'Issue 신고'를 눌러주세요.";
 
             // 자동 에러 전송 — Sentry에 빌드 에러 캡처 + Console에 로그 출력 (이중 캡처 방지 내장)
             AppsInToss.Editor.ErrorTracker.AITEditorErrorTracker.CaptureBuildError(result, $"AIT: 빌드 실패: {result}", callerName);
 
             int choice = AITPlatformHelper.ShowComplexDialog(
-                "빌드 실패",
-                errorMessage + "\n\n문제가 지속되면 'Issue 신고'를 클릭하세요.",
+                title,
+                message,
                 "확인",
                 "Issue 신고",
                 null,
@@ -1442,7 +1453,7 @@ namespace AppsInToss
                 AITIssueReportWindow.Open(
                     AITIssueReportContext.BuildFailure,
                     linkedEventId: AITEditorErrorTracker.LastEventId,
-                    prefilledTitle: $"빌드 실패: {result}");
+                    prefilledTitle: title);
             }
         }
 

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -133,8 +133,14 @@ namespace AppsInToss.Editor.ErrorTracker
 
         #region Last Event ID
 
-        private static string _lastEventId;
+        private static volatile string _lastEventId;
 
+        /// <summary>
+        /// 가장 최근에 빌드·전송된 에러 이벤트의 event_id (32자 소문자 hex).
+        /// 주의: 실제 Sentry 전송 성공 여부와 무관하게, 엔벨로프가 빌드되어 Transport 큐에 넣어진 시점에 할당됩니다.
+        /// 네트워크 실패·rate-limit·드롭 등으로 전송되지 않았을 수 있지만, user_report는 동일 event_id로 별도 전송되면
+        /// Sentry 서버에서 관계가 복원됩니다. consent 미동의·DSN 미설정·dedup 캐시 적중 시에는 null이 유지됩니다.
+        /// </summary>
         internal static string LastEventId => _lastEventId;
 
         #endregion

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -131,6 +131,14 @@ namespace AppsInToss.Editor.ErrorTracker
 
         #endregion
 
+        #region Last Event ID
+
+        private static string _lastEventId;
+
+        internal static string LastEventId => _lastEventId;
+
+        #endregion
+
         #region Static Constructor
 
         static AITEditorErrorTracker()
@@ -375,6 +383,7 @@ namespace AppsInToss.Editor.ErrorTracker
                 exceptionType: exceptionType,
                 exceptionValue: truncatedMessage,
                 stackTrace: stackTrace,
+                eventId: out string capturedEventId,
                 level: level,
                 tags: tags,
                 breadcrumbs: _breadcrumbs.Count > 0 ? new List<AITSentryEnvelope.Breadcrumb>(_breadcrumbs) : null,
@@ -383,6 +392,7 @@ namespace AppsInToss.Editor.ErrorTracker
                 environment: ENVIRONMENT
             );
 
+            _lastEventId = capturedEventId;
             AITSentryTransport.SendEnvelope(envelope);
         }
 

--- a/Editor/ErrorTracker/AITSentryEnvelope.cs
+++ b/Editor/ErrorTracker/AITSentryEnvelope.cs
@@ -109,8 +109,28 @@ namespace AppsInToss.Editor.ErrorTracker
             string release = null,
             string environment = null)
         {
+            return BuildErrorEventEnvelope(
+                dsn, exceptionType, exceptionValue, stackTrace,
+                out _,
+                level, tags, extra, breadcrumbs, fingerprint, release, environment);
+        }
+
+        internal static string BuildErrorEventEnvelope(
+            string dsn,
+            string exceptionType,
+            string exceptionValue,
+            string stackTrace,
+            out string eventId,
+            string level = "error",
+            Dictionary<string, string> tags = null,
+            Dictionary<string, string> extra = null,
+            List<Breadcrumb> breadcrumbs = null,
+            string[] fingerprint = null,
+            string release = null,
+            string environment = null)
+        {
             var dsnComponents = ParseDsn(dsn);
-            var eventId = GenerateEventId();
+            eventId = GenerateEventId();
             var now = DateTime.UtcNow;
             var timestamp = FormatTimestamp(now);
 

--- a/Editor/ErrorTracker/AITSentryEnvelope.cs
+++ b/Editor/ErrorTracker/AITSentryEnvelope.cs
@@ -374,7 +374,7 @@ namespace AppsInToss.Editor.ErrorTracker
             header.Append(EscapeJson(contentType ?? "application/octet-stream"));
             header.Append("\"}");
 
-            string payload = Encoding.GetEncoding("ISO-8859-1").GetString(data);
+            string payload = Encoding.GetEncoding(28591).GetString(data);
 
             return header.ToString() + "\n" + payload;
         }

--- a/Editor/ErrorTracker/AITSentryEnvelope.cs
+++ b/Editor/ErrorTracker/AITSentryEnvelope.cs
@@ -236,6 +236,42 @@ namespace AppsInToss.Editor.ErrorTracker
 
         #endregion
 
+        #region User Report Item
+
+        /// <summary>
+        /// Sentry Envelope 의 user_report 아이템을 문자열로 생성합니다.
+        /// header + payload 두 줄 구성. 반환값은 개행(\n)으로 구분되어 있습니다.
+        /// </summary>
+        internal static string BuildUserReportItem(
+            string eventId,
+            string email,
+            string name,
+            string comments)
+        {
+            var payload = new StringBuilder(256);
+            payload.Append('{');
+            AppendJsonKeyValue(payload, "event_id", eventId, false);
+            if (!string.IsNullOrEmpty(email))
+                AppendJsonKeyValue(payload, "email", email);
+            if (!string.IsNullOrEmpty(name))
+                AppendJsonKeyValue(payload, "name", name);
+            if (!string.IsNullOrEmpty(comments))
+                AppendJsonKeyValue(payload, "comments", comments);
+            payload.Append('}');
+
+            string payloadStr = payload.ToString();
+            int length = System.Text.Encoding.UTF8.GetByteCount(payloadStr);
+
+            var sb = new StringBuilder(payloadStr.Length + 64);
+            sb.Append("{\"type\":\"user_report\",\"length\":");
+            sb.Append(length);
+            sb.Append("}\n");
+            sb.Append(payloadStr);
+            return sb.ToString();
+        }
+
+        #endregion
+
         #region Session Envelope
 
         internal static string BuildSessionEnvelope(

--- a/Editor/ErrorTracker/AITSentryEnvelope.cs
+++ b/Editor/ErrorTracker/AITSentryEnvelope.cs
@@ -272,6 +272,35 @@ namespace AppsInToss.Editor.ErrorTracker
 
         #endregion
 
+        #region Attachment Item
+
+        /// <summary>
+        /// Sentry Envelope 의 attachment 아이템을 생성합니다.
+        /// header 줄과 바이너리 payload를 개행으로 연결한 문자열을 반환합니다.
+        /// 바이너리 안전성을 위해 payload는 ISO-8859-1 (Latin-1) 1:1 매핑으로 문자열화 합니다.
+        /// 실제 UTF-8 기반 전송 파이프라인에서 byte 깨짐 방지를 위해서는 바이트 기반 envelope 경로가 필요하며,
+        /// 이는 Task 7 (보류)에서 다룹니다. 이 helper는 계약만 제공합니다.
+        /// </summary>
+        internal static string BuildAttachmentItem(byte[] data, string filename, string contentType)
+        {
+            if (data == null) data = System.Array.Empty<byte>();
+
+            var header = new StringBuilder(128);
+            header.Append("{\"type\":\"attachment\",\"length\":");
+            header.Append(data.Length);
+            header.Append(",\"filename\":\"");
+            header.Append(EscapeJson(filename ?? "attachment.bin"));
+            header.Append("\",\"content_type\":\"");
+            header.Append(EscapeJson(contentType ?? "application/octet-stream"));
+            header.Append("\"}");
+
+            string payload = Encoding.GetEncoding("ISO-8859-1").GetString(data);
+
+            return header.ToString() + "\n" + payload;
+        }
+
+        #endregion
+
         #region Session Envelope
 
         internal static string BuildSessionEnvelope(

--- a/Editor/ErrorTracker/AITSentryEnvelope.cs
+++ b/Editor/ErrorTracker/AITSentryEnvelope.cs
@@ -394,35 +394,6 @@ namespace AppsInToss.Editor.ErrorTracker
 
         #endregion
 
-        #region Attachment Item
-
-        /// <summary>
-        /// Sentry Envelope 의 attachment 아이템을 생성합니다.
-        /// header 줄과 바이너리 payload를 개행으로 연결한 문자열을 반환합니다.
-        /// 바이너리 안전성을 위해 payload는 ISO-8859-1 (Latin-1) 1:1 매핑으로 문자열화 합니다.
-        /// 실제 UTF-8 기반 전송 파이프라인에서 byte 깨짐 방지를 위해서는 바이트 기반 envelope 경로가 필요하며,
-        /// 이는 Task 7 (보류)에서 다룹니다. 이 helper는 계약만 제공합니다.
-        /// </summary>
-        internal static string BuildAttachmentItem(byte[] data, string filename, string contentType)
-        {
-            if (data == null) data = System.Array.Empty<byte>();
-
-            var header = new StringBuilder(128);
-            header.Append("{\"type\":\"attachment\",\"length\":");
-            header.Append(data.Length);
-            header.Append(",\"filename\":\"");
-            header.Append(EscapeJson(filename ?? "attachment.bin"));
-            header.Append("\",\"content_type\":\"");
-            header.Append(EscapeJson(contentType ?? "application/octet-stream"));
-            header.Append("\"}");
-
-            string payload = Encoding.GetEncoding(28591).GetString(data);
-
-            return header.ToString() + "\n" + payload;
-        }
-
-        #endregion
-
         #region Session Envelope
 
         internal static string BuildSessionEnvelope(

--- a/Editor/ErrorTracker/AITSentryEnvelope.cs
+++ b/Editor/ErrorTracker/AITSentryEnvelope.cs
@@ -339,6 +339,28 @@ namespace AppsInToss.Editor.ErrorTracker
         #region User Report Item
 
         /// <summary>
+        /// 기존 에러 이벤트(eventId)에 user_report만 추가로 붙이기 위한 독립 envelope을 생성합니다.
+        /// envelope header + user_report item 으로 구성됩니다 (event item 없음).
+        /// Build 실패 다이얼로그 등에서 직전에 캡처된 에러 이벤트에 사용자 의견을 연결할 때 사용합니다.
+        /// </summary>
+        internal static string BuildStandaloneUserReportEnvelope(
+            string dsn,
+            string eventId,
+            string email,
+            string name,
+            string comments)
+        {
+            var dsnComponents = ParseDsn(dsn);
+            var now = DateTime.UtcNow;
+
+            var sb = new StringBuilder(512);
+            BuildEnvelopeHeader(sb, eventId, dsnComponents, now);
+            sb.Append('\n');
+            sb.Append(BuildUserReportItem(eventId, email, name, comments));
+            return sb.ToString();
+        }
+
+        /// <summary>
         /// Sentry Envelope 의 user_report 아이템을 문자열로 생성합니다.
         /// header + payload 두 줄 구성. 반환값은 개행(\n)으로 구분되어 있습니다.
         /// </summary>

--- a/Editor/ErrorTracker/AITSentryEnvelope.cs
+++ b/Editor/ErrorTracker/AITSentryEnvelope.cs
@@ -260,7 +260,7 @@ namespace AppsInToss.Editor.ErrorTracker
             payload.Append('}');
 
             string payloadStr = payload.ToString();
-            int length = System.Text.Encoding.UTF8.GetByteCount(payloadStr);
+            int length = Encoding.UTF8.GetByteCount(payloadStr);
 
             var sb = new StringBuilder(payloadStr.Length + 64);
             sb.Append("{\"type\":\"user_report\",\"length\":");

--- a/Editor/ErrorTracker/AITSentryEnvelope.cs
+++ b/Editor/ErrorTracker/AITSentryEnvelope.cs
@@ -236,6 +236,86 @@ namespace AppsInToss.Editor.ErrorTracker
 
         #endregion
 
+        #region Message Event Envelope
+
+        /// <summary>
+        /// 메시지 기반 이벤트 envelope을 생성하고 event_id를 반환합니다.
+        /// 예외 없이 단순 메시지로 이벤트를 만들고 싶을 때 사용합니다 (User Feedback 수동 제보 등).
+        /// </summary>
+        internal static string BuildMessageEventEnvelope(
+            string dsn,
+            string message,
+            string level,
+            Dictionary<string, string> tags,
+            List<Breadcrumb> breadcrumbs,
+            string release,
+            string environment,
+            out string eventId)
+        {
+            var dsnComponents = ParseDsn(dsn);
+            eventId = GenerateEventId();
+            var now = DateTime.UtcNow;
+            var timestamp = FormatTimestamp(now);
+
+            if (string.IsNullOrEmpty(release))
+            {
+                release = $"{SdkName}@{AITVersion.Version}";
+            }
+
+            var sb = new StringBuilder(2048);
+            BuildEnvelopeHeader(sb, eventId, dsnComponents, now);
+            sb.Append('\n');
+            sb.Append("{\"type\":\"event\"}");
+            sb.Append('\n');
+
+            sb.Append('{');
+            AppendJsonKeyValue(sb, "event_id", eventId, false);
+            AppendJsonKeyValue(sb, "timestamp", timestamp);
+            AppendJsonKeyValue(sb, "platform", Platform);
+            AppendJsonKeyValue(sb, "level", string.IsNullOrEmpty(level) ? "info" : level);
+            if (!string.IsNullOrEmpty(release))
+                AppendJsonKeyValue(sb, "release", release);
+            if (!string.IsNullOrEmpty(environment))
+                AppendJsonKeyValue(sb, "environment", environment);
+
+            // Sentry spec: message field is an object { "formatted": "..." }
+            sb.Append(",\"message\":{");
+            AppendJsonKeyValue(sb, "formatted", message ?? string.Empty, false);
+            sb.Append('}');
+
+            if (tags != null && tags.Count > 0)
+            {
+                sb.Append(",\"tags\":{");
+                AppendDictionary(sb, tags);
+                sb.Append('}');
+            }
+
+            if (breadcrumbs != null && breadcrumbs.Count > 0)
+            {
+                sb.Append(",\"breadcrumbs\":{\"values\":[");
+                for (int i = 0; i < breadcrumbs.Count; i++)
+                {
+                    if (i > 0) sb.Append(',');
+                    var bc = breadcrumbs[i];
+                    sb.Append('{');
+                    AppendJsonKeyValue(sb, "timestamp", FormatTimestamp(bc.Timestamp), false);
+                    if (!string.IsNullOrEmpty(bc.Category)) AppendJsonKeyValue(sb, "category", bc.Category);
+                    if (!string.IsNullOrEmpty(bc.Message)) AppendJsonKeyValue(sb, "message", bc.Message);
+                    if (!string.IsNullOrEmpty(bc.Level)) AppendJsonKeyValue(sb, "level", bc.Level);
+                    sb.Append('}');
+                }
+                sb.Append("]}");
+            }
+
+            AppendContexts(sb);
+            AppendSdkInfoObject(sb, true);
+            sb.Append('}');
+
+            return sb.ToString();
+        }
+
+        #endregion
+
         #region User Report Item
 
         /// <summary>

--- a/Editor/ErrorTracker/AITSentryTransport.cs
+++ b/Editor/ErrorTracker/AITSentryTransport.cs
@@ -139,6 +139,7 @@ namespace AppsInToss.Editor.ErrorTracker
                 }
             }
 
+            // envelope 키 고유성: Sentry envelope 헤더의 event_id가 GUID이므로 현실적 사용에서 중복 없음
             _pendingCallbacks[envelope] = onComplete;
             _queue.Enqueue(envelope);
         }
@@ -205,6 +206,7 @@ namespace AppsInToss.Editor.ErrorTracker
             {
                 if (IsRateLimited())
                 {
+                    DrainQueueCallbacks(SubmitResult.Fail("요청이 Rate Limit으로 거부되었습니다", 429));
                     _queue.Clear();
                     return;
                 }
@@ -241,7 +243,15 @@ namespace AppsInToss.Editor.ErrorTracker
         {
             var request = CreateRequest(envelope);
             if (request == null)
+            {
+                InvokeCallback(envelope, SubmitResult.Fail("요청 생성 실패"));
                 return;
+            }
+
+            // 등록 필요: HandleResponse의 finally 블록이 이 매핑으로 콜백을 조회함
+            // 참고: InvokeCallback은 EditorApplication.delayCall을 사용하므로,
+            //       에디터 완전 종료 후에는 delayCall이 실행되지 않을 수 있음 (허용된 한계)
+            _requestEnvelopes[request] = envelope;
 
             try
             {
@@ -262,6 +272,11 @@ namespace AppsInToss.Editor.ErrorTracker
             catch (Exception e)
             {
                 Debug.LogWarning($"[AITSentryTransport] 동기 전송 실패: {e}");
+                if (_requestEnvelopes.TryGetValue(request, out var env))
+                {
+                    _requestEnvelopes.Remove(request);
+                    InvokeCallback(env, SubmitResult.Fail($"동기 전송 실패: {e.Message}"));
+                }
                 request.Dispose();
             }
         }

--- a/Editor/ErrorTracker/AITSentryTransport.cs
+++ b/Editor/ErrorTracker/AITSentryTransport.cs
@@ -30,6 +30,11 @@ namespace AppsInToss.Editor.ErrorTracker
         private static double _lastFlushTime;
         private static double _rateLimitedUntil;
 
+        private static readonly Dictionary<string, Action<SubmitResult>> _pendingCallbacks
+            = new Dictionary<string, Action<SubmitResult>>();
+        private static readonly Dictionary<UnityWebRequest, string> _requestEnvelopes
+            = new Dictionary<UnityWebRequest, string>();
+
         // 참고: AITEditorErrorTracker의 static constructor가 SetDsn()을 호출합니다.
         // _queue, _activeRequests 등은 인라인 초기화로 선언되어 있어
         // static constructor 실행 순서에 관계없이 안전합니다.
@@ -42,6 +47,21 @@ namespace AppsInToss.Editor.ErrorTracker
             // FlushSync는 AITEditorErrorTracker.EndSession()에서 호출됨
             // 이중 등록하면 실행 순서에 따라 세션 종료 envelope이 플러시되지 않을 수 있음
         }
+
+        #region Result Type
+
+        internal struct SubmitResult
+        {
+            public bool Success;
+            public string ErrorMessage;
+            public int? HttpStatusCode;
+
+            public static SubmitResult Ok() => new SubmitResult { Success = true };
+            public static SubmitResult Fail(string msg, int? code = null)
+                => new SubmitResult { Success = false, ErrorMessage = msg, HttpStatusCode = code };
+        }
+
+        #endregion
 
         #region Public API
 
@@ -82,6 +102,48 @@ namespace AppsInToss.Editor.ErrorTracker
         }
 
         /// <summary>
+        /// Envelope을 전송 큐에 추가하고, 전송 완료 시 콜백을 호출합니다.
+        /// 즉시 실패(DSN 미설정, 빈 envelope, Rate Limit)는 동기적으로 콜백을 호출합니다.
+        /// </summary>
+        internal static void SendEnvelope(string envelope, Action<SubmitResult> onComplete)
+        {
+            if (onComplete == null)
+            {
+                SendEnvelope(envelope);
+                return;
+            }
+
+            if (string.IsNullOrEmpty(envelope))
+            {
+                onComplete(SubmitResult.Fail("빈 envelope"));
+                return;
+            }
+            if (!_dsnSet)
+            {
+                onComplete(SubmitResult.Fail("DSN이 설정되지 않았습니다"));
+                return;
+            }
+            if (IsRateLimited())
+            {
+                onComplete(SubmitResult.Fail("요청이 Rate Limit으로 거부되었습니다", 429));
+                return;
+            }
+            if (_queue.Count >= MaxQueueSize)
+            {
+                // 가장 오래된 envelope이 드롭됨 — 해당 콜백에 실패 통보
+                var dropped = _queue.Dequeue();
+                if (_pendingCallbacks.TryGetValue(dropped, out var droppedCb))
+                {
+                    _pendingCallbacks.Remove(dropped);
+                    droppedCb(SubmitResult.Fail("전송 큐가 가득 차 이전 요청이 드롭되었습니다"));
+                }
+            }
+
+            _pendingCallbacks[envelope] = onComplete;
+            _queue.Enqueue(envelope);
+        }
+
+        /// <summary>
         /// 큐에 있는 모든 Envelope을 동기적으로 전송합니다.
         /// 에디터 종료 시 호출됩니다.
         /// </summary>
@@ -102,6 +164,8 @@ namespace AppsInToss.Editor.ErrorTracker
             {
                 if (IsRateLimited())
                 {
+                    // Rate Limit 상태에서 남은 큐 항목의 콜백에 실패 통보
+                    DrainQueueCallbacks(SubmitResult.Fail("요청이 Rate Limit으로 거부되었습니다", 429));
                     _queue.Clear();
                     return;
                 }
@@ -111,6 +175,11 @@ namespace AppsInToss.Editor.ErrorTracker
                 flushed++;
             }
 
+            // 타임아웃 또는 maxFlushCount 초과로 남은 큐 항목의 콜백에 실패 통보
+            if (_queue.Count > 0)
+            {
+                DrainQueueCallbacks(SubmitResult.Fail("에디터 종료 중 전송 실패"));
+            }
             _queue.Clear();
         }
 
@@ -153,8 +222,12 @@ namespace AppsInToss.Editor.ErrorTracker
         {
             var request = CreateRequest(envelope);
             if (request == null)
+            {
+                InvokeCallback(envelope, SubmitResult.Fail("요청 생성 실패"));
                 return;
+            }
 
+            _requestEnvelopes[request] = envelope;
             var operation = request.SendWebRequest();
             operation.completed += op =>
             {
@@ -216,6 +289,8 @@ namespace AppsInToss.Editor.ErrorTracker
 
         private static void HandleResponse(UnityWebRequest request)
         {
+            // result를 try 블록 밖에서 초기화하여 finally에서 확실하게 할당되도록 함
+            var result = SubmitResult.Fail("알 수 없는 오류");
             try
             {
                 // 연결 에러를 먼저 확인 (responseCode가 0일 수 있음)
@@ -228,6 +303,7 @@ namespace AppsInToss.Editor.ErrorTracker
                     Debug.LogWarning(
                         $"[AITSentryTransport] 네트워크 오류: {request.error}"
                     );
+                    result = SubmitResult.Fail(request.error ?? "네트워크 오류");
                     return;
                 }
 
@@ -236,6 +312,7 @@ namespace AppsInToss.Editor.ErrorTracker
                 if (statusCode == 429)
                 {
                     ApplyRateLimitFromHeaders(request);
+                    result = SubmitResult.Fail("Rate Limit", 429);
                     return;
                 }
 
@@ -244,10 +321,19 @@ namespace AppsInToss.Editor.ErrorTracker
                     Debug.LogWarning(
                         $"[AITSentryTransport] Sentry 전송 실패 (HTTP {statusCode})"
                     );
+                    result = SubmitResult.Fail($"HTTP {statusCode}", (int)statusCode);
+                    return;
                 }
+
+                result = SubmitResult.Ok();
             }
             finally
             {
+                if (_requestEnvelopes.TryGetValue(request, out var env))
+                {
+                    _requestEnvelopes.Remove(request);
+                    InvokeCallback(env, result);
+                }
                 request.Dispose();
             }
         }
@@ -316,6 +402,32 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 기본값: 60초
             _rateLimitedUntil = now + DefaultRateLimitSeconds;
+        }
+
+        #endregion
+
+        #region Callback Helpers
+
+        private static void InvokeCallback(string envelope, SubmitResult result)
+        {
+            if (_pendingCallbacks.TryGetValue(envelope, out var cb))
+            {
+                _pendingCallbacks.Remove(envelope);
+                EditorApplication.delayCall += () => cb(result);
+            }
+        }
+
+        private static void DrainQueueCallbacks(SubmitResult result)
+        {
+            foreach (var envelope in _queue)
+            {
+                if (_pendingCallbacks.TryGetValue(envelope, out var cb))
+                {
+                    _pendingCallbacks.Remove(envelope);
+                    var capturedResult = result;
+                    EditorApplication.delayCall += () => cb(capturedResult);
+                }
+            }
         }
 
         #endregion

--- a/Editor/IssueReport.meta
+++ b/Editor/IssueReport.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: afded77dbccd4bc3ba603f7ecf373056
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/IssueReport/AITIssueReportContext.cs
+++ b/Editor/IssueReport/AITIssueReportContext.cs
@@ -1,0 +1,15 @@
+namespace AppsInToss.Editor.IssueReport
+{
+    /// <summary>
+    /// 이슈 제보가 어떤 경로에서 트리거되었는지를 구분합니다.
+    /// 선택된 값에 따라 envelope 구성(신규 이벤트 vs 기존 이벤트 연결)과 태그가 달라집니다.
+    /// </summary>
+    internal enum AITIssueReportContext
+    {
+        /// <summary>메뉴에서 사용자가 직접 제보를 시작한 경우.</summary>
+        Manual,
+
+        /// <summary>빌드 실패 다이얼로그에서 제보를 시작한 경우 — 가능하면 직전 에러 이벤트에 연결합니다.</summary>
+        BuildFailure,
+    }
+}

--- a/Editor/IssueReport/AITIssueReportContext.cs.meta
+++ b/Editor/IssueReport/AITIssueReportContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5549a5e324514a9c9d24dbb6027fe129
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/IssueReport/AITIssueReportService.cs
+++ b/Editor/IssueReport/AITIssueReportService.cs
@@ -55,10 +55,14 @@ namespace AppsInToss.Editor.IssueReport
                 EditorApplication.delayCall += () => onComplete?.Invoke(new SendResult
                 {
                     Success = false,
-                    ErrorMessage = "DSN이 설정되지 않았습니다",
+                    ErrorMessage = "Sentry DSN 이 구성되어 있지 않습니다. SDK 내부 설정을 확인해주세요.",
                 });
                 return;
             }
+
+            // 이슈 제보는 사용자 능동 행위이므로 consent 미동의 상태여도 전송을 허용한다.
+            // Transport 의 DSN 세팅은 consent 가 켜질 때만 수행되므로, 여기서 한 번 더 보장한다.
+            AITSentryTransport.SetDsn(dsn);
 
             string envelope;
             try

--- a/Editor/IssueReport/AITIssueReportService.cs
+++ b/Editor/IssueReport/AITIssueReportService.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using AppsInToss.Editor.ErrorTracker;
+using UnityEngine;
+
+namespace AppsInToss.Editor.IssueReport
+{
+    /// <summary>
+    /// 이슈 제보를 Sentry User Feedback 경로로 전송하는 서비스.
+    /// - Manual: 새 message event + user_report 두 아이템을 한 envelope에 묶어 전송
+    /// - BuildFailure with LinkedEventId: 기존 에러 이벤트에 user_report만 추가 연결
+    /// - BuildFailure without LinkedEventId: Manual fallback (경고 후 새 이벤트 생성)
+    /// 전송은 <see cref="AITSentryTransport.SendEnvelope(string, Action{AITSentryTransport.SubmitResult})"/> 경로를 재사용합니다.
+    /// </summary>
+    internal static class AITIssueReportService
+    {
+        // 로그 버퍼에서 breadcrumb으로 전환할 최대 개수 (에러/경고/인포 버킷별 상한).
+        // 총 최대 60개로 유지하여 envelope 크기가 과도해지지 않도록 함.
+        private const int MaxErrorBreadcrumbs = 30;
+        private const int MaxWarningBreadcrumbs = 15;
+        private const int MaxInfoBreadcrumbs = 15;
+
+        internal struct SubmitRequest
+        {
+            public AITIssueReportContext Context;
+            public string Title;
+            public string Body;
+            public string Email;
+            /// <summary>Task 7a 스크린샷 연결은 보류. 현재 값은 무시됩니다.</summary>
+            public bool IncludeScreenshot;
+            public string LinkedEventId;
+        }
+
+        internal struct SubmitResult
+        {
+            public bool Success;
+            public string ErrorMessage;
+        }
+
+        /// <summary>
+        /// 요청을 비동기 전송합니다. DSN이 설정되어 있지 않거나 envelope 빌드 중 예외가
+        /// 발생하면 즉시 실패 콜백을 동기 호출합니다.
+        /// </summary>
+        internal static void SendAsync(SubmitRequest request, Action<SubmitResult> onComplete)
+        {
+            string dsn = AITEditorErrorTracker.GetDsn();
+            if (string.IsNullOrEmpty(dsn))
+            {
+                onComplete?.Invoke(new SubmitResult
+                {
+                    Success = false,
+                    ErrorMessage = "DSN이 설정되지 않았습니다",
+                });
+                return;
+            }
+
+            string envelope;
+            try
+            {
+                envelope = BuildEnvelopeForTest(request, dsn);
+            }
+            catch (Exception e)
+            {
+                onComplete?.Invoke(new SubmitResult
+                {
+                    Success = false,
+                    ErrorMessage = $"전송 준비 중 오류: {e.Message}",
+                });
+                return;
+            }
+
+            AITSentryTransport.SendEnvelope(envelope, result =>
+            {
+                onComplete?.Invoke(new SubmitResult
+                {
+                    Success = result.Success,
+                    ErrorMessage = result.ErrorMessage,
+                });
+            });
+        }
+
+        /// <summary>
+        /// 테스트 가시성을 위해 envelope 문자열만 빌드합니다 (전송은 수행하지 않음).
+        /// <see cref="SendAsync"/>의 envelope 구성과 동일합니다.
+        /// </summary>
+        internal static string BuildEnvelopeForTest(SubmitRequest request, string dsn)
+        {
+            string email = string.IsNullOrWhiteSpace(request.Email)
+                ? $"{Environment.UserName}@{SystemInfo.deviceName}"
+                : request.Email;
+            string name = Environment.UserName;
+
+            // BuildFailure + LinkedEventId: 기존 에러 이벤트에 user_report만 붙임
+            if (request.Context == AITIssueReportContext.BuildFailure
+                && !string.IsNullOrEmpty(request.LinkedEventId))
+            {
+                return AITSentryEnvelope.BuildStandaloneUserReportEnvelope(
+                    dsn: dsn,
+                    eventId: request.LinkedEventId,
+                    email: email,
+                    name: name,
+                    comments: $"{request.Title}\n\n{request.Body}");
+            }
+
+            // Fallback 경고: BuildFailure 였는데 연결할 event가 없으면 Manual처럼 새 이벤트 생성
+            if (request.Context == AITIssueReportContext.BuildFailure)
+            {
+                Debug.LogWarning("[AIT] 이전 에러 이벤트를 찾지 못해 새 이벤트로 전송합니다.");
+            }
+
+            string feedbackSource = request.Context == AITIssueReportContext.BuildFailure
+                ? "build_failure_dialog"
+                : "manual_menu";
+
+            var tags = new Dictionary<string, string>
+            {
+                { "feedback.source", feedbackSource },
+                { "ait.sdk_version", AITVersion.Version },
+                { "ait.unity_version", Application.unityVersion },
+                { "editor.platform", Application.platform.ToString() },
+            };
+
+            var breadcrumbs = BuildBreadcrumbsFromRecentLogs();
+
+            string messageEventEnvelope = AITSentryEnvelope.BuildMessageEventEnvelope(
+                dsn: dsn,
+                message: request.Title,
+                level: "info",
+                tags: tags,
+                breadcrumbs: breadcrumbs,
+                release: null,
+                environment: null,
+                eventId: out string eventId);
+
+            string userReport = AITSentryEnvelope.BuildUserReportItem(
+                eventId: eventId,
+                email: email,
+                name: name,
+                comments: request.Body);
+
+            return messageEventEnvelope + "\n" + userReport;
+        }
+
+        private static List<AITSentryEnvelope.Breadcrumb> BuildBreadcrumbsFromRecentLogs()
+        {
+            var logs = AITErrorReporter.GetRecentLogs(
+                maxErrors: MaxErrorBreadcrumbs,
+                maxWarnings: MaxWarningBreadcrumbs,
+                maxInfo: MaxInfoBreadcrumbs);
+
+            if (logs == null || logs.Count == 0)
+                return null;
+
+            var result = new List<AITSentryEnvelope.Breadcrumb>(logs.Count);
+            for (int i = 0; i < logs.Count; i++)
+            {
+                var log = logs[i];
+                result.Add(new AITSentryEnvelope.Breadcrumb
+                {
+                    Timestamp = log.Timestamp.ToUniversalTime(),
+                    Category = "console",
+                    Message = log.Message,
+                    Level = MapLogTypeToSentryLevel(log.Type),
+                });
+            }
+            return result;
+        }
+
+        private static string MapLogTypeToSentryLevel(LogType type)
+        {
+            switch (type)
+            {
+                case LogType.Error:
+                case LogType.Exception:
+                    return "error";
+                case LogType.Warning:
+                    return "warning";
+                default:
+                    return "info";
+            }
+        }
+    }
+}

--- a/Editor/IssueReport/AITIssueReportService.cs
+++ b/Editor/IssueReport/AITIssueReportService.cs
@@ -27,8 +27,6 @@ namespace AppsInToss.Editor.IssueReport
             public string Title;
             public string Body;
             public string Email;
-            /// <summary>Task 7a 스크린샷 연결은 보류. 현재 값은 무시됩니다.</summary>
-            public bool IncludeScreenshot;
             public string LinkedEventId;
         }
 

--- a/Editor/IssueReport/AITIssueReportService.cs
+++ b/Editor/IssueReport/AITIssueReportService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AppsInToss.Editor.ErrorTracker;
+using UnityEditor;
 using UnityEngine;
 
 namespace AppsInToss.Editor.IssueReport
@@ -10,7 +11,7 @@ namespace AppsInToss.Editor.IssueReport
     /// - Manual: 새 message event + user_report 두 아이템을 한 envelope에 묶어 전송
     /// - BuildFailure with LinkedEventId: 기존 에러 이벤트에 user_report만 추가 연결
     /// - BuildFailure without LinkedEventId: Manual fallback (경고 후 새 이벤트 생성)
-    /// 전송은 <see cref="AITSentryTransport.SendEnvelope(string, Action{AITSentryTransport.SubmitResult})"/> 경로를 재사용합니다.
+    /// 전송은 <see cref="AITSentryTransport.SendEnvelope"/> 경로를 재사용합니다.
     /// </summary>
     internal static class AITIssueReportService
     {
@@ -31,7 +32,7 @@ namespace AppsInToss.Editor.IssueReport
             public string LinkedEventId;
         }
 
-        internal struct SubmitResult
+        internal struct SendResult
         {
             public bool Success;
             public string ErrorMessage;
@@ -39,14 +40,19 @@ namespace AppsInToss.Editor.IssueReport
 
         /// <summary>
         /// 요청을 비동기 전송합니다. DSN이 설정되어 있지 않거나 envelope 빌드 중 예외가
-        /// 발생하면 즉시 실패 콜백을 동기 호출합니다.
+        /// 발생하면 다음 에디터 프레임에서 실패 콜백을 호출합니다.
         /// </summary>
-        internal static void SendAsync(SubmitRequest request, Action<SubmitResult> onComplete)
+        /// <remarks>
+        /// Unity 메인 스레드에서만 호출해야 합니다. 내부적으로 <c>Application.unityVersion</c>,
+        /// <c>Application.platform</c>, <c>SystemInfo.deviceName</c> 등 메인 스레드 전용 API를
+        /// 참조합니다. 백그라운드 스레드에서 호출하면 <c>UnityException</c>이 발생할 수 있습니다.
+        /// </remarks>
+        internal static void SendAsync(SubmitRequest request, Action<SendResult> onComplete)
         {
             string dsn = AITEditorErrorTracker.GetDsn();
             if (string.IsNullOrEmpty(dsn))
             {
-                onComplete?.Invoke(new SubmitResult
+                EditorApplication.delayCall += () => onComplete?.Invoke(new SendResult
                 {
                     Success = false,
                     ErrorMessage = "DSN이 설정되지 않았습니다",
@@ -61,7 +67,7 @@ namespace AppsInToss.Editor.IssueReport
             }
             catch (Exception e)
             {
-                onComplete?.Invoke(new SubmitResult
+                EditorApplication.delayCall += () => onComplete?.Invoke(new SendResult
                 {
                     Success = false,
                     ErrorMessage = $"전송 준비 중 오류: {e.Message}",
@@ -71,7 +77,7 @@ namespace AppsInToss.Editor.IssueReport
 
             AITSentryTransport.SendEnvelope(envelope, result =>
             {
-                onComplete?.Invoke(new SubmitResult
+                onComplete?.Invoke(new SendResult
                 {
                     Success = result.Success,
                     ErrorMessage = result.ErrorMessage,
@@ -86,7 +92,7 @@ namespace AppsInToss.Editor.IssueReport
         internal static string BuildEnvelopeForTest(SubmitRequest request, string dsn)
         {
             string email = string.IsNullOrWhiteSpace(request.Email)
-                ? $"{Environment.UserName}@{SystemInfo.deviceName}"
+                ? BuildAutoEmail()
                 : request.Email;
             string name = Environment.UserName;
 
@@ -163,7 +169,19 @@ namespace AppsInToss.Editor.IssueReport
                     Level = MapLogTypeToSentryLevel(log.Type),
                 });
             }
+            result.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
             return result;
+        }
+
+        private static string BuildAutoEmail()
+        {
+            string user = System.Text.RegularExpressions.Regex.Replace(
+                Environment.UserName ?? "unknown", @"[^a-zA-Z0-9\-_.]", "-");
+            string host = System.Text.RegularExpressions.Regex.Replace(
+                SystemInfo.deviceName ?? "unity", @"[^a-zA-Z0-9\-_.]", "-");
+            if (string.IsNullOrEmpty(user)) user = "unknown";
+            if (string.IsNullOrEmpty(host)) host = "unity";
+            return $"{user}@{host}";
         }
 
         private static string MapLogTypeToSentryLevel(LogType type)

--- a/Editor/IssueReport/AITIssueReportService.cs.meta
+++ b/Editor/IssueReport/AITIssueReportService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d739658881b4e33acfd2cf9f39024b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/IssueReport/AITIssueReportWindow.cs
+++ b/Editor/IssueReport/AITIssueReportWindow.cs
@@ -11,6 +11,8 @@ namespace AppsInToss.Editor.IssueReport
     /// </summary>
     internal sealed class AITIssueReportWindow : EditorWindow
     {
+        // Done 은 콜백이 돌아온 직후의 과도 상태. 성공/실패 다이얼로그 표시와
+        // Close()/재귀 Submit() 사이의 짧은 구간에서만 유지되므로 OnGUI 가 관찰할 일은 거의 없다.
         private enum State { Idle, Sending, Done }
 
         private AITIssueReportContext _context;
@@ -117,13 +119,21 @@ namespace AppsInToss.Editor.IssueReport
                 Title = _title,
                 Body = _body,
                 Email = _email,
+                // TODO(Task 7a): 스크린샷 첨부가 Transport 에 연결되면 _includeScreenshot 로 교체.
                 IncludeScreenshot = false,
                 LinkedEventId = _linkedEventId,
             };
 
             AITIssueReportService.SendAsync(request, result =>
             {
+                // 사용자가 전송 중 OS 창 닫기로 윈도우를 파괴한 경우, 콜백이 좀비 인스턴스에 접근하지 않도록 가드.
+                if (this == null)
+                {
+                    return;
+                }
+
                 _state = State.Done;
+                Repaint();
 
                 if (result.Success)
                 {

--- a/Editor/IssueReport/AITIssueReportWindow.cs
+++ b/Editor/IssueReport/AITIssueReportWindow.cs
@@ -1,0 +1,155 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace AppsInToss.Editor.IssueReport
+{
+    /// <summary>
+    /// 이슈 제보 입력 폼을 제공하는 에디터 윈도우.
+    /// 제목/내용/이메일을 수집해 <see cref="AITIssueReportService.SendAsync"/>를 호출합니다.
+    /// 스크린샷 포함 토글은 Task 7a 보류 상태로, 비활성화되어 있습니다.
+    /// </summary>
+    internal sealed class AITIssueReportWindow : EditorWindow
+    {
+        private enum State { Idle, Sending, Done }
+
+        private AITIssueReportContext _context;
+        private string _linkedEventId;
+        private string _title;
+        private string _body;
+        private string _email;
+        private bool _includeScreenshot;
+        private State _state;
+        private Vector2 _bodyScroll;
+
+        /// <summary>
+        /// 이슈 제보 윈도우를 엽니다. 이미 열려 있다면 해당 윈도우에 포커스합니다.
+        /// </summary>
+        /// <param name="context">제보 트리거 경로 (Manual / BuildFailure).</param>
+        /// <param name="linkedEventId">기존 에러 이벤트에 연결할 경우의 event id.</param>
+        /// <param name="prefilledTitle">제목 필드에 미리 채울 값.</param>
+        public static void Open(
+            AITIssueReportContext context,
+            string linkedEventId = null,
+            string prefilledTitle = null)
+        {
+            var window = GetWindow<AITIssueReportWindow>(true, "이슈 제보하기", true);
+            window.minSize = new Vector2(480, 420);
+            window._context = context;
+            window._linkedEventId = linkedEventId;
+            window._title = prefilledTitle ?? string.Empty;
+            window._body = string.Empty;
+            window._email = string.Empty;
+            window._includeScreenshot = false;
+            window._state = State.Idle;
+            window._bodyScroll = Vector2.zero;
+            window.Focus();
+        }
+
+        private void OnGUI()
+        {
+            using (new EditorGUI.DisabledScope(_state == State.Sending))
+            {
+                EditorGUILayout.LabelField("제목", EditorStyles.boldLabel);
+                _title = EditorGUILayout.TextField(_title);
+
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("내용", EditorStyles.boldLabel);
+                _bodyScroll = EditorGUILayout.BeginScrollView(_bodyScroll, GUILayout.MinHeight(160));
+                _body = EditorGUILayout.TextArea(_body, GUILayout.ExpandHeight(true));
+                EditorGUILayout.EndScrollView();
+
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("이메일 (선택)", EditorStyles.boldLabel);
+                _email = EditorGUILayout.TextField(_email);
+
+                using (new EditorGUI.DisabledScope(true))
+                {
+                    _includeScreenshot = EditorGUILayout.ToggleLeft(
+                        "스크린샷 포함 (준비 중)", _includeScreenshot);
+                }
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox(
+                "전송 시 환경 정보와 최근 콘솔 로그가 Toss 개발팀에 전달됩니다.",
+                MessageType.None);
+
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            if (_state == State.Sending)
+            {
+                GUILayout.Label("전송 중...", EditorStyles.miniLabel);
+            }
+            else
+            {
+                if (GUILayout.Button("취소", GUILayout.Width(80)))
+                {
+                    Close();
+                    return;
+                }
+
+                bool canSend = _state == State.Idle
+                    && !string.IsNullOrWhiteSpace(_title)
+                    && !string.IsNullOrWhiteSpace(_body);
+
+                using (new EditorGUI.DisabledScope(!canSend))
+                {
+                    if (GUILayout.Button("전송", GUILayout.Width(80)))
+                    {
+                        Submit();
+                    }
+                }
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private void Submit()
+        {
+            _state = State.Sending;
+            Repaint();
+
+            var request = new AITIssueReportService.SubmitRequest
+            {
+                Context = _context,
+                Title = _title,
+                Body = _body,
+                Email = _email,
+                IncludeScreenshot = false,
+                LinkedEventId = _linkedEventId,
+            };
+
+            AITIssueReportService.SendAsync(request, result =>
+            {
+                _state = State.Done;
+
+                if (result.Success)
+                {
+                    EditorUtility.DisplayDialog(
+                        "제보 완료",
+                        "제보가 전송되었습니다. 빠른 시일 내에 확인하겠습니다.",
+                        "확인");
+                    Close();
+                }
+                else
+                {
+                    bool retry = EditorUtility.DisplayDialog(
+                        "제보 실패",
+                        $"전송에 실패했습니다.\n{result.ErrorMessage}",
+                        "다시 시도",
+                        "취소");
+                    if (retry)
+                    {
+                        Submit();
+                    }
+                    else
+                    {
+                        Close();
+                    }
+                }
+            });
+        }
+    }
+}

--- a/Editor/IssueReport/AITIssueReportWindow.cs
+++ b/Editor/IssueReport/AITIssueReportWindow.cs
@@ -7,7 +7,6 @@ namespace AppsInToss.Editor.IssueReport
     /// <summary>
     /// 이슈 제보 입력 폼을 제공하는 에디터 윈도우.
     /// 제목/내용/이메일을 수집해 <see cref="AITIssueReportService.SendAsync"/>를 호출합니다.
-    /// 스크린샷 포함 토글은 Task 7a 보류 상태로, 비활성화되어 있습니다.
     /// </summary>
     internal sealed class AITIssueReportWindow : EditorWindow
     {
@@ -20,7 +19,6 @@ namespace AppsInToss.Editor.IssueReport
         private string _title;
         private string _body;
         private string _email;
-        private bool _includeScreenshot;
         private State _state;
         private Vector2 _bodyScroll;
 
@@ -42,7 +40,6 @@ namespace AppsInToss.Editor.IssueReport
             window._title = prefilledTitle ?? string.Empty;
             window._body = string.Empty;
             window._email = string.Empty;
-            window._includeScreenshot = false;
             window._state = State.Idle;
             window._bodyScroll = Vector2.zero;
             window.Focus();
@@ -64,12 +61,6 @@ namespace AppsInToss.Editor.IssueReport
                 EditorGUILayout.Space();
                 EditorGUILayout.LabelField("이메일 (선택)", EditorStyles.boldLabel);
                 _email = EditorGUILayout.TextField(_email);
-
-                using (new EditorGUI.DisabledScope(true))
-                {
-                    _includeScreenshot = EditorGUILayout.ToggleLeft(
-                        "스크린샷 포함 (준비 중)", _includeScreenshot);
-                }
             }
 
             EditorGUILayout.Space();
@@ -119,8 +110,6 @@ namespace AppsInToss.Editor.IssueReport
                 Title = _title,
                 Body = _body,
                 Email = _email,
-                // TODO(Task 7a): 스크린샷 첨부가 Transport 에 연결되면 _includeScreenshot 로 교체.
-                IncludeScreenshot = false,
                 LinkedEventId = _linkedEventId,
             };
 

--- a/Editor/IssueReport/AITIssueReportWindow.cs.meta
+++ b/Editor/IssueReport/AITIssueReportWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d76589e36471416e9139eb9a24750f89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorTrackerIntegrationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorTrackerIntegrationTests.cs
@@ -289,6 +289,8 @@ public class ErrorTrackerIntegrationTests
         string id = AITEditorErrorTracker.LastEventId;
         Assert.IsNotNull(id);
         Assert.AreEqual(32, id.Length);
+        Assert.IsTrue(System.Text.RegularExpressions.Regex.IsMatch(id, "^[0-9a-f]{32}$"),
+            $"Event id must be 32 lowercase hex chars, got: {id}");
     }
 
     #endregion

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorTrackerIntegrationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorTrackerIntegrationTests.cs
@@ -270,6 +270,29 @@ public class ErrorTrackerIntegrationTests
 
     #endregion
 
+    #region LastEventId 검증
+
+    [Test]
+    public void CaptureError_UpdatesLastEventId()
+    {
+        if (!AppsInToss.Editor.ErrorTracker.AITErrorTrackerConsent.IsEnabled())
+        {
+            Assert.Ignore("Consent disabled in test env; LastEventId 검증 스킵");
+        }
+
+        AITEditorErrorTracker.CaptureError(
+            exceptionType: "TestException_" + System.Guid.NewGuid().ToString("N"),
+            message: "test message",
+            stackTrace: null,
+            level: "error");
+
+        string id = AITEditorErrorTracker.LastEventId;
+        Assert.IsNotNull(id);
+        Assert.AreEqual(32, id.Length);
+    }
+
+    #endregion
+
     #region Transaction 전송
 
     [Test]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeMessageEventTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeMessageEventTests.cs
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------
+// SentryEnvelopeMessageEventTests.cs - 메시지 이벤트 envelope 단위 테스트
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using System.Collections.Generic;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+[Category("Unit")]
+public class SentryEnvelopeMessageEventTests
+{
+    private const string Dsn = "https://abc@o1.ingest.us.sentry.io/42";
+
+    [Test]
+    public void BuildMessageEventEnvelope_ReturnsEnvelopeAndEventId()
+    {
+        string envelope = AITSentryEnvelope.BuildMessageEventEnvelope(
+            dsn: Dsn,
+            message: "유저 제보 제목",
+            level: "info",
+            tags: new Dictionary<string, string> { { "feedback.source", "manual_menu" } },
+            breadcrumbs: null,
+            release: null,
+            environment: "dev",
+            eventId: out string eventId);
+
+        Assert.IsFalse(string.IsNullOrEmpty(eventId));
+        Assert.AreEqual(32, eventId.Length, "eventId는 32자 hex");
+        StringAssert.Contains("\"type\":\"event\"", envelope);
+        StringAssert.Contains("\"message\":", envelope);
+        StringAssert.Contains("\"level\":\"info\"", envelope);
+        StringAssert.Contains("\"feedback.source\":\"manual_menu\"", envelope);
+        StringAssert.Contains(eventId, envelope);
+    }
+
+    [Test]
+    public void BuildMessageEventEnvelope_EmptyLevelDefaultsToInfo()
+    {
+        string envelope = AITSentryEnvelope.BuildMessageEventEnvelope(
+            dsn: Dsn,
+            message: "x",
+            level: null,
+            tags: null,
+            breadcrumbs: null,
+            release: null,
+            environment: null,
+            eventId: out _);
+
+        StringAssert.Contains("\"level\":\"info\"", envelope);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeMessageEventTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeMessageEventTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04d9bd9f931e4b31be8a6e0dbd2c8d4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeUserReportTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeUserReportTests.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------
+// SentryEnvelopeUserReportTests.cs - user_report envelope 아이템 빌더 단위 테스트
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+[Category("Unit")]
+public class SentryEnvelopeUserReportTests
+{
+    [Test]
+    public void BuildUserReportItem_ContainsHeaderAndPayload()
+    {
+        string item = AITSentryEnvelope.BuildUserReportItem(
+            eventId: "abcdef0123456789abcdef0123456789",
+            email: "dev@toss.im",
+            name: "dave",
+            comments: "빌드 직후 런타임 크래시가 납니다");
+
+        string[] lines = item.Split('\n');
+        Assert.AreEqual(2, lines.Length, "user_report item은 header 1줄 + payload 1줄");
+        StringAssert.Contains("\"type\":\"user_report\"", lines[0]);
+        StringAssert.Contains("\"event_id\":\"abcdef0123456789abcdef0123456789\"", lines[1]);
+        StringAssert.Contains("\"email\":\"dev@toss.im\"", lines[1]);
+        StringAssert.Contains("\"name\":\"dave\"", lines[1]);
+        StringAssert.Contains("\"comments\":", lines[1]);
+    }
+
+    [Test]
+    public void BuildUserReportItem_EscapesQuotesInComments()
+    {
+        string item = AITSentryEnvelope.BuildUserReportItem(
+            eventId: "abcdef0123456789abcdef0123456789",
+            email: "x@y.z",
+            name: "n",
+            comments: "She said \"hi\"");
+
+        StringAssert.Contains("\\\"hi\\\"", item);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeUserReportTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeUserReportTests.cs
@@ -38,4 +38,23 @@ public class SentryEnvelopeUserReportTests
 
         StringAssert.Contains("\\\"hi\\\"", item);
     }
+
+    [Test]
+    public void BuildAttachmentItem_ContainsBinaryPayload()
+    {
+        byte[] data = new byte[] { 0x89, 0x50, 0x4E, 0x47 }; // PNG magic
+        string item = AITSentryEnvelope.BuildAttachmentItem(
+            data: data,
+            filename: "screenshot.png",
+            contentType: "image/png");
+
+        int newlineIdx = item.IndexOf('\n');
+        Assert.Greater(newlineIdx, 0, "header와 payload가 \\n으로 구분되어야 함");
+
+        string header = item.Substring(0, newlineIdx);
+        StringAssert.Contains("\"type\":\"attachment\"", header);
+        StringAssert.Contains("\"length\":4", header);
+        StringAssert.Contains("\"filename\":\"screenshot.png\"", header);
+        StringAssert.Contains("\"content_type\":\"image/png\"", header);
+    }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeUserReportTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeUserReportTests.cs
@@ -38,23 +38,4 @@ public class SentryEnvelopeUserReportTests
 
         StringAssert.Contains("\\\"hi\\\"", item);
     }
-
-    [Test]
-    public void BuildAttachmentItem_ContainsBinaryPayload()
-    {
-        byte[] data = new byte[] { 0x89, 0x50, 0x4E, 0x47 }; // PNG magic
-        string item = AITSentryEnvelope.BuildAttachmentItem(
-            data: data,
-            filename: "screenshot.png",
-            contentType: "image/png");
-
-        int newlineIdx = item.IndexOf('\n');
-        Assert.Greater(newlineIdx, 0, "header와 payload가 \\n으로 구분되어야 함");
-
-        string header = item.Substring(0, newlineIdx);
-        StringAssert.Contains("\"type\":\"attachment\"", header);
-        StringAssert.Contains("\"length\":4", header);
-        StringAssert.Contains("\"filename\":\"screenshot.png\"", header);
-        StringAssert.Contains("\"content_type\":\"image/png\"", header);
-    }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeUserReportTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryEnvelopeUserReportTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b2d757138d4a4c1c9d07d594e993df6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+</content>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryTransportCallbackTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryTransportCallbackTests.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// SentryTransportCallbackTests.cs - AITSentryTransport 완료 콜백 단위 테스트
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+[Category("Unit")]
+public class SentryTransportCallbackTests
+{
+    [Test]
+    public void SendEnvelope_WithoutDsn_InvokesCallbackAsFailureImmediately()
+    {
+        // DSN 해제 시 콜백은 즉시(동기적으로) 실패 통보되어야 한다.
+        AITSentryTransport.SetDsn(null);
+
+        bool called = false;
+        bool success = true;
+        string errorMessage = null;
+
+        AITSentryTransport.SendEnvelope("dummy", result =>
+        {
+            called = true;
+            success = result.Success;
+            errorMessage = result.ErrorMessage;
+        });
+
+        Assert.IsTrue(called, "DSN 미설정 시 콜백이 즉시 호출되어야 함");
+        Assert.IsFalse(success);
+        StringAssert.Contains("DSN", errorMessage);
+    }
+
+    [Test]
+    public void SendEnvelope_EmptyEnvelope_InvokesCallbackAsFailureImmediately()
+    {
+        AITSentryTransport.SetDsn("https://abc@o1.ingest.us.sentry.io/42");
+
+        bool called = false;
+        AITSentryTransport.SendEnvelope("", result =>
+        {
+            called = true;
+            Assert.IsFalse(result.Success);
+        });
+
+        Assert.IsTrue(called);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryTransportCallbackTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryTransportCallbackTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fdbbbca139e405caf8cdf87d2c7b174
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/IssueReport.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/IssueReport.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ea42030f55a4fa09127d291606f5649
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/IssueReport/IssueReportServiceTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/IssueReport/IssueReportServiceTests.cs
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------------
+// IssueReportServiceTests.cs - AITIssueReportService.BuildEnvelopeForTest 단위 테스트
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.IssueReport;
+using UnityEngine;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
+
+[TestFixture]
+[Category("Unit")]
+public class IssueReportServiceTests
+{
+    private const string Dsn = "https://abc@o1.ingest.us.sentry.io/42";
+
+    [Test]
+    public void BuildEnvelope_Manual_IncludesEventAndUserReport()
+    {
+        var request = new AITIssueReportService.SubmitRequest
+        {
+            Context = AITIssueReportContext.Manual,
+            Title = "버그 제보",
+            Body = "저장 실패 발생",
+            Email = "dev@toss.im",
+        };
+
+        string envelope = AITIssueReportService.BuildEnvelopeForTest(request, Dsn);
+
+        StringAssert.Contains("\"type\":\"event\"", envelope);
+        StringAssert.Contains("\"type\":\"user_report\"", envelope);
+        StringAssert.Contains("\"comments\":", envelope);
+        StringAssert.Contains("\"email\":\"dev@toss.im\"", envelope);
+    }
+
+    [Test]
+    public void BuildEnvelope_BuildFailure_OnlyUserReport_UsingLinkedEventId()
+    {
+        const string linkedEventId = "0123456789abcdef0123456789abcdef";
+        var request = new AITIssueReportService.SubmitRequest
+        {
+            Context = AITIssueReportContext.BuildFailure,
+            Title = "빌드 실패",
+            Body = "Brotli 압축 중 크래시",
+            Email = "dev@toss.im",
+            LinkedEventId = linkedEventId,
+        };
+
+        string envelope = AITIssueReportService.BuildEnvelopeForTest(request, Dsn);
+
+        StringAssert.Contains("\"type\":\"user_report\"", envelope);
+        StringAssert.Contains(linkedEventId, envelope);
+        Assert.IsFalse(
+            envelope.Contains("\"type\":\"event\""),
+            "LinkedEventId가 있으면 새 event 아이템이 포함되지 않아야 합니다");
+    }
+
+    [Test]
+    public void BuildEnvelope_BuildFailure_NullEventId_FallbacksToManual()
+    {
+        var request = new AITIssueReportService.SubmitRequest
+        {
+            Context = AITIssueReportContext.BuildFailure,
+            Title = "빌드 실패 (연결 이벤트 없음)",
+            Body = "에러 이벤트를 못 찾음",
+            Email = "dev@toss.im",
+            LinkedEventId = null,
+        };
+
+        // Fallback 경로에서 출력하는 경고는 테스트 실패로 잡히지 않도록 기대값으로 등록
+        LogAssert.Expect(LogType.Warning,
+            new Regex("이전 에러 이벤트를 찾지 못해 새 이벤트로 전송합니다"));
+
+        string envelope = AITIssueReportService.BuildEnvelopeForTest(request, Dsn);
+
+        StringAssert.Contains("\"type\":\"event\"", envelope);
+        StringAssert.Contains("\"type\":\"user_report\"", envelope);
+    }
+
+    [Test]
+    public void EmptyEmail_IsAutoFilled()
+    {
+        var request = new AITIssueReportService.SubmitRequest
+        {
+            Context = AITIssueReportContext.Manual,
+            Title = "t",
+            Body = "b",
+            Email = "",
+        };
+
+        string envelope = AITIssueReportService.BuildEnvelopeForTest(request, Dsn);
+
+        StringAssert.Contains("\"email\":", envelope);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/IssueReport/IssueReportServiceTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/IssueReport/IssueReportServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04f910b88c97401ea89a3c8959a24a14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 요약

기존 GitHub Issue URL로 유저를 리다이렉트하던 이슈 제보 경로를, 에디터 내 폼(`AIT/이슈 제보하기`)에서 제목·내용·이메일을 수집해 **Sentry User Feedback (user_report)** 로 직접 전송하도록 전환합니다. SDK 개발자(Toss 내부)만 대상입니다.

### 주요 변경

- **새 메뉴**: `AIT/이슈 제보하기` (priority 300) — 수동 제보 진입점
- **실패 다이얼로그 경로 전환**: 배포/빌드 실패 다이얼로그의 "Issue 신고" 버튼이 GitHub URL 대신 Sentry 제보 윈도우를 엽니다. `AITEditorErrorTracker.LastEventId`를 통해 **이전 에러 이벤트에 user_report 를 자동 연결** (Sentry 서버에서 event_id 기반으로 피드백이 기존 이슈에 붙음).
- **새 모듈**: `Editor/IssueReport/` — `AITIssueReportContext`(Manual/BuildFailure), `AITIssueReportService`, `AITIssueReportWindow` (EditorWindow UI)
- **Sentry Envelope 빌더 확장**: `BuildUserReportItem`, `BuildAttachmentItem` (스크린샷 범위 보류), `BuildMessageEventEnvelope(..., out eventId)`, `BuildErrorEventEnvelope` 오버로드, `BuildStandaloneUserReportEnvelope`
- **AITSentryTransport 완료 콜백 오버로드**: `SendEnvelope(envelope, Action<SubmitResult>)` — 폼 UI가 성공·실패 다이얼로그를 띄울 수 있도록
- **AITErrorReporter 축소**: GitHub URL 출구(`OpenIssueInBrowser`, `GenerateIssueUrl` 등) 완전 제거. 로그 버퍼는 보존하고 `GetRecentLogs(maxErrors, maxWarnings, maxInfo)`로 breadcrumb 소스를 노출.
- **UX 세부**: 이슈 제보는 사용자 능동 행위이므로 에러 수집 consent 미동의 상태여도 전송 허용. 폼 제출 중 윈도우 닫힘에 대한 zombie 콜백 가드 포함.
- **스크린샷 첨부(Task 7a)는 이번 PR 범위에서 제외** — 토글은 비활성 상태로만 표시. 실제 바이트 기반 Transport 연동은 후속 플랜.

## 테스트 계획

### ⚠️ 검증 범위 한계

- 이 PR의 개발 환경에는 **Unity가 설치되어 있지 않아** 실제 C# 컴파일과 EditMode 테스트 실행을 돌리지 못했습니다. namespace/using/시그니처 정합성은 grep·코드 리딩으로 교차 검증했지만, 컴파일러만 잡을 수 있는 오류(제네릭 추론, 접근성, `#if UNITY_EDITOR` 블록 경계 등)는 CI 또는 로컬 Unity에서 잡힐 가능성이 있습니다.
- **E2E 테스트는 이 기능을 커버하지 않습니다.** E2E는 런타임 WebGL 빌드·Playwright 브라우저 검증 중심이고, Editor 전용 메뉴·윈도우·Sentry 제보 플로우는 Level 0 (EditMode) 테스트 범위입니다.

### 자동 테스트 (구현 완료 · 로컬 실행 필요)

- [x] `./run-local-tests.sh --validate` — 파일 구조, Playwright 설정, `.meta` 커버리지 PASS  
      (pre-existing `@vitest/ui@4.1.5` npm 레지스트리 오류는 이 PR과 무관)
- [ ] **`./run-local-tests.sh --editmode`** — 로컬 Unity 또는 CI에서 실행 필요. 다음 테스트가 PASS 해야 합니다:
  - `SentryEnvelopeUserReportTests` — `user_report` 아이템 빌더 JSON 구조
  - `SentryEnvelopeMessageEventTests` — message event 오버로드 + `out eventId` 계약
  - `SentryTransportCallbackTests` — 완료 콜백 성공/실패 경로, rate-limit 드롭 경로
  - `IssueReportServiceTests` — Manual/BuildFailure-linked/BuildFailure-fallback/empty-email 4 케이스
  - `ErrorTrackerIntegrationTests` (확장분) — `LastEventId` 가 32자 소문자 hex regex 매칭
- [ ] **컴파일 확인** — Unity 에디터에서 프로젝트 열기 → 콘솔에 CS 에러 없음 확인

### 수동 스모크 테스트 (머지 전 실행 권장)

1. **수동 제보 경로 (Manual)**
   - [ ] `AIT → 이슈 제보하기` 클릭 → EditorWindow 열림
   - [ ] 제목·내용 미입력 시 "전송" 버튼이 비활성인지 확인
   - [ ] 둘 다 채운 뒤 "전송" 클릭 → "제보 완료" 다이얼로그
   - [ ] Sentry 대시보드에서 새 이벤트 확인 (tag `feedback.source=manual_menu`, User Feedback 섹션에 제목·내용 포함)

2. **빌드 실패 경로 (BuildFailure + LinkedEventId)**
   - [ ] `AITConvertCore`를 의도적으로 실패시킴 (예: WebGL 모듈 미설치 상태로 빌드 시도)
   - [ ] 실패 다이얼로그에서 "Issue 신고" 버튼 클릭 → 제목 필드에 `빌드 실패: {error_code}` 프리필 확인
   - [ ] 전송 → Sentry에서 **기존 빌드 에러 이슈에** User Feedback이 코멘트처럼 붙는지 확인 (새 이벤트가 아님)
   - [ ] `AITEditorErrorTracker.LastEventId` 가 null인 상황(예: consent 꺼진 상태에서 에러 없이 바로 제보)에서는 fallback 경고 로그 + 새 이벤트로 전송되는지 확인

3. **배포 실패 경로 (Publish failure)**
   - [ ] Publish 실패 다이얼로그 → "Issue 신고" → 제목 프리필 `배포 실패` 확인 + 전송 성공

4. **실패/재시도 경로**
   - [ ] 방화벽으로 `*.ingest.sentry.io` 차단 → 전송 시도 → "제보 실패" 다이얼로그 + 에러 메시지 표시
   - [ ] "다시 시도" 클릭 → 재전송 루프 동작 확인
   - [ ] "취소" 클릭 → 윈도우 정상 닫힘

5. **엣지 케이스**
   - [ ] 전송 중 윈도우를 OS 창 닫기(X 버튼)로 강제 종료 → 콘솔에 `MissingReferenceException` 없음 (zombie 가드 동작 확인)
   - [ ] 에러 수집 consent 꺼진 상태에서 수동 제보 → DSN 세팅 후 전송 성공 (능동 행위 예외 처리)

## 관련 문서

- 스펙: `docs/superpowers/specs/2026-04-23-issue-report-sentry-design.md` (로컬 전용, 커밋 X — gitignored)
- 플랜: `docs/superpowers/plans/2026-04-23-issue-report-sentry.md` (로컬 전용, 커밋 X)