### PR TITLE
수정: stale pnpm-lock.yaml로 인한 Dev Server 시작 실패 회복

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -217,8 +217,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Checkout (버전 참조용)
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,8 +135,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: web-framework 버전 업데이트 및 SDK 재생성
         working-directory: sdk-runtime-generator~
@@ -630,8 +628,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Checkout (버전 참조용)
         uses: actions/checkout@v6

--- a/.github/workflows/sdk-update-rebase.yml
+++ b/.github/workflows/sdk-update-rebase.yml
@@ -157,8 +157,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: 버전 설정
         id: version

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -148,8 +148,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Dependencies
         working-directory: sdk-runtime-generator~

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Dependencies
         working-directory: sdk-runtime-generator~

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -184,8 +184,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: 버전 설정
         id: version

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Dependencies
         working-directory: sdk-runtime-generator~

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,16 @@
 - SDK API 변경이 필요하면 반드시 `sdk-runtime-generator~/` 내 코드를 수정할 것
 - 생성기 수정 후 검증 순서: `pnpm generate` → `pnpm validate` → `pnpm test`
 
+### pnpm 버전 핀 동기화
+
+`Editor/AITPackageManagerHelper.cs`의 `PNPM_VERSION` 상수와 다음 세 파일의 `"packageManager"` 필드는 **항상 같은 버전**으로 유지해야 한다. 한 곳을 bump하면 나머지도 함께 bump:
+
+- `package.json` (UPM 매니페스트)
+- `sdk-runtime-generator~/package.json`
+- `WebGLTemplates/AITTemplate/BuildConfig~/package.json`
+
+값이 갈라지면 클라이언트 SDK가 사용하는 pnpm과 lockfile을 갱신한 pnpm이 달라져 미세한 specifier drift가 발생할 수 있다.
+
 ### GitHub Actions 관련
 - `gh workflow run` 명령어 사용 불가 (GraphQL 차단) — REST API 사용 필수
 - 워크플로우 트리거 예시와 ID 참조 테이블은 `docs/claude/github-actions.md` 참조

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -419,46 +419,8 @@ namespace AppsInToss.Editor
             // 1. package.json - dependencies 머지
             Package.BuildConfigMerger.MergePackageJson(projectBuildConfigPath, sdkBuildConfigPath, buildProjectPath);
 
-            // 2. pnpm-lock.yaml - 프로젝트 lockfile + package.json이 정합 상태일 때만 사용,
-            //    아니면 SDK lockfile로 폴백 (stale lockfile 회귀 방지).
-            string pnpmLockProject = Path.Combine(projectBuildConfigPath, "pnpm-lock.yaml");
-            string pnpmLockSdk = Path.Combine(sdkBuildConfigPath, "pnpm-lock.yaml");
-            string pnpmLockDst = Path.Combine(buildProjectPath, "pnpm-lock.yaml");
-            string projectPackageJson = Path.Combine(projectBuildConfigPath, "package.json");
-
-            bool useProjectLockfile = false;
-            if (File.Exists(pnpmLockProject))
-            {
-                if (File.Exists(projectPackageJson))
-                {
-                    if (Package.LockfileValidator.IsLockfileInSync(projectPackageJson, pnpmLockProject, out string mismatchSummary))
-                    {
-                        useProjectLockfile = true;
-                    }
-                    else
-                    {
-                        Debug.LogWarning(
-                            "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml이 package.json과 정합되지 않아 SDK lockfile로 폴백합니다. " +
-                            "불일치: " + mismatchSummary);
-                    }
-                }
-                else
-                {
-                    Debug.LogWarning(
-                        "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml은 있지만 package.json이 없어 검증 불가. SDK lockfile로 폴백합니다.");
-                }
-            }
-
-            if (useProjectLockfile)
-            {
-                File.Copy(pnpmLockProject, pnpmLockDst, true);
-                Debug.Log("[AIT]   ✓ pnpm-lock.yaml (프로젝트에서 복사, 정합 확인됨)");
-            }
-            else if (File.Exists(pnpmLockSdk))
-            {
-                File.Copy(pnpmLockSdk, pnpmLockDst, true);
-                Debug.Log("[AIT]   ✓ pnpm-lock.yaml (SDK에서 복사)");
-            }
+            // 2. pnpm-lock.yaml - 정합성 검증 후 폴백 정책 (Fix A, BuildConfigMerger 위임)
+            Package.BuildConfigMerger.CopyPnpmLockfileWithFallback(projectBuildConfigPath, sdkBuildConfigPath, buildProjectPath);
 
             // 3. vite.config.ts - 마커 기반 업데이트
             Package.BuildConfigMerger.UpdateViteConfig(projectBuildConfigPath, sdkBuildConfigPath, buildProjectPath, config);

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -419,14 +419,40 @@ namespace AppsInToss.Editor
             // 1. package.json - dependencies 머지
             Package.BuildConfigMerger.MergePackageJson(projectBuildConfigPath, sdkBuildConfigPath, buildProjectPath);
 
-            // 2. pnpm-lock.yaml - 프로젝트 우선, 없으면 SDK
+            // 2. pnpm-lock.yaml - 프로젝트 lockfile + package.json이 정합 상태일 때만 사용,
+            //    아니면 SDK lockfile로 폴백 (stale lockfile 회귀 방지).
             string pnpmLockProject = Path.Combine(projectBuildConfigPath, "pnpm-lock.yaml");
             string pnpmLockSdk = Path.Combine(sdkBuildConfigPath, "pnpm-lock.yaml");
             string pnpmLockDst = Path.Combine(buildProjectPath, "pnpm-lock.yaml");
