### PR TITLE
수정: Windows EditMode PowerShell 인코딩 회귀 핫픽스

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -775,10 +775,16 @@ jobs:
         if: inputs.os == 'windows' && inputs.run-e2e-test
         shell: powershell
         run: |
+          # Windows PowerShell 5.1 reads scripts using the system code page; non-ASCII
+          # string literals (e.g. Korean) can be mis-decoded under CP949 and break the
+          # parser. Force UTF-8 output and keep user-facing messages ASCII-only.
+          [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+          $OutputEncoding = [System.Text.Encoding]::UTF8
+
           $unityPath = "${{ steps.unity-windows.outputs.UNITY_PATH }}"
           $projectPath = "${{ github.workspace }}\Tests~\E2E\SampleUnityProject-${{ inputs.unity-version }}"
           $resultsFile = "$projectPath\editmode-results.xml"
-          $maxWaitSeconds = 600  # Unity 프로세스 최대 대기 시간 (10분)
+          $maxWaitSeconds = 600  # Unity process max wait (10 minutes)
 
           Write-Host "Running EditMode Tests..."
           Write-Host "Unity Version: ${{ steps.unity-windows.outputs.UNITY_VERSION }}"
@@ -793,7 +799,7 @@ jobs:
             "-logFile", $logFile
           ) -PassThru -NoNewWindow
 
-          # 로그 실시간 출력 + 타임아웃 감시
+          # Stream log to console and watch for timeout
           $logReader = $null
           $waitSeconds = 0
           while (-not $proc.HasExited) {
@@ -810,7 +816,7 @@ jobs:
               if ($chunk) { Write-Host $chunk -NoNewline }
             }
 
-            # 결과 파일이 생성된 후 60초 내에 프로세스가 종료되지 않으면 강제 종료
+            # Force-kill if process does not exit within 60s after results file was written
             if ((Test-Path $resultsFile) -and $waitSeconds -gt 60) {
               $resultAge = (New-TimeSpan -Start (Get-Item $resultsFile).LastWriteTime -End (Get-Date)).TotalSeconds
               if ($resultAge -gt 60) {
@@ -834,7 +840,8 @@ jobs:
             $logReader.Close()
           }
 
-          # 결과 확인 — 결과 파일이 없으면 인프라 문제(라이선스/Hub/캐시 등)이므로 fail 처리한다.
+          # Inspect results - missing results file means infra fault (license/Hub/cache),
+          # so fail the step loudly so the classifier picks it up as results-missing.
           if (Test-Path $resultsFile) {
             $content = Get-Content $resultsFile -Raw
             if ($content -match 'result="Failed"') {
@@ -845,7 +852,7 @@ jobs:
               Write-Host "EditMode tests passed ($passed tests)"
             }
           } else {
-            Write-Host "::error::EditMode test results file not found at $resultsFile — Unity가 테스트를 실행하지 못함 (라이선스/Hub/캐시 의심)"
+            Write-Host "::error::EditMode test results file not found at $resultsFile - Unity failed to run tests (suspect license/Hub/cache)"
             exit 1
           }
 


### PR DESCRIPTION
## Summary

PR #503에서 Windows EditMode step의 results-missing 에러 메시지에 한국어를 사용했으나, Windows PowerShell 5.1이 시스템 코드페이지(CP949 등)로 스크립트를 읽으면서 비-ASCII 리터럴이 깨져 ParseException이 발생했다. 그 결과 Windows 매트릭스 5개 모두의 EditMode 잡이 실패 (run 25178949031).

```
+ ... °€ í…ŒìŠ¤íŠ¸ë¥¼ ì‹¤í–‰í•˜ì§€ ëª»í•¨ (ë¼ì´ì„ ìŠ¤/Hub/ìºì‹œ ì˜ì‹¬)"
+ CategoryInfo          : ParserError: (:) [], ParseException
+ FullyQualifiedErrorId : MissingEndParenthesisInExpression
##[error]Process completed with exit code 1.
```

## Changes

- Run EditMode Tests (Windows) step:
  - 에러 메시지의 한국어를 영문 ASCII로 교체
  - step 시작에 `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8` 및 `$OutputEncoding` 추가 (향후 비-ASCII 출력 안전성)
  - 같은 step의 코멘트도 영문으로 통일 (방어 일관성)

다른 PowerShell step의 한국어 코멘트는 그대로 둔다 — PR #503 이전부터 통과해 왔고, 코멘트는 깨져도 파서를 깨뜨리지 않는다.

## Why this slipped through

- 로컬에서는 macOS/Linux 환경이라 PowerShell 인코딩 문제 재현 불가
- `bash -n` syntax 체크는 PowerShell 코드를 검증하지 않음
- E2E 트리거하기 전엔 Windows runner에서 실제 실행되지 않음

## Test plan

- [x] `./run-local-tests.sh --validate`
- [ ] CI: lint / validate
- [ ] 머지 후 PR #498/#500 재트리거 → Windows EditMode가 라이선스 정상이면 passed, 아니면 results-missing → infra:license-token-expired로 분류