### PR TITLE
[auto-resolve] 테스트: 분류기 false positive 회귀 (order Recover fail)

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs
@@ -101,8 +101,11 @@ public class StrictErrorSourceGateTests
     // SDK v2.4.7 (strict gate 도입 전) 에서 38건 캡처된 시나리오.
     // 메시지에는 SDK 키워드가 없지만 스택의 어딘가(파일 경로/네임스페이스 substring)에
     // AIT/AppsInToss 토큰이 들어가 IsAitRelated 의 substring 매치를 통과한 케이스.
-    // 파싱된 frame 의 filename 은 SDK package path 도 Assets/ 도 아니므로
-    // DetermineErrorSource 는 unknown 을 반환해야 하고 strict gate 가 드롭해야 한다.
+    // SanitizeFilePath 가 Library/PackageCache/<vendor>@... 경로를 그대로 보존하므로
+    // DetermineErrorSource 의 frame filename 비교는 SdkPackagePath / SdkPackageCachePath /
+    // UserProjectPathPrefix(Assets/) 어느 것에도 매칭되지 않고, 메시지 fallback 단계에서도
+    // MessageContainsSdkKeyword 가 message 본문에서 SDK 키워드를 찾지 못해 unknown 을 반환 →
+    // strict gate 가 드롭해야 한다.
 
     [Test]
     public void OrderRecoverFail_AitSubstringInNonSdkPath_Drops()
@@ -122,7 +125,10 @@ public class StrictErrorSourceGateTests
     [Test]
     public void OrderRecoverFail_NoStackNoSdkKeyword_Drops()
     {
-        // stackTrace 가 비어있고 메시지에 SDK 키워드도 없는 변형 — unknown → 드롭
+        // R2 의 실제 재현 경로(스택에 AIT 토큰 substring 존재) 는 위 테스트가 커버한다.
+        // 본 케이스는 strict gate 도입 후 동일 메시지가 스택 없이 들어와도 일관되게 드롭됨을
+        // 확인하는 보완 케이스 — NoStackTrace_NoSdkKeyword_Drops 와 경로는 같지만 R2 메시지 문자열
+        // 로 회귀 표면을 한 번 더 고정한다.
         const string message = "order Recover fail ex: Object reference not set to an instance of an object";
         Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource(message, ""));
         Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource(message, null));

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs
@@ -94,4 +94,39 @@ public class StrictErrorSourceGateTests
     }
 
     #endregion
+
+    #region 분류기 false positive 회귀 (Sentry APPS-IN-TOSS-UNITY-SDK-R2)
+
+    // 사용자 코드의 Debug.LogError("order Recover fail ex: ...") 가
+    // SDK v2.4.7 (strict gate 도입 전) 에서 38건 캡처된 시나리오.
+    // 메시지에는 SDK 키워드가 없지만 스택의 어딘가(파일 경로/네임스페이스 substring)에
+    // AIT/AppsInToss 토큰이 들어가 IsAitRelated 의 substring 매치를 통과한 케이스.
+    // 파싱된 frame 의 filename 은 SDK package path 도 Assets/ 도 아니므로
+    // DetermineErrorSource 는 unknown 을 반환해야 하고 strict gate 가 드롭해야 한다.
+
+    [Test]
+    public void OrderRecoverFail_AitSubstringInNonSdkPath_Drops()
+    {
+        // 메시지 본문은 사용자 코드 출력 — SDK 키워드 없음
+        const string message = "order Recover fail ex: Object reference not set to an instance of an object";
+
+        // 스택의 frame filename 이 SDK package path (Packages/im.toss.apps-in-toss-unity-sdk/...) 도 아니고
+        // Assets/ 도 아닌 third-party/UPM 경로. 그러나 substring "AppsInToss" 가 들어 있어
+        // 과거 IsAitRelated 의 단순 IndexOf 매치를 통과시켰던 케이스.
+        const string stackTrace =
+            "at SomeVendor.AppsInTossBridge.Recover () in Library/PackageCache/com.vendor.bridge@1.0.0/Runtime/Bridge.cs:42";
+
+        Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource(message, stackTrace));
+    }
+
+    [Test]
+    public void OrderRecoverFail_NoStackNoSdkKeyword_Drops()
+    {
+        // stackTrace 가 비어있고 메시지에 SDK 키워드도 없는 변형 — unknown → 드롭
+        const string message = "order Recover fail ex: Object reference not set to an instance of an object";
+        Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource(message, ""));
+        Assert.IsTrue(AITEditorErrorTracker.ShouldDropAsNonSdkSource(message, null));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-R2

