### PR TITLE
기능: Sentry strict error_source 게이트 + 노이즈 패턴 확장

### DIFF
--- a/Editor/AITDeprecationChecker.cs
+++ b/Editor/AITDeprecationChecker.cs
@@ -124,7 +124,8 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AIT] sdk-policy.json fetch 실패: {e}");
+                // 네트워크/접근 실패 fallback — SDK 결함 아니므로 Sentry 전송 억제
+                AITLog.Warning($"[AIT] sdk-policy.json fetch 실패: {e}", sentryCapture: false);
                 return null;
             }
 

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -311,6 +311,11 @@ namespace AppsInToss.Editor.ErrorTracker
                 && message.IndexOf("immutable packages", StringComparison.OrdinalIgnoreCase) >= 0)
                 return;
 
+            // Strict error_source 게이트: 출처가 SDK로 확정되지 않은 메시지는 전송하지 않음.
+            // DetermineErrorSource는 스택트레이스 우선, 그 다음 메시지 키워드(AIT/Sentry/SdkMessagePatterns) 순으로 분류.
+            if (ShouldDropAsNonSdkSource(message, stackTrace))
+                return;
+
             string level;
             string exceptionType;
 
@@ -627,6 +632,16 @@ namespace AppsInToss.Editor.ErrorTracker
                 return true;
 
             return false;
+        }
+
+        /// <summary>
+        /// strict error_source 게이트 판정. DetermineErrorSource() != "sdk"이면 true(드롭).
+        /// 필터 체인의 다른 단계(LogType, _suppressLogCaptureCount, IsAitRelated, IsKnownNonSdkMessage,
+        /// immutable packages)를 모두 통과한 메시지에 대해 마지막으로 출처를 strict 검사한다.
+        /// </summary>
+        internal static bool ShouldDropAsNonSdkSource(string message, string stackTrace)
+        {
+            return DetermineErrorSource(stackTrace, message) != "sdk";
         }
 
         private static string ExtractExceptionType(string message)

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -312,7 +312,6 @@ namespace AppsInToss.Editor.ErrorTracker
                 return;
 
             // Strict error_source 게이트: 출처가 SDK로 확정되지 않은 메시지는 전송하지 않음.
-            // DetermineErrorSource는 스택트레이스 우선, 그 다음 메시지 키워드(AIT/Sentry/SdkMessagePatterns) 순으로 분류.
             if (ShouldDropAsNonSdkSource(message, stackTrace))
                 return;
 
@@ -638,9 +637,11 @@ namespace AppsInToss.Editor.ErrorTracker
         /// strict error_source 게이트 판정. DetermineErrorSource() != "sdk"이면 true(드롭).
         /// 필터 체인의 다른 단계(LogType, _suppressLogCaptureCount, IsAitRelated, IsKnownNonSdkMessage,
         /// immutable packages)를 모두 통과한 메시지에 대해 마지막으로 출처를 strict 검사한다.
+        /// 분류 우선순위는 DetermineErrorSource를 따른다: 스택트레이스 우선, 그 다음 메시지 키워드(AIT/Sentry/SdkMessagePatterns).
         /// </summary>
         internal static bool ShouldDropAsNonSdkSource(string message, string stackTrace)
         {
+            // 인수 순서 주의: DetermineErrorSource는 (stackTrace, message) 순.
             return DetermineErrorSource(stackTrace, message) != "sdk";
         }
 

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -72,9 +72,14 @@ namespace AppsInToss.Editor.ErrorTracker
             "[ServicesCore]",
             "ProfileValueReference: GetValue called with empty id",
             "The Editor does not support 32-bit plugins",
+            // Unity 라이프사이클 경고 — 사용자 MonoBehaviour의 Awake/OnValidate에서 발생
+            "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate",
+            // Unity Animator — 사용자 프로젝트의 레거시 클립 사용
+            "Legacy AnimationClips are not allowed in Animator Controllers",
 
             // 사용자 프로젝트 에셋 문제
             "matches more than one built-in atlases",
