### PR TITLE
[auto-resolve] 수정: WebGL 빌드 Cancelled/Failed Sentry 노이즈 제거

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -992,9 +992,9 @@ namespace AppsInToss
             {
                 // 사용자가 빌드를 취소한 경우 — Unity가 BuildResult.Cancelled를 반환한다.
                 // 이것은 사용자 의사이므로 SDK 결함 보고 대상이 아니다.
-                if (MapBuildResultToExportError(result.summary.result) == AITExportError.CANCELLED)
+                if (result.summary.result == UnityEditor.Build.Reporting.BuildResult.Cancelled)
                 {
-                    AITLog.Error("[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.", sentryCapture: false);
+                    Debug.LogWarning("[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.");
                     return AITExportError.CANCELLED;
                 }
 

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -160,6 +160,24 @@ namespace AppsInToss
         }
 
         /// <summary>
+        /// Unity의 BuildResult를 AIT 내부 에러 코드로 매핑합니다.
+        /// Cancelled는 사용자 의사이므로 SDK 결함 보고 대상이 아니며 CANCELLED로 매핑됩니다.
+        /// </summary>
+        internal static AITExportError MapBuildResultToExportError(
+            UnityEditor.Build.Reporting.BuildResult result)
+        {
+            switch (result)
+            {
+                case UnityEditor.Build.Reporting.BuildResult.Succeeded:
+                    return AITExportError.SUCCEED;
+                case UnityEditor.Build.Reporting.BuildResult.Cancelled:
+                    return AITExportError.CANCELLED;
+                default:
+                    return AITExportError.BUILD_WEBGL_FAILED;
+            }
+        }
+
+        /// <summary>
         /// 에러 코드를 사용자 친화적 메시지로 변환
         /// </summary>
         public static string GetErrorMessage(AITExportError error)
@@ -972,6 +990,14 @@ namespace AppsInToss
 
             if (result.summary.result != UnityEditor.Build.Reporting.BuildResult.Succeeded)
             {
+                // 사용자가 빌드를 취소한 경우 — Unity가 BuildResult.Cancelled를 반환한다.
+                // 이것은 사용자 의사이므로 SDK 결함 보고 대상이 아니다.
+                if (MapBuildResultToExportError(result.summary.result) == AITExportError.CANCELLED)
+                {
+                    AITLog.Error("[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.", sentryCapture: false);
+                    return AITExportError.CANCELLED;
+                }
+
                 var sb = new System.Text.StringBuilder();
                 sb.AppendLine("[AIT] WebGL 빌드가 실패했습니다.");
                 sb.AppendLine($"  결과: {result.summary.result}");
@@ -1019,7 +1045,11 @@ namespace AppsInToss
                     sb.Append($"  ... 외 {messageCount - maxMessages}개 메시지 생략");
                 }
 
-                Debug.LogError(sb.ToString().TrimEnd());
+                // BuildPipeline.BuildPlayer 실패는 거의 항상 사용자 프로젝트(컴파일 에러,
+                // 사용자 에셋 문제, 환경 OOM 등) 또는 Unity 자체의 비정상 종료에서 비롯되며
+                // SDK 측에서 분기/수정할 수 있는 정보가 아니다. 콘솔에는 진단 메시지를 남기되
+                // Sentry로는 보내지 않아 분류 노이즈를 만들지 않는다.
+                AITLog.Error(sb.ToString().TrimEnd(), sentryCapture: false);
                 return AITExportError.BUILD_WEBGL_FAILED;
             }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildResultMappingTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildResultMappingTests.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// BuildResultMappingTests.cs - BuildResult → AITExportError 매핑 회귀 테스트