## 요약

Sentry 이슈 **APPS-IN-TOSS-UNITY-SDK-R2** ("UnityError: order Recover fail ex: Object reference not set to an instance of an object", 38건, environment=editor, release=2.4.7) 의 분류기 false positive 시나리오를 회귀 테스트로 못박는다. 코드 fix 는 이미 main 에 반영되어 있어 추가하지 않는다.

## 재현 절차 / 원인 분석

1. Sentry 이벤트 조회 결과 모든 38건이 다음 공통 특성을 가짐:
   - 메시지: "order Recover fail ex: Object reference not set to an instance of an object"
   - **stacktrace 없음** ("No stacktrace available")
   - **error_source: unknown**
   - editor_platform=WindowsEditor, environment=editor, sdk_version=2.4.7
   - 한 사용자 (Geumcheon-gu, KR), 2026-05-04 ~ 05-05
2. 메시지 본문 ("order Recover fail ex:") 은 SDK 저장소 어디에서도 출력되지 않음 (`grep -rni "order recover\|recover fail\|fail ex:"` → 0건). → 메시지는 사용자 게임 코드의 `Debug.LogError` 출력.
3. 분류기 v2.4.7 시점 흐름 (`Editor/ErrorTracker/AITEditorErrorTracker.cs`):
   - `IsAitRelated(message, stackTrace)`: 메시지 또는 스택에 SDK 키워드 substring → 통과 필요. 메시지에는 없음 → **스택의 어딘가 substring "AppsInToss" 가 있어 통과**한 것으로 추정 (예: third-party 패키지 클래스명, 사용자 폴더명 등).
   - `IsKnownNonSdkMessage`: NonSdkMessagePatterns 비매치 → 통과.
   - `error_source` 태그는 진단용으로 `DetermineErrorSource` 결과 (unknown) 만 기록 → **드롭 없이 캡처**됨.
4. **핵심**: PR #485 ("기능: Sentry strict error_source 게이트 + 노이즈 패턴 확장", 2026-04-28 머지) 가 도입한 strict gate (`ShouldDropAsNonSdkSource`) 는 `DetermineErrorSource() != "sdk"` 인 모든 케이스를 드롭한다. v2.4.7 (2026-04-22 릴리즈) 은 이 gate 가 들어가기 전 시점이라 통과했다.

## 변경 사항

`Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/StrictErrorSourceGateTests.cs` 에 회귀 테스트 두 개 추가:

- **`OrderRecoverFail_AitSubstringInNonSdkPath_Drops`**: 메시지에 SDK 키워드 없음 + 스택 frame 의 filename 이 SDK package path 도 `Assets/` 도 아닌 third-party UPM 경로 (substring "AppsInToss" 만 포함). `DetermineErrorSource` → unknown → strict gate 가 드롭하는지 검증.
- **`OrderRecoverFail_NoStackNoSdkKeyword_Drops`**: stacktrace 가 빈 문자열·null 인 변형도 unknown → 드롭 검증 (실제 R2 이벤트의 "stacktrace 없음" 형태 모사).

코드 변경 없음 (이미 main 이 fix 상태). 테스트만 추가해 미래 리팩토링 시 같은 노이즈가 재발하지 않도록 잠가둔다.

## 검증

- `./run-local-tests.sh --validate` ✓ (3/3 passed — 파일 구조, Playwright config, SDK invariants)
- 신규 NUnit 테스트는 Unity EditMode 러너에서 실행되며 (Validate 의 빠른 경로 외), 기존 `StrictErrorSourceGateTests` 와 동일한 `AITEditorErrorTracker.ShouldDropAsNonSdkSource` 헬퍼만 사용해 컴파일 안전성 확인.

## 사용자 영향

- 사용자가 v2.4.8 이상으로 업그레이드하면 이 이슈는 자동으로 사라진다 (strict gate 가 드롭).
- v2.4.7 이하 사용자에게는 별도 조치 없음 (분류기 노이즈로, 실제 SDK 결함이 아님).

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [x] git diff 검토: 테스트 파일 1개만 수정, 코드 변경 0건
- [x] `.meta` 파일 누락/과잉 없음
- [x] TODO.md: 이번 PR 로 해결된 항목 없음 → 변경 없음
