### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — missing-script-user-asset

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -82,10 +82,6 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 사용자 프로젝트 에셋 문제
             "matches more than one built-in atlases",
-            // 사용자 prefab의 missing script 경고 (Sentry SDK-H1, SDK-GY 등) —
-            // Unity 표준 경고 문구로 SDK가 출력하지 않음. 717-720 라인의 composite 조건과
-            // 중복 매칭되지만 더 직관적인 단일 substring 매치를 우선 적용한다.
-            "is missing or no valid script is attached",
             "Warnings during import of AudioClip",
             // FMOD/오디오 — 사용자 에셋 import/포맷 문제
             "Cannot create FMOD::Sound instance for clip",
@@ -732,7 +728,7 @@ namespace AppsInToss.Editor.ErrorTracker
             }
 
             // "Script attached to ... is missing" 패턴은 Assets/ 경로가 포함된 경우에만 사용자 프로젝트로 분류.
-            // "in Assets/..." 직접 경로 형태와 "in scene 'Assets/...'" 변형(SDK-H0/GX/GW) 모두 매칭한다.
+            // "in Assets/..." 직접 경로 형태(SDK-H1/GY), "in scene 'Assets/...'" 변형(SDK-H0/GX/GW) 모두 매칭한다.
             if (message.IndexOf("Script attached to", StringComparison.Ordinal) >= 0
                 && message.IndexOf("is missing", StringComparison.Ordinal) >= 0
                 && message.IndexOf("Assets/", StringComparison.Ordinal) >= 0)

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -82,6 +82,10 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 사용자 프로젝트 에셋 문제
             "matches more than one built-in atlases",
+            // 사용자 prefab의 missing script 경고 (Sentry SDK-H1, SDK-GY 등) —
+            // Unity 표준 경고 문구로 SDK가 출력하지 않음. 717-720 라인의 composite 조건과
+            // 중복 매칭되지만 더 직관적인 단일 substring 매치를 우선 적용한다.
+            "is missing or no valid script is attached",
             "Warnings during import of AudioClip",
             // FMOD/오디오 — 사용자 에셋 import/포맷 문제
             "Cannot create FMOD::Sound instance for clip",

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -283,12 +283,13 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void ScriptMissingWithoutAssets_ReturnsFalse()
     {
-        // "Script attached to" + "is missing"이지만 Assets/ 경로가 없으면 필터링 안 함
+        // "Script attached to" + "is missing"이지만 Assets/ 경로가 없으면
+        // composite 조건이 매칭되지 않고, 단일 substring "is missing or no valid script is attached"는
+        // 정확한 Unity 표준 문구만 매칭하므로 짧은 변형은 필터링되지 않는다.
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Script attached to 'GameObject' is missing or no valid script"));
     }
 
-    [Test]
     [TestCase(
         "Script attached to '_iOSUpdate' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached.",
         TestName = "ScriptMissingInUserScene_iOSUpdate_ReturnsTrue")]