+            "Warnings during import of AudioClip",
 
             // Unity 패키지 내부
             "Localization-String-Tables-",
@@ -88,6 +93,9 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // Unity URP 내부
             "exceeds previous array size",
+
+            // 사용자 Addressable 설정
+            "does not have any associated AddressableAssetGroupSchemas",
 
             // 사용자 Unity 설치에 WebGL 모듈 미설치 — SDK-DD
             "Build target 'WebGL' not supported",

--- a/Editor/Menu/PortResolver.cs
+++ b/Editor/Menu/PortResolver.cs
@@ -127,7 +127,8 @@ namespace AppsInToss.Editor.Menu
                 {
                     // 타임아웃 — 그래도 브라우저 열기 (사용자가 직접 새로고침 가능)
                     EditorApplication.update -= PollVitePort;
-                    Debug.LogWarning($"[AIT] Vite 포트 {port} 대기 타임아웃 ({maxWaitSeconds}초), 브라우저를 엽니다");
+                    // 정상 흐름의 timeout fallback이므로 Sentry 전송 억제
+                    AITLog.Warning($"[AIT] Vite 포트 {port} 대기 타임아웃 ({maxWaitSeconds}초), 브라우저를 엽니다", sentryCapture: false);
                     Application.OpenURL(url);
                 }
             }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -336,6 +336,71 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 신규 추가 패턴 (PR2 strict source gate)
+
+    [Test]
+    public void SendMessageDuringAwake_ReturnsTrue()
+    {
+        // Sentry KQ/KD/KC/KB — Unity 자체 경고
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate."));
+    }
+
+    [Test]
+    public void SendMessageDuringAwake_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 보호 가드: AIT prefix 붙으면 필터 안 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] SendMessage cannot be called during Awake, CheckConsistency, or OnValidate."));
+    }
+
+    [Test]
+    public void LegacyAnimationClips_ReturnsTrue()
+    {
+        // Sentry KT/KV — Unity 자체 경고
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Legacy AnimationClips are not allowed in Animator Controllers"));
+    }
+
+    [Test]
+    public void LegacyAnimationClips_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Legacy AnimationClips are not allowed in Animator Controllers"));
+    }
+
+    [Test]
+    public void AddressableGroupSchemasMissing_ReturnsTrue()
+    {
+        // Sentry KR — 사용자 프로젝트의 Addressable 설정 문제
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Group 'Default Local Group' does not have any associated AddressableAssetGroupSchemas"));
+    }
+
+    [Test]
+    public void AddressableGroupSchemasMissing_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Group 'Foo' does not have any associated AddressableAssetGroupSchemas"));
+    }
+
+    [Test]
+    public void AudioClipImportWarning_ReturnsTrue()
+    {
+        // Sentry GT/GV — 사용자 프로젝트 에셋 import 경고
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Warnings during import of AudioClip Assets/Sounds/bgm.wav"));
+    }
+
+    [Test]
+    public void AudioClipImportWarning_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Warnings during import of AudioClip Assets/Sounds/bgm.wav"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -142,6 +142,37 @@ public class IsKnownNonSdkMessageTests
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage("The Editor does not support 32-bit plugins"));
     }
 
+    [Test]
+    public void SendMessageDuringAwake_ReturnsTrue()
+    {
+        // Sentry KQ/KD/KC/KB — Unity 자체 경고
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate."));
+    }
+
+    [Test]
+    public void SendMessageDuringAwake_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 보호 가드: AIT prefix 붙으면 필터 안 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] SendMessage cannot be called during Awake, CheckConsistency, or OnValidate."));
+    }
+
+    [Test]
+    public void LegacyAnimationClips_ReturnsTrue()
+    {
+        // Sentry KT/KV — Unity 자체 경고
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Legacy AnimationClips are not allowed in Animator Controllers"));
+    }
+
+    [Test]
+    public void LegacyAnimationClips_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Legacy AnimationClips are not allowed in Animator Controllers"));
+    }
+
     #endregion
 
     #region 사용자 프로젝트 에셋 문제
