### PR TITLE
진단: Sentry 429 응답 헤더 로깅

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorTrackerIntegrationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorTrackerIntegrationTests.cs
@@ -74,10 +74,25 @@ public class ErrorTrackerIntegrationTests
 
         long statusCode = request.responseCode;
         string error = request.error;
+        string rateLimits = request.GetResponseHeader("X-Sentry-Rate-Limits");
+        string retryAfter = request.GetResponseHeader("Retry-After");
+        string sentryError = request.GetResponseHeader("X-Sentry-Error");
+        string responseBody = request.downloadHandler != null ? request.downloadHandler.text : null;
         request.Dispose();
 
         if (!string.IsNullOrEmpty(error))
             Debug.Log($"[Test] HTTP 에러: {error}");
+
+        if (statusCode != 200)
+        {
+            Debug.Log(
+                $"[Test] Sentry non-200 응답: status={statusCode}, " +
+                $"X-Sentry-Rate-Limits={rateLimits ?? "(none)"}, " +
+                $"Retry-After={retryAfter ?? "(none)"}, " +
+                $"X-Sentry-Error={sentryError ?? "(none)"}, " +
+                $"body={(string.IsNullOrEmpty(responseBody) ? "(empty)" : responseBody)}"
+            );
+        }
 
         return statusCode;
     }


### PR DESCRIPTION
## Summary
- `ErrorTrackerIntegrationTests.SendEnvelopeSync`에서 non-200 응답을 받을 때 `X-Sentry-Rate-Limits`, `Retry-After`, `X-Sentry-Error`, response body를 한 줄로 묶어 로그에 남긴다
- run 25411516019에서 10개 매트릭스 전부 ErrorTracker 통합 테스트 6개가 HTTP 429로 실패 — 어떤 카테고리(error/transaction/session)와 어떤 사유(spike_protection / org_quota / burst_limit 등)인지 정확히 모르는 상태
- 응답 헤더가 모이면 다음 대응(매트릭스 1개 한정 / 429 허용 / DSN 분리 / spike protection 조정)을 정확하게 결정할 수 있음

## Test plan
- [ ] E2E 트리거 후 429를 한 번이라도 받으면 unity-editmode-*.log에 `[Test] Sentry non-200 응답: status=429, X-Sentry-Rate-Limits=..., Retry-After=..., X-Sentry-Error=..., body=...` 라인이 찍히는지 확인
- [ ] 200 정상 응답일 때는 로그가 추가로 찍히지 않는지 확인 (노이즈 방지)