### PR TITLE
빌드: E2E 실패 분류기 composite action 추가 (POC)

### DIFF
--- a/.github/actions/classify-failure/action.yml
+++ b/.github/actions/classify-failure/action.yml
@@ -1,0 +1,106 @@
+name: Classify Failure
+description: |
+  E2E/EditMode/Build 잡 실패 시 산출물(editmode-results.xml, WebGL 빌드 디렉토리)을
+  검사해 코드/인프라/빌드 실패를 구분한다. 잡 step 안에서는 자기 자신의 로그를 받을 수
+  없으므로 라이선스/Brotli 같은 로그 grep이 필요한 케이스는 후속 통합 잡에서
+  세분화한다(이 액션은 results-missing/build-no-output까지만 분류).
+
+inputs:
+  os:
+    required: true
+    description: 'macos | windows'
+  unity-version:
+    required: true
+    description: 'Unity 버전 (예: 6000.2)'
+  editmode-results-path:
+    required: false
+    description: 'editmode-results.xml 절대 경로 (기본: Tests~/E2E/SampleUnityProject-<version>/editmode-results.xml)'
+    default: ''
+  webgl-output-path:
+    required: false
+    description: 'WebGL 빌드 산출물 디렉토리 (기본: webgl)'
+    default: 'webgl'
+
+outputs:
+  failure_category:
+    description: 'code | results-missing | build-no-output | unknown'
+    value: ${{ steps.classify.outputs.failure_category }}
+  failure_detail:
+    description: '실패 요약 (한 줄)'
+    value: ${{ steps.classify.outputs.failure_detail }}
+  results_artifact:
+    description: 'present | absent'
+    value: ${{ steps.classify.outputs.results_artifact }}
+
+runs:
+  using: composite
+  steps:
+    - name: Classify
+      id: classify
+      shell: bash
+      env:
+        OS_NAME: ${{ inputs.os }}
+        UNITY_VERSION: ${{ inputs.unity-version }}
+        RESULTS_PATH_INPUT: ${{ inputs.editmode-results-path }}
+        WEBGL_PATH: ${{ inputs.webgl-output-path }}
+      run: |
+        set +e
+
+        if [ -n "$RESULTS_PATH_INPUT" ]; then
+          RESULTS_FILE="$RESULTS_PATH_INPUT"
+        else
+          RESULTS_FILE="${GITHUB_WORKSPACE}/Tests~/E2E/SampleUnityProject-${UNITY_VERSION}/editmode-results.xml"
+        fi
+
+        category="unknown"
+        detail=""
+        artifact="absent"
+
+        if [ -f "$RESULTS_FILE" ]; then
+          artifact="present"
+          if grep -q 'result="Failed"' "$RESULTS_FILE"; then
+            category="code"
+            failed_names=$(grep -oE 'fullname="[^"]*"[^>]*result="Failed"' "$RESULTS_FILE" \
+              | grep -oE 'fullname="[^"]*"' \
+              | sed 's/fullname="//; s/"$//' \
+              | sort -u)
+            count=$(printf '%s\n' "$failed_names" | grep -c .)
+            first=$(printf '%s\n' "$failed_names" | head -1)
+            if [ "$count" -le 1 ]; then
+              detail="failed test: ${first}"
+            else
+              detail="failed tests (${count}): ${first} +$((count-1)) more"
+            fi
+          fi
+        fi
+
+        if [ "$category" = "unknown" ] && [ "$artifact" = "absent" ]; then
+          category="results-missing"
+          detail="editmode-results.xml not produced (license/setup/crash suspected; needs log inspection)"
+        fi
+
+        if [ "$category" = "unknown" ]; then
+          if [ -d "$WEBGL_PATH" ]; then
+            unityweb_count=$(find "$WEBGL_PATH" -type f -name '*.unityweb' 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$unityweb_count" = "0" ]; then
+              category="build-no-output"
+              detail="WebGL output dir exists but no .unityweb files (possible Brotli/compression failure)"
+            fi
+          fi
+        fi
+
+        echo "failure_category=${category}" >> "$GITHUB_OUTPUT"
+        echo "failure_detail=${detail}" >> "$GITHUB_OUTPUT"
+        echo "results_artifact=${artifact}" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Failure Classification (${OS_NAME}, Unity ${UNITY_VERSION})"
+          echo ""
+          echo "| field | value |"
+          echo "|---|---|"
+          echo "| failure_category | \`${category}\` |"
+          echo "| results_artifact | \`${artifact}\` |"
+          echo "| failure_detail | ${detail:-_(none)_} |"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        echo "::notice title=Failure Classification::category=${category} artifact=${artifact} detail=${detail}"

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -848,6 +848,15 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      # POC: 실패 분류기 — 우선 macOS Unity 6000.2 한 잡에만 활성화하여 출력 모양을 검증한다.
+      # 만족스러우면 후속 PR에서 전 매트릭스 + 통합 코멘트 잡으로 확장한다.
+      - name: Classify Failure (POC)
+        if: failure() && inputs.os == 'macos' && inputs.unity-version == '6000.2'
+        uses: ./.github/actions/classify-failure
+        with:
+          os: ${{ inputs.os }}
+          unity-version: ${{ inputs.unity-version }}
+
       # =====================================================
       # macOS Keychain 잠금 해제
       # 화면 잠금 상태에서 Unity Licensing Client가 Keychain에 접근하지


### PR DESCRIPTION
## 개요

E2E 매트릭스 잡 실패 시 **코드 결함 vs 인프라 이슈**를 사람·LLM이 헷갈리지 않게 구별하기 위한 분류기 composite action을 추가한다. 이번 PR은 POC 단계로 **macOS Unity 6000.2 한 잡에만** 활성화하여 출력 모양을 검증한다.

## 배경

PR #497의 E2E 실패에서 라이선스 경고 로그 한 줄(`Access token is unavailable`)을 보고 인프라 이슈로 오판한 사례가 있었다. 실제로는 결과 XML에 `result="Failed"`가 명확히 찍혀 있는 코드 결함(`IsKnownNonSdkMessageTests.Cs0414UnusedField_ReturnsTrue`)이었다. 라이선스 경고 라인은 비치명적 토큰 갱신 실패였고 직후 `Successfully resolved entitlement details`가 따라왔다.

사람이 매번 결과 XML을 다운로드해 `<failure>` 노드를 봐야만 정확한 판정이 가능하다는 것은 운영 비용이 너무 크다. CI가 그 판정을 한 줄로 돌려주면 된다.

## 분류 카테고리

| category | 의미 | 권장 조치 |
|---|---|---|
| `code` | 결과 XML이 있고 `result="Failed"` 테스트가 있음 | 코드 수정 — rerun 무의미 |
| `results-missing` | 결과 XML이 생성되지 않음 (라이선스/setup/크래시 의심) | 후속 잡에서 로그 grep 후 infra/flaky 세분화 |
| `build-no-output` | WebGL 디렉토리는 있는데 `.unityweb` 없음 (Brotli 등 압축 실패) | flaky 의심, `rerun-failed-jobs` |
| `unknown` | 위 어디에도 안 걸림 | 로그 직접 검토 |

## 구현

- `.github/actions/classify-failure/action.yml`: composite action. 입력은 `os`, `unity-version`, (선택) 결과 파일/빌드 디렉토리 경로. 출력은 `failure_category`, `failure_detail`, `results_artifact`. Step Summary에 표 + `::notice` 어노테이션을 남긴다.
- `unity-build.yml`: `Upload EditMode Test Results` 직후에 `if: failure() && inputs.os == 'macos' && inputs.unity-version == '6000.2'` 가드로 한 잡에만 활성화.
- 잡이 자기 자신의 로그를 step 도중에 받을 수 없으므로, 라이선스/Brotli 같은 로그 grep이 필요한 케이스는 후속 PR의 통합 잡(`needs: [matrix]`)에서 `gh api .../jobs/{id}/logs`로 후처리한다.

## 다음 PR (after this one merges)

- 전 매트릭스 잡으로 확장 (`if: failure()`만 남기고 os/version 가드 제거)
- `test-e2e.yml`에 통합 잡 추가: 매트릭스 실패 후 `results-missing`인 잡들의 로그를 받아 `infra` (license-block / runner-issue) vs `flaky` (Brotli 등)로 세분화 → PR에 단일 코멘트 게시
- CLAUDE.md "E2E 테스트 실패 대응" 섹션 단순화

## 검증 계획

1. 머지 후 PR #497(코드 실패가 재현되는 PR)에 E2E 트리거 → macOS 6000.2 잡의 Step Summary에 `failure_category=code`와 실패 테스트 fullname이 박히는지 확인
2. 후속 PR로 매트릭스 확장 진행

## 검증

- ✅ `./run-local-tests.sh --validate` (18 invariants passed)
- ✅ `actionlint` 무 경고 (composite action.yml의 syntax-check 경고는 actionlint가 워크플로우로 잘못 인식해 발생하는 false positive)

## Test plan

- [ ] 머지 후 PR #497을 대상으로 E2E 트리거하여 macOS 6000.2 잡의 Step Summary에 분류 표가 출력되는지 확인
- [ ] `failure_category=code`, `failure_detail`에 `IsKnownNonSdkMessageTests.Cs0414UnusedField_ReturnsTrue`가 들어 있는지 확인
- [ ] 다른 매트릭스 잡들은 영향 없는지 확인 (분류 step이 실행되지 않아야 함)
