### PR TITLE
빌드: 실패 분류기를 통합 잡으로 이전 + test-case 정규식 정밀화

### DIFF
--- a/.github/actions/classify-failure/action.yml
+++ b/.github/actions/classify-failure/action.yml
@@ -58,9 +58,9 @@ runs:
 
         if [ -f "$RESULTS_FILE" ]; then
           artifact="present"
-          if grep -q 'result="Failed"' "$RESULTS_FILE"; then
+          if grep -q '<test-case [^>]*result="Failed"' "$RESULTS_FILE"; then
             category="code"
-            failed_names=$(grep -oE 'fullname="[^"]*"[^>]*result="Failed"' "$RESULTS_FILE" \
+            failed_names=$(grep -oE '<test-case [^>]*fullname="[^"]*"[^>]*result="Failed"' "$RESULTS_FILE" \
               | grep -oE 'fullname="[^"]*"' \
               | sed 's/fullname="//; s/"$//' \
               | sort -u)

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -288,6 +288,74 @@ jobs:
         with:
           path: artifacts
 
+      - name: Classify Matrix Failures
+        id: classify
+        shell: bash
+        run: |
+          set +e
+          # 매트릭스 잡별 결과 분류기.
+          # editmode-results-{os}-{version}/ 아티팩트가 있는 매트릭스만 대상으로 한다
+          # (아티팩트가 없으면 EditMode 단계 이전에 실패한 것 — 별도 처리 불필요).
+          mkdir -p classification
+          rows=""
+          shopt -s nullglob
+          for dir in artifacts/editmode-results-*; do
+            base=$(basename "$dir")
+            # editmode-results-<os>-<version> 에서 os/version 추출
+            target="${base#editmode-results-}"
+            os="${target%%-*}"
+            version="${target#*-}"
+
+            results_file="$dir/editmode-results.xml"
+            category="unknown"
+            detail=""
+            artifact="absent"
+
+            if [ -f "$results_file" ]; then
+              artifact="present"
+              if grep -q '<test-case [^>]*result="Failed"' "$results_file"; then
+                category="code"
+                failed_names=$(grep -oE '<test-case [^>]*fullname="[^"]*"[^>]*result="Failed"' "$results_file" \
+                  | grep -oE 'fullname="[^"]*"' \
+                  | sed 's/fullname="//; s/"$//' \
+                  | sort -u)
+                count=$(printf '%s\n' "$failed_names" | grep -c .)
+                first=$(printf '%s\n' "$failed_names" | head -1)
+                if [ "$count" -le 1 ]; then
+                  detail="failed test: ${first}"
+                else
+                  detail="failed tests (${count}): ${first} +$((count-1)) more"
+                fi
+              else
+                category="passed"
+                detail="all editmode tests passed"
+              fi
+            else
+              category="results-missing"
+              detail="editmode-results.xml not produced (license/setup/crash suspected; needs log inspection)"
+            fi
+
+            rows+="| ${os} | ${version} | \`${category}\` | \`${artifact}\` | ${detail:-_(none)_} |"$'\n'
+            echo "::notice title=Failure Classification (${os}, ${version})::category=${category} artifact=${artifact} detail=${detail}"
+          done
+
+          if [ -z "$rows" ]; then
+            echo "has_classification=false" >> "$GITHUB_OUTPUT"
+            echo "분류 가능한 매트릭스 결과 없음 (editmode-results 아티팩트 부재)"
+            exit 0
+          fi
+
+          {
+            echo "### Failure Classification"
+            echo ""
+            echo "| OS | Unity | category | results | detail |"
+            echo "|---|---|---|---|---|"
+            printf '%s' "$rows"
+          } > classification/classification.md
+
+          cat classification/classification.md >> "$GITHUB_STEP_SUMMARY"
+          echo "has_classification=true" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -337,6 +405,13 @@ jobs:
             BENCHMARK_CONTENT="벤치마크 데이터 없음"
           fi
 
+          # 실패 분류 리포트 읽기 (있으면)
+          if [ -f "classification/classification.md" ]; then
+            CLASSIFICATION_CONTENT=$(cat classification/classification.md)
+          else
+            CLASSIFICATION_CONTENT=""
+          fi
+
           # PR 코멘트 생성
           COMMENT_BODY=$(cat <<EOF
           ## ${STATUS_EMOJI} E2E Test Report
@@ -348,6 +423,8 @@ jobs:
           | E2E Windows | ${WINDOWS_RESULT} |
 
           **Status**: ${STATUS_TEXT}
+
+          ${CLASSIFICATION_CONTENT}
 
           <details>
           <summary>📊 Benchmark Report</summary>

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -848,15 +848,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      # POC: 실패 분류기 — 우선 macOS Unity 6000.2 한 잡에만 활성화하여 출력 모양을 검증한다.
-      # 만족스러우면 후속 PR에서 전 매트릭스 + 통합 코멘트 잡으로 확장한다.
-      - name: Classify Failure (POC)
-        if: failure() && inputs.os == 'macos' && inputs.unity-version == '6000.2'
-        uses: ./.github/actions/classify-failure
-        with:
-          os: ${{ inputs.os }}
-          unity-version: ${{ inputs.unity-version }}
-
       # =====================================================
       # macOS Keychain 잠금 해제
       # 화면 잠금 상태에서 Unity Licensing Client가 Keychain에 접근하지


### PR DESCRIPTION
## 배경

#499에서 `.github/actions/classify-failure` 컴포지트 액션을 도입했지만, 매트릭스 잡 안에서 step으로 호출해 두 가지 한계가 있었다.

1. step 안에서는 자기 잡의 로그/결과 외부를 볼 수 없어 매트릭스 잡별 결과를 모아 코멘트로 요약하기 어렵다.
2. PR #497 검증 run(25153945051)에서 `failure_detail`이 `failed tests (4): /Users/.../AppsInTossEditModeTests.dll +3 more`로 잘못 노출됨 — 상위 `<test-suite>`(프로젝트 루트, 어셈블리 dll 경로 등)까지 매칭되어 dll 경로가 detail에 들어갔다. 실제 실패는 1건(`IsKnownNonSdkMessageTests.Cs0414UnusedField_ReturnsTrue`).

## 변경 내용

### (c) 분류기 step → 통합 잡 이전
- `unity-build.yml`: 매트릭스 잡의 `Classify Failure (POC)` step 제거.
- `test-e2e.yml`의 `test-report` 잡에 `Classify Matrix Failures` step 추가.
  - `artifacts/editmode-results-{os}-{version}/editmode-results.xml`을 매트릭스별로 순회.
  - 각 매트릭스에 대해 `code` / `passed` / `results-missing`으로 분류.
  - `classification/classification.md`로 표를 만들어 STEP_SUMMARY와 PR 코멘트에 함께 게시.
  - 매트릭스별 `::notice title=Failure Classification (os, version)::category=...` 어노테이션 추가.

### (b1) `<test-case>` 정규식 정밀화
`.github/actions/classify-failure/action.yml`의 grep을 `<test-case ` 접두사로 한정.

```diff
-if grep -q 'result="Failed"' "$RESULTS_FILE"; then
+if grep -q '<test-case [^>]*result="Failed"' "$RESULTS_FILE"; then
   category="code"
-  failed_names=$(grep -oE 'fullname="[^"]*"[^>]*result="Failed"' "$RESULTS_FILE" \
+  failed_names=$(grep -oE '<test-case [^>]*fullname="[^"]*"[^>]*result="Failed"' "$RESULTS_FILE" \
     | grep -oE 'fullname="[^"]*"' \
     | sed 's/fullname="//; s/"$//' \
     | sort -u)
```

## 로컬 검증

실제 PR #497의 `editmode-results.xml`로 회귀 검증:

| 단계 | 결과 |
|---|---|
| 기존(buggy) regex | `dll 경로`, `IsKnownNonSdkMessageTests`, `IsKnownNonSdkMessageTests.Cs0414...`, `SampleUnityProject-6000.2` (4건) |
| 수정 regex | `IsKnownNonSdkMessageTests.Cs0414UnusedField_ReturnsTrue` (1건) |

어그리게이터 dry-run 출력:

```
### Failure Classification

| OS | Unity | category | results | detail |
|---|---|---|---|---|
| macos | 6000.2 | `code` | `present` | failed test: IsKnownNonSdkMessageTests.Cs0414UnusedField_ReturnsTrue |
```

`./run-local-tests.sh --validate` 통과.

## Test plan

- [ ] 머지 후 PR #497에 E2E 트리거 → `test-report` 잡이 분류 표를 PR 코멘트에 게시하는지 확인
- [ ] 매트릭스 일부가 success일 때도 분류 표가 적절히 노출되는지 확인 (모든 매트릭스 success인 경우 detail은 `all editmode tests passed`)
- [ ] EditMode 단계 진입 전에 실패해 아티팩트가 없는 경우 step이 'has_classification=false'로 끝나고 빈 코멘트가 깨지지 않는지 확인
