### PR TITLE
빌드: EditMode 결과 파일 부재 시 fail 처리 (라이선스 회귀 가시성 강화)

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -747,7 +747,9 @@ jobs:
           wait $UNITY_PID 2>/dev/null || true
 
           # Unity Test Runner는 테스트 실패 시 exit code 2를 반환
-          # editmode-results.xml을 파싱하여 실제 실패 여부 확인
+          # editmode-results.xml을 파싱하여 실제 실패 여부 확인.
+          # 결과 파일이 없으면 라이선스/Hub/캐시 등 인프라 문제로 Unity가 테스트를 실행하지 못한 것이므로
+          # 회귀가 조용히 묻히지 않도록 fail 처리한다 (분류기가 results-missing으로 잡아낼 수 있도록).
           if [ -f "$RESULTS_FILE" ]; then
             echo "EditMode test results:"
             if grep -q 'result="Failed"' "$RESULTS_FILE"; then
@@ -759,7 +761,8 @@ jobs:
               echo "✓ EditMode tests passed (${PASSED} tests)"
             fi
           else
-            echo "::warning::EditMode test results file not found (tests may not have run)"
+            echo "::error::EditMode test results file not found at $RESULTS_FILE — Unity가 테스트를 실행하지 못함 (라이선스/Hub/캐시 의심)"
+            exit 1
           fi
 
       - name: Run EditMode Tests (Windows)
@@ -825,7 +828,7 @@ jobs:
             $logReader.Close()
           }
 
-          # 결과 확인
+          # 결과 확인 — 결과 파일이 없으면 인프라 문제(라이선스/Hub/캐시 등)이므로 fail 처리한다.
           if (Test-Path $resultsFile) {
             $content = Get-Content $resultsFile -Raw
             if ($content -match 'result="Failed"') {
@@ -836,7 +839,8 @@ jobs:
               Write-Host "EditMode tests passed ($passed tests)"
             }
           } else {
-            Write-Host "::warning::EditMode test results file not found"
+            Write-Host "::error::EditMode test results file not found at $resultsFile — Unity가 테스트를 실행하지 못함 (라이선스/Hub/캐시 의심)"
+            exit 1
           }
 
       - name: Upload EditMode Test Results


### PR DESCRIPTION
## Summary

- Unity가 라이선스/Hub/캐시 등 인프라 문제로 EditMode 테스트를 실행하지 못해 `editmode-results.xml`이 생성되지 않으면, 그동안은 `::warning::`만 남기고 잡이 exit 0으로 통과했다.
- 이로 인해 macOS 2021.3 self-hosted runner의 ULF 토큰 만료 같은 인프라 회귀가 "성공"으로 묻혔다 (예: PR #498/#500 macOS 2021.3 EditMode 잡이 3초 만에 종료되었으나 분류기는 아무것도 못 잡음).
- 결과 파일 부재는 곧 인프라 문제이므로 `::error::` + `exit 1`로 강제 fail시킨다. 이렇게 하면 `.github/actions/classify-failure`가 `category=results-missing`으로 분류해 인프라 문제임을 즉시 노출한다.

## Root cause

macOS 2021.3 EditMode 잡 로그(예: 73761155094):
- `[Licensing::Module] Error: Access token is unavailable; failed to update`
- `[Licensing::Client] Error: Code 500 ... No ULF license found., Token not found in cache`
- `[Licensing::Module] Error: 'com.unity.editor.headless' was not found.`
- `EditMode test results file not found`

라이선스 캐시가 만료되어 헤드리스 에디터를 띄울 수 없는 상태였으나, 워크플로우는 warning만 남기고 통과시켜 회귀가 보이지 않았다.

## Changes

- `.github/workflows/unity-build.yml`
  - macOS Run EditMode Tests: 결과 파일 부재 시 `::error::` + `exit 1`
  - Windows Run EditMode Tests: 동일 처리 (PowerShell `Write-Host ::error::` + `exit 1`)
  - 주변 주석에 인프라 문제 가시성 강화의 의도를 명시

후속 산출물 업로드 step은 `if-no-files-found: ignore`이므로 산출물이 없어도 성공하고, 통합 잡의 분류기는 이를 `results-missing`으로 정확히 분류한다.

## Note

이 PR이 머지되면 라이선스가 만료된 상태에서 macOS 2021.3 잡이 빨갛게 노출된다. 즉 인프라(ULF 캐시 갱신) 작업이 별도로 필요하며, 이 PR은 다음 회귀 발생 시 더 이상 조용히 묻히지 않게 만드는 가시성 패치다.

## Test plan

- [x] `./run-local-tests.sh --validate` (~30초)
- [ ] CI: lint / validate
- [ ] 머지 후 macOS 2021.3 EditMode 잡이 라이선스 미해결 상태에서 빨강으로 노출되는지 확인