### PR TITLE
기능: SDK Generator DOM 전용 타입 정책 적용

### DIFF
--- a/Runtime/SDK/AIT.GameCenter.cs
+++ b/Runtime/SDK/AIT.GameCenter.cs
@@ -113,7 +113,7 @@ namespace AppsInToss
         private static extern void __getUserKeyForGame_Internal(string callbackId, string typeName);
 #endif
         /// <param name="paramsParam">포인트를 지급하기 위해 필요한 정보예요.</param>
-        /// <returns>포인트 지급 결과를 반환해요. { key: string }: 포인트 지급에 성공했어요. key는 리워드 키를 의미해요. { errorCode: string, message: string }: 포인트 지급에 실패했어요. 에러 코드는 다음과 같아요. "40000": 게임이 아닌 미니앱에서 호출했을 때 "4100": 프로모션 정보를 찾을 수 없을 때 "4104": 프로모션이 중지되었을 때 "4105": 프로모션이 종료되었을 때 "4108": 프로모션이 승인되지 않았을 때 "4109": 프로모션이 실행중이 아닐 때 "4110": 리워드를 지급/회수할 수 없을 때 "4112": 프로모션 머니가 부족할 때 "4113": 이미 지급/회수된 내역일 때 "4114": 프로모션에 설정된 1회 지급 금액을 초과할 때 'ERROR': 알 수 없는 오류가 발생했어요. undefined: 앱 버전이 최소 지원 버전보다 낮아요.</returns>
+        /// <returns>포인트 지급 결과를 반환해요. { key: string }: 포인트 지급에 성공했어요. key는 리워드 키를 의미해요. { errorCode: string, message: string }: 포인트 지급에 실패했어요. 에러 코드는 다음과 같아요. "40000": 게임이 아닌 미니앱에서 호출했을 때 "4100": 프로모션 정보를 찾을 수 없을 때 "4104": 프로모션이 중지되었을 때 "4105": 프로모션이 종료되었을 때 "4108": 프로모션이 승인되지 않았을 때 "4109": 프로모션이 실행중이 아닐 때 "4110": 리워드를 지급/회수할 수 없을 때 "4112": 프로모션 머니가 부족할 때 "4113": 이미 지급/회수된 내역일 때 "4114": 프로모션에 설정된 1회 지급 금액을 초과할 때 'ERROR': 알 수 없는 오류가 발생했어요. undefined: 앱 버전이 최소 지원 버전보다 낮아요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
         [Preserve]
         [APICategory("GameCenter")]

--- a/Runtime/SDK/AIT.Other.cs
+++ b/Runtime/SDK/AIT.Other.cs
@@ -114,7 +114,7 @@ namespace AppsInToss
         private static extern void __getGroupId_Internal(string callbackId, string typeName);
 #endif
         /// <param name="paramsParam">포인트를 지급하기 위해 필요한 정보예요.</param>
-        /// <returns>포인트 지급 결과를 반환해요. { key: string }: 포인트 지급에 성공했어요. key는 리워드 키를 의미해요. { errorCode: string, message: string }: 포인트 지급에 실패했어요. 에러 코드는 다음과 같아요. "4100": 프로모션 정보를 찾을 수 없을 때 "4104": 프로모션이 중지되었을 때 "4105": 프로모션이 종료되었을 때 "4108": 프로모션이 승인되지 않았을 때 "4109": 프로모션이 실행중이 아닐 때 "4110": 리워드를 지급/회수할 수 없을 때 "4112": 프로모션 머니가 부족할 때 "4113": 이미 지급/회수된 내역일 때 "4114": 프로모션에 설정된 1회 지급 금액을 초과할 때 'ERROR': 알 수 없는 오류가 발생했어요. undefined: 앱 버전이 최소 지원 버전보다 낮아요.</returns>
+        /// <returns>포인트 지급 결과를 반환해요. { key: string }: 포인트 지급에 성공했어요. key는 리워드 키를 의미해요. { errorCode: string, message: string }: 포인트 지급에 실패했어요. 에러 코드는 다음과 같아요. "4100": 프로모션 정보를 찾을 수 없을 때 "4104": 프로모션이 중지되었을 때 "4105": 프로모션이 종료되었을 때 "4108": 프로모션이 승인되지 않았을 때 "4109": 프로모션이 실행중이 아닐 때 "4110": 리워드를 지급/회수할 수 없을 때 "4112": 프로모션 머니가 부족할 때 "4113": 이미 지급/회수된 내역일 때 "4114": 프로모션에 설정된 1회 지급 금액을 초과할 때 'ERROR': 알 수 없는 오류가 발생했어요. undefined: 앱 버전이 최소 지원 버전보다 낮아요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
         [Preserve]
         [APICategory("Other")]