+// Level 0: BuildResult.Cancelled가 사용자 의사로 분류되는지 검증
+//   (Sentry APPS-IN-TOSS-UNITY-SDK-8E: 사용자 빌드 취소가 SDK 실패로 잘못 보고되던 회귀 방지)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss;
+using UnityEditor.Build.Reporting;
+
+[TestFixture]
+public class BuildResultMappingTests
+{
+    [Test]
+    public void Cancelled_MapsTo_CANCELLED_NotBuildFailure()
+    {
+        // 사용자가 빌드를 취소한 경우 SDK 결함이 아니다.
+        // BUILD_WEBGL_FAILED로 매핑되어 Sentry 노이즈를 만들면 안 된다.
+        Assert.AreEqual(
+            AITConvertCore.AITExportError.CANCELLED,
+            AITConvertCore.MapBuildResultToExportError(BuildResult.Cancelled));
+    }
+
+    [Test]
+    public void Succeeded_MapsTo_SUCCEED()
+    {
+        Assert.AreEqual(
+            AITConvertCore.AITExportError.SUCCEED,
+            AITConvertCore.MapBuildResultToExportError(BuildResult.Succeeded));
+    }
+
+    [Test]
+    public void Failed_MapsTo_BUILD_WEBGL_FAILED()
+    {
+        Assert.AreEqual(
+            AITConvertCore.AITExportError.BUILD_WEBGL_FAILED,
+            AITConvertCore.MapBuildResultToExportError(BuildResult.Failed));
+    }
+
+    [Test]
+    public void Unknown_MapsTo_BUILD_WEBGL_FAILED()
+    {
+        // BuildResult.Unknown은 Unity가 빌드 결과를 정상적으로 보고하지 않은 비정상 상태.
+        // SDK가 진단할 수 있는 추가 정보가 없으므로 일반 빌드 실패로 매핑한다.
+        Assert.AreEqual(
+            AITConvertCore.AITExportError.BUILD_WEBGL_FAILED,
+            AITConvertCore.MapBuildResultToExportError(BuildResult.Unknown));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildResultMappingTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildResultMappingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25f9e261fac640ff9b05275023829df2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-8E, APPS-IN-TOSS-UNITY-SDK-HC

## 재현 단서 (Sentry)

| Issue | 발생 | BuildResult | 메시지 패턴 |
|---|---|---|---|
| `APPS-IN-TOSS-UNITY-SDK-8E` | 51건 | `Cancelled` 1건, 나머지 `Failed` | `Building Player was cancelled` / 사용자 코드 `CS0103/CS0117/CS0246` / `OutOfMemoryException` / FMOD/패키지 충돌 |
| `APPS-IN-TOSS-UNITY-SDK-HC` | 7건 | `Unknown` 전부 | 에러 0/경고 0 (Unity가 결과를 보고하지 않은 비정상 종료) |

표시된 모든 케이스가 **사용자 프로젝트 책임 또는 사용자 환경 문제 또는 사용자 의사**이며, SDK 측에서 분기·수정할 수 있는 단서는 없다.

## 원인

`Editor/AITConvertCore.cs:976`의 `if (result.summary.result != BuildResult.Succeeded)` 분기가 **너무 광범위한 catch-all**이었다. `BuildResult` enum (`Unknown(0), Succeeded(1), Failed(2), Cancelled(3)`)의 모든 비-Succeeded 값을 동일 fingerprint로 묶어 `Debug.LogError`로 출력하여 Sentry로 전송했다.

특히 `BuildResult.Cancelled`는 사용자가 빌드를 취소한 정상 동작인데, SDK가 이를 "WebGL 빌드 실패"로 잘못 보고하고 있었다.

## 수정

- `MapBuildResultToExportError` 헬퍼 추출 (`AITConvertCore.cs`):
  - `Succeeded` → `SUCCEED`
  - `Cancelled` → `CANCELLED` (이미 정의된 사용자 취소 코드)
  - 그 외 → `BUILD_WEBGL_FAILED`
- `BuildWebGL()` 본체에서 `Cancelled`를 별도 분기 처리 — `AITLog.Error(..., sentryCapture: false)`로 콘솔에는 보이되 Sentry 미전송, `AITExportError.CANCELLED` 반환
- `Failed`/`Unknown` 분기도 `Debug.LogError` → `AITLog.Error(..., sentryCapture: false)`로 변경. 콘솔 진단 메시지는 그대로 유지하되 SDK 결함 채널에서 제외 (이 분기의 거의 모든 케이스가 사용자 프로젝트/환경 책임이며 SDK가 진단 가능한 분기가 아님)

## 회귀 테스트

`Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildResultMappingTests.cs` 추가:

- `Cancelled` → `CANCELLED` (사용자 취소를 SDK 실패로 잘못 보고하던 회귀 방지)
- `Succeeded` → `SUCCEED`
- `Failed` / `Unknown` → `BUILD_WEBGL_FAILED`

## 검증

`./run-local-tests.sh --validate` 통과 (3/3 passed).

## 영향 범위

- 사용자 시야: 빌드가 취소됐을 때 다이얼로그·콘솔에서 "사용자에 의해 취소됨"으로 표시됨 (이미 `CANCELLED` 메시지가 정의되어 있음, line 201, 305)
- Sentry: `sdk-webgl-build-failure` 카테고리의 노이즈 대폭 감소 예상. 만약 진짜 SDK 결함이 이 분기를 통해 들어오던 케이스가 있다면 별도 분기/메시지를 추가해 fingerprint를 분리해야 한다 — 현재 데이터로는 그런 케이스는 보이지 않음.

사람 머지 검토 필요.