### PR TITLE
수정: 모든 Sample 프로젝트 WebGL Graphics API 명시적 설정 적용

### DIFF
--- a/Tests~/E2E/SampleUnityProject-2021.3/ProjectSettings/ProjectSettings.asset
+++ b/Tests~/E2E/SampleUnityProject-2021.3/ProjectSettings/ProjectSettings.asset
@@ -277,7 +277,10 @@ PlayerSettings:
   m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs: []
   m_BuildTargetGraphicsJobMode: []
-  m_BuildTargetGraphicsAPIs: []
+  m_BuildTargetGraphicsAPIs:
+  - m_BuildTarget: WebGLSupport
+    m_APIs: 0b000000
+    m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16
   m_DefaultShaderChunkCount: 0

--- a/Tests~/E2E/SampleUnityProject-2022.3/ProjectSettings/ProjectSettings.asset
+++ b/Tests~/E2E/SampleUnityProject-2022.3/ProjectSettings/ProjectSettings.asset
@@ -292,7 +292,10 @@ PlayerSettings:
   m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs: []
   m_BuildTargetGraphicsJobMode: []
-  m_BuildTargetGraphicsAPIs: []
+  m_BuildTargetGraphicsAPIs:
+  - m_BuildTarget: WebGLSupport
+    m_APIs: 0b000000
+    m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16
   m_DefaultShaderChunkCount: 0

--- a/Tests~/E2E/SampleUnityProject-6000.0/ProjectSettings/ProjectSettings.asset
+++ b/Tests~/E2E/SampleUnityProject-6000.0/ProjectSettings/ProjectSettings.asset
@@ -296,7 +296,10 @@ PlayerSettings:
   m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs: []
   m_BuildTargetGraphicsJobMode: []
-  m_BuildTargetGraphicsAPIs: []
+  m_BuildTargetGraphicsAPIs:
+  - m_BuildTarget: WebGLSupport
+    m_APIs: 0b000000
+    m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16
   m_DefaultShaderChunkCount: 0

--- a/Tests~/E2E/SampleUnityProject-6000.2/ProjectSettings/ProjectSettings.asset
+++ b/Tests~/E2E/SampleUnityProject-6000.2/ProjectSettings/ProjectSettings.asset
@@ -297,7 +297,10 @@ PlayerSettings:
   m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs: []
   m_BuildTargetGraphicsJobMode: []
-  m_BuildTargetGraphicsAPIs: []
+  m_BuildTargetGraphicsAPIs:
+  - m_BuildTarget: WebGLSupport
+    m_APIs: 0b000000
+    m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16
   m_DefaultShaderChunkCount: 0

--- a/Tests~/E2E/SampleUnityProject-6000.3/ProjectSettings/ProjectSettings.asset
+++ b/Tests~/E2E/SampleUnityProject-6000.3/ProjectSettings/ProjectSettings.asset
@@ -299,7 +299,10 @@ PlayerSettings:
   m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs: []
   m_BuildTargetGraphicsJobMode: []
-  m_BuildTargetGraphicsAPIs: []
+  m_BuildTargetGraphicsAPIs:
+  - m_BuildTarget: WebGLSupport
+    m_APIs: 0b000000
+    m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16
   m_DefaultShaderChunkCount: 0


### PR DESCRIPTION
## Summary

- Unity로 `SampleUnityProject-2022.3`을 열었을 때 자동 생성된 `m_BuildTargetGraphicsAPIs` 변경사항을 나머지 4개 sample 프로젝트에도 동일하게 적용
- WebGL 플랫폼의 Graphics API를 빈 배열(`[]`)에서 명시적 설정으로 변경:
  - `m_BuildTarget: WebGLSupport`
  - `m_APIs: 0b000000` (WebGL 2.0 / OpenGL ES 3.0)
  - `m_Automatic: 0` (자동 선택 비활성화, 수동 지정)

## 변경된 파일

- `SampleUnityProject-2021.3/ProjectSettings/ProjectSettings.asset`
- `SampleUnityProject-2022.3/ProjectSettings/ProjectSettings.asset`
- `SampleUnityProject-6000.0/ProjectSettings/ProjectSettings.asset`
- `SampleUnityProject-6000.2/ProjectSettings/ProjectSettings.asset`
- `SampleUnityProject-6000.3/ProjectSettings/ProjectSettings.asset`

## Test plan

- [ ] E2E 테스트 통과 확인 (WebGL 빌드 포함)