### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — exec-git-breadcrumb

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -111,6 +111,11 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 사용자 Unity 설치에 WebGL 모듈 미설치 — SDK-DD
             "Build target 'WebGL' not supported",
+
+            // 서브프로세스 실행 브레드크럼 — SDK가 아닌 외부(Unity Collab/CCD/사용자 도구)가 출력
+            // 예: "Exec> git show -s --pretty=%D HEAD", "Exec> git log -1 --pretty=format:%h"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-NX, APPS-IN-TOSS-UNITY-SDK-NW
+            "Exec> git ",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -538,6 +538,30 @@ public class IsKnownNonSdkMessageTests
             "[AIT] Group 'Foo' does not have any associated AddressableAssetGroupSchemas"));
     }
 
+    [Test]
+    public void ExecGitBreadcrumb_GitShow_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-NX — 외부 도구의 git 서브프로세스 실행 브레드크럼
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Exec> git show -s --pretty=%D HEAD"));
+    }
+
+    [Test]
+    public void ExecGitBreadcrumb_GitLog_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-NW
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Exec> git log -1 --pretty=format:%h"));
+    }
+
+    [Test]
+    public void ExecGitBreadcrumb_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: SDK가 [AIT] prefix와 함께 동일 메시지를 출력했다면 필터되면 안 됨
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Exec> git show -s --pretty=%D HEAD"));
+    }
+
     #endregion
 
     #region SDK 관련 메시지는 통과 (negative cases)


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-NX, APPS-IN-TOSS-UNITY-SDK-NW

## 대상 Sentry 이슈

| Issue ID | 제목 | events |
|---|---|---|
| APPS-IN-TOSS-UNITY-SDK-NX | UnityWarning: `Exec> git show -s --pretty=%D HEAD` | (auto-resolve 입력) |
| APPS-IN-TOSS-UNITY-SDK-NW | UnityWarning: `Exec> git log -1 --pretty=format:%h` | (auto-resolve 입력) |

## 분석

`Exec> git ...` 패턴은 외부 도구(예: Unity Collab, Git LFS, 사용자 빌드 스크립트)가 Editor 내에서 자식 git 프로세스를 실행하면서 출력하는 **서브프로세스 실행 브레드크럼**입니다. SDK 코드에는 `Exec>` 문자열이 존재하지 않음을 grep으로 확인했고, 따라서 SDK가 출력하지 않는 외부 노이즈로 분류됩니다.

## 추출 패턴

`NonSdkMessagePatterns`에 단일 부분 문자열 추가:

- `"Exec> git "` (trailing space로 `Exec> github-cli` 등 다른 토큰 시작과의 우발 매칭 방지)

`AitKeywords` 가드(`[AIT`, `AppsInToss` 등)가 우선하므로, 만약 SDK가 향후 동일 prefix로 로그를 출력해도 `[AIT]` 등이 함께 있으면 보호됩니다.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열에 1개 패턴 추가
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 2건(`git show`, `git log`) + AIT prefix 보호 negative 1건

## 검증

`./run-local-tests.sh --validate` 통과:

```
Passed:  3
Failed:  0
Skipped: 0
✓ All tests passed!
```

(E2E Test Files Validation, Playwright Config Validation, SDK Generator Unit Tests 18/18 invariants)

## 머지 검토

자동 생성된 PR이므로 **사람 머지 검토가 필요합니다**. 패턴 정확성과 SDK 보호 가드 회귀 여부를 확인해주세요.