@@ -193,6 +224,21 @@ public class IsKnownNonSdkMessageTests
         // "Script attached to" + "is missing"이지만 Assets/ 경로가 없으면 필터링 안 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Script attached to 'GameObject' is missing or no valid script"));
+    }
+
+    [Test]
+    public void AudioClipImportWarning_ReturnsTrue()
+    {
+        // Sentry GT/GV — 사용자 프로젝트 에셋 import 경고
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Warnings during import of AudioClip Assets/Sounds/bgm.wav"));
+    }
+
+    [Test]
+    public void AudioClipImportWarning_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Warnings during import of AudioClip Assets/Sounds/bgm.wav"));
     }
 
     #endregion
@@ -334,41 +380,6 @@ public class IsKnownNonSdkMessageTests
             "[AIT] GUID [abc123] for asset 'Assets/Foo/bar.png' conflicts with: 'Assets/Baz/bar.png'"));
     }
 
-    #endregion
-
-    #region 신규 추가 패턴 (PR2 strict source gate)
-
-    [Test]
-    public void SendMessageDuringAwake_ReturnsTrue()
-    {
-        // Sentry KQ/KD/KC/KB — Unity 자체 경고
-        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate."));
-    }
-
-    [Test]
-    public void SendMessageDuringAwake_WithAitPrefix_NeverFiltered()
-    {
-        // SDK 보호 가드: AIT prefix 붙으면 필터 안 함
-        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "[AIT] SendMessage cannot be called during Awake, CheckConsistency, or OnValidate."));
-    }
-
-    [Test]
-    public void LegacyAnimationClips_ReturnsTrue()
-    {
-        // Sentry KT/KV — Unity 자체 경고
-        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "Legacy AnimationClips are not allowed in Animator Controllers"));
-    }
-
-    [Test]
-    public void LegacyAnimationClips_WithAitPrefix_NeverFiltered()
-    {
-        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "[AIT] Legacy AnimationClips are not allowed in Animator Controllers"));
-    }
-
     [Test]
     public void AddressableGroupSchemasMissing_ReturnsTrue()
     {
@@ -382,21 +393,6 @@ public class IsKnownNonSdkMessageTests
     {
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AIT] Group 'Foo' does not have any associated AddressableAssetGroupSchemas"));
-    }
-
-    [Test]
-    public void AudioClipImportWarning_ReturnsTrue()
-    {
-        // Sentry GT/GV — 사용자 프로젝트 에셋 import 경고
-        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "Warnings during import of AudioClip Assets/Sounds/bgm.wav"));
-    }
-
-    [Test]
-    public void AudioClipImportWarning_WithAitPrefix_NeverFiltered()
-    {
-        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "[AIT] Warnings during import of AudioClip Assets/Sounds/bgm.wav"));
     }
 
     #endregion

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------------
+// StrictErrorSourceGateTests.cs - strict error_source 게이트 단위 테스트
+// OnLogMessageReceived 필터 체인 7.5 단계의 ShouldDropAsNonSdkSource 헬퍼 검증.
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+[Category("Unit")]
+public class StrictErrorSourceGateTests
+{
+    #region SDK 출처 → 통과 (false 반환)
+
+    [Test]
+    public void SdkStackFrame_DoesNotDrop()
+    {
+        string stackTrace =
+            "at AppsInToss.Editor.AITConvertCore.DoExport () in Packages/im.toss.apps-in-toss-unity-sdk/Editor/AITConvertCore.cs:42";
+
+        Assert.IsFalse(AITEditorErrorTracker.ShouldDropAsNonSdkSource("some sdk error", stackTrace));
+    }
+
+    [Test]
+    public void NoStackTrace_AitKeywordInMessage_DoesNotDrop()
+    {
+        // 스택 없으면 메시지 기반 fallback이 SDK 키워드로 sdk 분류
+        Assert.IsFalse(AITEditorErrorTracker.ShouldDropAsNonSdkSource("[AIT] build failed", null));
+    }
+
+    [Test]
+    public void NoStackTrace_SentryPrefix_DoesNotDrop()
+    {
+        // Sentry transport 자체 에러는 sdk로 분류되어 통과
+        Assert.IsFalse(AITEditorErrorTracker.ShouldDropAsNonSdkSource("Sentry: failed to flush envelope", ""));
+    }
+
+    [Test]
+    public void NoStackTrace_SdkMessagePattern_DoesNotDrop()
+    {
+        // SdkMessagePatterns의 [Validation], [pnpm], webgl/Build/ 등은 sdk
+        Assert.IsFalse(AITEditorErrorTracker.ShouldDropAsNonSdkSource("[Validation] failed", ""));
+    }
+
+    #endregion
+
+    #region 사용자 프로젝트 출처 → 드롭 (true 반환)
+
+    [Test]
+    public void UserProjectStackFrame_Drops()
+    {
+        string stackTrace =
+            "at MyGame.PlayerController.Start () in Assets/Scripts/PlayerController.cs:15";
+
+        Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource("user error", stackTrace));
+    }
+
+    #endregion
+
+    #region 분류 불가 (unknown) → 드롭 (true 반환)
+
+    [Test]
+    public void NoStackTrace_NoSdkKeyword_Drops()
+    {
+        // 스택 없음 + AIT/Sentry/SdkMessagePatterns 어느 것도 매칭 안 됨 → unknown → 드롭
+        Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource("Random Unity warning text", null));
+    }
+
+    [Test]
+    public void EmptyStackAndMessage_Drops()
+    {
+        Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource("", ""));
+    }
+
+    [Test]
+    public void NullMessageAndStack_Drops()
+    {
+        Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource(null, null));
+    }
+
+    #endregion
+
+    #region 메시지 기반 fallback과의 상호작용
+
+    [Test]
+    public void UserStackButSdkMessage_Drops()
+    {
+        // 스택은 user_project로 결정됨 — 메시지 키워드보다 스택이 우선이므로 드롭
+        // (DetermineErrorSource는 스택이 있으면 스택으로 결정, 없을 때만 메시지 fallback)
+        string stackTrace =
+            "at MyGame.PlayerController.Start () in Assets/Scripts/PlayerController.cs:15";
+
+        Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource("[AIT] suppressed by user code", stackTrace));
+    }
+
+    #endregion
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a839ac823cfb4dd28040333676224c69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs/claude/sentry-known-issues.md
+++ b/docs/claude/sentry-known-issues.md
@@ -34,3 +34,32 @@ resolve 처리됨, 재발 시 모니터링합니다.
   - "Filter by environment" 활성화 → `edit-mode-test` 차단
   - 추가 안전망: "Filter by error message" → `[AIT-TEST]` prefix 포함 메시지 차단
 - 이 필터 설정 없이는 CI에서 통합 테스트가 돌 때마다 프로덕션 Sentry에 이벤트가 유입됨
