### PR TITLE
빌드: 인프라 결함 세분화 분류기 (라이선스/Brotli/디스크 등)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -294,20 +294,96 @@ jobs:
         run: |
           set +e
           # 매트릭스 잡별 결과 분류기.
-          # editmode-results-{os}-{version}/ 아티팩트가 있는 매트릭스만 대상으로 한다
-          # (아티팩트가 없으면 EditMode 단계 이전에 실패한 것 — 별도 처리 불필요).
+          #
+          # 카테고리:
+          #   passed                          모든 EditMode 테스트 통과
+          #   code                            EditMode 테스트 실패 (이름 추출)
+          #   results-missing                 editmode-results.xml 없음 — 인프라 결함 의심
+          #   build-no-output                 빌드 산출물 없음 — Brotli/디스크 의심
+          #   unknown                         분류 불가
+          #
+          # results-missing/build-no-output/unknown은 `unity-log-*` 아티팩트를 grep해
+          # infra:* 서브카테고리로 세분화한다 (라이선스/Hub/캐시/Brotli/디스크 등).
+          #
+          # 매트릭스를 명시적으로 enumerate해서 아티팩트 자체가 없는 잡(예: setup 직후
+          # 라이선스 실패)도 표에 노출되게 한다.
           mkdir -p classification
           rows=""
-          shopt -s nullglob
-          for dir in artifacts/editmode-results-*; do
-            base=$(basename "$dir")
-            # editmode-results-<os>-<version> 에서 os/version 추출
-            target="${base#editmode-results-}"
-            os="${target%%-*}"
-            version="${target#*-}"
 
