### PR TITLE
[auto-resolve] 수정: pnpm install 중간 단계 실패의 Sentry false positive 차단

### DIFF
--- a/Editor/Package/PnpmRunner.cs
+++ b/Editor/Package/PnpmRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using AppsInToss.Editor.ErrorTracker;
 using UnityEngine;
 
 namespace AppsInToss.Editor.Package
@@ -8,9 +9,19 @@ namespace AppsInToss.Editor.Package
     /// pnpm install 실행 (동기/비동기/백그라운드).
     /// PnpmStoreManager의 InstallStages 정책을 기반으로 frozen → lockfile 갱신 → lockfile 폐기 → clean 재시도 순으로 진행.
     /// 실패 시 NodeModulesValidator.CleanNodeModules로 복구 후 재시도.
+    ///
+    /// Sentry 캡처 정책: 중간 단계 실패는 정상 fallback이므로 LogError가 발생해도 Sentry로
+    /// 보내지 않는다 (BeginSuppressLogCapture). 모든 단계가 실패한 최종 LogError만 캡처되도록
+    /// 한다 — false positive(SDK-B8/SDK-HB) 방지.
     /// </summary>
     internal static class PnpmRunner
     {
+        /// <summary>
+        /// 마지막 단계 실패 시 한 번만 출력하는 최종 에러 메시지.
+        /// PnpmRunner의 sync/async/background 경로에서 일관되게 사용된다.
+        /// </summary>
+        internal const string FinalFailureMessage = "[AIT] pnpm install 실패 (모든 재시도 후에도 실패)";
+
         /// <summary>
         /// ThreadPool에서 pnpm install을 백그라운드 OS 프로세스로 실행합니다.
         /// WebGL 빌드가 메인 스레드를 블로킹하는 동안 독립적으로 실행됩니다.
@@ -52,106 +63,116 @@ namespace AppsInToss.Editor.Package
             var ct = earlyCtx.PnpmCancellationToken;
             var additionalPaths = AITNpmRunner.BuildAdditionalPaths(earlyCtx.PnpmPath);
 
-            foreach (var (args, label, cleanFirst, deleteLockfileFirst) in PnpmStoreManager.InstallStages)
+            // 중간 단계의 실행 오류/시간 초과 LogError는 정상 fallback의 일부라 Sentry로 보내지 않는다.
+            // 모든 단계가 실패한 경우에만 스코프 밖에서 단일 LogError를 발생시킨다.
+            AITEditorErrorTracker.BeginSuppressLogCapture();
+            try
             {
-                if (ct.IsCancellationRequested)
-                    return AITConvertCore.AITExportError.CANCELLED;
-
-                if (cleanFirst) NodeModulesValidator.CleanNodeModules(earlyCtx.BuildProjectPath);
-                if (deleteLockfileFirst) DeleteLockfileIfExists(earlyCtx.BuildProjectPath);
-
-                string fullArguments = AITNpmRunner.BuildFullArguments(args, earlyCtx.LocalCachePath);
-                string command = $"\"{earlyCtx.PnpmPath}\" {fullArguments}";
-
-                Debug.Log($"[AIT] [병렬] pnpm {label} 실행 중...");
-                Debug.Log($"[AIT] [병렬] 명령: {command}");
-
-                try
+                foreach (var (args, label, cleanFirst, deleteLockfileFirst) in PnpmStoreManager.InstallStages)
                 {
-                    var processInfo = AITPlatformHelper.CreateProcessStartInfo(
-                        command, earlyCtx.BuildProjectPath, additionalPaths.ToArray());
+                    if (ct.IsCancellationRequested)
+                        return AITConvertCore.AITExportError.CANCELLED;
 
-                    using (var process = new System.Diagnostics.Process { StartInfo = processInfo })
+                    if (cleanFirst) NodeModulesValidator.CleanNodeModules(earlyCtx.BuildProjectPath);
+                    if (deleteLockfileFirst) DeleteLockfileIfExists(earlyCtx.BuildProjectPath);
+
+                    string fullArguments = AITNpmRunner.BuildFullArguments(args, earlyCtx.LocalCachePath);
+                    string command = $"\"{earlyCtx.PnpmPath}\" {fullArguments}";
+
+                    Debug.Log($"[AIT] [병렬] pnpm {label} 실행 중...");
+                    Debug.Log($"[AIT] [병렬] 명령: {command}");
+
+                    try
                     {
-                        int pid = -1;
-                        try
+                        var processInfo = AITPlatformHelper.CreateProcessStartInfo(
+                            command, earlyCtx.BuildProjectPath, additionalPaths.ToArray());
+
+                        using (var process = new System.Diagnostics.Process { StartInfo = processInfo })
                         {
-                            var outputBuilder = new System.Text.StringBuilder();
-                            var errorBuilder = new System.Text.StringBuilder();
-
-                            process.OutputDataReceived += (sender, e) =>
+                            int pid = -1;
+                            try
                             {
-                                if (e.Data != null)
-                                    outputBuilder.AppendLine(AITPlatformHelper.StripAnsiCodes(e.Data));
-                            };
-                            process.ErrorDataReceived += (sender, e) =>
-                            {
-                                if (e.Data != null)
-                                    errorBuilder.AppendLine(AITPlatformHelper.StripAnsiCodes(e.Data));
-                            };
+                                var outputBuilder = new System.Text.StringBuilder();
+                                var errorBuilder = new System.Text.StringBuilder();
 
-                            process.Start();
-                            pid = process.Id;
-                            AITBuildSession.RecordPid(pid);
-                            process.BeginOutputReadLine();
-                            process.BeginErrorReadLine();
-
-                            // HasExited 폴링 + CancellationToken 체크
-                            int maxWaitMs = 300000; // 5분
-                            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-
-                            while (!process.HasExited)
-                            {
-                                if (ct.IsCancellationRequested)
+                                process.OutputDataReceived += (sender, e) =>
                                 {
-                                    Debug.Log($"[AIT] [병렬] pnpm install 취소 요청. 프로세스를 종료합니다.");
-                                    process.Kill();
-                                    process.WaitForExit(5000);
-                                    return AITConvertCore.AITExportError.CANCELLED;
+                                    if (e.Data != null)
+                                        outputBuilder.AppendLine(AITPlatformHelper.StripAnsiCodes(e.Data));
+                                };
+                                process.ErrorDataReceived += (sender, e) =>
+                                {
+                                    if (e.Data != null)
+                                        errorBuilder.AppendLine(AITPlatformHelper.StripAnsiCodes(e.Data));
+                                };
+
+                                process.Start();
+                                pid = process.Id;
+                                AITBuildSession.RecordPid(pid);
+                                process.BeginOutputReadLine();
+                                process.BeginErrorReadLine();
+
+                                // HasExited 폴링 + CancellationToken 체크
+                                int maxWaitMs = 300000; // 5분
+                                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+                                while (!process.HasExited)
+                                {
+                                    if (ct.IsCancellationRequested)
+                                    {
+                                        Debug.Log($"[AIT] [병렬] pnpm install 취소 요청. 프로세스를 종료합니다.");
+                                        process.Kill();
+                                        process.WaitForExit(5000);
+                                        return AITConvertCore.AITExportError.CANCELLED;
+                                    }
+
+                                    if (stopwatch.ElapsedMilliseconds > maxWaitMs)
+                                    {
+                                        process.Kill();
+                                        process.WaitForExit(5000);
+                                        Debug.LogError($"[AIT] [병렬] pnpm {label} 시간 초과 ({maxWaitMs / 1000}초)");
+                                        break; // 다음 단계로
+                                    }
+
+                                    Thread.Sleep(200);
                                 }
 
-                                if (stopwatch.ElapsedMilliseconds > maxWaitMs)
+                                // 아직 종료 안 된 경우 (타임아웃으로 빠져나온 경우) → 다음 단계
+                                if (!process.HasExited) continue;
+
+                                process.WaitForExit(5000); // 출력 버퍼 플러시
+
+                                if (process.ExitCode == 0)
                                 {
-                                    process.Kill();
-                                    process.WaitForExit(5000);
-                                    Debug.LogError($"[AIT] [병렬] pnpm {label} 시간 초과 ({maxWaitMs / 1000}초)");
-                                    break; // 다음 단계로
+                                    Debug.Log($"[AIT] [병렬] ✓ pnpm {label} 성공");
+                                    return AITConvertCore.AITExportError.SUCCEED;
                                 }
 
-                                Thread.Sleep(200);
+                                string output = outputBuilder.ToString();
+                                string error = errorBuilder.ToString();
+                                Debug.Log($"[AIT] [병렬] pnpm {label} 실패 (Exit Code: {process.ExitCode})");
+                                if (!string.IsNullOrEmpty(output))
+                                    Debug.Log($"[AIT] [병렬] 출력:\n{output.Trim()}");
+                                if (!string.IsNullOrEmpty(error))
+                                    Debug.Log($"[AIT] [병렬] 오류:\n{error.Trim()}");
                             }
-
-                            // 아직 종료 안 된 경우 (타임아웃으로 빠져나온 경우) → 다음 단계
-                            if (!process.HasExited) continue;
-
-                            process.WaitForExit(5000); // 출력 버퍼 플러시
-
-                            if (process.ExitCode == 0)
+                            finally
                             {
-                                Debug.Log($"[AIT] [병렬] ✓ pnpm {label} 성공");
-                                return AITConvertCore.AITExportError.SUCCEED;
+                                if (pid > 0) AITBuildSession.ClearPid(pid);
                             }
-
-                            string output = outputBuilder.ToString();
-                            string error = errorBuilder.ToString();
-                            Debug.Log($"[AIT] [병렬] pnpm {label} 실패 (Exit Code: {process.ExitCode})");
-                            if (!string.IsNullOrEmpty(output))
-                                Debug.Log($"[AIT] [병렬] 출력:\n{output.Trim()}");
-                            if (!string.IsNullOrEmpty(error))
-                                Debug.Log($"[AIT] [병렬] 오류:\n{error.Trim()}");
-                        }
-                        finally
-                        {
-                            if (pid > 0) AITBuildSession.ClearPid(pid);
                         }
                     }
-                }
-                catch (Exception e)
-                {
-                    Debug.LogError($"[AIT] [병렬] pnpm {label} 실행 오류: {e}");
-                }
+                    catch (Exception e)
+                    {
+                        Debug.LogError($"[AIT] [병렬] pnpm {label} 실행 오류: {e}");
+                    }
 
-                Debug.Log($"[AIT] [병렬] pnpm install ({label}) 실패, 다음 단계로...");
+                    Debug.Log($"[AIT] [병렬] pnpm install ({label}) 실패, 다음 단계로...");
+                }
+            }
+            finally
+            {
+                AITEditorErrorTracker.EndSuppressLogCapture();
             }
 
             Debug.LogError("[AIT] [병렬] pnpm install 실패 (모든 재시도 후에도 실패)");
