### PR TITLE
chore: disable superpowers plugin by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
     ]
   },
   "enabledPlugins": {
-    "superpowers@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": false,
     "playwright@claude-plugins-official": true,
     "sentry@claude-plugins-official": true
   }


### PR DESCRIPTION
## Summary
- Set `superpowers@claude-plugins-official` to `false` in `.claude/settings.json` to reduce token consumption for team members who don't actively use it.
- Plugin remains installed; anyone can re-enable on demand via `/plugin` or by toggling the value back to `true`.

## Test plan
- [ ] Verify `.claude/settings.json` parses as valid JSON
- [ ] Confirm other `enabledPlugins` entries are preserved