### PR TITLE
테스트: ErrorTrackerIntegrationTests CI에서 skip 처리

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorTrackerIntegrationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/ErrorTrackerIntegrationTests.cs
@@ -17,6 +17,7 @@ using SpanData = AppsInToss.Editor.ErrorTracker.AITSentryEnvelope.SpanData;
 
 [TestFixture]
 [Category("Integration")]
+[Ignore("Sentry organization quota 소진 시 모든 envelope이 429로 throttle됨. CI에서는 quota 영향을 피하기 위해 skip하고, 필요 시 로컬에서 명시적으로 실행한다.")]
 public class ErrorTrackerIntegrationTests
 {
     private string _dsn;


### PR DESCRIPTION
## Summary
- ErrorTrackerIntegrationTests 클래스에 `[Ignore]`를 부착해 CI에서 6개 통합 테스트를 skip
- run 25414928261(PR #514 진단 코드 적용본)의 응답 헤더 분석으로 원인 확정:
  - `X-Sentry-Rate-Limits: 60:default;error;security;attachment:organization:error_usage_exceeded`
  - `X-Sentry-Rate-Limits: 60:transaction;profile;transaction_indexed;span;span_indexed:organization:span_usage_exceeded`
  - `Retry-After: 60`
  - body: `Sentry dropped data due to a quota or internal rate limit being reached`
- scope=`organization`, reason=`*_usage_exceeded` → spike protection이 아니라 **plan quota 소진**. 매트릭스/jitter/DSN 단위 조정으로는 해결 불가.
- PR #498을 비롯한 모든 PR이 동일하게 영향받음. quota reset 또는 별도 Sentry 프로젝트 분리(별도 작업) 전까지 통합 테스트는 운영 quota를 잡아먹지 않도록 skip.
- 필요 시 로컬에서는 `[Ignore]` 제거하거나 `--testFilter ErrorTrackerIntegrationTests`로 명시적 실행 가능.

## Test plan
- [ ] PR E2E 트리거 후 ErrorTrackerIntegrationTests 6개가 NUnit 결과에서 `Skipped`로 표기되는지 확인
- [ ] EditMode tests 단계가 더 이상 실패하지 않고 통과하는지 확인 (다른 테스트들이 통과한다면 이 PR로 EditMode green)
- [ ] EditMode 로그에 `[Test] Sentry non-200` 라인이 더 이상 나타나지 않는지 확인 (실제 호출 자체가 일어나지 않아야 함)

## Follow-up
- 별도 Sentry 프로젝트로 통합 테스트용 DSN 분리해 `[Ignore]` 해제하는 후속 작업 필요