### PR TITLE
수정: AITBuildSession FilePathAttribute 추가 및 Sentry 노이즈 패턴 확장

### DIFF
--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -186,6 +186,7 @@ namespace AppsInToss.Editor
     ///   리로드가 Save 직전에 발생하면 마지막 변경이 디스크에 반영되지 못할 수 있으나,
     ///   이는 "자식 PID 하나 누락" 정도의 손실이고 asset corruption 은 방지된다.
     /// </summary>
+    [FilePath("Library/AppsInToss/AITBuildSession.asset", FilePathAttribute.Location.ProjectFolder)]
     internal sealed class AITBuildSession : ScriptableSingleton<AITBuildSession>
     {
         [SerializeField] public string sessionId;

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -80,6 +80,12 @@ namespace AppsInToss.Editor.ErrorTracker
             // 사용자 프로젝트 에셋 문제
             "matches more than one built-in atlases",
             "Warnings during import of AudioClip",
+            // FMOD/오디오 — 사용자 에셋 import/포맷 문제
+            "Cannot create FMOD::Sound instance for clip",
+            "Failed getting load state of FSB for audio clip",
+            "Cannot load audio data for audio clip",
+            // Animator — 사용자 컨트롤러 설정 누락
+            "doesn't have an Exit Time or any condition",
 
             // Unity 패키지 내부
             "Localization-String-Tables-",
@@ -87,6 +93,10 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 사용자 프로젝트 직렬화 ([Assembly-CSharp] 한정 — SDK 어셈블리의 직렬화 경고는 보호)
             "Fields serialized in [Assembly-CSharp]",
+            // [Assembly-CSharp] 타입의 player/editor 직렬화 mismatch (AdSwitcher 등 사용자 코드)
+            "Type '[Assembly-CSharp]",
+            // 사용자 게임 코드의 player script 컴파일 실패 (스택 없이 메시지만 도착)
+            "Failed to compile player scripts",
 
             // 외부 패키지 (Unity 버전별 괄호 유무에 관계없이 매칭되도록 핵심 문구만 추출)
             "exists but its folder",
@@ -109,6 +119,17 @@ namespace AppsInToss.Editor.ErrorTracker
             "[Validation]",
             "[pnpm]",
             "webgl/Build/",
+        };
+
+        // 외부(샘플/사용자 게임 코드)에서 AIT prefix를 사용하지만 SDK가 출력하지 않는 메시지.
+        // AitKeywords 가드보다 먼저 매칭되어 SDK 보호 가드를 우회하고 노이즈로 분류된다.
+        // 새 prefix 추가 시: SDK 코드에서 grep으로 해당 문자열이 출력되지 않음을 반드시 확인.
+        // 대상 Sentry 이슈:
+        //   - SDK-D2: [AIT Login][src=AIT_MOCK_OR_TIMEOUT] ...
+        //   - SDK-D3: [AIT Login] InitSession failed: FORBIDDEN_ORIGIN
+        private static readonly string[] ExternalAitPrefixes =
+        {
+            "[AIT Login]",
         };
 
         #endregion
@@ -602,11 +623,21 @@ namespace AppsInToss.Editor.ErrorTracker
         /// <summary>
         /// 메시지가 확실히 SDK와 무관한 Unity 내부/사용자 프로젝트 패턴인지 판별합니다.
         /// AIT 키워드(<see cref="AitKeywords"/>)가 포함되면 절대 필터링하지 않습니다.
