### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-uncompiled-changes-warning

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -79,6 +79,8 @@ namespace AppsInToss.Editor.ErrorTracker
             // ↑ 동일 경고의 첫 줄 변형 — Unity 출력 포맷("cannot be used in the State \"X\".")과 밀착시키려
             // 따옴표를 포함해 좁힘 (SDK-KV/KT)
             "cannot be used in the State \"",
+            // Unity 빌드 — 미컴파일 코드 변경 상태에서 빌드 시도 시 Unity가 직접 출력 (SDK-NE)
+            "You are building a player, but you have uncompiled code changes",
 
             // 사용자 프로젝트 에셋 문제
             "matches more than one built-in atlases",

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -272,6 +272,22 @@ public class IsKnownNonSdkMessageTests
             "[AIT] The legacy Animation Clip \"foo\" cannot be used in the State \"foo\"."));
     }
 
+    [Test]
+    public void UncompiledCodeChangesBuild_ReturnsTrue()
+    {
+        // Sentry SDK-NE — Unity가 미컴파일 변경 상태에서 빌드 시도 시 출력하는 자체 경고
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "You are building a player, but you have uncompiled code changes. This means that any post-processing or importing code you may have changed will not affect this player build."));
+    }
+
+    [Test]
+    public void UncompiledCodeChangesBuild_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙으면 SDK 자체 로그로 간주되어야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] You are building a player, but you have uncompiled code changes."));
+    }
+
     #endregion
 
     #region 사용자 프로젝트 에셋 문제


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-NE

## 대상 Sentry 이슈

- **Item ID**: `APPS-IN-TOSS-UNITY-SDK-NE`
- **Title**: `UnityWarning: You are building a player, but you have uncompiled code changes. This means that any post-processing or importing code you may have changed will not affect this player build.`
- **분석 근거**: 미컴파일 코드 변경 상태에서 빌드 시도 시 Unity가 직접 출력하는 자체 경고 — SDK가 출력하지 않는 Unity 노이즈

## 추출 패턴

`NonSdkMessagePatterns`에 다음 부분 문자열을 추가:

- `"You are building a player, but you have uncompiled code changes"`

(Unity 버전/환경에 따라 후행 문구가 달라질 수 있어 핵심 불변 부분만 매칭)

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열의 "Unity 라이프사이클/Animator" 그룹에 추가 (SDK-NE 주석 포함)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 케이스(`UncompiledCodeChangesBuild_ReturnsTrue`) + AIT prefix 보호 negative 케이스(`UncompiledCodeChangesBuild_WithAitPrefix_NeverFiltered`) 추가

## 검증 결과

`./run-local-tests.sh --validate` 실행:

- **E2E Test Files Validation**: ✓ 통과
- **Playwright Config Validation**: ✓ 통과
- **SDK Generator Unit Tests**: ⚠️ pre-existing 실패 — 본 PR과 무관
  - `tests/unit/differential.test.ts` (3 fail), `tests/unit/multi-version.test.ts` (1 timeout)
  - `git stash`로 본 PR 변경을 제거하고 `origin/main` 동일 커밋(bbdbc29)에서 재현 확인됨 — 최근 머지된 generator 분류기 변경(#509/#511) 이후 golden snapshot 미갱신으로 추정
  - 본 PR은 C# Editor 파일 두 개만 변경하며 sdk-runtime-generator 출력에 영향 없음

## 사람 머지 검토 필요

자동 생성 PR입니다. 패턴 적합성과 SDK 보호 가드 회귀 여부를 사람이 검토 후 머지해주세요.