### PR TITLE
[auto-resolve] 수정: AITTemplate 미사용 빌드 폴백 경고 Sentry 캡처 차단

### DIFF
--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -184,8 +184,10 @@ namespace AppsInToss.Editor.Package
             else
             {
                 // SDK 템플릿에서 Runtime 폴더 복사 (수동 WebGL 빌드 시 AITTemplate 미사용 대응)
-                Debug.LogWarning("[AIT] WebGL 빌드에 Runtime 폴더가 없습니다. SDK 템플릿에서 복사합니다.");
-                Debug.LogWarning("[AIT]    ⚠️ AITTemplate이 아닌 다른 템플릿으로 빌드되었을 수 있습니다.");
+                // 사용자 환경(다른 WebGL 템플릿 선택)에서 발생하는 폴백 경로이므로 콘솔에는
+                // 진단 메시지를 남기되 Sentry로는 보내지 않는다 — SDK 결함이 아닌 사용자 설정 문제.
+                AITLog.Warning("[AIT] WebGL 빌드에 Runtime 폴더가 없습니다. SDK 템플릿에서 복사합니다.", sentryCapture: false);
+                AITLog.Warning("[AIT]    ⚠️ AITTemplate이 아닌 다른 템플릿으로 빌드되었을 수 있습니다.", sentryCapture: false);
                 string sdkRuntimePath = SdkPathResolver.FindSdkRuntimePath();
                 if (!string.IsNullOrEmpty(sdkRuntimePath) && Directory.Exists(sdkRuntimePath))
                 {

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -183,9 +183,9 @@ namespace AppsInToss.Editor.Package
             }
             else
             {
-                // SDK 템플릿에서 Runtime 폴더 복사 (수동 WebGL 빌드 시 AITTemplate 미사용 대응)
-                // 사용자 환경(다른 WebGL 템플릿 선택)에서 발생하는 폴백 경로이므로 콘솔에는
-                // 진단 메시지를 남기되 Sentry로는 보내지 않는다 — SDK 결함이 아닌 사용자 설정 문제.
+                // 사용자가 AITTemplate 외 다른 WebGL 템플릿으로 직접 빌드한 webgl/을 패키징하는
+                // 경우의 폴백: SDK 템플릿에서 Runtime 폴더를 복사한다. 콘솔 진단은 남기되
+                // Sentry 캡처는 차단한다 — SDK 결함이 아닌 사용자 설정 문제이기 때문.
                 AITLog.Warning("[AIT] WebGL 빌드에 Runtime 폴더가 없습니다. SDK 템플릿에서 복사합니다.", sentryCapture: false);
                 AITLog.Warning("[AIT]    ⚠️ AITTemplate이 아닌 다른 템플릿으로 빌드되었을 수 있습니다.", sentryCapture: false);
                 string sdkRuntimePath = SdkPathResolver.FindSdkRuntimePath();

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs
@@ -12,6 +12,10 @@
 // 텍스트 수준에서 가드한다 — `CopyWebGLToPublic`을 통째로 호출하면
 // AITPackagePathResolver, AITTemplateManager, BuildMarker 등 의존 그래프가
 // 너무 커서 EditMode 단위 테스트로 격리하기 어렵다.
+//
+// 제약: 검증은 라인 단위로 수행하므로 두 경고 호출은 **단일 라인**에
+// `AITLog.Warning(..., sentryCapture: false)` 형태를 유지해야 한다.
+// named argument를 다음 줄로 줄바꿈하면 false negative가 발생한다.
 // -----------------------------------------------------------------------
 
 using System.IO;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs
@@ -16,6 +16,7 @@
 
 using System.IO;
 using NUnit.Framework;
+using AppsInToss;
 using AppsInToss.Editor;
 
 [TestFixture]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs
@@ -1,0 +1,94 @@
+// -----------------------------------------------------------------------
+// WebGLTemplateMismatchWarningTests.cs
+// Sentry APPS-IN-TOSS-UNITY-SDK-R9 회귀 가드.
+//
+// `webglPath/Runtime` 폴더가 없을 때 WebGLBuildCopier가 출력하는 두 줄의
+// 진단 경고는 "사용자가 AITTemplate 외 템플릿으로 빌드한 경우"의 폴백 경로
+// 알림이지 SDK 결함이 아니다. 따라서 콘솔에는 남기되 Sentry로는 캡처되지
+// 않아야 한다 — 즉 `Debug.LogWarning`이 아니라 `AITLog.Warning(..., sentryCapture: false)`
+// 호출이어야 한다.
+//
+// 이 테스트는 `WebGLBuildCopier.cs` 소스를 읽어 그 두 줄이 회귀하지 않도록
+// 텍스트 수준에서 가드한다 — `CopyWebGLToPublic`을 통째로 호출하면
+// AITPackagePathResolver, AITTemplateManager, BuildMarker 등 의존 그래프가
+// 너무 커서 EditMode 단위 테스트로 격리하기 어렵다.
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+using AppsInToss.Editor;
+
+[TestFixture]
+[Category("Unit")]
+public class WebGLTemplateMismatchWarningTests
+{
+    private const string WarningMessage1Substring = "WebGL 빌드에 Runtime 폴더가 없습니다";
+    private const string WarningMessage2Substring = "AITTemplate이 아닌 다른 템플릿으로 빌드되었을 수 있습니다";
+
+    [Test]
+    public void TemplateMismatchWarnings_AreSuppressedFromSentry()
+    {
+        string source = ReadCopierSource();
+
+        AssertWarningSentryCaptureFalse(source, WarningMessage1Substring);
+        AssertWarningSentryCaptureFalse(source, WarningMessage2Substring);
+    }
+
+    [Test]
+    public void TemplateMismatchWarnings_DoNotUseRawDebugLogWarning()
+    {
+        // Debug.LogWarning은 ErrorTracker 로그 핸들러를 그대로 통과해 Sentry로
+        // 캡처된다. 이 두 메시지에 대해서는 절대 Debug.LogWarning을 직접 호출하면 안 된다.
+        string source = ReadCopierSource();
+
+        Assert.IsFalse(
+            ContainsLineWith(source, "Debug.LogWarning", WarningMessage1Substring),
+            $"Debug.LogWarning(...\"{WarningMessage1Substring}...\") 직접 호출 금지 — Sentry 노이즈 발생.");
+        Assert.IsFalse(
+            ContainsLineWith(source, "Debug.LogWarning", WarningMessage2Substring),
+            $"Debug.LogWarning(...\"{WarningMessage2Substring}...\") 직접 호출 금지 — Sentry 노이즈 발생.");
+    }
+
+    private static string ReadCopierSource()
+    {
+        Assert.IsTrue(
+            AITPackagePathResolver.TryResolveFile(
+                "Editor/Package/WebGLBuildCopier.cs",
+                out string path,
+                typeof(AITConvertCore)),
+            "WebGLBuildCopier.cs 소스 경로를 찾지 못했습니다.");
+        Assert.IsTrue(File.Exists(path), $"파일이 존재하지 않습니다: {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static bool ContainsLineWith(string source, string apiToken, string messageSubstring)
+    {
+        foreach (string line in source.Split('\n'))
+        {
+            if (line.Contains(apiToken) && line.Contains(messageSubstring))
+                return true;
+        }
+        return false;
+    }
+
+    private static void AssertWarningSentryCaptureFalse(string source, string messageSubstring)
+    {
+        bool foundCorrect = false;
+        foreach (string line in source.Split('\n'))
+        {
+            if (!line.Contains(messageSubstring)) continue;
+
+            // 메시지를 담는 호출 라인은 AITLog.Warning이고 sentryCapture: false 여야 한다.
+            if (line.Contains("AITLog.Warning") && line.Contains("sentryCapture: false"))
+            {
+                foundCorrect = true;
+                break;
+            }
+        }
+
+        Assert.IsTrue(
+            foundCorrect,
+            $"\"{messageSubstring}\" 경고는 AITLog.Warning(..., sentryCapture: false) 로 호출되어야 합니다. " +
+            "Debug.LogWarning이나 sentryCapture: true 로의 회귀가 발생하면 Sentry APPS-IN-TOSS-UNITY-SDK-R9 노이즈가 다시 잡힙니다.");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4dd5ac4ec964ed7927ffc00e8032903
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-R9

## 재현 절차
1. Unity 프로젝트에서 `PlayerSettings.WebGL.template`을 `AITTemplate` 외 다른 템플릿(예: `APPLICATION:Default`)으로 직접 설정한 뒤 `BuildPipeline.BuildPlayer`로 WebGL 빌드를 만든다.
2. AIT 메뉴에서 "Package Only" 또는 `AITConvertCore.DoExport(buildWebGL: false, doPackaging: true, ...)`를 호출하여 위 1번에서 생성된 `webgl/`을 패키징한다.
3. `WebGLBuildCopier.CopyWebGLToPublic` 내부에서 `webgl/Runtime/`이 부재하므로 폴백 경로로 진입, `Debug.LogWarning` 두 줄을 출력 → ErrorTracker 로그 핸들러가 그대로 Sentry로 캡처.

> 참고: `AITConvertCore.DoExport(buildWebGL: true, ...)` 정상 경로에서는 `AITBuildInitializer.Init`이 `PlayerSettings.WebGL.template = "PROJECT:AITTemplate"`을 강제하여 이 폴백이 발생하지 않는다. 즉 본 경고는 "사용자가 외부에서 빌드한 webgl/을 패키징만 돌리는 경우"의 진단이지 SDK 결함이 아니다.

## 원인
`Editor/Package/WebGLBuildCopier.cs`의 `CopyWebGLToPublic`에서 `webgl/Runtime/` 부재 시 두 줄의 경고를 `Debug.LogWarning`으로 직접 출력해 왔다. ErrorTracker는 모든 `LogType.Warning`을 Sentry 캡처 대상으로 보내기 때문에, **사용자 설정 문제로 발생하는 폴백 진단**까지 Sentry 노이즈로 누적되었다.

## 수정 요약
- `Debug.LogWarning(...)` 호출 두 줄을 `AITLog.Warning(..., sentryCapture: false)`로 교체.
  - 콘솔 메시지(사용자가 보는 진단 가치)는 그대로 유지.
  - Sentry 캡처는 `_suppressLogCaptureCount` 스코프로 차단.
- 회귀 가드용 EditMode 테스트 `WebGLTemplateMismatchWarningTests` 추가 — 두 경고 라인이 `AITLog.Warning(..., sentryCapture: false)` 형태인지 소스 텍스트 수준에서 검증. `Debug.LogWarning` 회귀 시 즉시 실패한다.

`CopyWebGLToPublic`을 통째로 호출하는 통합 테스트는 `AITPackagePathResolver`/`AITTemplateManager`/`BuildMarker`/`SdkPathResolver` 등 의존 그래프가 광범위해 EditMode 단위로 격리하기 어려워 소스 가드 방식을 택했다.

## 검증
- `./run-local-tests.sh --validate` 통과 (3 passed, 0 failed)
- `git diff`로 변경 범위가 두 줄 + 테스트 파일에 한정됨을 확인

## 영향 범위
- 콘솔 출력 메시지 동일 (LogWarning 레벨 유지)
- Sentry 이벤트만 더 이상 발생하지 않음
- 정상 AITTemplate 빌드 경로에는 영향 없음 (이 경고는 폴백 진입 시에만 출력)