+
+## 정상 흐름 fallback warning 컨벤션
+
+SDK 정상 흐름의 fallback / timeout / 예측된 분기에서 발생하는 warning은
+`Debug.LogWarning(...)`이 아닌 `AITLog.Warning(msg, sentryCapture: false)`을
+사용한다 (`Editor/AITLog.cs`).
+
+**판정 기준**: "이 메시지가 Sentry 이슈로 등록되었을 때 SDK 결함 조사가 필요한가?"
+필요 없으면(예: 네트워크 timeout, 사용자 환경 차이로 인한 분기) `sentryCapture: false`.
+
+**예시 (현재 적용)**:
+- `Editor/Menu/PortResolver.cs` — Vite 포트 polling timeout 후 브라우저 직접 열기
+- `Editor/AITDeprecationChecker.cs` — sdk-policy.json fetch 실패 시 호환성 검사 스킵
+
+**리뷰 항목**: 새 PR에서 `Debug.LogWarning(` 추가 시 — 진짜 결함 조사가 필요한지
+호출 지점 컨텍스트로 판정. 불필요하면 `AITLog.Warning(..., sentryCapture: false)` 권고.
+
+## 이중 안전망: strict 게이트 + NonSdkMessagePatterns
+
+`AITEditorErrorTracker.cs`의 필터 체인은 두 메커니즘으로 노이즈를 차단한다.
+
+1. **`NonSdkMessagePatterns`** (`AITEditorErrorTracker.cs:65-`): 알려진 Unity/사용자
+   메시지의 부분 문자열 매칭. 명시적이라 코드 리뷰로 의도 확인 가능.
+2. **strict error_source 게이트** (`ShouldDropAsNonSdkSource`): `DetermineErrorSource()`가
+   `"sdk"`로 분류하지 않은 메시지를 모두 드롭. 새 노이즈가 등장해도 패턴 추가 없이 차단.
+
+두 메커니즘은 독립적이라 한쪽이 실패해도 다른 쪽이 보완한다. strict 게이트가
+SDK 결함을 false negative로 드롭하면 §"무시해도 되는 이슈 패턴" 모니터링에서
+포착 → `IsAitRelated` 화이트리스트 또는 `SdkMessagePatterns` 키워드 추가로 복구.