@@ -163,18 +184,29 @@ namespace AppsInToss.Editor.Package
         /// </summary>
         internal static AITConvertCore.AITExportError RunPnpmInstallSync(AITPackageBuilder.PackageContext ctx)
         {
-            foreach (var (args, label, cleanFirst, deleteLockfileFirst) in PnpmStoreManager.InstallStages)
+            // 중간 단계 실패는 정상 fallback이라 Sentry로 보내지 않는다.
+            // 마지막 단계까지 실패하면 스코프 밖에서 단일 LogError를 발생시켜 Sentry가 캡처하게 한다.
+            AITEditorErrorTracker.BeginSuppressLogCapture();
+            try
             {
-                if (cleanFirst) NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
-                if (deleteLockfileFirst) DeleteLockfileIfExists(ctx.BuildProjectPath);
-                var result = AITNpmRunner.RunNpmCommandWithCache(
-                    ctx.BuildProjectPath, ctx.PnpmPath, args, ctx.LocalCachePath,
-                    $"pnpm {label}...");
-                if (result == AITConvertCore.AITExportError.SUCCEED) return result;
-                if (result == AITConvertCore.AITExportError.CANCELLED) return result;
-                Debug.Log($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
+                foreach (var (args, label, cleanFirst, deleteLockfileFirst) in PnpmStoreManager.InstallStages)
+                {
+                    if (cleanFirst) NodeModulesValidator.CleanNodeModules(ctx.BuildProjectPath);
+                    if (deleteLockfileFirst) DeleteLockfileIfExists(ctx.BuildProjectPath);
+                    var result = AITNpmRunner.RunNpmCommandWithCache(
+                        ctx.BuildProjectPath, ctx.PnpmPath, args, ctx.LocalCachePath,
+                        $"pnpm {label}...");
+                    if (result == AITConvertCore.AITExportError.SUCCEED) return result;
+                    if (result == AITConvertCore.AITExportError.CANCELLED) return result;
+                    Debug.Log($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
+                }
             }
-            Debug.LogError("[AIT] pnpm install 실패 (모든 재시도 후에도 실패)");
+            finally
+            {
+                AITEditorErrorTracker.EndSuppressLogCapture();
+            }
+
+            Debug.LogError(FinalFailureMessage);
             return AITConvertCore.AITExportError.FAIL_NPM_BUILD;
         }
 
@@ -192,7 +224,7 @@ namespace AppsInToss.Editor.Package
         {
             if (stageIndex >= PnpmStoreManager.InstallStages.Count)
             {
-                Debug.LogError("[AIT] pnpm install 실패 (모든 재시도 후에도 실패)");
+                Debug.LogError(FinalFailureMessage);
                 onComplete?.Invoke(AITConvertCore.AITExportError.FAIL_NPM_BUILD);
                 return;
             }
@@ -203,27 +235,49 @@ namespace AppsInToss.Editor.Package
 
             Debug.Log($"[AIT] pnpm {label} 실행 중...");
 
-            AITNpmRunner.RunNpmCommandWithCacheAsync(
-                buildProjectPath, pnpmPath, args, localCachePath,
-                onComplete: (result) =>
-                {
-                    if (result == AITConvertCore.AITExportError.SUCCEED)
-                    {
-                        onComplete?.Invoke(result);
-                        return;
-                    }
+            // 중간 단계 실패는 정상 fallback이라 Sentry로 보내지 않는다.
+            // 비동기 콜백 경계를 넘기 위해 Begin/End를 직접 호출한다.
+            AITEditorErrorTracker.BeginSuppressLogCapture();
+            bool suppressReleased = false;
+            void ReleaseSuppress()
+            {
+                if (suppressReleased) return;
+                suppressReleased = true;
+                AITEditorErrorTracker.EndSuppressLogCapture();
+            }
 
-                    if (ct.IsCancellationRequested)
+            try
+            {
+                AITNpmRunner.RunNpmCommandWithCacheAsync(
+                    buildProjectPath, pnpmPath, args, localCachePath,
+                    onComplete: (result) =>
                     {
-                        onComplete?.Invoke(AITConvertCore.AITExportError.CANCELLED);
-                        return;
-                    }
+                        ReleaseSuppress();
 
-                    Debug.Log($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
-                    RunPnpmInstallAsync(buildProjectPath, pnpmPath, localCachePath, ct, onOutput, onComplete, stageIndex + 1);
-                },
-                onOutputReceived: onOutput
-            );
+                        if (result == AITConvertCore.AITExportError.SUCCEED)
+                        {
+                            onComplete?.Invoke(result);
+                            return;
+                        }
+
+                        if (ct.IsCancellationRequested)
+                        {
+                            onComplete?.Invoke(AITConvertCore.AITExportError.CANCELLED);
+                            return;
+                        }
+
+                        Debug.Log($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
+                        RunPnpmInstallAsync(buildProjectPath, pnpmPath, localCachePath, ct, onOutput, onComplete, stageIndex + 1);
+                    },
+                    onOutputReceived: onOutput
+                );
+            }
+            catch
+            {
+                // RunNpmCommandWithCacheAsync 자체가 동기적으로 throw할 경우 suppress 누수를 막는다.
+                ReleaseSuppress();
+                throw;
+            }
         }
 
         /// <summary>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStagesTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStagesTests.cs
@@ -8,6 +8,32 @@ using NUnit.Framework;
 
 namespace AppsInToss.Editor.Package.Tests
 {
+    /// <summary>
+    /// PnpmRunner 메시지/상수 정책 회귀 테스트.
+    /// Sentry SDK-R5 fingerprint와 일치하는 최종 실패 메시지가 변경되지 않도록 보장한다.
+    /// </summary>
+    [TestFixture]
+    public class PnpmRunnerMessagesTests
+    {
+        [Test]
+        public void FinalFailureMessage_MatchesSentrySdkR5Fingerprint()
+        {
+            // Sentry 이슈 SDK-R5는 정확히 이 메시지로 fingerprint되어 있으므로 변경 시 이슈가 분리된다.
+            // 메시지를 바꾸려면 Sentry 측 fingerprint도 함께 갱신해야 한다.
+            Assert.AreEqual("[AIT] pnpm install 실패 (모든 재시도 후에도 실패)", PnpmRunner.FinalFailureMessage);
+        }
+
+        [Test]
+        public void FinalFailureMessage_IsClassifiedAsAitSdkSource()
+        {
+            // FinalFailureMessage는 [AIT] 토큰을 포함해 ErrorTracker가 SDK 출처로 분류해야 한다.
+            // 분류기와 메시지가 어긋나면 진짜 실패가 Sentry에서 누락될 수 있다.
+            StringAssert.Contains("[AIT]", PnpmRunner.FinalFailureMessage);
+            StringAssert.Contains("pnpm install", PnpmRunner.FinalFailureMessage);
+            StringAssert.Contains("모든 재시도 후에도 실패", PnpmRunner.FinalFailureMessage);
+        }
+    }
+
     [TestFixture]
     public class PnpmInstallStagesTests
     {


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-B8, APPS-IN-TOSS-UNITY-SDK-HB, APPS-IN-TOSS-UNITY-SDK-R5

## 원인 분석

`PnpmRunner`는 `PnpmStoreManager.InstallStages`(4단계: frozen → no-frozen → lockfile 폐기 → clean)로 자가복구 retry를 한다. 중간 단계가 실패해도 다음 단계가 성공하면 빌드는 정상 완료된다 — 그러나 sync/async 경로 모두 `AITNpmRunner.RunNpmCommandWithCache(...)` 안에서 단계마다 다음 패턴으로 `Debug.LogError`를 찍었다:

- sync (`AITNpmRunner.cs:323`): `[pnpm] 명령 실패 (Exit Code: ...): pnpm install --frozen-lockfile`
- async (`AITNpmRunner.cs:398`): `[pnpm] 비동기 명령 실패 (Exit Code: ...): pnpm install --no-frozen-lockfile`

이 메시지는 `SdkMessagePatterns`의 `[pnpm]` 토큰으로 **SDK 출처**로 분류되어 `Application.logMessageReceived` → Sentry로 전송된다. 결과적으로 빌드가 1단계 fallback 후 성공해도 매번 SDK-B8/SDK-HB가 노이즈로 쌓였다.

| Sentry 이슈 | 메시지 | 정체 |
|-----|-----|-----|
| SDK-B8 | `[pnpm] 명령 실패 (Exit Code: 1): pnpm install --frozen-lockfile` | 1단계 실패 후 fallback 성공한 false positive |
| SDK-HB | `[pnpm] 명령 실패 (Exit Code: 1): pnpm install --no-frozen-lockfile` | 2/3/4단계 실패 후 fallback 성공한 false positive |
| SDK-R5 | `[AIT] pnpm install 실패 (모든 재시도 후에도 실패)` | 4단계 모두 실패한 진짜 SDK 빌드 실패 (유지) |

## 재현 절차

1. `Editor/Package/PnpmRunner.cs:164` `RunPnpmInstallSync` 또는 `:184` `RunPnpmInstallAsync` 진입
2. 1단계 `install --frozen-lockfile`이 lockfile drift로 실패 → `RunNpmCommandWithCache`가 `Debug.LogError("[pnpm] 명령 실패 ...")` 호출
3. `AITEditorErrorTracker.OnLogMessageReceived`가 `[pnpm]` 토큰으로 SDK 출처 분류 → `CaptureError`로 Sentry 전송
4. 2단계 `--no-frozen-lockfile`이 lockfile을 갱신하며 성공 → 빌드는 정상 완료, 그러나 Sentry에는 SDK-B8 노이즈 1건 적립

## 수정 내용

- `PnpmRunner` sync/async/background 세 경로 모두 InstallStages 루프 전체를 `AITEditorErrorTracker.BeginSuppressLogCapture()` ... `EndSuppressLogCapture()` 스코프로 감싼다.
- 스코프 안에서 발생한 `Debug.LogError`는 `OnLogMessageReceived`의 `_suppressLogCaptureCount > 0` 분기로 Sentry 캡처에서 제외된다.
- 모든 단계가 실패한 경우에만 스코프 **밖에서** 단일 `Debug.LogError(FinalFailureMessage)`를 발생시켜 SDK-R5의 진짜 실패는 그대로 캡처되도록 보존한다.
- 비동기 경로는 콜백 경계를 넘기 위해 명시적 Begin/End를 호출하며, 콜백 진입 즉시 `EndSuppressLogCapture`를 1회만 실행하는 idempotent helper(`ReleaseSuppress`)와 동기 throw 시 누수 방지 catch를 추가했다.
- 마지막 실패 메시지를 `PnpmRunner.FinalFailureMessage` 상수로 추출 — sync/async 경로가 같은 SDK-R5 fingerprint를 공유하도록 한다.

병렬(`RunPnpmInstallInThread`) 경로는 자체 process를 돌려 단계별 `Debug.Log`만 찍지만, 시간 초과/실행 예외에서는 `Debug.LogError`를 발생시켰다. 동일하게 SuppressScope으로 감싸 일관되게 처리.

## 검증

- `./run-local-tests.sh --validate` 통과 (E2E Test Files / Playwright Config / SDK Generator Unit Tests, 3/3)
- 신규 회귀 테스트 (`PnpmRunnerMessagesTests`):
  - `FinalFailureMessage_MatchesSentrySdkR5Fingerprint` — Sentry SDK-R5 fingerprint와 정확 일치 보장
  - `FinalFailureMessage_IsClassifiedAsAitSdkSource` — `[AIT]`/`pnpm install`/`모든 재시도 후에도 실패` 토큰 보존
- 기존 `PnpmInstallStagesTests`는 그대로 통과 (InstallStages 4단계 정책 invariant)

## 영향 범위

- 동작 변경 없음: retry 정책, 명령 인자, 빌드 결과 모두 동일
- Sentry 캡처 정책만 변경: 중간 단계 LogError → Sentry 차단 / 최종 실패 LogError → 그대로 SDK-R5로 캡처