+        /// 단, <see cref="ExternalAitPrefixes"/>는 SDK가 출력하지 않는 외부 코드 prefix로
+        /// AitKeywords 가드보다 먼저 매칭되어 노이즈로 드롭됩니다.
         /// </summary>
         internal static bool IsKnownNonSdkMessage(string message)
         {
             if (string.IsNullOrEmpty(message))
                 return false;
+
+            // 외부 코드가 사용하는 AIT prefix는 SDK 가드를 우회하여 먼저 드롭한다.
+            // SDK 코드는 이 prefix를 출력하지 않음이 보장되므로 안전.
+            for (int i = 0; i < ExternalAitPrefixes.Length; i++)
+            {
+                if (message.IndexOf(ExternalAitPrefixes[i], StringComparison.Ordinal) >= 0)
+                    return true;
+            }
 
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용
             if (MessageContainsSdkKeyword(message))

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -26,6 +26,35 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 외부 AIT prefix (SDK가 출력하지 않는 prefix) — 가드 우회 드롭
+
+    [Test]
+    public void ExternalAitLoginPrefix_AitMockOrTimeout_ReturnsTrue()
+    {
+        // Sentry SDK-D2 — 외부 코드가 [AIT Login] prefix로 출력한 fallback 경고.
+        // SDK 코드에는 "[AIT Login]" 문자열이 존재하지 않으므로 노이즈로 드롭한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT Login][src=AIT_MOCK_OR_TIMEOUT] status=RanToCompletion, len=0 → device fallback"));
+    }
+
+    [Test]
+    public void ExternalAitLoginPrefix_ForbiddenOrigin_ReturnsTrue()
+    {
+        // Sentry SDK-D3
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT Login] InitSession failed: FORBIDDEN_ORIGIN"));
+    }
+
+    [Test]
+    public void RegularAitPrefix_NotMatchingExternal_StillProtected()
+    {
+        // "[AIT Login]"이 아닌 일반 [AIT] prefix는 SDK 보호 가드로 필터링되지 않아야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] InitSession started"));
+    }
+
+    #endregion
+
     #region SDK 보호: AIT 키워드 포함 시 절대 필터링 안 함
 
     [Test]
@@ -241,6 +270,45 @@ public class IsKnownNonSdkMessageTests
             "[AIT] Warnings during import of AudioClip Assets/Sounds/bgm.wav"));
     }
 
+    [Test]
+    public void FmodSoundCreateError_ReturnsTrue()
+    {
+        // Sentry NM/NK/N9/CJ 등 — 사용자 프로젝트의 FMOD 오디오 에셋 문제
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Error: Cannot create FMOD::Sound instance for clip \"button_tick\" (FMOD error: Couldn't perform seek operation. ...)"));
+    }
+
+    [Test]
+    public void FmodSoundCreateError_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Cannot create FMOD::Sound instance for clip \"foo\""));
+    }
+
+    [Test]
+    public void FmodFsbLoadStateError_ReturnsTrue()
+    {
+        // Sentry CX/N5/N7/N8 — FSB 로드 실패
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Failed getting load state of FSB for audio clip \"bensound-ukulele\""));
+    }
+
+    [Test]
+    public void AudioClipLoadError_ReturnsTrue()
+    {
+        // Sentry P2/P3 — 오디오 데이터 로드 실패
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Error: Cannot load audio data for audio clip \"button_tick\""));
+    }
+
+    [Test]
+    public void AnimatorTransitionMissingExitTime_ReturnsTrue()
+    {
+        // Sentry NY — 사용자 Animator 컨트롤러 설정 누락
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Asset 'Machine': Transition 'Spin -> Exit' in state 'Spin' doesn't have an Exit Time or any condition, transition will be ignored"));
+    }
+
     #endregion
 
     #region Unity 패키지 내부
@@ -276,6 +344,37 @@ public class IsKnownNonSdkMessageTests
         // SDK 어셈블리(AppsInTossSDKEditor 등)의 직렬화 경고는 보호되어야 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Fields serialized in [AppsInTossSDKEditor] AITConfig changed"));
