### PR TITLE
진단: Windows runner의 자식 PowerShell PATH 노출

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -771,6 +771,31 @@ jobs:
             exit 1
           fi
 
+      - name: Probe Windows runner PATH (diagnostic)
+        if: inputs.os == 'windows' && inputs.run-e2e-test
+        shell: powershell
+        run: |
+          [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+          $OutputEncoding = [System.Text.Encoding]::UTF8
+          Write-Host "=== runner-spawned PowerShell environment ==="
+          Write-Host "USERNAME: $env:USERNAME"
+          Write-Host "USERPROFILE: $env:USERPROFILE"
+          Write-Host ""
+          Write-Host "=== PATH (one entry per line) ==="
+          $env:PATH -split ';' | ForEach-Object { Write-Host "  $_" }
+          Write-Host ""
+          Write-Host "=== git lookup ==="
+          $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+          if ($gitCmd) {
+            Write-Host "git found at: $($gitCmd.Source)"
+            & git --version
+          } else {
+            Write-Host "::warning::git NOT in PATH for runner-spawned shell"
+          }
+          Write-Host ""
+          Write-Host "=== where.exe git ==="
+          where.exe git 2>&1 | ForEach-Object { Write-Host "  $_" }
+
       - name: Run EditMode Tests (Windows)
         if: inputs.os == 'windows' && inputs.run-e2e-test
         shell: powershell


### PR DESCRIPTION
## Summary

Windows ULF 갱신 + actions-runner 재시작 후에도 `No 'git' executable was found`가 계속 발생. PowerShell이 직접 git을 부르는 게 아니라 PowerShell이 `Start-Process`로 띄운 Unity.exe(배치 모드) 자식 프로세스가 git을 spawn하므로, 결국 actions-runner 서비스가 자식 셸에 어떤 PATH를 상속시키는지가 핵심.

EditMode Tests (Windows) 직전에 한 번만 출력:
- `USERNAME` (서비스가 SYSTEM/dave 중 어느 계정으로 도는지)
- `PATH` 항목 전체
- `Get-Command git` / `where.exe git`

## Why a separate PR

진단 정보를 본 다음 즉시 제거할 임시 변경. `unity-build.yml`은 `workflow_call`로만 트리거되므로 main에 머지되어도 다른 워크플로우에 부수 효과 없음. PR #498 머지 후 별도 cleanup PR로 제거.

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] 머지 후 PR #498 재트리거하여 진단 출력 확인
- [ ] PATH에 git이 있는지 / 사용자 PATH vs 시스템 PATH 구분 / 서비스 계정 확인