--- a/docs/claude/sentry-known-issues.md
+++ b/docs/claude/sentry-known-issues.md
@@ -38,7 +38,7 @@ resolve 처리됨, 재발 시 모니터링합니다.
 ## 정상 흐름 fallback warning 컨벤션
 
 SDK 정상 흐름의 fallback / timeout / 예측된 분기에서 발생하는 warning은
-`Debug.LogWarning(...)`이 아닌 `AITLog.Warning(msg, sentryCapture: false)`을
+`Debug.LogWarning(...)`이 아닌 `AITLog.Warning(msg, sentryCapture: false)`를
 사용한다 (`Editor/AITLog.cs`).
 
 **판정 기준**: "이 메시지가 Sentry 이슈로 등록되었을 때 SDK 결함 조사가 필요한가?"

--- a/docs/claude/sentry-known-issues.md
+++ b/docs/claude/sentry-known-issues.md
@@ -44,19 +44,23 @@ SDK 정상 흐름의 fallback / timeout / 예측된 분기에서 발생하는 wa
 **판정 기준**: "이 메시지가 Sentry 이슈로 등록되었을 때 SDK 결함 조사가 필요한가?"
 필요 없으면(예: 네트워크 timeout, 사용자 환경 차이로 인한 분기) `sentryCapture: false`.
 
-**예시 (현재 적용)**:
+**대표 사례 (점진 적용 중)**:
 - `Editor/Menu/PortResolver.cs` — Vite 포트 polling timeout 후 브라우저 직접 열기
 - `Editor/AITDeprecationChecker.cs` — sdk-policy.json fetch 실패 시 호환성 검사 스킵
 
+`AITDeprecationChecker.cs`에는 다른 `Debug.LogWarning(...)` 호출이 남아 있다(파싱 실패,
+minVersion 비정상, 태그 자동 감지 실패 등). 이 컨벤션은 일괄 적용이 아니라 신규/수정
+호출 지점에서 판정 기준에 따라 점진 적용한다.
+
 **리뷰 항목**: 새 PR에서 `Debug.LogWarning(` 추가 시 — 진짜 결함 조사가 필요한지
-호출 지점 컨텍스트로 판정. 불필요하면 `AITLog.Warning(..., sentryCapture: false)` 권고.
+호출 지점 컨텍스트로 판정. 불필요하면 `AITLog.Warning(..., sentryCapture: false)`를 권고.
 
 ## 이중 안전망: strict 게이트 + NonSdkMessagePatterns
 