-            results_file="$dir/editmode-results.xml"
+          # OS × Unity 버전 조합 — e2e-test-{macos,windows} 잡의 matrix와 동일하게 유지.
+          declare -a TARGETS=(
+            "macos:2021.3"
+            "macos:2022.3"
+            "macos:6000.0"
+            "macos:6000.2"
+            "macos:6000.3"
+            "windows:2021.3"
+            "windows:2022.3"
+            "windows:6000.0"
+            "windows:6000.2"
+            "windows:6000.3"
+          )
+
+          # 인프라 서브카테고리 grep 패턴 (첫 매치가 detail에 노출됨).
+          # 패턴 추가 시 docs/claude/github-actions.md에도 반영을 권장.
+          classify_infra() {
+            local logs_glob="$1"
+            local hit_subcat="" hit_line=""
+            local file
+            for file in $logs_glob; do
+              [ -f "$file" ] || continue
+              # 라이선스 토큰 만료 / ULF 부재
+              hit_line=$(grep -m1 -E 'No ULF license found|Access token is unavailable|Token not found in cache' "$file" 2>/dev/null)
+              if [ -n "$hit_line" ]; then
+                hit_subcat="infra:license-token-expired"
+                printf '%s\t%s\n' "$hit_subcat" "$hit_line"
+                return 0
+              fi
+              # 라이선스 모듈 누락 (com.unity.editor.headless 등)
+              hit_line=$(grep -m1 -E "'com\.unity\.editor\.[a-z]+' was not found" "$file" 2>/dev/null)
+              if [ -n "$hit_line" ]; then
+                hit_subcat="infra:license-module-missing"
+                printf '%s\t%s\n' "$hit_subcat" "$hit_line"
+                return 0
+              fi
+              # Unity Hub 부재/실행 실패
+              hit_line=$(grep -m1 -E 'Unity Hub not found|hub: command not found' "$file" 2>/dev/null)
+              if [ -n "$hit_line" ]; then
+                hit_subcat="infra:hub-missing"
+                printf '%s\t%s\n' "$hit_subcat" "$hit_line"
+                return 0
+              fi
+              # Brotli 압축 크래시 (self-hosted runner 동시 빌드 리소스 경합)
+              hit_line=$(grep -m1 -E '\[BUSY [0-9]+s\] Brotli .*\.unityweb' "$file" 2>/dev/null)
+              if [ -n "$hit_line" ]; then
+                hit_subcat="infra:brotli-crash"
+                printf '%s\t%s\n' "$hit_subcat" "$hit_line"
+                return 0
+              fi
+              # 디스크 풀
+              hit_line=$(grep -m1 -E 'No space left on device|disk full' "$file" 2>/dev/null)
+              if [ -n "$hit_line" ]; then
+                hit_subcat="infra:disk-full"
+                printf '%s\t%s\n' "$hit_subcat" "$hit_line"
+                return 0
+              fi
+              # Library 잠금 (이전 잡 잔여 프로세스)
+              hit_line=$(grep -m1 -E 'Library directory is locked|Lockfile.*Library' "$file" 2>/dev/null)
+              if [ -n "$hit_line" ]; then
+                hit_subcat="infra:library-locked"
+                printf '%s\t%s\n' "$hit_subcat" "$hit_line"
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          for target in "${TARGETS[@]}"; do
+            os="${target%%:*}"
+            version="${target##*:}"
+            results_file="artifacts/editmode-results-${os}-${version}/editmode-results.xml"
             category="unknown"
+            subcategory=""
             detail=""
             artifact="absent"
 
@@ -331,17 +407,59 @@ jobs:
                 detail="all editmode tests passed"
               fi
             else
-              category="results-missing"
-              detail="editmode-results.xml not produced (license/setup/crash suspected; needs log inspection)"
+              # 결과 파일이 없는 두 가지 가능성:
+              #   1. EditMode 단계가 results-missing으로 실패 (라이선스/Hub/캐시 등)
+              #   2. 빌드 단계에서 Brotli/디스크 등으로 실패 → editmode 도달 못함
+              # 빌드 산출물 디렉토리가 있는데 파일이 없는 경우는 build-no-output.
+              build_artifact_dir=$(ls -d "artifacts/ait-build-${os}-${version}"* 2>/dev/null | head -1)
+              if [ -n "$build_artifact_dir" ] && [ -d "$build_artifact_dir" ]; then
+                unityweb_count=$(find "$build_artifact_dir" -type f -name '*.unityweb' 2>/dev/null | wc -l | tr -d ' ')
+                if [ "$unityweb_count" = "0" ]; then
+                  category="build-no-output"
+                  detail="no .unityweb files in build artifact (compression failure suspected)"
+                else
+                  category="results-missing"
+                  detail="editmode-results.xml not produced (license/setup/crash suspected)"
+                fi
+              else
+                category="results-missing"
+                detail="editmode-results.xml not produced (license/setup/crash suspected)"
+              fi
             fi
 
-            rows+="| ${os} | ${version} | \`${category}\` | \`${artifact}\` | ${detail:-_(none)_} |"$'\n'
-            echo "::notice title=Failure Classification (${os}, ${version})::category=${category} artifact=${artifact} detail=${detail}"
+            # 인프라 서브카테고리: 결과가 코드/통과가 아닐 때만 시도.
+            if [ "$category" != "passed" ] && [ "$category" != "code" ]; then
+              shopt -s nullglob
+              # build → unit-test → editmode 순으로 grep (인프라 결함은 보통 빌드/EditMode에서 먼저 노출).
+              for kind in build unit-test editmode; do
+                infra_match=$(classify_infra "artifacts/unity-log-${kind}-${os}-${version}/*.log" 2>/dev/null)
+                if [ -n "$infra_match" ]; then
+                  subcategory="${infra_match%%	*}"
+                  hit="${infra_match#*	}"
+                  # detail에 매칭 라인 한 줄 첨부 (너무 길면 80자로 자름).
+                  # 마크다운 표 셀이 깨지지 않도록 `|`는 ⎮(U+23AE)로 치환.
+                  hit_short="${hit:0:80}"
+                  hit_safe="${hit_short//|/⎮}"
+                  detail_safe="${detail//|/⎮}"
+                  detail="${detail_safe} — ${subcategory}: ${hit_safe}"
+                  break
+                fi
+              done
+              shopt -u nullglob
+            fi
+
+            display_category="${category}"
+            if [ -n "$subcategory" ]; then
+              display_category="${category} → ${subcategory}"
+            fi
+
+            rows+="| ${os} | ${version} | \`${display_category}\` | \`${artifact}\` | ${detail:-_(none)_} |"$'\n'
+            echo "::notice title=Failure Classification (${os}, ${version})::category=${category} subcategory=${subcategory:-none} artifact=${artifact} detail=${detail}"
           done
 
           if [ -z "$rows" ]; then
             echo "has_classification=false" >> "$GITHUB_OUTPUT"
-            echo "분류 가능한 매트릭스 결과 없음 (editmode-results 아티팩트 부재)"
+            echo "분류 가능한 매트릭스 결과 없음"
             exit 0
           fi
 

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -710,16 +710,22 @@ jobs:
           UNITY_PATH="${{ steps.unity-macos.outputs.UNITY_PATH }}"
           PROJECT_PATH="${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}"
           RESULTS_FILE="$PROJECT_PATH/editmode-results.xml"
+          LOG_FILE="/tmp/unity-editmode-${{ inputs.unity-version }}.log"
           MAX_WAIT=600  # Unity 프로세스 최대 대기 시간 (10분)
 
           echo "Running EditMode Tests..."
           echo "Unity Version: ${{ steps.unity-macos.outputs.UNITY_VERSION }}"
+          echo "Log file: $LOG_FILE"
 
+          # 프로세스 치환으로 stdout/stderr를 tee에 흘려 파일을 보존한다 — 잡 종료 후
+          # 통합 분류기가 라이선스/Hub/캐시 등 인프라 결함을 grep으로 세분화할 수 있도록 한다.
+          # 파이프(`| tee`)를 쓰면 `$!`이 tee의 PID가 되어 아래 wait 루프가 깨지므로
+          # `> >(tee ...)` 형태를 사용해 `$!`이 Unity PID를 가리키도록 한다.
           "$UNITY_PATH" -batchmode -nographics \
             -projectPath "$PROJECT_PATH" \
             -runTests -testPlatform EditMode \
             -testResults "$RESULTS_FILE" \
-            -logFile - 2>&1 &
+            -logFile - > >(tee "$LOG_FILE") 2>&1 &
           UNITY_PID=$!
 
           # 타임아웃 대기: 결과 파일이 생성되면 프로세스 종료를 기다리되, 최대 MAX_WAIT초
@@ -849,6 +855,26 @@ jobs:
         with:
           name: editmode-results-${{ inputs.os }}-${{ inputs.unity-version }}
           path: Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/editmode-results.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # EditMode 로그를 통합 분류기에서 grep할 수 있도록 보존
+      # (라이선스/Hub/캐시 등 인프라 결함 세분화에 필요).
+      - name: Upload EditMode Unity Log (macOS)
+        if: inputs.os == 'macos' && inputs.run-e2e-test && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unity-log-editmode-${{ inputs.os }}-${{ inputs.unity-version }}
+          path: /tmp/unity-editmode-${{ inputs.unity-version }}.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload EditMode Unity Log (Windows)
+        if: inputs.os == 'windows' && inputs.run-e2e-test && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unity-log-editmode-${{ inputs.os }}-${{ inputs.unity-version }}
+          path: ${{ runner.temp }}\unity-editmode-${{ inputs.unity-version }}.log
           if-no-files-found: ignore
           retention-days: 7
 
@@ -1179,6 +1205,24 @@ jobs:
           path: |
             /tmp/unity-test-results-${{ inputs.unity-version }}.xml
             ${{ runner.temp }}/unity-test-results-${{ inputs.unity-version }}.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Unit Test Unity Log (macOS)
+        if: inputs.os == 'macos' && inputs.run-unit-test && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unity-log-unit-test-${{ inputs.os }}-${{ inputs.unity-version }}
+          path: /tmp/unity-test-${{ inputs.unity-version }}.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Unit Test Unity Log (Windows)
+        if: inputs.os == 'windows' && inputs.run-unit-test && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unity-log-unit-test-${{ inputs.os }}-${{ inputs.unity-version }}
+          path: ${{ runner.temp }}\unity-test-${{ inputs.unity-version }}.log
           if-no-files-found: ignore
           retention-days: 7
 
@@ -1572,6 +1616,26 @@ jobs:
             Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/ait-build/granite.config.ts
             Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/ait-build/build-validation.json
           if-no-files-found: error
+          retention-days: 7
+
+      # WebGL 빌드 Unity 로그를 통합 분류기로 보낸다 — Brotli 크래시/디스크 풀 등
+      # 빌드 실패의 인프라 원인을 grep으로 세분화하기 위함.
+      - name: Upload Build Unity Log (macOS)
+        if: inputs.os == 'macos' && inputs.run-build && (inputs.test-level || '2') != '0' && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unity-log-build-${{ inputs.os }}-${{ inputs.unity-version }}
+          path: /tmp/unity-build-${{ inputs.unity-version }}.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Build Unity Log (Windows)
+        if: inputs.os == 'windows' && inputs.run-build && (inputs.test-level || '2') != '0' && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unity-log-build-${{ inputs.os }}-${{ inputs.unity-version }}
+          path: ${{ runner.temp }}\unity-build-${{ inputs.unity-version }}.log
+          if-no-files-found: ignore
           retention-days: 7
 
       # =====================================================


### PR DESCRIPTION
## Summary

기존 분류기는 `results-missing` / `build-no-output`까지만 분류해서, 라이선스 만료·Hub 부재·Brotli 크래시·디스크 풀 같은 인프라 결함이 한 덩어리로 묶였다. 이 PR은 Unity 로그를 아티팩트로 보존하고 통합 분류기에서 grep하여 **infra:* 서브카테고리**로 세분화한다.

## Changes

### `unity-build.yml` — Unity 로그 보존

- macOS EditMode 잡: `-logFile -`에서 `> >(tee FILE) 2>&1`로 변경. stdout 출력은 그대로 두면서 `/tmp/unity-editmode-<ver>.log`에도 동시 보존. `&` 뒤의 `$!`이 Unity PID를 가리키도록 파이프 대신 프로세스 치환을 사용 (파이프를 쓰면 `$!`이 tee의 PID가 되어 wait 루프가 깨짐).
- 다음 3종 로그를 `unity-log-{kind}-{os}-{version}` 아티팩트로 `always()` 업로드:
  - `unity-log-editmode-*` — EditMode 단계 로그
  - `unity-log-unit-test-*` — Unit Test 단계 로그
  - `unity-log-build-*` — WebGL 빌드 로그

### `test-e2e.yml` — 통합 분류기 강화

- 매트릭스를 명시적으로 enumerate (`macos × {2021.3,2022.3,6000.0,6000.2,6000.3}`, windows 동일). 이전엔 `editmode-results-*` 아티팩트가 있는 매트릭스만 표에 노출되어 setup 직후 실패한 잡은 사라졌었다.
- `results-missing` / `build-no-output` / `unknown`인 매트릭스에 대해 `unity-log-*` 아티팩트를 grep해 다음 서브카테고리를 부여:

| 서브카테고리 | 매칭 패턴 |
|---|---|
| `infra:license-token-expired` | `No ULF license found` / `Access token is unavailable` / `Token not found in cache` |
| `infra:license-module-missing` | `'com.unity.editor.<name>' was not found` |
| `infra:hub-missing` | `Unity Hub not found` / `hub: command not found` |
| `infra:brotli-crash` | `[BUSY Ns] Brotli ...unityweb` |
| `infra:disk-full` | `No space left on device` / `disk full` |
| `infra:library-locked` | `Library directory is locked` / `Lockfile.*Library` |

- 매칭 라인 한 줄을 detail 셀에 첨부 (80자 트림). 마크다운 표 호환을 위해 `|`는 `⎮`(U+23AE)로 치환.
- 빌드 산출물 디렉토리는 있는데 `.unityweb` 파일이 없는 경우는 `build-no-output`으로 분류.

## Verification

4가지 시나리오 fixture로 로컬 검증:

| 시나리오 | 입력 | 결과 |
|---|---|---|
| passed | macos 6000.2: 정상 XML | `passed` |
| license-missing | macos 2021.3: 로그에 ULF 에러 | `results-missing → infra:license-token-expired` + 매칭 라인 |
| brotli-crash | windows 6000.0: build dir에 .unityweb 없음 + Brotli 로그 | `build-no-output → infra:brotli-crash` + 매칭 라인 |
| code failure | windows 2021.3: XML에 Failed | `code` + 실패 테스트 이름 |
| 누락 매트릭스 | 8개 (아티팩트 부재) | `results-missing` (이전엔 표에서 사라졌음) |

표가 깨지지 않고 한 페이지에서 모든 매트릭스의 상태가 보임.

## Test plan

- [x] `./run-local-tests.sh --validate`
- [x] 분류기 bash 문법 (`bash -n`)
- [x] 4종 시나리오 fixture 통합 실행
- [ ] CI: lint / validate
- [ ] 머지 후 다음 E2E 트리거 시 macOS 2021.3 매트릭스가 `infra:license-token-expired`로 분류되는지 확인