+    }
+
+    [Test]
+    public void AssemblyCSharpTypeMismatch_ReturnsTrue()
+    {
+        // Sentry NG/NF — 사용자 코드 타입의 player/editor 직렬화 mismatch
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Type '[Assembly-CSharp]AdSwitcher' has an extra field 'adGoogleAdPlacementManager' of type 'AdGoogleAdPlacementManager' in the player and thus can't be serialized"));
+    }
+
+    [Test]
+    public void SdkAssemblyTypeMismatch_NeverFiltered()
+    {
+        // SDK 어셈블리의 동일 패턴은 필터링되지 않아야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Type '[AppsInTossSDKEditor]AITConfig' has an extra field 'foo'"));
+    }
+
+    [Test]
+    public void FailedToCompilePlayerScripts_ReturnsTrue()
+    {
+        // Sentry H3 — 사용자 게임 코드 컴파일 실패 (스택 없이 메시지만 도착)
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Failed to compile player scripts"));
+    }
+
+    [Test]
+    public void FailedToCompilePlayerScripts_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Failed to compile player scripts"));
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- **SDK-KE (159건) 해결**: `AITBuildSession`에 `FilePathAttribute` 추가로 `ScriptableSingleton.Save()` 시 발생하던 경고 제거
- **노이즈 게이트 확장**: FMOD/Animator/`[Assembly-CSharp]` 직렬화/컴파일 실패 등 사용자 프로젝트 발 패턴 추가 차단
- **외부 AIT prefix 처리**: SDK가 출력하지 않지만 외부(샘플/사용자 게임)에서 `[AIT Login]` prefix를 사용해 발생한 SDK-D2/D3 노이즈를 SDK 보호 가드 우회 경로로 드롭

## 배경

`/seer` 결과 최근 7일 unresolved 100건 분석:
- SDK-KE (159건): 단순 attribute 누락 — 한 줄 수정으로 제거 가능
- FMOD/Animator/직렬화/컴파일 실패 다수: 사용자 게임 코드/에셋 발 — `error_source` 분류로는 잡히지 않아 명시 패턴 필요
- SDK-D2/D3 (480건): 코드베이스에 `[AIT Login]`/`AIT_MOCK_OR_TIMEOUT`/`FORBIDDEN_ORIGIN` 문자열이 존재하지 않음 — SDK가 출력한 게 아닌 외부 통합 코드 출처

## 변경 사항

### `Editor/AITBuildSession.cs`
- `[FilePath("Library/AppsInToss/AITBuildSession.asset", FilePathAttribute.Location.ProjectFolder)]` 추가

### `Editor/ErrorTracker/AITEditorErrorTracker.cs`
- `NonSdkMessagePatterns`에 6개 패턴 추가 (FMOD/Animator/직렬화/컴파일)
- `ExternalAitPrefixes` 신규 도입 (`[AIT Login]`) — `IsKnownNonSdkMessage`에서 SDK 보호 가드보다 **먼저** 검사하여 드롭

### `Tests~/.../IsKnownNonSdkMessageTests.cs`
- 신규 패턴별 positive/negative 케이스 추가
- 일반 `[AIT]` prefix는 보호 유지 회귀 테스트 포함

## 대상 Sentry 이슈

| Issue | 제목 | Events |
|---|---|---|
| SDK-KE | AITBuildSession FilePathAttribute 누락 | 159 |
| SDK-D2 | `[AIT Login][src=AIT_MOCK_OR_TIMEOUT]` device fallback | 242 |
| SDK-D3 | `[AIT Login] InitSession failed: FORBIDDEN_ORIGIN` | 238 |
| SDK-NM/NK/N9/CJ/P8/P7 | FMOD::Sound 생성 실패 | ~60 |
| SDK-CX/N5/N7/N8 | FSB 로드 실패 | ~25 |
| SDK-P2/P3 | audio clip 로드 실패 | 14 |
| SDK-NY | Animator transition Exit Time 누락 | 2 |
| SDK-NG/NF | `[Assembly-CSharp]AdSwitcher` 직렬화 mismatch | 4 |
| SDK-H3 | Failed to compile player scripts | 9 |

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] EditMode 테스트 (CI에서 검증 — 로컬 Unity 미설치)
- [ ] E2E 테스트 (이 PR에서 트리거)
- [ ] 머지 후 며칠 모니터링하여 위 이슈들이 더 이상 보고되지 않음 확인 → Sentry resolve