@@ -312,6 +313,31 @@ public class IsKnownNonSdkMessageTests
         // "[AIT" 키워드가 MessageContainsSdkKeyword 가드에 먼저 매칭되어 composite 가드 도달 전에 return false 한다.
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AIT] Script attached to '_iOSUpdate' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached."));
+    }
+
+    [Test]
+    public void ScriptMissingInUserPrefab_LasercahrgingFixture_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-H1 실측 메시지.
+        // 사용자 Resources/Effect 하위 prefab의 missing script 경고 — Unity 표준 문구로 SDK 외부.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Script attached to '_NotUse_Effetc_Lasercharging' in asset 'Assets/Resources/Effect/_NotUse_Effetc_Lasercharging.prefab' is missing or no valid script is attached."));
+    }
+
+    [Test]
+    public void ScriptMissingInUserPrefab_HitMissileFixture_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-GY 실측 메시지.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Script attached to '_NotUse_HitMissile_P10' in asset 'Assets/Resources/Effect/_NotUse_HitMissile_P10.prefab' is missing or no valid script is attached."));
+    }
+
+    [Test]
+    public void ScriptMissingInUserPrefab_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙으면 SDK 자체 로그로 간주되어 필터링되지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Script attached to 'Foo' in asset 'Assets/Resources/Foo.prefab' is missing or no valid script is attached."));
     }
 
     [Test]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -283,9 +283,7 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void ScriptMissingWithoutAssets_ReturnsFalse()
     {
-        // "Script attached to" + "is missing"이지만 Assets/ 경로가 없으면
-        // composite 조건이 매칭되지 않고, 단일 substring "is missing or no valid script is attached"는
-        // 정확한 Unity 표준 문구만 매칭하므로 짧은 변형은 필터링되지 않는다.
+        // "Script attached to" + "is missing"이지만 Assets/ 경로가 없으면 필터링 안 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Script attached to 'GameObject' is missing or no valid script"));
     }
@@ -319,7 +317,8 @@ public class IsKnownNonSdkMessageTests
     public void ScriptMissingInUserPrefab_LasercahrgingFixture_ReturnsTrue()
     {
         // Sentry APPS-IN-TOSS-UNITY-SDK-H1 실측 메시지.
-        // 사용자 Resources/Effect 하위 prefab의 missing script 경고 — Unity 표준 문구로 SDK 외부.
+        // "Script attached to" + "is missing" + "Assets/" composite 조건으로 매칭됨.
+        // 필터가 향후 anchored/regex로 tightening되어도 이 실측 메시지를 놓치지 않도록 fixture로 박아둠.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Script attached to '_NotUse_Effetc_Lasercharging' in asset 'Assets/Resources/Effect/_NotUse_Effetc_Lasercharging.prefab' is missing or no valid script is attached."));
     }


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-H1, APPS-IN-TOSS-UNITY-SDK-GY

## 대상 Sentry 이슈

- `APPS-IN-TOSS-UNITY-SDK-H1` — `Script attached to '_NotUse_Effetc_Lasercharging' in asset 'Assets/Resources/Effect/_NotUse_Effetc_Lasercharging.prefab' is missing or no valid script is attached.`
- `APPS-IN-TOSS-UNITY-SDK-GY` — `Script attached to '_NotUse_HitMissile_P10' in asset 'Assets/Resources/Effect/_NotUse_HitMissile_P10.prefab' is missing or no valid script is attached.`

두 건 모두 사용자 프로젝트의 `Assets/Resources/Effect/` 하위 prefab에 빈/유실 MonoBehaviour 참조가 남아있어 발생한 Unity 표준 경고. SDK 코드와 무관 (SDK는 해당 문구를 출력하지 않음).

## 추출 패턴

`Editor/ErrorTracker/AITEditorErrorTracker.cs` 의 `NonSdkMessagePatterns` 배열에 단일 substring 1개 추가:

- `"is missing or no valid script is attached"` — Unity 표준 경고 본문의 안정적 문구

기존 717-720 라인의 composite 조건(`"Script attached to"` + `"is missing"` + `"Assets/"`)이 이미 동일 케이스를 커버하지만, 더 직관적이고 단일 substring 매치로도 충돌 위험이 없는(SDK 출력 없음) 문구를 우선 적용.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` "사용자 프로젝트 에셋 문제" 섹션
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — 실측 fixture 2건(H1, GY) + AIT prefix 보호 negative 테스트 1건

## 검증

`./run-local-tests.sh --validate` 통과 (Passed: 3 / Failed: 0)
- E2E Test Files Validation ✓
- Playwright Config Validation ✓
- SDK Generator Unit Tests ✓ (18/18 passed)

## 머지 방식

**사람 머지 검토 필요** — squash merge로 병합. body가 squash 커밋 메시지에 그대로 들어가 `Fixes ...` 키워드를 통해 Sentry가 자동 resolve.