### PR TITLE
수정: 분류기 license-module-missing을 license-token-expired로 흡수

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -340,13 +340,6 @@ jobs:
                 printf '%s\t%s\n' "$hit_subcat" "$hit_line"
                 return 0
               fi
-              # 라이선스 모듈 누락 (com.unity.editor.headless 등)
-              hit_line=$(grep -m1 -E "'com\.unity\.editor\.[a-z]+' was not found" "$file" 2>/dev/null)
-              if [ -n "$hit_line" ]; then
-                hit_subcat="infra:license-module-missing"
-                printf '%s\t%s\n' "$hit_subcat" "$hit_line"
-                return 0
-              fi
               # Unity Hub 부재/실행 실패
               hit_line=$(grep -m1 -E 'Unity Hub not found|hub: command not found' "$file" 2>/dev/null)
               if [ -n "$hit_line" ]; then
@@ -375,9 +368,11 @@ jobs:
                 printf '%s\t%s\n' "$hit_subcat" "$hit_line"
                 return 0
               fi
-              # 라이선스 토큰 만료 / ULF 부재 — 자가복구 시 false positive를 일으키므로 마지막에 검사하고
+              # 라이선스 만료/시트 부재 — 자가복구 시 false positive를 일으키므로 마지막에 검사하고
               # 같은 로그 안에서 라이선스가 정상 발급된 흔적이 있으면 무시한다.
-              hit_line=$(grep -m1 -E 'No ULF license found|Access token is unavailable|Token not found in cache' "$file" 2>/dev/null)
+              # 표면 증상이 다양해도(ULF 부재 / 토큰 부재 / entitlement 0개 / Pro 모듈 미부여)
+              # 운영상 해결책은 동일(ULF 갱신)이므로 한 카테고리로 묶는다.
+              hit_line=$(grep -m1 -E "No ULF license found|Access token is unavailable|Token not found in cache|Found 0 entitlement groups|'com\.unity\.editor\.[a-z]+' was not found" "$file" 2>/dev/null)
               if [ -n "$hit_line" ]; then
                 if grep -qE 'Successfully updated license|Serial number assigned to' "$file"; then
                   : # 라이선스가 자가복구되었으므로 진짜 원인이 아님


### PR DESCRIPTION
## Summary

기존에 별개 카테고리(`infra:license-module-missing`)로 잡던 `'com.unity.editor.headless' was not found` 메시지는 사실 별개 라이선스 누락이 아니라, 라이선스 시트(=ULF)가 만료/미발급되어 entitlement 조회 결과가 0개로 떨어진 결과의 표면 증상이다. `Found 0 entitlement groups`도 같은 원인의 다른 표현일 뿐.

실제 로그 흐름 (run 25256450192 macOS 2021.3):
```
Code 500 ... No ULF license found, Token not found in cache    ← 시트 자체가 없음
Code 404 ... Found 0 entitlement groups and 0 free entitlements ← 그래서 entitlement 0개
'com.unity.editor.headless' was not found.                      ← 그래서 헤드리스 권한 부재
Pro License: NO
```

운영상 해결책은 모두 동일(ULF 갱신)이므로 분류 카테고리를 한 개로 통합:
- 패턴 추가: `Found 0 entitlement groups`, `'com.unity.editor.X' was not found`
- 자가복구 가드(`Successfully updated license` / `Serial number assigned to`)는 그대로 공유
- `license-module-missing` 별도 블록 제거 (4줄 단순화)

## Test plan

로컬 픽스처 4종으로 검증 완료:
- [x] macOS 2021.3 entitlement-missing 로그 → `infra:license-token-expired` (직전엔 `license-module-missing`이었음)
- [x] 자가복구 + git 누락 → `infra:package-resolution` (라이선스 매치 안 함)
- [x] 진짜 라이선스 만료 → `infra:license-token-expired`
- [x] 자가복구만 있고 다른 실패 없음 → 매치 없음 (false positive 가드)
- [x] `./run-local-tests.sh --validate` 통과