+            string projectPackageJson = Path.Combine(projectBuildConfigPath, "package.json");
+
+            bool useProjectLockfile = false;
             if (File.Exists(pnpmLockProject))
             {
+                if (File.Exists(projectPackageJson))
+                {
+                    if (Package.LockfileValidator.IsLockfileInSync(projectPackageJson, pnpmLockProject, out string mismatchSummary))
+                    {
+                        useProjectLockfile = true;
+                    }
+                    else
+                    {
+                        Debug.LogWarning(
+                            "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml이 package.json과 정합되지 않아 SDK lockfile로 폴백합니다. " +
+                            "불일치: " + mismatchSummary);
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning(
+                        "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml은 있지만 package.json이 없어 검증 불가. SDK lockfile로 폴백합니다.");
+                }
+            }
+
+            if (useProjectLockfile)
+            {
                 File.Copy(pnpmLockProject, pnpmLockDst, true);
-                Debug.Log("[AIT]   ✓ pnpm-lock.yaml (프로젝트에서 복사)");
+                Debug.Log("[AIT]   ✓ pnpm-lock.yaml (프로젝트에서 복사, 정합 확인됨)");
             }
             else if (File.Exists(pnpmLockSdk))
             {

--- a/Editor/Package/BuildConfigMerger.cs
+++ b/Editor/Package/BuildConfigMerger.cs
@@ -69,6 +69,53 @@ namespace AppsInToss.Editor.Package
         }
 
         /// <summary>
+        /// pnpm-lock.yaml을 destPath로 복사한다. 프로젝트 lockfile이 package.json과 정합 상태일 때만 사용,
+        /// 그렇지 않으면 SDK lockfile로 폴백한다 (stale lockfile 회귀 방지, Fix A).
+        /// 둘 다 없으면 no-op.
+        /// </summary>
+        internal static void CopyPnpmLockfileWithFallback(string projectBuildConfigPath, string sdkBuildConfigPath, string destPath)
+        {
+            string pnpmLockProject = Path.Combine(projectBuildConfigPath, "pnpm-lock.yaml");
+            string pnpmLockSdk = Path.Combine(sdkBuildConfigPath, "pnpm-lock.yaml");
+            string pnpmLockDst = Path.Combine(destPath, "pnpm-lock.yaml");
+            string projectPackageJson = Path.Combine(projectBuildConfigPath, "package.json");
+
+            bool useProjectLockfile = false;
+            if (File.Exists(pnpmLockProject))
+            {
+                if (File.Exists(projectPackageJson))
+                {
+                    if (LockfileValidator.IsLockfileInSync(projectPackageJson, pnpmLockProject, out string mismatchSummary))
+                    {
+                        useProjectLockfile = true;
+                    }
+                    else
+                    {
+                        Debug.LogWarning(
+                            "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml이 package.json과 정합되지 않아 SDK lockfile로 폴백합니다. " +
+                            "불일치: " + mismatchSummary);
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning(
+                        "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml은 있지만 package.json이 없어 검증 불가. SDK lockfile로 폴백합니다.");
+                }
+            }
+
+            if (useProjectLockfile)
+            {
+                File.Copy(pnpmLockProject, pnpmLockDst, true);
+                Debug.Log("[AIT]   ✓ pnpm-lock.yaml (프로젝트에서 복사, 정합 확인됨)");
+            }
+            else if (File.Exists(pnpmLockSdk))
+            {
+                File.Copy(pnpmLockSdk, pnpmLockDst, true);
+                Debug.Log("[AIT]   ✓ pnpm-lock.yaml (SDK에서 복사)");
+            }
+        }
+
+        /// <summary>
         /// dependencies 딕셔너리를 머지합니다. SDK 패키지가 우선됩니다.
         /// </summary>
         internal static Dictionary<string, object> MergeDependencies(Dictionary<string, object> project, Dictionary<string, object> sdk)

--- a/Editor/Package/LockfileValidator.cs
+++ b/Editor/Package/LockfileValidator.cs
@@ -12,6 +12,7 @@ namespace AppsInToss.Editor.Package
     /// 외부 YAML 라이브러리에 의존하지 않기 위해 lockfile은 정규식 기반으로
     /// 'importers."."' 섹션의 specifier 값만 추출한다. lockfileVersion이
     /// 검증되지 않은 형식이면 false를 반환하여 안전 폴백을 유도한다.
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
     /// </summary>
     internal static class LockfileValidator
     {

--- a/Editor/Package/LockfileValidator.cs
+++ b/Editor/Package/LockfileValidator.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// 사용자 프로젝트 BuildConfig~ 의 package.json과 pnpm-lock.yaml 사이
+    /// dep specifier 정합성을 검증한다. mismatch가 있으면 SDK 출하 lockfile로
+    /// 폴백할 수 있도록 호출자에게 정보를 제공한다.
+    ///
+    /// 외부 YAML 라이브러리에 의존하지 않기 위해 lockfile은 정규식 기반으로
+    /// 'importers."."' 섹션의 specifier 값만 추출한다. lockfileVersion이
+    /// 검증되지 않은 형식이면 false를 반환하여 안전 폴백을 유도한다.
+    /// </summary>
+    internal static class LockfileValidator
+    {
+        // 지원하는 lockfileVersion. pnpm 9, 10이 동일한 v9.0 형식을 사용.
+        // 미래 메이저 변경 시 의도적으로 false를 반환해 SDK 폴백 경로로 보낸다.
+        private static readonly HashSet<string> SupportedLockfileVersions = new HashSet<string> { "9.0", "9" };
+
+        /// <summary>
+        /// package.json의 dependencies/devDependencies 모든 항목의 specifier가
+        /// lockfile importers."."의 specifier와 정확히 일치하면 true.
+        /// 그렇지 않으면 false 와 함께 mismatchSummary 에 사람이 읽을 수 있는
+        /// 한 줄 요약을 채운다.
+        /// </summary>
+        internal static bool IsLockfileInSync(string packageJsonPath, string lockfilePath, out string mismatchSummary)
+        {
+            mismatchSummary = "";
+
+            if (!File.Exists(packageJsonPath))
+            {
+                mismatchSummary = $"package.json 없음: {packageJsonPath}";
+                return false;
+            }
+            if (!File.Exists(lockfilePath))
+            {
+                mismatchSummary = $"pnpm-lock.yaml 없음: {lockfilePath}";
+                return false;
+            }
+
+            // package.json 파싱 (MiniJson 재사용)
+            var manifest = ParseManifestSpecifiers(packageJsonPath);
+            if (manifest == null)
+            {
+                mismatchSummary = "package.json 파싱 실패";
+                return false;
+            }
+
+            // lockfile 파싱 (lockfileVersion 가드 포함)
+            string lockfileText = File.ReadAllText(lockfilePath);
+            string version = ParseLockfileVersion(lockfileText);
+            if (version == null || !SupportedLockfileVersions.Contains(version))
+            {
+                mismatchSummary = $"지원하지 않는 lockfileVersion: '{version}'";
+                return false;
+            }
+
+            var lockfileSpecs = ParseLockfileImporterSpecifiers(lockfileText);
+
+            // 정합성 비교: 양방향 검증 (manifest의 모든 dep이 lockfile에 있고 specifier 일치)
+            var diffs = new List<string>();
+            foreach (var kvp in manifest)
+            {
+                if (!lockfileSpecs.TryGetValue(kvp.Key, out string lockSpec))
+                {
+                    diffs.Add($"{kvp.Key} (manifest={kvp.Value}, lockfile=없음)");
+                }
+                else if (lockSpec != kvp.Value)
+                {
+                    diffs.Add($"{kvp.Key} (lockfile={lockSpec}, manifest={kvp.Value})");
+                }
+            }
+            // lockfile에만 있는 dep은 stale 잔재로 간주
+            foreach (var kvp in lockfileSpecs)
+            {
+                if (!manifest.ContainsKey(kvp.Key))
+                {
+                    diffs.Add($"{kvp.Key} (lockfile={kvp.Value}, manifest=없음)");
+                }
+            }
+
+            if (diffs.Count == 0) return true;
+
+            mismatchSummary = string.Join(", ", diffs);
+            return false;
+        }
+
+        private static Dictionary<string, string> ParseManifestSpecifiers(string packageJsonPath)
+        {
+            try
+            {
+                string json = File.ReadAllText(packageJsonPath);
+                var root = MiniJson.Deserialize(json) as Dictionary<string, object>;
+                if (root == null) return null;
+
+                var result = new Dictionary<string, string>();
+                CollectStringMap(root, "dependencies", result);
+                CollectStringMap(root, "devDependencies", result);
+                return result;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void CollectStringMap(Dictionary<string, object> root, string key, Dictionary<string, string> dest)
+        {
+            if (!root.ContainsKey(key)) return;
+            if (!(root[key] is Dictionary<string, object> map)) return;
+            foreach (var kvp in map)
+            {
+                if (kvp.Value is string s) dest[kvp.Key] = s;
+            }
+        }
+
+        // 'lockfileVersion: '9.0'' 또는 'lockfileVersion: 9.0' 첫 줄에서 값 추출.
+        private static readonly Regex LockfileVersionRegex =
+            new Regex(@"^lockfileVersion:\s*'?([0-9.]+)'?\s*$", RegexOptions.Multiline);
+
+        private static string ParseLockfileVersion(string lockfileText)
+        {
+            var m = LockfileVersionRegex.Match(lockfileText);
+            return m.Success ? m.Groups[1].Value : null;
+        }
+
+        // importers."." 블록의 dependencies / devDependencies 섹션에서
+        // <name>: \n  specifier: <value> 패턴을 추출한다.
+        // pnpm-lock.yaml v9.0 형식에 맞춤.
+        internal static Dictionary<string, string> ParseLockfileImporterSpecifiers(string lockfileText)
+        {
+            var result = new Dictionary<string, string>();
+
+            // 1) importers 섹션 진입 (단일 importer 'root' = '.:').
+            var importersMatch = Regex.Match(lockfileText, @"^importers:\s*$", RegexOptions.Multiline);
+            if (!importersMatch.Success) return result;
+
+            // 2) importers 섹션 내 '.:' 블록 추출.
+            //    pnpm v9.0은 '.:' 다음 들여쓰기 4칸으로 dependencies/devDependencies가 옴.
+            //    다음 importer가 없으면 packages: 섹션까지가 끝.
+            int importersStart = importersMatch.Index + importersMatch.Length;
+            string afterImporters = lockfileText.Substring(importersStart);
+
+            var rootMatch = Regex.Match(afterImporters, @"^\s*\.:\s*$", RegexOptions.Multiline);
+            if (!rootMatch.Success) return result;
+
+            int rootStart = rootMatch.Index + rootMatch.Length;
+            string afterRoot = afterImporters.Substring(rootStart);
+
+            // 3) 다음 top-level 섹션('packages:', 'snapshots:' 등) 또는 다른 importer 시작 전까지
+            //    동일 들여쓰기 레벨('  ' 다음 들여쓰기 안 들어간 라인)에서 끝남.
+            var endMatch = Regex.Match(afterRoot, @"^[a-zA-Z]", RegexOptions.Multiline);
+            string rootBlock = endMatch.Success ? afterRoot.Substring(0, endMatch.Index) : afterRoot;
+
+            // 4) dependencies / devDependencies 안에서 <name>: + specifier: <value> 추출.
+            //    name 형식: 인용된 '@scope/pkg' 또는 일반 식별자.
+            var specifierRegex = new Regex(
+                @"^\s{6}'?(?<name>[^:\s']+)'?:\s*\n\s+specifier:\s*(?<spec>.+?)\s*$",
+                RegexOptions.Multiline);
+
+            foreach (Match m in specifierRegex.Matches(rootBlock))
+            {
+                string name = m.Groups["name"].Value;
+                string spec = m.Groups["spec"].Value.Trim().Trim('\'', '"');
+                result[name] = spec;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Editor/Package/LockfileValidator.cs.meta
+++ b/Editor/Package/LockfileValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 710d755c85964877ad3ebba91b301c4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/PnpmRunner.cs
+++ b/Editor/Package/PnpmRunner.cs
@@ -229,8 +229,9 @@ namespace AppsInToss.Editor.Package
         /// <summary>
         /// ait-build/pnpm-lock.yaml 을 안전하게 삭제한다. 파일이 없으면 no-op.
         /// 파일 잠금 등 IO 예외는 로그만 남기고 무시 — pnpm install이 어차피 lockfile을 재생성한다.
+        /// internal: EditMode 테스트가 임시 디렉토리에서 IO 동작을 검증하기 위해 접근.
         /// </summary>
-        private static void DeleteLockfileIfExists(string buildProjectPath)
+        internal static void DeleteLockfileIfExists(string buildProjectPath)
         {
             string lockfilePath = System.IO.Path.Combine(buildProjectPath, "pnpm-lock.yaml");
             if (!System.IO.File.Exists(lockfilePath)) return;

--- a/Editor/Package/PnpmRunner.cs
+++ b/Editor/Package/PnpmRunner.cs
@@ -6,7 +6,7 @@ namespace AppsInToss.Editor.Package
 {
     /// <summary>
     /// pnpm install 실행 (동기/비동기/백그라운드).
-    /// PnpmStoreManager의 InstallStages 정책을 기반으로 frozen → lockfile 갱신 → clean 재시도 순으로 진행.
+    /// PnpmStoreManager의 InstallStages 정책을 기반으로 frozen → lockfile 갱신 → lockfile 폐기 → clean 재시도 순으로 진행.
     /// 실패 시 NodeModulesValidator.CleanNodeModules로 복구 후 재시도.
     /// </summary>
     internal static class PnpmRunner
@@ -52,12 +52,13 @@ namespace AppsInToss.Editor.Package
             var ct = earlyCtx.PnpmCancellationToken;
             var additionalPaths = AITNpmRunner.BuildAdditionalPaths(earlyCtx.PnpmPath);
 
-            foreach (var (args, label, cleanFirst) in PnpmStoreManager.InstallStages)
+            foreach (var (args, label, cleanFirst, deleteLockfileFirst) in PnpmStoreManager.InstallStages)
             {
                 if (ct.IsCancellationRequested)
                     return AITConvertCore.AITExportError.CANCELLED;
 
                 if (cleanFirst) NodeModulesValidator.CleanNodeModules(earlyCtx.BuildProjectPath);
+                if (deleteLockfileFirst) DeleteLockfileIfExists(earlyCtx.BuildProjectPath);
 
                 string fullArguments = AITNpmRunner.BuildFullArguments(args, earlyCtx.LocalCachePath);
                 string command = $"\"{earlyCtx.PnpmPath}\" {fullArguments}";
@@ -162,9 +163,10 @@ namespace AppsInToss.Editor.Package
         /// </summary>
         internal static AITConvertCore.AITExportError RunPnpmInstallSync(AITPackageBuilder.PackageContext ctx)
         {
-            foreach (var (args, label, cleanFirst) in PnpmStoreManager.InstallStages)
+            foreach (var (args, label, cleanFirst, deleteLockfileFirst) in PnpmStoreManager.InstallStages)
             {
                 if (cleanFirst) NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
+                if (deleteLockfileFirst) DeleteLockfileIfExists(ctx.BuildProjectPath);
                 var result = AITNpmRunner.RunNpmCommandWithCache(
                     ctx.BuildProjectPath, ctx.PnpmPath, args, ctx.LocalCachePath,
                     $"pnpm {label}...");
@@ -195,8 +197,9 @@ namespace AppsInToss.Editor.Package
                 return;
             }
 
-            var (args, label, cleanFirst) = PnpmStoreManager.InstallStages[stageIndex];
+            var (args, label, cleanFirst, deleteLockfileFirst) = PnpmStoreManager.InstallStages[stageIndex];
             if (cleanFirst) NodeModulesValidator.CleanNodeModules(buildProjectPath);
+            if (deleteLockfileFirst) DeleteLockfileIfExists(buildProjectPath);
 
             Debug.Log($"[AIT] pnpm {label} 실행 중...");
 
@@ -221,6 +224,26 @@ namespace AppsInToss.Editor.Package
                 },
                 onOutputReceived: onOutput
             );
+        }
+
+        /// <summary>
+        /// ait-build/pnpm-lock.yaml 을 안전하게 삭제한다. 파일이 없으면 no-op.
+        /// 파일 잠금 등 IO 예외는 로그만 남기고 무시 — pnpm install이 어차피 lockfile을 재생성한다.
+        /// </summary>
+        private static void DeleteLockfileIfExists(string buildProjectPath)
+        {
+            string lockfilePath = System.IO.Path.Combine(buildProjectPath, "pnpm-lock.yaml");
+            if (!System.IO.File.Exists(lockfilePath)) return;
+
+            try
+            {
+                System.IO.File.Delete(lockfilePath);
+                Debug.Log("[AIT] pnpm-lock.yaml 삭제됨 (lockfile 폐기 후 재시도 단계)");
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"[AIT] pnpm-lock.yaml 삭제 실패 (무시하고 진행): {e.Message}");
+            }
         }
     }
 }

--- a/Editor/Package/PnpmStoreManager.cs
+++ b/Editor/Package/PnpmStoreManager.cs
@@ -28,15 +28,19 @@ namespace AppsInToss.Editor.Package
         }
 
         /// <summary>
-        /// pnpm install 재시도 정책 (args, label, cleanFirst).
-        /// 1단계 frozen → 2단계 lockfile 갱신 → 3단계 clean 재시도.
+        /// pnpm install 재시도 정책 (args, label, cleanFirst, deleteLockfileFirst).
+        /// 1단계: frozen-lockfile (lockfile 정합 시 통과)
+        /// 2단계: --no-frozen-lockfile (lockfile 갱신 허용)
+        /// 3단계: lockfile 삭제 후 --no-frozen-lockfile (손상된 lockfile 폐기 후 재생성)
+        /// 4단계: node_modules clean + --no-frozen-lockfile (최종 폴백)
         /// </summary>
-        internal static readonly IReadOnlyList<(string args, string label, bool cleanFirst)> InstallStages =
-            new (string args, string label, bool cleanFirst)[]
+        internal static readonly IReadOnlyList<(string args, string label, bool cleanFirst, bool deleteLockfileFirst)> InstallStages =
+            new (string args, string label, bool cleanFirst, bool deleteLockfileFirst)[]
             {
-                ("install --frozen-lockfile", "frozen-lockfile", false),
-                ("install --no-frozen-lockfile", "lockfile 갱신", false),
-                ("install --no-frozen-lockfile", "clean 재시도", true),
+                ("install --frozen-lockfile",    "frozen-lockfile",         false, false),
+                ("install --no-frozen-lockfile", "lockfile 갱신",            false, false),
+                ("install --no-frozen-lockfile", "lockfile 폐기 후 재시도",  false, true),
+                ("install --no-frozen-lockfile", "clean 재시도",            true,  false),
             };
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerJsonTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerJsonTests.cs
@@ -146,5 +146,22 @@ namespace AppsInToss.Editor.Package.Tests
             StringAssert.Contains("\"2.0.0\"", merged);
             Assert.IsFalse(merged.Contains("\"1.0.0\""), "SDK 버전이 우선해야 하는데 프로젝트 버전이 남아있음");
         }
+
+        [Test]
+        public void MergePackageJson_PreservesSdkPackageManagerField()
+        {
+            // SDK의 top-level packageManager 필드가 머지 결과에 보존되는지 검증.
+            // Fix C 회귀 보호: ait-build/package.json에 pnpm 버전 핀이 들어가야 한다.
+            File.WriteAllText(Path.Combine(_projectDir, "package.json"),
+                "{\"dependencies\":{\"user-pkg\":\"1.0.0\"}}");
+            File.WriteAllText(Path.Combine(_sdkDir, "package.json"),
+                "{\"name\":\"sdk\",\"packageManager\":\"pnpm@10.28.0\",\"dependencies\":{}}");
+
+            BuildConfigMerger.MergePackageJson(_projectDir, _sdkDir, _destDir);
+
+            string merged = File.ReadAllText(Path.Combine(_destDir, "package.json"));
+            StringAssert.Contains("packageManager", merged);
+            StringAssert.Contains("pnpm@10.28.0", merged);
+        }
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerLockfileFallbackTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerLockfileFallbackTests.cs
@@ -1,0 +1,134 @@
+// -----------------------------------------------------------------------
+// BuildConfigMergerLockfileFallbackTests.cs - CopyPnpmLockfileWithFallback 통합 검증
+// Level 0: 임시 디렉토리(project/sdk/dest)로 Fix A 폴백 동작 검증
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+
+namespace AppsInToss.Editor.Package.Tests
+{
+    [TestFixture]
+    public class BuildConfigMergerLockfileFallbackTests
+    {
+        private string _projectDir;
+        private string _sdkDir;
+        private string _destDir;
+
+        [SetUp]
+        public void SetupTempDirs()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "ait-lockfile-fallback-tests-" + System.Guid.NewGuid().ToString("N"));
+            _projectDir = Path.Combine(root, "project");
+            _sdkDir = Path.Combine(root, "sdk");
+            _destDir = Path.Combine(root, "dest");
+            Directory.CreateDirectory(_projectDir);
+            Directory.CreateDirectory(_sdkDir);
+            Directory.CreateDirectory(_destDir);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            string root = Path.GetDirectoryName(_projectDir);
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        private const string ProjectLockfileMarker = "PROJECT_LOCKFILE_MARKER";
+        private const string SdkLockfileMarker = "SDK_LOCKFILE_MARKER";
+
+        private static string MakePackageJson(string webFrameworkSpec)
+        {
+            return "{\n  \"dependencies\": {\n    \"@apps-in-toss/web-framework\": \"" + webFrameworkSpec + "\"\n  },\n  \"devDependencies\": {}\n}\n";
+        }
+
+        private static string MakeLockfile(string webFrameworkSpec, string marker)
+        {
+            return "lockfileVersion: '9.0'\n\n" +
+                   "# " + marker + "\n\n" +
+                   "settings:\n  autoInstallPeers: true\n\n" +
+                   "importers:\n\n" +
+                   "  .:\n" +
+                   "    dependencies:\n" +
+                   "      '@apps-in-toss/web-framework':\n" +
+                   "        specifier: " + webFrameworkSpec + "\n" +
+                   "        version: " + webFrameworkSpec + "\n";
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_UsesProjectLockfile_WhenInSync()
+        {
+            File.WriteAllText(Path.Combine(_projectDir, "package.json"), MakePackageJson("2.4.7"));
+            File.WriteAllText(Path.Combine(_projectDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", ProjectLockfileMarker));
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string copied = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(ProjectLockfileMarker, copied,
+                "정합 상태일 때는 프로젝트 lockfile이 그대로 복사되어야 한다");
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_FallsBackToSdk_WhenLockfileStale()
+        {
+            // Sentry B8 시나리오: 사용자 lockfile이 SDK 업그레이드 후 구 specifier를 보유.
+            File.WriteAllText(Path.Combine(_projectDir, "package.json"), MakePackageJson("2.4.7"));
+            File.WriteAllText(Path.Combine(_projectDir, "pnpm-lock.yaml"), MakeLockfile("2.4.1", ProjectLockfileMarker));
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            UnityEngine.TestTools.LogAssert.Expect(UnityEngine.LogType.Warning,
+                new System.Text.RegularExpressions.Regex("정합되지 않아 SDK lockfile로 폴백"));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string copied = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(SdkLockfileMarker, copied,
+                "stale 상태일 때는 SDK lockfile로 폴백해야 한다");
+            Assert.IsFalse(copied.Contains(ProjectLockfileMarker),
+                "stale 프로젝트 lockfile이 dest에 남아있으면 안 된다");
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_FallsBackToSdk_WhenProjectPackageJsonMissing()
+        {
+            // package.json이 없으면 검증 불가 → 안전 폴백.
+            File.WriteAllText(Path.Combine(_projectDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", ProjectLockfileMarker));
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            UnityEngine.TestTools.LogAssert.Expect(UnityEngine.LogType.Warning,
+                new System.Text.RegularExpressions.Regex("package.json이 없어 검증 불가"));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string copied = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(SdkLockfileMarker, copied);
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_UsesSdkLockfile_WhenProjectLockfileMissing()
+        {
+            // 프로젝트 lockfile이 없는 일반 케이스: 경고 없이 SDK 사용.
+            File.WriteAllText(Path.Combine(_projectDir, "package.json"), MakePackageJson("2.4.7"));
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string copied = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(SdkLockfileMarker, copied);
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_NoOp_WhenBothMissing()
+        {
+            // 양쪽 모두 없으면 dest에 lockfile이 생성되지 않아야 한다 (회귀 보호).
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            Assert.IsFalse(File.Exists(Path.Combine(_destDir, "pnpm-lock.yaml")),
+                "양쪽 lockfile이 모두 없을 때 dest에 lockfile이 생성되면 안 된다");
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerLockfileFallbackTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerLockfileFallbackTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16cef72754e446779d38e658211f18e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/LockfileValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/LockfileValidatorTests.cs
@@ -103,6 +103,25 @@ namespace AppsInToss.Editor.Package.Tests
         }
 
         [Test]
+        public void IsLockfileInSync_StaleLeftoverInLockfile_ReturnsFalse()
+        {
+            File.WriteAllText(_packageJsonPath,
+                MakePackageJson("\"@apps-in-toss/web-framework\": \"2.4.7\""));
+            File.WriteAllText(_lockfilePath, MakeLockfile("9.0",
+                "      '@apps-in-toss/web-framework':\n" +
+                "        specifier: 2.4.7\n" +
+                "        version: 2.4.7\n" +
+                "      old-dep-removed-from-manifest:\n" +
+                "        specifier: 1.0.0\n" +
+                "        version: 1.0.0\n"));
+
+            bool result = LockfileValidator.IsLockfileInSync(_packageJsonPath, _lockfilePath, out string summary);
+
+            Assert.IsFalse(result);
+            StringAssert.Contains("old-dep-removed-from-manifest", summary);
+        }
+
+        [Test]
         public void IsLockfileInSync_DevDependenciesAlsoChecked()
         {
             File.WriteAllText(_packageJsonPath,

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/LockfileValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/LockfileValidatorTests.cs
@@ -1,0 +1,166 @@
+// -----------------------------------------------------------------------
+// LockfileValidatorTests.cs - 사용자 BuildConfig~ 의 lockfile/package.json 정합성 검증
+// Level 0: 임시 파일 fixture로 정합성 판정 로직 검증
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+
+namespace AppsInToss.Editor.Package.Tests
+{
+    [TestFixture]
+    public class LockfileValidatorTests
+    {
+        private string _dir;
+        private string _packageJsonPath;
+        private string _lockfilePath;
+
+        [SetUp]
+        public void SetupTempDir()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "ait-lockfile-tests-" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _packageJsonPath = Path.Combine(_dir, "package.json");
+            _lockfilePath = Path.Combine(_dir, "pnpm-lock.yaml");
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+        }
+
+        private static string MakePackageJson(string deps, string devDeps = "")
+        {
+            return "{\n" +
+                   "  \"name\": \"test\",\n" +
+                   "  \"dependencies\": {" + deps + "},\n" +
+                   "  \"devDependencies\": {" + devDeps + "}\n" +
+                   "}\n";
+        }
+
+        private static string MakeLockfile(string lockfileVersion, string depsBlock, string devDepsBlock = "")
+        {
+            return $"lockfileVersion: '{lockfileVersion}'\n\n" +
+                   "settings:\n" +
+                   "  autoInstallPeers: true\n\n" +
+                   "importers:\n\n" +
+                   "  .:\n" +
+                   "    dependencies:\n" + depsBlock +
+                   (string.IsNullOrEmpty(devDepsBlock) ? "" : "    devDependencies:\n" + devDepsBlock);
+        }
+
+        [Test]
+        public void IsLockfileInSync_AllSpecifiersMatch_ReturnsTrue()
+        {
+            File.WriteAllText(_packageJsonPath,
+                MakePackageJson("\"@apps-in-toss/web-framework\": \"2.4.7\""));
+            File.WriteAllText(_lockfilePath, MakeLockfile("9.0",
+                "      '@apps-in-toss/web-framework':\n" +
+                "        specifier: 2.4.7\n" +
+                "        version: 2.4.7\n"));
+
+            bool result = LockfileValidator.IsLockfileInSync(_packageJsonPath, _lockfilePath, out string summary);
+
+            Assert.IsTrue(result, "All specifiers match should return true. Summary: " + summary);
+            Assert.IsEmpty(summary);
+        }
+
+        [Test]
+        public void IsLockfileInSync_StaleSpecifier_ReturnsFalse()
+        {
+            File.WriteAllText(_packageJsonPath,
+                MakePackageJson("\"@apps-in-toss/web-framework\": \"2.4.7\""));
+            File.WriteAllText(_lockfilePath, MakeLockfile("9.0",
+                "      '@apps-in-toss/web-framework':\n" +
+                "        specifier: 2.4.1\n" +
+                "        version: 2.4.1\n"));
+
+            bool result = LockfileValidator.IsLockfileInSync(_packageJsonPath, _lockfilePath, out string summary);
+
+            Assert.IsFalse(result);
+            StringAssert.Contains("@apps-in-toss/web-framework", summary);
+            StringAssert.Contains("2.4.1", summary);
+            StringAssert.Contains("2.4.7", summary);
+        }
+
+        [Test]
+        public void IsLockfileInSync_DepMissingFromLockfile_ReturnsFalse()
+        {
+            File.WriteAllText(_packageJsonPath,
+                MakePackageJson(
+                    "\"@apps-in-toss/web-framework\": \"2.4.7\"," +
+                    "\"new-dep\": \"1.0.0\""));
+            File.WriteAllText(_lockfilePath, MakeLockfile("9.0",
+                "      '@apps-in-toss/web-framework':\n" +
+                "        specifier: 2.4.7\n" +
+                "        version: 2.4.7\n"));
+
+            bool result = LockfileValidator.IsLockfileInSync(_packageJsonPath, _lockfilePath, out string summary);
+
+            Assert.IsFalse(result);
+            StringAssert.Contains("new-dep", summary);
+        }
+
+        [Test]
+        public void IsLockfileInSync_DevDependenciesAlsoChecked()
+        {
+            File.WriteAllText(_packageJsonPath,
+                MakePackageJson(
+                    "\"@apps-in-toss/web-framework\": \"2.4.7\"",
+                    "\"vite\": \"8.0.10\""));
+            File.WriteAllText(_lockfilePath, MakeLockfile("9.0",
+                "      '@apps-in-toss/web-framework':\n" +
+                "        specifier: 2.4.7\n" +
+                "        version: 2.4.7\n",
+                "      vite:\n" +
+                "        specifier: 8.0.8\n" +
+                "        version: 8.0.8\n"));
+
+            bool result = LockfileValidator.IsLockfileInSync(_packageJsonPath, _lockfilePath, out string summary);
+
+            Assert.IsFalse(result);
+            StringAssert.Contains("vite", summary);
+        }
+
+        [Test]
+        public void IsLockfileInSync_UnknownLockfileVersion_ReturnsFalse()
+        {
+            File.WriteAllText(_packageJsonPath,
+                MakePackageJson("\"@apps-in-toss/web-framework\": \"2.4.7\""));
+            File.WriteAllText(_lockfilePath, MakeLockfile("99.0",
+                "      '@apps-in-toss/web-framework':\n" +
+                "        specifier: 2.4.7\n" +
+                "        version: 2.4.7\n"));
+
+            bool result = LockfileValidator.IsLockfileInSync(_packageJsonPath, _lockfilePath, out string summary);
+
+            Assert.IsFalse(result);
+            StringAssert.Contains("lockfileVersion", summary);
+        }
+
+        [Test]
+        public void IsLockfileInSync_PackageJsonMissing_ReturnsFalse()
+        {
+            File.WriteAllText(_lockfilePath, MakeLockfile("9.0",
+                "      '@apps-in-toss/web-framework':\n" +
+                "        specifier: 2.4.7\n" +
+                "        version: 2.4.7\n"));
+
+            bool result = LockfileValidator.IsLockfileInSync(_packageJsonPath, _lockfilePath, out string summary);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void IsLockfileInSync_LockfileMissing_ReturnsFalse()
+        {
+            File.WriteAllText(_packageJsonPath,
+                MakePackageJson("\"@apps-in-toss/web-framework\": \"2.4.7\""));
+
+            bool result = LockfileValidator.IsLockfileInSync(_packageJsonPath, _lockfilePath, out string summary);
+
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/LockfileValidatorTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/LockfileValidatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fc31c3fb179481aac4cf6829a342c1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStagesTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStagesTests.cs
@@ -1,0 +1,109 @@
+// -----------------------------------------------------------------------
+// PnpmInstallStagesTests.cs - InstallStages 정책 + DeleteLockfileIfExists IO 동작 검증
+// Level 0: pnpm 실행 없이 정책 데이터와 파일 삭제 헬퍼만 검증
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+
+namespace AppsInToss.Editor.Package.Tests
+{
+    [TestFixture]
+    public class PnpmInstallStagesTests
+    {
+        private string _tempDir;
+
+        [SetUp]
+        public void CreateTempDir()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "ait-stages-tests-" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TearDown]
+        public void CleanupTempDir()
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+
+        [Test]
+        public void InstallStages_HasFourStages()
+        {
+            Assert.AreEqual(4, PnpmStoreManager.InstallStages.Count,
+                "Fix B로 lockfile 폐기 단계가 추가되어 총 4단계여야 한다");
+        }
+
+        [Test]
+        public void InstallStages_FirstStageIsFrozenLockfile()
+        {
+            var first = PnpmStoreManager.InstallStages[0];
+            StringAssert.Contains("--frozen-lockfile", first.args);
+            Assert.IsFalse(first.cleanFirst);
+            Assert.IsFalse(first.deleteLockfileFirst);
+        }
+
+        [Test]
+        public void InstallStages_LockfileDeleteStageExistsBeforeCleanRetry()
+        {
+            // Fix B 핵심 정책: lockfile 폐기 단계가 clean 재시도보다 먼저 와야 한다.
+            // node_modules는 보존하면서 손상 lockfile만 폐기해 install 비용을 최소화한다.
+            int deleteIdx = -1, cleanIdx = -1;
+            for (int i = 0; i < PnpmStoreManager.InstallStages.Count; i++)
+            {
+                var stage = PnpmStoreManager.InstallStages[i];
+                if (stage.deleteLockfileFirst) deleteIdx = i;
+                if (stage.cleanFirst) cleanIdx = i;
+            }
+
+            Assert.GreaterOrEqual(deleteIdx, 0, "lockfile 폐기 단계가 정의되어 있어야 한다");
+            Assert.GreaterOrEqual(cleanIdx, 0, "clean 재시도 단계가 정의되어 있어야 한다");
+            Assert.Less(deleteIdx, cleanIdx, "lockfile 폐기 단계가 clean 재시도보다 먼저여야 한다");
+        }
+
+        [Test]
+        public void InstallStages_NoStageHasBothCleanAndLockfileDelete()
+        {
+            // 두 플래그가 동시에 켜진 단계는 의미 중복 (clean이 lockfile도 결과적으로 무효화).
+            foreach (var stage in PnpmStoreManager.InstallStages)
+            {
+                Assert.IsFalse(stage.cleanFirst && stage.deleteLockfileFirst,
+                    $"단계 '{stage.label}'에서 cleanFirst와 deleteLockfileFirst가 동시에 true");
+            }
+        }
+
+        [Test]
+        public void DeleteLockfileIfExists_RemovesLockfile_WhenPresent()
+        {
+            string lockfilePath = Path.Combine(_tempDir, "pnpm-lock.yaml");
+            File.WriteAllText(lockfilePath, "lockfileVersion: '9.0'\n");
+
+            PnpmRunner.DeleteLockfileIfExists(_tempDir);
+
+            Assert.IsFalse(File.Exists(lockfilePath), "lockfile이 삭제되어야 한다");
+        }
+
+        [Test]
+        public void DeleteLockfileIfExists_NoOp_WhenLockfileMissing()
+        {
+            // 파일이 없을 때 예외를 던지지 않아야 한다.
+            Assert.DoesNotThrow(() => PnpmRunner.DeleteLockfileIfExists(_tempDir));
+        }
+
+        [Test]
+        public void DeleteLockfileIfExists_DoesNotTouchOtherFiles()
+        {
+            string lockfilePath = Path.Combine(_tempDir, "pnpm-lock.yaml");
+            string packageJsonPath = Path.Combine(_tempDir, "package.json");
+            File.WriteAllText(lockfilePath, "lockfileVersion: '9.0'\n");
+            File.WriteAllText(packageJsonPath, "{\"name\":\"test\"}");
+
+            PnpmRunner.DeleteLockfileIfExists(_tempDir);
+
+            Assert.IsFalse(File.Exists(lockfilePath));
+            Assert.IsTrue(File.Exists(packageJsonPath), "package.json은 보존되어야 한다");
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStagesTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStagesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cdde6ebdc9c442c8d78e2cac13e3524
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/WebGLTemplates/AITTemplate/BuildConfig~/package.json
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/package.json
@@ -16,6 +16,7 @@
     "vite": "8.0.10",
     "typescript": "6.0.3"
   },
+  "packageManager": "pnpm@10.28.0",
   "pnpm": {
     "overrides": {
       "@granite-js/plugin-core": "0.1.30",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "com.unity.nuget.newtonsoft-json": "3.0.2"
   },
   "category": "Platform SDK",
+  "packageManager": "pnpm@10.28.0",
   "devDependencies": {
     "typescript": "^6.0.2"
   }

--- a/sdk-runtime-generator~/package.json
+++ b/sdk-runtime-generator~/package.json
@@ -21,6 +21,7 @@
     "test:differential": "vitest run tests/unit/differential.test.ts",
     "test:multi-version": "vitest run tests/unit/multi-version.test.ts"
   },
+  "packageManager": "pnpm@10.28.0",
   "dependencies": {
     "@apps-in-toss/framework": "1.6.0",
     "@apps-in-toss/web-analytics": "2.4.7",


### PR DESCRIPTION
## Summary

- BuildConfig~ pnpm-lock.yaml 정합성 검증 추가 — package.json과 specifier mismatch 시 SDK 출하본으로 폴백 (Fix A)
- pnpm install 폴백에 lockfile 폐기 재시도 단계 추가 — `--no-frozen-lockfile`로도 안 되는 손상 lockfile을 통째로 폐기 후 재생성 (Fix B)
- `packageManager: pnpm@10.28.0` 필드 추가로 클라이언트/CI 사이 pnpm 버전 drift 차단 (Fix C)

연관 Sentry 이슈: APPS-IN-TOSS-UNITY-SDK-B8 (187회), APPS-IN-TOSS-UNITY-SDK-HB (84회).

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] 빈 Unity 프로젝트에서 stale BuildConfig~/pnpm-lock.yaml을 두고 Build & Package → 폴백 경고 로그 확인 → install Stage 1 통과 확인
- [ ] 손상된 ait-build/pnpm-lock.yaml로 Build & Package → Stage 3(lockfile 폐기) 도달 후 통과 확인
- [ ] ait-build/package.json에 `packageManager: pnpm@10.28.0` 머지된 상태 확인