--- a/Runtime/SDK/AIT.Types.cs
+++ b/Runtime/SDK/AIT.Types.cs
@@ -529,6 +529,9 @@ namespace AppsInToss
         [Preserve]
         [JsonProperty("stack")]
         public string Stack; // optional
+        [Preserve]
+        [JsonProperty("cause")]
+        public object Cause; // optional
 
         [Preserve]
         [Newtonsoft.Json.JsonExtensionData]

--- a/Runtime/SDK/Plugins/AppsInToss-TossAds.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-TossAds.jslib
@@ -35,7 +35,7 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
 
         try {
-            var result = window.AppsInToss.TossAds.attach(UTF8ToString(adGroupId), target, JSON.parse(UTF8ToString(options)));
+            var result = window.AppsInToss.TossAds.attach(UTF8ToString(adGroupId), UTF8ToString(target), JSON.parse(UTF8ToString(options)));
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -58,7 +58,7 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
 
         try {
-            var result = window.AppsInToss.TossAds.attachBanner(UTF8ToString(adGroupId), target, JSON.parse(UTF8ToString(options)));
+            var result = window.AppsInToss.TossAds.attachBanner(UTF8ToString(adGroupId), UTF8ToString(target), JSON.parse(UTF8ToString(options)));
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/sdk-runtime-generator~/src/index.ts
+++ b/sdk-runtime-generator~/src/index.ts
@@ -5,7 +5,7 @@ import picocolors from 'picocolors';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import * as crypto from 'crypto';
-import { TypeScriptParser } from './parser/index.js';
+import { TypeScriptParser, drainDomViolations, type DomViolation } from './parser/index.js';
 import { validateAllTypes } from './validators/types.js';
 import { validateCompleteness, printSummary } from './validators/completeness.js';
 import { CSharpGenerator, CSharpTypeGenerator } from './generators/csharp/index.js';
@@ -387,6 +387,22 @@ async function getInstalledWebFrameworkVersion(webFrameworkPath: string): Promis
   }
 }
 
+function formatDomViolations(violations: DomViolation[]): string {
+  const lines = violations.map((v) => {
+    const where =
+      v.location === 'parameter'
+        ? `parameter "${v.paramName}"`
+        : 'return type';
+    const fnLabel = v.category ? `${v.category}.${v.functionName}` : v.functionName;
+    return `  - ${fnLabel}: ${where} has DOM-only type "${v.rawType}" (${v.file})`;
+  });
+  return [
+    `SDK generation failed: ${violations.length} API(s) use unsupported DOM types.`,
+    ...lines,
+    'Refactor these APIs (e.g. accept a CSS selector string only) or remove them from the SDK.',
+  ].join('\n');
+}
+
 /**
  * 메인 생성 로직
  */
