### PR TITLE
[auto-resolve] 수정: AIT/Clean이 read-only 파일에서 ait-build/ 삭제 실패

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -396,29 +396,30 @@ namespace AppsInToss
 
             if (webglExists)
             {
-                try
+                // ait-build/node_modules 내 pnpm 의존성처럼 read-only 속성이 깔린 파일이
+                // 섞여 있을 수 있어 Directory.Delete 직호출은 UnauthorizedAccessException을
+                // 발생시킨다 (Sentry: APPS-IN-TOSS-UNITY-SDK-CA). 헬퍼는 ReadOnly를 선제 해제한다.
+                if (AITFileUtils.DeleteDirectory(webglPath))
                 {
-                    Directory.Delete(webglPath, true);
                     Debug.Log($"AIT: ✓ webgl/ 폴더 삭제 완료");
                     deletedCount++;
                 }
-                catch (Exception e)
+                else
                 {
-                    Debug.LogError($"AIT: webgl/ 폴더 삭제 실패: {e}");
+                    Debug.LogError($"AIT: webgl/ 폴더 삭제 실패: {webglPath}");
                 }
             }
 
             if (aitBuildExists)
             {
-                try
+                if (AITFileUtils.DeleteDirectory(aitBuildPath))
                 {
-                    Directory.Delete(aitBuildPath, true);
                     Debug.Log($"AIT: ✓ ait-build/ 폴더 삭제 완료");
                     deletedCount++;
                 }
-                catch (Exception e)
+                else
                 {
-                    Debug.LogError($"AIT: ait-build/ 폴더 삭제 실패: {e}");
+                    Debug.LogError($"AIT: ait-build/ 폴더 삭제 실패: {aitBuildPath}");
                 }
             }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFileSystemHelperTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFileSystemHelperTests.cs
@@ -194,6 +194,61 @@ public class AITFileSystemHelperTests
         }
     }
 
