### PR TITLE
수정: 2021.3/2022.3 com.unity.test-framework 1.4.6 업그레이드 (async Task 테스트 호환)

### DIFF
--- a/Tests~/E2E/SampleUnityProject-2021.3/Packages/manifest.json
+++ b/Tests~/E2E/SampleUnityProject-2021.3/Packages/manifest.json
@@ -3,7 +3,7 @@
     "im.toss.apps-in-toss-unity-sdk": "file:../../../..",
     "im.toss.sdk-test-scripts": "file:../../SharedScripts",
     "io.sentry.unity": "https://github.com/getsentry/unity.git#4.1.0",
-    "com.unity.test-framework": "1.1.33",
+    "com.unity.test-framework": "1.4.6",
     "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",

--- a/Tests~/E2E/SampleUnityProject-2022.3/Packages/manifest.json
+++ b/Tests~/E2E/SampleUnityProject-2022.3/Packages/manifest.json
@@ -3,7 +3,7 @@
     "im.toss.apps-in-toss-unity-sdk": "file:../../../..",
     "im.toss.sdk-test-scripts": "file:../../SharedScripts",
     "io.sentry.unity": "https://github.com/getsentry/unity.git#4.1.0",
-    "com.unity.test-framework": "1.1.33",
+    "com.unity.test-framework": "1.4.6",
     "com.unity.ide.rider": "3.0.36",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",


### PR DESCRIPTION
## 요약
- PR #482 (a027b8d) 이후 Unity 2021.3 / 2022.3 EditMode E2E 가 일관되게 실패한 원인 수정
- `AITEditorIdleWaiterTests` 4개 (`[Test] async Task ...`) 가 `runstate=NotRunnable, label=Invalid` 로 처리되어 EditMode exit 1
- 두 LTS 의 `com.unity.test-framework` 를 `1.1.33` → `1.4.6` 으로 업그레이드

## 원인
`com.unity.test-framework` 1.1.33 은 NUnit 3.5 기반이라 `async Task` 시그니처 테스트를 실행 가능 메서드로 인식하지 않음. UTF 1.3.0 (2022-10) 부터 자체 `AsyncTestMethodCommand` 구현으로 async Task 가 정식 지원됨 (NUnit 버전은 3.5 그대로 유지).

증거 (E2E run 25045168951, macOS Unity 2021.3):

```xml
<test-fixture name="AITEditorIdleWaiterTests" testcasecount="4"
              result="Failed" passed="0" failed="4">
  <test-case name="WaitAsync_ReturnsTrue_WhenAlreadyIdle"
             runstate="NotRunnable" result="Failed" label="Invalid"/>
  ...
```

Unity 6000.x 는 엔진 임베디드 1.6.0 사용으로 정상 통과 — 실패는 정확히 2021.3 / 2022.3 (둘 다 1.1.33) 에서만 발생.

## 변경 범위
- `Tests~/E2E/SampleUnityProject-2021.3/Packages/manifest.json`: `1.1.33` → `1.4.6`
- `Tests~/E2E/SampleUnityProject-2022.3/Packages/manifest.json`: `1.1.33` → `1.4.6`

## 왜 1.4.6 인가
- 1.x 라인의 LTS 호환 마지막 버전. `1.5.1` 부터 Unity 엔진 임베디드 패키지로 전환되어 Unity 6 전용.
- async Task 지원 (1.3.0+) 포함. 1.1.33 → 1.4.6 사이 BREAKING 라벨 changelog 항목 없음. `[UnityTest]` 코루틴 / TestRunner CLI / Code Coverage 연동은 모두 동일 API 유지.

## 왜 6000.x 는 손대지 않는가
- `com.unity.test-framework` 1.5.1+ 은 엔진 임베디드라 `manifest.json` 의 버전 선언이 우선되지 않음 (Package Manager 가 임베디드 버전을 사용).
- Unity 6.2 부터 `overrideBuiltIns` 도 공식 제거. 다운그레이드 경로 차단.
- 결과적으로 5개 매니페스트를 단일 버전으로 통일하는 것은 기술적으로 불가. 2021.3/2022.3 만 수동 업그레이드, 6000.x 는 임베디드 그대로 두는 것이 유일한 안전 경로.

## Test plan
- [x] `./run-local-tests.sh --validate` (~30초) — 파일 구조 + Playwright 설정 + SDK 유닛 테스트 통과
- [ ] CI: Lint / Validate 통과
- [ ] CI: E2E (macOS / Windows × Unity 2021.3 / 2022.3 / 6000.0 / 6000.2 / 6000.3) — 특히 2021.3 / 2022.3 의 `AITEditorIdleWaiterTests` 4개가 통과하는지 확인
- [ ] 수동 (선택): 로컬 Unity 2021.3 또는 2022.3 에서 EditMode 테스트 실행해 `AITEditorIdleWaiterTests` 4개 그린 확인