### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — pnpm-stdout-passthrough

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -141,6 +141,11 @@ namespace AppsInToss.Editor.ErrorTracker
             // (다른 YAML 에셋 파싱 오류 메시지와 충돌 방지).
             "does not have a valid GUID",
             "' cannot be extracted by the YAML Parser",
+
+            // pnpm stdout 패스스루 노이즈 — 본문 없는 "[pnpm] 출력:" 라인 (SDK-HA, SDK-R6).
+            // AitKeywords에 "[pnpm]"이 없어 SDK 보호 가드는 우회되며,
+            // SDK 자체 로그는 "[AIT...]" prefix와 함께 출력되므로 보호된다.
+            "[pnpm] 출력:",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -781,6 +781,33 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region pnpm stdout 패스스루 (SDK-HA, SDK-R6)
+
+    [Test]
+    public void PnpmStdoutPassthrough_TrailingAnchor_ReturnsTrue()
+    {
+        // Sentry SDK-HA — 본문 없는 "[pnpm] 출력:" stdout passthrough
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage("[pnpm] 출력:"));
+    }
+
+    [Test]
+    public void PnpmStdoutPassthrough_LeadingAnchor_ReturnsTrue()
+    {
+        // Sentry SDK-R6 — "[pnpm] 출력:"으로 시작하는 패스스루 라인 (후행 본문이 있어도 노이즈)
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[pnpm] 출력: WARN deprecated some message"));
+    }
+
+    [Test]
+    public void PnpmStdoutPassthrough_WithAitPrefix_NeverFiltered()
+    {
+        // SDK가 직접 출력한 "[AIT...]" prefix가 붙으면 SDK 보호 가드로 필터링되지 않아야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] [pnpm] 출력: build failed"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-HA, APPS-IN-TOSS-UNITY-SDK-R6

## Summary

- 본문 없는 `[pnpm] 출력:` stdout 패스스루 라인을 노이즈로 분류하여 Sentry 캡처에서 제외
- `NonSdkMessagePatterns`에 substring 1개 추가 — `IndexOf` 부분 매칭이라 trailing/leading anchor 두 케이스 모두 커버

## 대상 Sentry 이슈

| Issue | 형태 | Events |
|---|---|---|
| APPS-IN-TOSS-UNITY-SDK-HA | `[pnpm] 출력:` + stdout 본문 (Lockfile/Packages 등) | 148 |
| APPS-IN-TOSS-UNITY-SDK-R6 | `[pnpm] 출력:` + stdout 본문 (Progress/WARN deprecated 등) | 4 |

둘 다 Windows 11 + Unity 6000.0.69f1 + release 2.4.7에서 발생, `error_source=sdk` (SdkMessagePatterns의 `[pnpm]` 매칭). 첫 줄이 동일한 `[pnpm] 출력:`이지만 후행 본문이 달라 별도 group hash로 분기됨.

## 변경 사항

### `Editor/ErrorTracker/AITEditorErrorTracker.cs`
- `NonSdkMessagePatterns`에 `"[pnpm] 출력:"` 1개 추가
- AitKeywords에 `[pnpm]`이 없으므로 SDK 보호 가드는 우회되며, SDK 자체 로그는 `[AIT...]` prefix와 함께 출력되므로 보호됨

### `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`
- positive 2개: 본문 없는 trailing 케이스, leading + 후행 본문 케이스
- AIT prefix 보호 negative 1개: `[AIT] [pnpm] 출력:` 메시지가 SDK 보호 가드로 필터링되지 않음

## 분석 근거

후보 패턴은 두 정규식 anchor 형태(`'\[pnpm\] 출력:$'`, `'^\[pnpm\] 출력:'`)였으나, 현재 `IsKnownNonSdkMessage`는 `IndexOf` substring 매칭을 사용하므로 `[pnpm] 출력:` 단일 substring으로 두 경우를 모두 커버. 배열당 한 번에 최대 3개 패턴 제약도 준수 (1개만 추가).

## Test plan

- [x] `./run-local-tests.sh --validate` 통과 (E2E File Validation, Playwright Config, SDK Generator Unit Tests 3 passed / 0 failed)
- [ ] EditMode 테스트 (CI에서 검증 — 로컬 Unity 미설치)
- [x] **사람 머지 검토 필요** — auto-resolve 자동화 PR이므로 squash 머지 전 패턴/테스트 검토
- [ ] 머지 후 며칠 모니터링하여 위 이슈들이 더 이상 보고되지 않음 확인 → Sentry 자동 resolve