+    [Test]
+    public void SafeDeleteDirectory_NodeModulesShape_WithDeepReadOnlyFiles_RemovesAll()
+    {
+        // 회귀: Sentry APPS-IN-TOSS-UNITY-SDK-CA
+        // ait-build/node_modules/.pnpm/.../@jridgewell/gen-mapping/... 처럼
+        // 깊게 중첩된 read-only 트리(pnpm/npm 의존성)를 정리하지 못하면
+        // "ait-build/ 폴더 삭제 실패: UnauthorizedAccessException ... gen-mapping" 발생.
+        string aitBuild = Path.Combine(tempDir, "ait-build");
+        string nodeModules = Path.Combine(aitBuild, "node_modules");
+        string pnpmStore = Path.Combine(nodeModules, ".pnpm", "@jridgewell+gen-mapping@0.3.5", "node_modules", "@jridgewell", "gen-mapping");
+        Directory.CreateDirectory(pnpmStore);
+
+        // Symlink 형태로 의존성을 노출하는 pnpm 레이아웃을 모사 — 실제 심볼릭 링크 생성은
+        // 권한 의존이라 디렉토리/파일로 대체하되, read-only 속성은 동일하게 깐다.
+        string distDir = Path.Combine(pnpmStore, "dist");
+        Directory.CreateDirectory(distDir);
+
+        var readOnlyPaths = new[]
+        {
+            Path.Combine(pnpmStore, "package.json"),
+            Path.Combine(pnpmStore, "README.md"),
+            Path.Combine(distDir, "gen-mapping.umd.js"),
+            Path.Combine(distDir, "gen-mapping.mjs"),
+            Path.Combine(distDir, "types", "gen-mapping.d.ts"),
+        };
+
+        Directory.CreateDirectory(Path.Combine(distDir, "types"));
+        foreach (var p in readOnlyPaths)
+        {
+            File.WriteAllText(p, "{}");
+            File.SetAttributes(p, FileAttributes.ReadOnly);
+        }
+
+        try
+        {
+            bool result = InvokeSafeDeleteDirectory(aitBuild);
+
+            Assert.IsTrue(result,
+                "node_modules에 read-only 파일이 깔린 트리도 ait-build 전체가 재귀 삭제되어야 함");
+            Assert.IsFalse(Directory.Exists(aitBuild),
+                "ait-build/ 폴더가 완전히 제거되어야 함");
+        }
+        finally
+        {
+            // TearDown 보호: 실패해서 일부 파일이 남아있을 경우에도 read-only 속성 해제
+            foreach (var p in readOnlyPaths)
+            {
+                if (File.Exists(p))
+                {
+                    File.SetAttributes(p, FileAttributes.Normal);
+                }
+            }
+        }
+    }
+
     // =====================================================
     // logOnFailure / logPrefix (Windows 한정: 파일 공유 락으로 실패 강제)
     // macOS/Linux는 `FileShare.None`이 `File.Delete`를 막지 않아

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/CleanMenuSafetyTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/CleanMenuSafetyTests.cs
@@ -1,0 +1,142 @@
+// -----------------------------------------------------------------------
+// CleanMenuSafetyTests.cs - AIT/Clean 메뉴 안전 삭제 회귀 검증
+// Level 0: AppsInTossMenu.Clean이 Directory.Delete를 직접 호출하지 않고
+//          AITFileUtils.DeleteDirectory(=AITFileSystemHelper.SafeDeleteDirectory)
+//          를 통해 read-only 속성을 처리하도록 보장한다.
+//
+// 회귀 대상: Sentry APPS-IN-TOSS-UNITY-SDK-CA
+//   "AIT: ait-build/ 폴더 삭제 실패: System.UnauthorizedAccessException:
+//    Access to the path 'gen-mapping' is denied."
+//   ait-build/node_modules/.../@jridgewell/gen-mapping에 깔린 read-only
+//   파일을 Directory.Delete(recursive:true)가 처리하지 못해 발생.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using AppsInToss;
+
+[TestFixture]
+public class CleanMenuSafetyTests
+{
+    /// <summary>
+    /// AppsInTossMenu.cs 소스 파일을 정적으로 읽어, Clean() 메서드 본문 영역 내부에
+    /// `Directory.Delete(` 직호출이 없음을 확인한다.
+    ///
+    /// IL 기반 검증보다 단순하고 의존이 적다. Unity가 패키지를 어떻게 마운트하든
+    /// AppsInTossMenu 타입에서 MonoScript를 통해 실제 .cs 경로를 얻을 수 있다.
+    /// </summary>
+    [Test]
+    public void Clean_SourceDoesNotCall_DirectoryDelete()
+    {
+        string sourcePath = LocateAppsInTossMenuSource();
+        Assert.IsNotNull(sourcePath,
+            "AppsInTossMenu.cs 소스 경로를 찾을 수 없음 (MonoScript 또는 알려진 후보 경로 모두 실패).");
+        Assert.IsTrue(File.Exists(sourcePath),
+            $"AppsInTossMenu.cs가 존재해야 함: {sourcePath}");
+
+        string source = File.ReadAllText(sourcePath);
+
+        // Clean 메서드 본문을 추출 (signature ~ 다음 같은 들여쓰기 레벨의 닫는 중괄호)
+        string cleanBody = ExtractMethodBody(source, "public static void Clean()");
+        Assert.IsNotNull(cleanBody,
+            "AppsInTossMenu.Clean() 메서드를 소스에서 찾을 수 없음.");
+
+        // 핵심 회귀 가드:
+        //   Directory.Delete( 직호출은 read-only 파일에서 UnauthorizedAccessException을 던진다.
+        //   대신 AITFileUtils.DeleteDirectory 또는 AITFileSystemHelper.SafeDeleteDirectory를 사용해야 한다.
+        bool callsDirectoryDelete = cleanBody.Contains("Directory.Delete(");
+        Assert.IsFalse(callsDirectoryDelete,
+            "AppsInTossMenu.Clean()은 Directory.Delete()를 직접 호출하면 안 됨. " +
+            "ait-build/node_modules의 read-only 파일에서 UnauthorizedAccessException이 발생한다 " +
+            "(Sentry APPS-IN-TOSS-UNITY-SDK-CA). " +
+            "AITFileUtils.DeleteDirectory 또는 AITFileSystemHelper.SafeDeleteDirectory를 사용할 것.");
+
+        bool usesSafeHelper =
+            cleanBody.Contains("AITFileUtils.DeleteDirectory(") ||
+            cleanBody.Contains("AITFileSystemHelper.SafeDeleteDirectory(");
+        Assert.IsTrue(usesSafeHelper,
+            "AppsInTossMenu.Clean()은 안전 삭제 헬퍼(AITFileUtils.DeleteDirectory 또는 " +
+            "AITFileSystemHelper.SafeDeleteDirectory)를 사용해야 한다.");
+    }
+
+    private static string LocateAppsInTossMenuSource()
+    {
+        // 1) 가장 견고한 방법: AssetDatabase에서 MonoScript를 검색해 자산 경로를 얻는다.
+        //    Unity가 패키지를 어떤 경로(`Packages/...` 또는 `Library/PackageCache/...`)로
+        //    마운트하든 AssetDatabase가 해석한 실제 경로를 돌려준다.
+        var guids = AssetDatabase.FindAssets("AppsInTossMenu t:MonoScript");
+        foreach (var guid in guids)
+        {
+            string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+            if (string.IsNullOrEmpty(assetPath)) continue;
+            // 정확히 AppsInTossMenu.cs만 매칭 (다른 파일에 클래스가 들어있을 수 있어 파일명으로 한 번 더 체크)
+            if (Path.GetFileName(assetPath) == "AppsInTossMenu.cs" && File.Exists(assetPath))
+            {
+                var ms = AssetDatabase.LoadAssetAtPath<MonoScript>(assetPath);
+                if (ms != null && ms.GetClass() == typeof(AppsInTossMenu))
+                {
+                    return assetPath;
+                }
+            }
+        }
+
+        // 2) AssetDatabase 검색이 실패하면 알려진 상대 경로 후보를 순회.
+        //    저장소 루트에서 직접 돌리는 경우 / Packages/ 임베드 / PackageCache 임베드.
+        string[] candidates = new[]
+        {
+            "Editor/AppsInTossMenu.cs",
+            "Packages/im.toss.apps-in-toss-unity-sdk/Editor/AppsInTossMenu.cs",
+        };
+        foreach (var c in candidates)
+        {
+            if (File.Exists(c)) return c;
+        }
+
+        // PackageCache 패턴 (`Library/PackageCache/im.toss.apps-in-toss-unity-sdk@<hash>/`)
+        string packageCache = "Library/PackageCache";
+        if (Directory.Exists(packageCache))
+        {
+            var dirs = Directory.GetDirectories(packageCache, "im.toss.apps-in-toss-unity-sdk*");
+            foreach (var d in dirs)
+            {
+                string p = Path.Combine(d, "Editor", "AppsInTossMenu.cs");
+                if (File.Exists(p)) return p;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// 단순한 brace 카운팅으로 메서드 본문(여는 중괄호 다음부터 매칭되는 닫는 중괄호 직전까지)을 추출.
+    /// 문자열/주석 안의 중괄호는 정확하게 처리하지 못하지만, AppsInTossMenu.Clean의 실제 구현에는
+    /// 그런 패턴이 없으므로 충분하다.
+    /// </summary>
+    private static string ExtractMethodBody(string source, string signatureSubstring)
+    {
+        int sigIdx = source.IndexOf(signatureSubstring);
+        if (sigIdx < 0) return null;
+
+        int openIdx = source.IndexOf('{', sigIdx);
+        if (openIdx < 0) return null;
+
+        int depth = 0;
+        for (int i = openIdx; i < source.Length; i++)
+        {
+            char ch = source[i];
+            if (ch == '{') depth++;
+            else if (ch == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(openIdx + 1, i - openIdx - 1);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/CleanMenuSafetyTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/CleanMenuSafetyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40b711d1b80a4ef59694af3dc8165ba7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-CA

## 재현 절차
1. AIT 미니앱 빌드를 1회 이상 수행해 `ait-build/node_modules/`에 pnpm 의존성이 풀린 상태를 만든다.
   - 의존성 트리 안에는 `@jridgewell/gen-mapping` 같이 read-only 속성으로 풀리는 파일이 섞여 있다.
2. Unity Editor 메뉴 `AIT > Clean`을 실행한다.
3. `ait-build/` 트리를 재귀 삭제하던 중 read-only 파일에서 `UnauthorizedAccessException`이 발생.
   - 콘솔/Sentry: `AIT: ait-build/ 폴더 삭제 실패: System.UnauthorizedAccessException: Access to the path 'gen-mapping' is denied.`

## 원인
`Editor/AppsInTossMenu.cs`의 `Clean()`이 `Directory.Delete(aitBuildPath, true)`를 직접 호출했다.
이 API는 내부 파일에 `FileAttributes.ReadOnly`가 걸려 있으면 그 파일에서 `UnauthorizedAccessException`을 던지고 전체 삭제가 중단된다. pnpm/npm 의존성 폴더는 일부 파일에 ReadOnly가 깔려 있어 이 패턴에서 자주 재현된다.

저장소에는 이미 read-only 속성을 선제 해제 후 재귀 삭제하는 안전 헬퍼 `AITFileSystemHelper.SafeDeleteDirectory`(및 그 위임자 `AITFileUtils.DeleteDirectory`)가 존재했고, 다른 코드 경로(`WebGLBuildCopier`, `NodeModulesValidator`, `AITNodeJSDownloader`)는 이미 그것을 사용하고 있었다. `AIT/Clean` 메뉴만 누락되어 있었다.

## Fix 요약
- `AppsInTossMenu.Clean()`의 `webgl/`, `ait-build/` 두 삭제 경로를 `Directory.Delete` 직호출에서 `AITFileUtils.DeleteDirectory`로 전환.
- 헬퍼는 ReadOnly 속성을 선제 해제하고 재귀 삭제하므로 동일한 의존성 트리도 깨끗이 정리된다.

## 회귀 테스트
1. **`AITFileSystemHelperTests.SafeDeleteDirectory_NodeModulesShape_WithDeepReadOnlyFiles_RemovesAll`** — pnpm 레이아웃(`ait-build/node_modules/.pnpm/.../@jridgewell/gen-mapping/...`)을 모사하고 내부 파일을 read-only로 깐 뒤, `SafeDeleteDirectory`가 전체 트리를 제거함을 검증.
2. **`CleanMenuSafetyTests.Clean_SourceDoesNotCall_DirectoryDelete`** — `AppsInTossMenu.cs` 소스를 정적으로 검사해 `Clean()` 메서드 본문에 `Directory.Delete(` 직호출이 남지 않고, 안전 헬퍼(`AITFileUtils.DeleteDirectory` 또는 `AITFileSystemHelper.SafeDeleteDirectory`)를 사용하도록 보장.

## 검증 결과
- `./run-local-tests.sh --validate` ✓ (3/3 passed)
  - E2E 파일 구조 / Playwright 설정 / SDK Generator 유닛 테스트(invariants 18/18) 통과
- 추가된 EditMode 테스트는 Unity Test Runner에서 실행됨 (CI E2E `lint` + EditMode 워크플로우가 검증)

## 영향 범위
- 행동 변경은 `AIT > Clean` 메뉴 한 곳에 한정.
- `AITFileUtils.DeleteDirectory`는 실패 시 예외를 던지는 대신 `false`를 반환하고 내부에서 경고 로그를 남기므로, 기존의 `try/catch`로 감싸 `Debug.LogError`를 찍던 흐름과 사용자 가시성은 동등하게 유지된다.
