### PR TITLE
수정: deploy 잡 pnpm/action-setup이 checkout 전 실행되는 순서 문제

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -210,14 +210,6 @@ jobs:
     if: success()
 
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
       - name: Checkout (버전 참조용)
         uses: actions/checkout@v6
         with:
@@ -226,6 +218,16 @@ jobs:
           sparse-checkout: |
             WebGLTemplates/AITTemplate/BuildConfig~/package.json
           sparse-checkout-cone-mode: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: WebGLTemplates/AITTemplate/BuildConfig~/package.json
 
       - name: Install AIT CLI
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,14 +621,6 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
       - name: Checkout (버전 참조용)
         uses: actions/checkout@v6
         with:
@@ -636,6 +628,16 @@ jobs:
           sparse-checkout: |
             WebGLTemplates/AITTemplate/BuildConfig~/package.json
           sparse-checkout-cone-mode: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: WebGLTemplates/AITTemplate/BuildConfig~/package.json
 
       - name: Install AIT CLI
         run: |


### PR DESCRIPTION
## Summary

- Bulk Release 실행 [25093375152](https://github.com/toss/apps-in-toss-unity-sdk/actions/runs/25093375152)에서 v2.4.0/v2.4.1/v2.4.2/v2.4.3의 **AIT 패키지 배포** 잡이 모두 `Error: No pnpm version is specified.`로 실패한 원인을 수정합니다.
- 원인: `release.yml`의 `deploy-ait` 잡과 `preview.yml`의 배포 잡에서 `Setup pnpm` (`pnpm/action-setup@v6`) 단계가 `Checkout` 단계보다 **앞서** 실행되고 있었습니다. PR #488에서 `version: 10` 입력을 제거하고 `packageManager` 필드를 단일 진실 공급원으로 삼은 뒤로는, v6가 참조할 `package.json`이 워크스페이스에 존재하지 않으면 즉시 실패합니다.
- 수정: 두 잡 모두 `Checkout`을 `Setup pnpm` 앞으로 이동하고, sparse checkout으로 가져오는 `WebGLTemplates/AITTemplate/BuildConfig~/package.json`을 `package_json_file`로 명시해 거기서 `packageManager: pnpm@10.28.0`을 읽도록 합니다.

## Test plan

- [ ] E2E 트리거 (`test-e2e.yml`)로 lint/검증 경로가 통과하는지 확인
- [ ] 다음 Bulk Release 또는 단일 Release 실행에서 `AIT 패키지 배포` 잡이 `Setup pnpm` 단계를 통과하는지 확인 (이번 PR 머지 후 검증)
- [ ] `preview` 워크플로우 한 번 실행해 동일한 회귀가 재발하지 않는지 확인

## 영향 범위

- 변경 파일: `.github/workflows/release.yml`, `.github/workflows/preview.yml`
- 다른 6개 워크플로우(`validate.yml`/`test-e2e.yml`/`update-changelog.yml`/`sdk-update-rebase.yml`/`update.yml`/`release.yml`의 `regenerate-sdk` 잡)는 이미 `Checkout`이 `Setup pnpm`보다 먼저 실행되어 영향 없음.