@@ -430,6 +446,12 @@ async function generate(options: {
       parser.addSourceDirectory(webAnalyticsPath);
     }
     const allParsedApis = await parser.parseAPIs(FRAMEWORK_APIS);
+
+    // DOM-only 타입 위반 검증: 파싱 중 누적된 위반을 한 번에 보고하고 실패시킨다.
+    const domViolations = drainDomViolations();
+    if (domViolations.length > 0) {
+      throw new Error(formatDomViolations(domViolations));
+    }
 
     // 제외 목록에 있는 API 필터링
     const excludedSet = new Set(EXCLUDED_APIS);

--- a/sdk-runtime-generator~/src/parser/api-parser.ts
+++ b/sdk-runtime-generator~/src/parser/api-parser.ts
@@ -1,9 +1,52 @@
 import { SourceFile, FunctionDeclaration, SyntaxKind } from 'ts-morph';
-import { ParsedAPI, ParsedParameter } from '../types.js';
+import { ParsedAPI, ParsedParameter, ParsedType } from '../types.js';
 import { toPascalCase, getCategoryFromPath } from './utils.js';
 import { parseType } from './type-parser.js';
 import { extractParamDescriptions, extractReturnsDescription, extractExamples } from './jsdoc-extractor.js';
 import { detectCallbackBasedPattern } from './namespace-parser.js';
+import { recordDomViolation } from './dom-violations.js';
+
+/**
+ * DOM 전용 타입 위반을 감지하고 collector에 기록.
+ * 위반이 하나라도 있으면 true를 반환한다.
+ */
+function checkAndRecordDomViolations(
+  functionName: string,
+  parameters: { name: string; type: ParsedType }[],
+  returnType: ParsedType,
+  sourceFile: SourceFile,
+): boolean {
+  const file = sourceFile.getFilePath();
+  const category = getCategoryFromPath(file);
+  let hasViolation = false;
+
+  for (const param of parameters) {
+    if (param.type.kind === 'dom-only') {
+      recordDomViolation({
+        functionName,
+        category,
+        location: 'parameter',
+        paramName: param.name,
+        rawType: param.type.raw ?? param.type.name,
+        file,
+      });
+      hasViolation = true;
+    }
+  }
+
+  if (returnType.kind === 'dom-only') {
+    recordDomViolation({
+      functionName,
+      category,
+      location: 'return',
+      rawType: returnType.raw ?? returnType.name,
+      file,
+    });
+    hasViolation = true;
+  }
+
+  return hasViolation;
+}
 
 /**
  * Permission 지원 여부 확인
@@ -53,6 +96,10 @@ export function parseFunctionDeclaration(
   });
 
   const returnType = parseType(func.getReturnType());
+
+  if (checkAndRecordDomViolations(name, parameters, returnType, sourceFile)) {
+    return null;
+  }
 
   // returnType이 Promise인지 확인하여 동기/비동기 구분
   const isAsync = returnType.kind === 'promise';
@@ -124,6 +171,11 @@ export function parseVariableFunction(
   });
 
   const returnType = parseType(signature.getReturnType());
+
+  if (checkAndRecordDomViolations(name, parameters, returnType, sourceFile)) {
+    return null;
+  }
+
   // returnType이 Promise인지 확인하여 동기/비동기 구분
   const isAsync = returnType.kind === 'promise';
   const hasPermission = false; // TODO: 검증 로직 추가

--- a/sdk-runtime-generator~/src/parser/dom-violations.ts
+++ b/sdk-runtime-generator~/src/parser/dom-violations.ts
@@ -1,0 +1,35 @@
+/**
+ * DOM 전용 타입(HTMLElement 등)을 시그니처에 사용한 API에 대한 위반 정보.
+ * generator 실행 중 수집되어 generate 종료 직전에 한 번에 보고된다.
+ */
+export interface DomViolation {
+  functionName: string;
+  category?: string;
+  location: 'parameter' | 'return';
+  paramName?: string;
+  rawType: string;
+  file: string;
+}
+
+const violations: DomViolation[] = [];
+
+export function recordDomViolation(violation: DomViolation): void {
+  violations.push(violation);
+}
+
+/**
+ * 수집된 위반을 모두 반환하고 collector를 비운다.
+ * generate 진입점에서 한 번 호출한다.
+ */
+export function drainDomViolations(): DomViolation[] {
+  const out = violations.slice();
+  violations.length = 0;
+  return out;
+}
+
+/**
+ * 테스트 셋업용. 매 케이스 시작에 호출해 격리한다.
+ */
+export function clearDomViolations(): void {
+  violations.length = 0;
+}

--- a/sdk-runtime-generator~/src/parser/index.ts
+++ b/sdk-runtime-generator~/src/parser/index.ts
@@ -75,3 +75,7 @@ export {
 
 // Constants
 export { DOM_TYPES, NAMESPACE_CATEGORY_OVERRIDES } from './constants.js';
+
+// DOM violations collector
+export { recordDomViolation, drainDomViolations, clearDomViolations } from './dom-violations.js';
+export type { DomViolation } from './dom-violations.js';

--- a/sdk-runtime-generator~/src/parser/namespace-parser.ts
+++ b/sdk-runtime-generator~/src/parser/namespace-parser.ts
@@ -2,6 +2,7 @@ import { SourceFile, FunctionDeclaration, SyntaxKind } from 'ts-morph';
 import { ParsedAPI, ParsedParameter, ParsedType, NestedCallback } from '../types.js';
 import { toPascalCase, getNamespaceCategory, getCategoryFromPath } from './utils.js';
 import { parseType } from './type-parser.js';
+import { recordDomViolation } from './dom-violations.js';
 import { extractJsDocForProperty, extractParamDescriptions, extractReturnsDescription, extractExamples } from './jsdoc-extractor.js';
 import {
   detectEventNamespaces,
@@ -189,15 +190,20 @@ export function parseNamespaceObject(
     }) || [];
 
     const returnType = parseType(signature.getReturnType());
-    const isAsync = returnType.kind === 'promise';
+
+    // 네임스페이스를 카테고리로 사용
+    const category = getNamespaceCategory(namespaceName);
 
     // C# 메서드 이름: 네임스페이스 + PascalCase 메서드명
     // 예: IAP.getProductItemList -> IAPGetProductItemList
     const pascalMethodName = toPascalCase(methodName);
     const fullName = `${namespaceName}${pascalMethodName}`;
 
-    // 네임스페이스를 카테고리로 사용
-    const category = getNamespaceCategory(namespaceName);
+    if (checkAndRecordDomViolationsNs(fullName, parameters, returnType, sourceFile, category)) {
+      continue;
+    }
+
+    const isAsync = returnType.kind === 'promise';
 
     // 중첩 콜백 감지 (options 파라미터 내부의 함수 타입)
     const nestedCallbacks = detectNestedCallbacks(parameters);
@@ -335,6 +341,10 @@ function parseFunctionDeclarationForNamespace(
 
   const returnType = parseType(func.getReturnType());
 
+  if (checkAndRecordDomViolationsNs(name, parameters, returnType, sourceFile, getCategoryFromPath(sourceFile.getFilePath()))) {
+    return null;
+  }
+
   // returnType이 Promise인지 확인하여 동기/비동기 구분
   const isAsync = returnType.kind === 'promise';
   const hasPermission = checkPermissionSupport(func);
@@ -403,6 +413,11 @@ function parseVariableFunctionForNamespace(
   });
 
   const returnType = parseType(signature.getReturnType());
+
+  if (checkAndRecordDomViolationsNs(name, parameters, returnType, sourceFile, getCategoryFromPath(sourceFile.getFilePath()))) {
+    return null;
+  }
+
   // returnType이 Promise인지 확인하여 동기/비동기 구분
   const isAsync = returnType.kind === 'promise';
 
@@ -436,4 +451,43 @@ function checkPermissionSupport(func: FunctionDeclaration): boolean {
   return properties.some(
     prop => prop.getName() === 'getPermission' || prop.getName() === 'openPermissionDialog'
   );
+}
+
+/**
+ * DOM 전용 타입 위반을 감지하고 collector에 기록 (네임스페이스 파서용).
+ * 위반이 하나라도 있으면 true를 반환한다.
+ */
+function checkAndRecordDomViolationsNs(
+  functionName: string,
+  parameters: { name: string; type: ParsedType }[],
+  returnType: ParsedType,
+  sourceFile: SourceFile,
+  category: string,
+): boolean {
+  const file = sourceFile.getFilePath();
+  let hasViolation = false;
+  for (const p of parameters) {
+    if (p.type.kind === 'dom-only') {
+      recordDomViolation({
+        functionName,
+        category,
+        location: 'parameter',
+        paramName: p.name,
+        rawType: p.type.raw ?? p.type.name,
+        file,
+      });
+      hasViolation = true;
+    }
+  }
+  if (returnType.kind === 'dom-only') {
+    recordDomViolation({
+      functionName,
+      category,
+      location: 'return',
+      rawType: returnType.raw ?? returnType.name,
+      file,
+    });
+    hasViolation = true;
+  }
+  return hasViolation;
 }

--- a/sdk-runtime-generator~/src/parser/type-parser.ts
+++ b/sdk-runtime-generator~/src/parser/type-parser.ts
@@ -9,12 +9,12 @@ import { cleanTypeName } from './utils.js';
 export function parseType(typeNode: any): ParsedType {
   const typeText = typeNode.getText?.() || typeNode.toString();
 
-  // DOM/브라우저 전용 타입 감지 (순환 참조로 인한 스택 오버플로우 방지)
-  // Unity에서는 DOM 타입을 사용할 수 없으므로 'object'로 처리
+  // DOM/브라우저 전용 타입 감지 — Unity에서는 사용 불가하므로 sentinel로 표시.
+  // 단일 DOM 타입 또는 union 잔여 0개일 때만 sentinel이 외부로 새어 나간다 (api-parser에서 위반으로 검출됨).
   if (DOM_TYPES.has(typeText)) {
     return {
-      name: 'object',
-      kind: 'primitive',
+      name: typeText,
+      kind: 'dom-only',
       raw: typeText,
     };
   }
@@ -173,19 +173,34 @@ export function parseType(typeNode: any): ParsedType {
       t.name !== 'null' && t.name !== 'undefined'
     );
 
-    // 단일 타입 + null/undefined = nullable 타입
-    if (nullTypes.length > 0 && nonNullTypes.length === 1) {
+    // DOM 타입 필터링: non-null 멤버에서 DOM-only 타입 제거
+    const nonDomTypes = nonNullTypes.filter((t: ParsedType) => t.kind !== 'dom-only');
+
+    // DOM 타입만 남은 경우 (non-DOM 멤버가 0개): dom-only sentinel 반환
+    if (nonDomTypes.length === 0) {
       return {
-        ...nonNullTypes[0],
-        isNullable: true,
+        name: typeText,
+        kind: 'dom-only',
         raw: typeText,
       };
     }
 
+    // DOM 제거 후 단일 타입만 남은 경우: 해당 타입 반환 (nullable 여부 보존)
+    if (nonDomTypes.length === 1) {
+      const result: ParsedType = {
+        ...nonDomTypes[0],
+        raw: typeText,
+      };
+      if (nullTypes.length > 0) {
+        result.isNullable = true;
+      }
+      return result;
+    }
+
     // Discriminated Union 감지: 객체 1개 + 문자열 리터럴 N개
     // undefined가 포함된 경우 제외하고 검사 (T | "error1" | "error2" | undefined)
-    const objectTypes = nonNullTypes.filter((t: ParsedType) => t.kind === 'object');
-    const stringLiterals = nonNullTypes.filter((t: ParsedType) =>
+    const objectTypes = nonDomTypes.filter((t: ParsedType) => t.kind === 'object');
+    const stringLiterals = nonDomTypes.filter((t: ParsedType) =>
       t.kind === 'primitive' && t.name === 'string' && t.raw.startsWith('"')
     );
 
@@ -195,7 +210,7 @@ export function parseType(typeNode: any): ParsedType {
       const result: ParsedType = {
         name: typeText,
         kind: 'union',
-        unionTypes: nonNullTypes, // undefined 제외
+        unionTypes: nonDomTypes, // undefined 및 DOM 타입 제외
         raw: typeText,
         isDiscriminatedUnion: true,
         successType: objectTypes[0],
@@ -208,12 +223,16 @@ export function parseType(typeNode: any): ParsedType {
       return result;
     }
 
-    return {
+    const finalResult: ParsedType = {
       name: typeText,
       kind: 'union',
-      unionTypes: parsedUnionTypes,
+      unionTypes: nonDomTypes,
       raw: typeText,
     };
+    if (nullTypes.length > 0) {
+      finalResult.isNullable = true;
+    }
+    return finalResult;
   }
 
   // Intersection 타입 (예: Sku & { processProductGrant: ... })

--- a/sdk-runtime-generator~/src/types.ts
+++ b/sdk-runtime-generator~/src/types.ts
@@ -58,7 +58,7 @@ export interface ParsedParameter {
  */
 export interface ParsedType {
   name: string;
-  kind: 'primitive' | 'object' | 'array' | 'promise' | 'function' | 'union' | 'record' | 'unknown';
+  kind: 'primitive' | 'object' | 'array' | 'promise' | 'function' | 'union' | 'record' | 'unknown' | 'dom-only';
   properties?: ParsedProperty[];
   elementType?: ParsedType;
   promiseType?: ParsedType;

--- a/sdk-runtime-generator~/tests/unit/dom-violations.test.ts
+++ b/sdk-runtime-generator~/tests/unit/dom-violations.test.ts
@@ -1,0 +1,365 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { Project } from 'ts-morph';
+import { parseType } from '../../src/parser/type-parser.js';
+import {
+  parseFunctionDeclaration,
+  parseVariableFunction,
+} from '../../src/parser/api-parser.js';
+import {
+  parseNamespaceObject,
+  parseNamespaceObjects,
+} from '../../src/parser/namespace-parser.js';
+import {
+  clearDomViolations,
+  drainDomViolations,
+  recordDomViolation,
+} from '../../src/parser/dom-violations.js';
+
+function makeProject(): Project {
+  return new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: {
+      strictNullChecks: true,
+      moduleResolution: 99, // NodeNext
+    },
+  });
+}
+
+function getFunctionType(source: string, funcName: string) {
+  const project = makeProject();
+  const sf = project.createSourceFile('/test.d.ts', source);
+  const fn = sf.getFunctionOrThrow(funcName);
+  return { project, sf, fn };
+}
+
+describe('DOM-only type handling in parseType', () => {
+  beforeEach(() => {
+    clearDomViolations();
+  });
+
+  test('단독 HTMLElement 파라미터는 dom-only sentinel을 반환', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(target: HTMLElement): void;`,
+      'foo',
+    );
+    const param = fn.getParameters()[0];
+    const parsed = parseType(param.getType());
+    expect(parsed.kind).toBe('dom-only');
+    expect(parsed.name).toBe('HTMLElement');
+    expect(parsed.raw).toBe('HTMLElement');
+  });
+
+  test('Element (DOM_TYPES의 다른 멤버)도 dom-only sentinel을 반환', () => {
+    const { fn } = getFunctionType(
+      `export declare function bar(target: Element): void;`,
+      'bar',
+    );
+    const param = fn.getParameters()[0];
+    const parsed = parseType(param.getType());
+    expect(parsed.kind).toBe('dom-only');
+    expect(parsed.name).toBe('Element');
+  });
+});
+
+describe('Union DOM filtering', () => {
+  beforeEach(() => {
+    clearDomViolations();
+  });
+
+  test('string | HTMLElement → string primitive (DOM member filtered out)', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(t: string | HTMLElement): void;`,
+      'foo',
+    );
+    const param = fn.getParameters()[0];
+    const typeNode = param.getType();
+    const parsed = parseType(typeNode);
+
+    expect(parsed.kind).toBe('primitive');
+    expect(parsed.name).toBe('string');
+    expect(parsed.raw).toBe(typeNode.getText());
+    expect(parsed.isNullable).toBeFalsy();
+  });
+
+  test('string | HTMLElement | undefined → string primitive, isNullable true', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(t: string | HTMLElement | undefined): void;`,
+      'foo',
+    );
+    const param = fn.getParameters()[0];
+    const typeNode = param.getType();
+    const parsed = parseType(typeNode);
+
+    expect(parsed.kind).toBe('primitive');
+    expect(parsed.name).toBe('string');
+    expect(parsed.raw).toBe(typeNode.getText());
+    expect(parsed.isNullable).toBe(true);
+  });
+
+  test('string | number | HTMLElement → union with 2 members, no dom-only member', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(t: string | number | HTMLElement): void;`,
+      'foo',
+    );
+    const param = fn.getParameters()[0];
+    const typeNode = param.getType();
+    const parsed = parseType(typeNode);
+
+    expect(parsed.kind).toBe('union');
+    expect(parsed.unionTypes).toBeDefined();
+    expect(parsed.unionTypes!.length).toBe(2);
+    const memberNames = parsed.unionTypes!.map((m) => m.name);
+    expect(memberNames).toContain('string');
+    expect(memberNames).toContain('number');
+    const domOnlyMember = parsed.unionTypes!.find((m) => m.kind === 'dom-only');
+    expect(domOnlyMember).toBeUndefined();
+  });
+
+  test('HTMLElement | Node → dom-only sentinel preserving original raw', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(t: HTMLElement | Node): void;`,
+      'foo',
+    );
+    const param = fn.getParameters()[0];
+    const typeNode = param.getType();
+    const actualTypeText = typeNode.getText();
+    const parsed = parseType(typeNode);
+
+    expect(parsed.kind).toBe('dom-only');
+    expect(parsed.raw).toBe(actualTypeText);
+  });
+});
+
+describe('DOM violation collection in api-parser', () => {
+  beforeEach(() => {
+    clearDomViolations();
+  });
+
+  test('단독 HTMLElement 파라미터: parseFunctionDeclaration이 null 반환 + 위반 1개 수집', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/test.d.ts',
+      `export declare function foo(target: HTMLElement): void;`,
+    );
+    const fn = sf.getFunctionOrThrow('foo');
+
+    const result = parseFunctionDeclaration(fn, sf);
+
+    expect(result).toBeNull();
+    const violations = drainDomViolations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      functionName: 'foo',
+      location: 'parameter',
+      paramName: 'target',
+      rawType: 'HTMLElement',
+    });
+  });
+
+  test('반환 타입 HTMLElement: parseFunctionDeclaration이 null 반환 + return 위반 수집', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/test.d.ts',
+      `export declare function bar(): HTMLElement;`,
+    );
+    const fn = sf.getFunctionOrThrow('bar');
+
+    const result = parseFunctionDeclaration(fn, sf);
+
+    expect(result).toBeNull();
+    const violations = drainDomViolations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      functionName: 'bar',
+      location: 'return',
+      rawType: 'HTMLElement',
+    });
+    expect(violations[0].paramName).toBeUndefined();
+  });
+
+  test('string | HTMLElement은 위반 아님: parseFunctionDeclaration이 non-null 반환', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/test.d.ts',
+      `export declare function baz(t: string | HTMLElement): void;`,
+    );
+    const fn = sf.getFunctionOrThrow('baz');
+
+    const result = parseFunctionDeclaration(fn, sf);
+
+    expect(result).not.toBeNull();
+    expect(result!.parameters[0].type.name).toBe('string');
+    const violations = drainDomViolations();
+    expect(violations).toHaveLength(0);
+  });
+
+  test('여러 함수 위반 누적: 3개 함수 파싱 후 drainDomViolations() length 3', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/test.d.ts',
+      [
+        `export declare function a(el: HTMLElement): void;`,
+        `export declare function b(): HTMLElement;`,
+        `export declare function c(node: HTMLElement | Node): void;`,
+      ].join('\n'),
+    );
+
+    parseFunctionDeclaration(sf.getFunctionOrThrow('a'), sf);
+    parseFunctionDeclaration(sf.getFunctionOrThrow('b'), sf);
+    parseFunctionDeclaration(sf.getFunctionOrThrow('c'), sf);
+
+    const violations = drainDomViolations();
+    expect(violations).toHaveLength(3);
+    const names = violations.map((v) => v.functionName).sort();
+    expect(names).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('DOM violation collection in namespace-parser', () => {
+  beforeEach(() => {
+    clearDomViolations();
+  });
+
+  test('네임스페이스 메서드 단독 HTMLElement: parseNamespaceObject가 해당 메서드를 제외하고 위반 1개 수집', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/Foo.d.ts',
+      [
+        `declare function attach(target: HTMLElement): void;`,
+        `export declare const Foo: {`,
+        `  attach: typeof attach;`,
+        `};`,
+      ].join('\n'),
+    );
+    const varDecl = sf.getVariableDeclarationOrThrow('Foo');
+
+    const apis = parseNamespaceObject('Foo', varDecl, sf);
+
+    const attachApi = apis.find((a) => a.originalName === 'attach');
+    expect(attachApi).toBeUndefined();
+
+    const violations = drainDomViolations();
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    const v = violations.find((x) => x.functionName === 'FooAttach');
+    expect(v).toBeDefined();
+    expect(v).toMatchObject({
+      functionName: 'FooAttach',
+      location: 'parameter',
+      paramName: 'target',
+    });
+  });
+
+  test('네임스페이스 메서드 string | HTMLElement은 정상: API 반환되고 위반 없음', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/Foo.d.ts',
+      [
+        `declare function attach(target: string | HTMLElement): void;`,
+        `export declare const Foo: {`,
+        `  attach: typeof attach;`,
+        `};`,
+      ].join('\n'),
+    );
+    const varDecl = sf.getVariableDeclarationOrThrow('Foo');
+
+    const apis = parseNamespaceObject('Foo', varDecl, sf);
+
+    const attachApi = apis.find((a) => a.originalName === 'attach');
+    expect(attachApi).toBeDefined();
+    expect(attachApi!.parameters[0].type.name).toBe('string');
+
+    const violations = drainDomViolations();
+    expect(violations).toHaveLength(0);
+  });
+});
+
+describe('namespace-parser global function paths', () => {
+  beforeEach(() => {
+    clearDomViolations();
+  });
+
+  test('parseNamespaceObjects가 글로벌 function 선언 단독 HTMLElement를 위반으로 수집', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/index.d.ts',
+      `export declare function attachThing(target: HTMLElement): void;`,
+    );
+    const apis = parseNamespaceObjects(sf);
+    expect(apis.find((a) => a.originalName === 'attachThing')).toBeUndefined();
+    const violations = drainDomViolations();
+    expect(violations.some((v) => v.functionName === 'attachThing' && v.paramName === 'target')).toBe(true);
+  });
+
+});
+
+describe('parseVariableFunction DOM hooks', () => {
+  beforeEach(() => {
+    clearDomViolations();
+  });
+
+  test('변수 함수 단독 HTMLElement는 null 반환 + 위반 수집', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/test.d.ts',
+      `export declare const foo: (target: HTMLElement) => void;`,
+    );
+    const varDecl = sf.getVariableDeclarationOrThrow('foo');
+    const result = parseVariableFunction('foo', varDecl, sf);
+    expect(result).toBeNull();
+    const violations = drainDomViolations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      functionName: 'foo',
+      location: 'parameter',
+      paramName: 'target',
+    });
+  });
+
+  test('변수 함수 string | HTMLElement는 string으로 축소', () => {
+    const project = makeProject();
+    const sf = project.createSourceFile(
+      '/test.d.ts',
+      `export declare const foo: (target: string | HTMLElement) => void;`,
+    );
+    const varDecl = sf.getVariableDeclarationOrThrow('foo');
+    const result = parseVariableFunction('foo', varDecl, sf);
+    expect(result).not.toBeNull();
+    expect(result!.parameters[0].type.name).toBe('string');
+    expect(drainDomViolations()).toHaveLength(0);
+  });
+});
+
+describe('Union DOM filtering — nullable preservation in 2+ residual path', () => {
+  test('string | number | HTMLElement | null → union 유지 + isNullable true', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(t: string | number | HTMLElement | null): void;`,
+      'foo',
+    );
+    const param = fn.getParameters()[0];
+    const parsed = parseType(param.getType());
+    expect(parsed.kind).toBe('union');
+    expect(parsed.unionTypes).toBeDefined();
+    expect(parsed.unionTypes!.length).toBe(2);
+    const memberNames = parsed.unionTypes!.map((m) => m.name).sort();
+    expect(memberNames).toEqual(['number', 'string']);
+    expect(parsed.isNullable).toBe(true);
+  });
+});
+
+describe('drainDomViolations semantics', () => {
+  beforeEach(() => {
+    clearDomViolations();
+  });
+
+  test('drainDomViolations는 호출 후 collector를 비운다', () => {
+    recordDomViolation({
+      functionName: 'foo',
+      location: 'parameter',
+      paramName: 'target',
+      rawType: 'HTMLElement',
+      file: '/foo.d.ts',
+    });
+    expect(drainDomViolations()).toHaveLength(1);
+    expect(drainDomViolations()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 개요

`@apps-in-toss/web-bridge`의 `.d.ts`에 포함된 DOM 전용 타입(HTMLElement, Element, Node 등)을 Unity SDK 생성 시 명시적으로 처리합니다. 사용자 요청은 "param이나 return의 union에 HTMLElement이 있으면 무시, 단독이면 에러" — 대표 케이스로 `TossAdsAttachBanner`의 `target: string | HTMLElement` 처리.

## 변경사항

**핵심 정책 (`sdk-runtime-generator~/`)**:
- `parseType`이 `kind: 'dom-only'` sentinel을 반환 (단일 DOM 또는 union 잔여 0개)
- Union에서 DOM 멤버는 무시 (e.g. `string | HTMLElement` → `string`, `string | number | HTMLElement` → `string | number`)
- api-parser/namespace-parser의 5개 진입점이 sentinel을 검출해 함수를 SDK에서 누락
- 위반은 모듈 스코프 collector에 모아서 generate 종료 직전 한 번에 보고하고 hard error로 실패

**부수 효과 (버그 수정)**:
- `TossAds.attach`/`attachBanner`의 jslib에서 `target` 파라미터가 올바르게 `UTF8ToString`으로 디코딩 (이전엔 raw IL2CPP 포인터 통과 — 이전 코드가 `HTMLElement`를 `object`로 오매핑한 결과)
- `T | null` union의 nullable 정보가 downstream에 정확히 전달 (GameCenter/Other API doc 코멘트에 nullable 표기 추가)

**C# 공개 API**: 변경 없음. `TossAdsAttachBanner(string adGroupId, string target, ...)` 시그니처 그대로 유지.

## Test plan

- [x] `pnpm generate` 위반 0건으로 성공
- [x] 17/17 신규 단위 테스트 통과 (`tests/unit/dom-violations.test.ts`)
- [x] `./run-local-tests.sh --validate` 통과
- [x] 인위적 위반 주입 시 `pnpm generate`가 명확한 에러 메시지로 실패 (검증 후 revert)
- [ ] CI 통과 확인