### PR TITLE
[auto-resolve] 수정: ErrorTracker가 [Toss Firebase] 외부 prefix를 노이즈로 드롭

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -129,9 +129,11 @@ namespace AppsInToss.Editor.ErrorTracker
         // 대상 Sentry 이슈:
         //   - SDK-D2: [AIT Login][src=AIT_MOCK_OR_TIMEOUT] ...
         //   - SDK-D3: [AIT Login] InitSession failed: FORBIDDEN_ORIGIN
+        //   - SDK-CF: [Toss Firebase] 게임로그인 실패: ... (사용자 게임 백엔드 통합 레이어)
         private static readonly string[] ExternalAitPrefixes =
         {
             "[AIT Login]",
+            "[Toss Firebase]",
         };
 
         #endregion

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -53,6 +53,15 @@ public class IsKnownNonSdkMessageTests
             "[AIT] InitSession started"));
     }
 
+    [Test]
+    public void ExternalTossFirebasePrefix_GameLoginFailure_ReturnsTrue()
+    {
+        // Sentry SDK-CF — 사용자 게임 백엔드의 [Toss Firebase] prefix.
+        // SDK 코드에는 "[Toss Firebase]"/"게임로그인" 문자열이 존재하지 않음.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[Toss Firebase] 게임로그인 실패: Object reference not set to an instance of an object"));
+    }
+
     #endregion
 
     #region SDK 보호: AIT 키워드 포함 시 절대 필터링 안 함


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-CF

## 요약

사용자 게임 백엔드("Toss Firebase" 통합 레이어)가 출력하는 `[Toss Firebase] 게임로그인 실패: ...` 패턴을 `ExternalAitPrefixes`에 추가. `[AIT Login]` 처리(SDK-D2/SDK-D3) 선례와 동일한 외부 prefix 노이즈 패턴이다.

## 재현 / 진단

Sentry 이슈 `APPS-IN-TOSS-UNITY-SDK-CF` 직접 조회 결과:

| 신호 | 값 |
|---|---|
| `environment` | editor (전부) |
| `editor_platform` | WindowsEditor (전부) |
| `user.geo` | KR, Yongin-si (전부) |
| `Users Impacted` | **0** |
| `Occurrences` | 425회 (14일) |
| `release` | `apps-in-toss.unity@2.0.5` |
| `event.type` | error (UnityError) |
| `metadata.value` | `[Toss Firebase] 게임로그인 실패: Object reference not set to an instance of an object` |
| stackTrace / breadcrumbs | 모든 425개 이벤트에 없음 |

→ 단일 한국 dev 머신이 Unity Editor에서 자기 게임 코드를 반복 실행하며 `Debug.LogError(...)`로 발생시킨 노이즈. 엔드유저 영향 0.

## 원인

저장소 전체 grep으로 `Toss Firebase` / `게임로그인` 문자열이 **0 hit** — SDK는 해당 prefix를 출력하지 않는다. 사용자 게임 코드가 자기 백엔드 통합 레이어에서 NRE를 catch한 뒤 다음과 같이 LogError한 결과로 추정된다:

```csharp
try {
    var result = await AIT.AppLogin();
    await TossFirebase.GameLogin(result);  // ← 사용자 코드의 NRE
}
catch (Exception e) {
    Debug.LogError($"[Toss Firebase] 게임로그인 실패: {e.Message}");
}
```

`event.type=error` + `exceptionType=UnityError` 조합이 이를 뒷받침한다 (SDK 내부에서 raw NRE가 throw됐다면 `LogType.Exception` → `exceptionType="NullReferenceException"`이 됐을 것).

v2.0.5 시점의 `IsAitRelated`는 메시지 또는 stackTrace 둘 중 하나에만 SDK 키워드가 있어도 통과시켰다. `await AIT.AppLogin()` continuation의 호출 체인에 SDK 프레임이 포함되어 stackTrace로 게이트를 통과한 것으로 보인다.

## 수정

- `ExternalAitPrefixes`에 `"[Toss Firebase]"` 추가 (`Editor/ErrorTracker/AITEditorErrorTracker.cs`). `[AIT Login]`(SDK-D2/D3) 선례와 동일.
- 회귀 테스트 1건 추가 (`Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`).

## 검증

- ✅ `./run-local-tests.sh --validate` 통과 (Passed: 3, Failed: 0)
- ✅ vitest invariants 18 passed
- ✅ Unity .meta 파일 검사 통과 (pre-commit hook)

## Test plan

- [ ] CI lint 워크플로우 통과
- [ ] CI E2E 워크플로우 통과
- [ ] 머지 후 Sentry가 `APPS-IN-TOSS-UNITY-SDK-CF`를 자동 resolve