-`AITEditorErrorTracker.cs`의 필터 체인은 두 메커니즘으로 노이즈를 차단한다.
+`Editor/ErrorTracker/AITEditorErrorTracker.cs`의 필터 체인은 두 메커니즘으로 노이즈를 차단한다.
 
-1. **`NonSdkMessagePatterns`** (`AITEditorErrorTracker.cs:65-`): 알려진 Unity/사용자
-   메시지의 부분 문자열 매칭. 명시적이라 코드 리뷰로 의도 확인 가능.
+1. **`NonSdkMessagePatterns` 배열**: 알려진 Unity/사용자 메시지의 부분 문자열 매칭.
+   명시적이라 코드 리뷰로 의도 확인 가능.
 2. **strict error_source 게이트** (`ShouldDropAsNonSdkSource`): `DetermineErrorSource()`가
    `"sdk"`로 분류하지 않은 메시지를 모두 드롭. 새 노이즈가 등장해도 패턴 추가 없이 차단.
 


### PR DESCRIPTION
## Summary

Sentry 노이즈 차단을 위한 이중 안전망(strict error_source 게이트 + `NonSdkMessagePatterns` 확장)을 추가하고, 정상 흐름 fallback warning 컨벤션을 두 호출 지점에 적용.

- **strict 게이트** (`AITEditorErrorTracker.cs`): `DetermineErrorSource()`가 `"sdk"`로 분류하지 않은 메시지를 필터 체인 7.5단계에서 드롭. 새 노이즈가 등장해도 패턴 추가 없이 차단.
- **`NonSdkMessagePatterns` 확장**: Unity 라이프사이클(SendMessageDuringAwake), Animator(LegacyAnimationClips), 사용자 에셋(AudioClipImportWarning), 사용자 Addressable(AddressableGroupSchemasMissing) 4개 패턴 추가.
- **호출 지점 마이그레이션** (2건): `Editor/Menu/PortResolver.cs`(Vite 포트 timeout fallback), `Editor/AITDeprecationChecker.cs`(sdk-policy fetch 실패 fallback)를 `AITLog.Warning(..., sentryCapture: false)`로 전환. 두 곳은 정상 흐름 분기이므로 Sentry 전송 불필요.
- **컨벤션 문서화** (`docs/claude/sentry-known-issues.md`): 정상 흐름 fallback warning 컨벤션 + 이중 안전망 메커니즘 설명. 신규 PR에서 `Debug.LogWarning(` 추가 시 리뷰 가이드 포함.

## 설계 메모

- 필터 체인 위치는 `_suppressLogCaptureCount`보다 뒤이므로 `AITLog.Warning(..., sentryCapture: false)` 호출은 strict 게이트에 도달하기 전 차단됨.
- 두 메커니즘(`NonSdkMessagePatterns` + strict gate)은 독립적이라 한쪽이 실패해도 다른 쪽이 보완. strict 게이트가 SDK 결함을 false negative로 드롭하면 `IsAitRelated` 화이트리스트 또는 `SdkMessagePatterns` 키워드로 복구.
- 스펙 §7 T3 `FilterChainOrderTests`는 의도적으로 제외(기존 인프라가 D2 시나리오 보장 — 새 게이트가 suppression 단계보다 뒤라서 영향 없음).

## Test plan

- [x] `./run-local-tests.sh --validate` PASS (3 passed, 0 failed) — 로컬 환경에 Unity 미설치이므로 EditMode 테스트는 CI에 위임.
- [ ] CI EditMode 테스트(`StrictErrorSourceGateTests`, `IsKnownNonSdkMessageTests` 신규 8건) 통과 확인.
- [ ] 머지 후 Sentry 대시보드에서 `editor` environment 신규 이슈 유입이 줄어드는지 모니터링.
