### PR TITLE
수정: 분류기 라이선스 자가복구 false positive 제거 + 패키지 의존성 패턴 추가

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -332,10 +332,11 @@ jobs:
             local file
             for file in $logs_glob; do
               [ -f "$file" ] || continue
-              # 라이선스 토큰 만료 / ULF 부재
-              hit_line=$(grep -m1 -E 'No ULF license found|Access token is unavailable|Token not found in cache' "$file" 2>/dev/null)
+
+              # 패키지 의존성 해결 실패 (git 누락 등) — 라이선스 자가복구 후에도 종료시키는 흔한 원인
+              hit_line=$(grep -m1 -E "No '?git'? executable|Project has invalid dependencies|Failed to resolve packages|Cannot fetch.*git" "$file" 2>/dev/null)
               if [ -n "$hit_line" ]; then
-                hit_subcat="infra:license-token-expired"
+                hit_subcat="infra:package-resolution"
                 printf '%s\t%s\n' "$hit_subcat" "$hit_line"
                 return 0
               fi
@@ -373,6 +374,18 @@ jobs:
                 hit_subcat="infra:library-locked"
                 printf '%s\t%s\n' "$hit_subcat" "$hit_line"
                 return 0
+              fi
+              # 라이선스 토큰 만료 / ULF 부재 — 자가복구 시 false positive를 일으키므로 마지막에 검사하고
+              # 같은 로그 안에서 라이선스가 정상 발급된 흔적이 있으면 무시한다.
+              hit_line=$(grep -m1 -E 'No ULF license found|Access token is unavailable|Token not found in cache' "$file" 2>/dev/null)
+              if [ -n "$hit_line" ]; then
+                if grep -qE 'Successfully updated license|Serial number assigned to' "$file"; then
+                  : # 라이선스가 자가복구되었으므로 진짜 원인이 아님
+                else
+                  hit_subcat="infra:license-token-expired"
+                  printf '%s\t%s\n' "$hit_subcat" "$hit_line"
+                  return 0
+                fi
               fi
             done
             return 1

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,9 @@ sdk-runtime-generator~/dist/
 sdk-runtime-generator~/.tmp/
 sdk-runtime-generator~/.temp-csharp-validation/
 
+# Local classifier/E2E debug downloads
+.tmp-artifacts/
+
 # E2E Test artifacts
 Tests~/E2E/SampleUnityProject*/Library/
 Tests~/E2E/SampleUnityProject*/Temp/


### PR DESCRIPTION
## Summary

- Unity가 첫 핸드셰이크에서 `Access token is unavailable`를 출력하고도 곧 `Successfully updated license`로 자가복구되는 경우, 기존 분류기는 첫 매치만 보고 `infra:license-token-expired`로 분류했다. 진짜 실패 원인(예: Sentry 패키지가 요구하는 git이 PATH에 없어 발생하는 패키지 해결 실패)이 가려진다.
- 라이선스 패턴 매칭 시 동일 로그에 자가복구 흔적(`Successfully updated license` 또는 `Serial number assigned to`)이 있으면 skip하는 가드 추가.
- `infra:package-resolution` 패턴 신설: `No 'git' executable`, `Project has invalid dependencies`, `Failed to resolve packages` 등.
- 우선순위 재배치: 결정적 실패(package-resolution, license-module-missing, hub-missing, brotli-crash, disk-full, library-locked)를 라이선스보다 먼저 검사.

## Why now

PR #498 재트리거 (run 25249283506)에서 Windows 5/5가 `infra:license-token-expired`로 분류되었지만, 실제 로그는 라이선스 자가복구 후 `Project has invalid dependencies: io.sentry.unity: No 'git' executable was found`로 종료됨. 인프라 팀이 ULF 토큰을 갱신해도 git PATH 이슈가 별도로 남아있어 실제 차단 요인이 두 단계인데 분류기가 첫 단계만 보여줘서 디버깅 시간을 낭비한다.

## Test plan

- [x] bash 픽스처 3종 (자가복구 + git 누락 / 진짜 라이선스 만료 / 자가복구만)으로 분류 결과 확인
- [x] `./run-local-tests.sh --validate` 통과
- [ ] 머지 후 PR #498 재트리거 → Windows 매트릭스가 `infra:package-resolution`으로 표시되는지 확인