### PR TITLE
[auto-resolve] 수정: Vite 포트 대기 타임아웃 15s → 60s 상향 + 폴링 결정 로직 분리

### DIFF
--- a/Editor/Menu/PortResolver.cs
+++ b/Editor/Menu/PortResolver.cs
@@ -85,9 +85,57 @@ namespace AppsInToss.Editor.Menu
         }
 
         /// <summary>
+        /// Vite 포트 폴링 결정.
+        /// </summary>
+        internal enum VitePollDecision
+        {
+            /// <summary>다음 update 콜백까지 대기.</summary>
+            Wait,
+            /// <summary>이번 호출에서 포트 상태를 다시 확인하고 결정.</summary>
+            CheckPort,
+            /// <summary>포트가 준비됨 — 브라우저 열기.</summary>
+            Ready,
+            /// <summary>최대 대기 시간 초과 — fallback으로 브라우저 열기.</summary>
+            Timeout,
+        }
+
+        /// <summary>
+        /// Vite 포트 대기 폴링의 결정을 시간 진행만으로 계산하는 순수 함수.
+        /// 결과가 <see cref="VitePollDecision.CheckPort"/>이면 호출자가 포트 상태를 확인한 뒤
+        /// 사용 중이면 <see cref="VitePollDecision.Ready"/>로, 아니면 <see cref="VitePollDecision.Wait"/>로 진행해야 한다.
+        /// 시간 우선 순위: 타임아웃이 polling interval보다 우선 — 인터벌이 매우 길더라도 타임아웃은 보장된다.
+        /// </summary>
+        internal static VitePollDecision EvaluateVitePollDecision(
+            double elapsedSeconds,
+            double lastCheckSeconds,
+            double maxWaitSeconds,
+            double checkIntervalSeconds)
+        {
+            // 타임아웃이 우선 — checkInterval이 maxWait보다 큰 경우에도 타임아웃은 발생해야 한다.
+            if (elapsedSeconds > maxWaitSeconds)
+                return VitePollDecision.Timeout;
+
+            if (elapsedSeconds - lastCheckSeconds < checkIntervalSeconds)
+                return VitePollDecision.Wait;
+
+            return VitePollDecision.CheckPort;
+        }
+
+        /// <summary>
+        /// Vite 포트 대기의 기본 타임아웃 (초). 콜드 스타트나 무거운 사용자 환경에서
+        /// 15초가 부족해 fallback 경고가 발생하던 사례를 흡수하기 위해 충분히 크게 설정.
+        /// </summary>
+        internal const double DefaultViteWaitMaxSeconds = 60.0;
+
+        /// <summary>
+        /// Vite 포트 폴링 체크 간격 (초). TCP bind/unbind 부하 방지.
+        /// </summary>
+        internal const double DefaultViteWaitIntervalSeconds = 0.5;
+
+        /// <summary>
         /// Vite 포트가 열릴 때까지 대기한 후 브라우저를 엽니다.
         /// Granite 포트가 먼저 감지되지만 Vite는 아직 준비되지 않았을 수 있으므로
-        /// EditorApplication.update 폴링으로 최대 15초 대기합니다.
+        /// EditorApplication.update 폴링으로 최대 <see cref="DefaultViteWaitMaxSeconds"/>초 대기합니다.
         /// </summary>
         internal static void WaitForPortAndOpenBrowser(int port, string url)
         {
@@ -102,33 +150,32 @@ namespace AppsInToss.Editor.Menu
             Debug.Log($"[AIT] Vite 포트 {port} 대기 중...");
             double startTime = EditorApplication.timeSinceStartup;
             double lastCheckTime = 0;
-            const double maxWaitSeconds = 15.0;
-            const double checkIntervalSeconds = 0.5;
+            const double maxWaitSeconds = DefaultViteWaitMaxSeconds;
+            const double checkIntervalSeconds = DefaultViteWaitIntervalSeconds;
 
             void PollVitePort()
             {
                 double elapsed = EditorApplication.timeSinceStartup - startTime;
+                var decision = EvaluateVitePollDecision(elapsed, lastCheckTime, maxWaitSeconds, checkIntervalSeconds);
 
-                // TCP bind/unbind 부하 방지: 0.5초 간격으로 체크
-                if (elapsed - lastCheckTime < checkIntervalSeconds)
+                if (decision == VitePollDecision.Wait)
                     return;
-                lastCheckTime = elapsed;
 
-                if (!IsPortAvailable(port))
+                if (decision == VitePollDecision.Timeout)
                 {
-                    // 포트가 사용 중 = Vite 서버 준비됨
                     EditorApplication.update -= PollVitePort;
-                    Debug.Log($"[AIT] Vite 포트 {port} 준비 완료 ({elapsed:F1}초 대기), 브라우저 열기");
+                    // 정상 흐름의 timeout fallback이므로 Sentry 전송 억제
+                    AITLog.Warning($"[AIT] Vite 포트 {port} 대기 타임아웃 ({maxWaitSeconds}초), 브라우저를 엽니다", sentryCapture: false);
                     Application.OpenURL(url);
                     return;
                 }
 
-                if (elapsed > maxWaitSeconds)
+                // CheckPort
+                lastCheckTime = elapsed;
+                if (!IsPortAvailable(port))
                 {
-                    // 타임아웃 — 그래도 브라우저 열기 (사용자가 직접 새로고침 가능)
                     EditorApplication.update -= PollVitePort;
-                    // 정상 흐름의 timeout fallback이므로 Sentry 전송 억제
-                    AITLog.Warning($"[AIT] Vite 포트 {port} 대기 타임아웃 ({maxWaitSeconds}초), 브라우저를 엽니다", sentryCapture: false);
+                    Debug.Log($"[AIT] Vite 포트 {port} 준비 완료 ({elapsed:F1}초 대기), 브라우저 열기");
                     Application.OpenURL(url);
                 }
             }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/VitePollDecisionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/VitePollDecisionTests.cs
@@ -1,0 +1,101 @@
+// -----------------------------------------------------------------------
+// VitePollDecisionTests.cs
+// Level 0: PortResolver.EvaluateVitePollDecision 순수 함수 검증
+// Sentry 이슈 APPS-IN-TOSS-UNITY-SDK-7D 회귀 방지 — Vite 포트 5173 대기 타임아웃
+// 경계 (15초 → 60초로 상향) 와 폴링 인터벌 동작이 시간 진행만으로 결정되는지 고정.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.Menu;
+
+[TestFixture]
+public class VitePollDecisionTests
+{
+    private const double Interval = PortResolver.DefaultViteWaitIntervalSeconds;
+    private const double MaxWait = PortResolver.DefaultViteWaitMaxSeconds;
+
+    [Test]
+    public void DefaultMaxWaitIsAtLeastSixtySeconds()
+    {
+        // 15초 타임아웃이 부족했던 회귀 — 60초 이상이어야 함
+        Assert.GreaterOrEqual(MaxWait, 60.0,
+            "Vite 포트 대기 기본 타임아웃은 60초 이상이어야 한다 (cold-start 환경 대응)");
+    }
+
+    [Test]
+    public void Wait_WhenIntervalNotElapsed()
+    {
+        var decision = PortResolver.EvaluateVitePollDecision(
+            elapsedSeconds: 0.1, lastCheckSeconds: 0.0,
+            maxWaitSeconds: MaxWait, checkIntervalSeconds: Interval);
+        Assert.AreEqual(PortResolver.VitePollDecision.Wait, decision);
+    }
+
+    [Test]
+    public void CheckPort_WhenIntervalElapsed()
+    {
+        var decision = PortResolver.EvaluateVitePollDecision(
+            elapsedSeconds: Interval + 0.01, lastCheckSeconds: 0.0,
+            maxWaitSeconds: MaxWait, checkIntervalSeconds: Interval);
+        Assert.AreEqual(PortResolver.VitePollDecision.CheckPort, decision);
+    }
+
+    [Test]
+    public void CheckPort_WhenIntervalElapsedSinceLastCheck()
+    {
+        var decision = PortResolver.EvaluateVitePollDecision(
+            elapsedSeconds: 5.0, lastCheckSeconds: 5.0 - Interval,
+            maxWaitSeconds: MaxWait, checkIntervalSeconds: Interval);
+        Assert.AreEqual(PortResolver.VitePollDecision.CheckPort, decision);
+    }
+
+    [Test]
+    public void Wait_WhenJustChecked()
+    {
+        var decision = PortResolver.EvaluateVitePollDecision(
+            elapsedSeconds: 5.0, lastCheckSeconds: 4.9,
+            maxWaitSeconds: MaxWait, checkIntervalSeconds: Interval);
+        Assert.AreEqual(PortResolver.VitePollDecision.Wait, decision);
+    }
+
+    [Test]
+    public void Timeout_WhenElapsedExceedsMaxWait()
+    {
+        var decision = PortResolver.EvaluateVitePollDecision(
+            elapsedSeconds: MaxWait + 0.1, lastCheckSeconds: MaxWait - 1.0,
+            maxWaitSeconds: MaxWait, checkIntervalSeconds: Interval);
+        Assert.AreEqual(PortResolver.VitePollDecision.Timeout, decision);
+    }
+
+    // 회귀 회피의 핵심: 사용자 환경에서 15초가 부족했던 케이스가 60초 기본값으로 흡수되는지 확인
+    [Test]
+    public void NotTimeout_AtFifteenSeconds_WithDefaultMaxWait()
+    {
+        // 과거 15초 타임아웃에서 발생하던 시점에 새 기본값(60s)에서는 아직 폴링이 진행되어야 함
+        var decision = PortResolver.EvaluateVitePollDecision(
+            elapsedSeconds: 15.5, lastCheckSeconds: 15.0,
+            maxWaitSeconds: MaxWait, checkIntervalSeconds: Interval);
+        Assert.AreNotEqual(PortResolver.VitePollDecision.Timeout, decision,
+            "기본 타임아웃이 60초 이상이어야 15초 시점에는 타임아웃이 발생하지 않아야 한다");
+    }
+
+    [Test]
+    public void Timeout_BoundaryAtMaxWait()
+    {
+        // elapsed == maxWait 정확히 같을 때는 타임아웃 아님 (>로 비교)
+        var decision = PortResolver.EvaluateVitePollDecision(
+            elapsedSeconds: MaxWait, lastCheckSeconds: MaxWait - Interval,
+            maxWaitSeconds: MaxWait, checkIntervalSeconds: Interval);
+        Assert.AreNotEqual(PortResolver.VitePollDecision.Timeout, decision);
+    }
+
+    [Test]
+    public void Timeout_TakesPrecedenceOverInterval()
+    {
+        // 타임아웃이 인터벌 검사보다 우선 — checkInterval이 매우 커도 타임아웃은 발생해야 함
+        var decision = PortResolver.EvaluateVitePollDecision(
+            elapsedSeconds: MaxWait + 1.0, lastCheckSeconds: MaxWait + 0.99,
+            maxWaitSeconds: MaxWait, checkIntervalSeconds: 100.0);
+        Assert.AreEqual(PortResolver.VitePollDecision.Timeout, decision);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/VitePollDecisionTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/VitePollDecisionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56a09177b34e49958fc0e1b9a1ee013a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-7D

## 요약

`PortResolver.WaitForPortAndOpenBrowser`의 Vite 포트 5173 대기 타임아웃을 15초 → 60초로 상향하고, 폴링 결정 로직을 시간만 입력으로 받는 순수 함수로 분리해 회귀 테스트를 추가했습니다.

## 재현 절차

1. 무거운 사용자 환경(cold-start, 디스크 I/O 경합 등) 또는 dev 서버 콜드 부팅 시점에 AIT 메뉴에서 dev/production 서버 시작.
2. Granite 포트는 빠르게 감지되지만 Vite는 15초 안에 준비되지 못하는 경우, `PortResolver.cs:131`의 fallback 경고 발생:
   `[AIT] Vite 포트 5173 대기 타임아웃 (15초), 브라우저를 엽니다`
3. 브라우저는 열리지만 Vite가 미준비 상태이므로 빈 페이지 표시 → 사용자가 직접 새로고침 필요.

EditMode 단위 재현은 `VitePollDecisionTests`로 결정 함수에 시간 값을 직접 주입하여 결정성 있게 고정.

## 원인

- `WaitForPortAndOpenBrowser`의 `maxWaitSeconds = 15.0`가 일부 환경에서 부족.
- 폴링 상태머신이 `EditorApplication.update` 콜백 안에 임베딩되어 있어 단위 테스트로 경계 조건을 직접 검증할 수 없었음 → 회귀가 잡히지 않음.

참고: Sentry 전송은 이미 PR #485에서 `sentryCapture: false`로 차단되어 있음. 이번 이슈 7D 이력은 그 fix 이전 캡처분으로 추정. 본 PR은 사용자 영향(cold-start fallback)을 직접 해결.

## Fix 요약

- **`Editor/Menu/PortResolver.cs`**
  - 결정 로직을 `EvaluateVitePollDecision(elapsed, lastCheck, maxWait, interval) → {Wait, CheckPort, Ready, Timeout}` 순수 함수로 추출.
  - 타임아웃이 인터벌 검사보다 우선하도록 명시 (인터벌이 매우 길어도 타임아웃은 보장).
  - `DefaultViteWaitMaxSeconds`: 15.0 → **60.0**.
  - `DefaultViteWaitIntervalSeconds`: 0.5 (기존 동일).
  - `WaitForPortAndOpenBrowser` 외부 시그니처/호출자 변경 없음.
- **`Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/VitePollDecisionTests.cs`** (신규, EditMode Level 0)
  - 9개 테스트: interval 미경과 시 Wait, 경과 시 CheckPort, 타임아웃 발생 경계, **15초 시점에 타임아웃 발생하지 않음 (60초 보장)**, 타임아웃이 인터벌보다 우선, 등.

## 검증

- 로컬 `./run-local-tests.sh --validate`: 다른 동시 Claude 세션의 pnpm install 경합으로 1시간 이상 멈춰 로컬에서 미실행. 변경 영역(Unity C# Editor)이 validate 검증 영역(파일 구조 + Playwright config + sdk-runtime-generator vitest)과 직교하므로 CI(GitHub Actions lint + E2E)에 검증 위임.
- pre-commit hook (Unity .meta 파일 검사) 통과.
- EditMode 회귀 테스트는 CI에서 실행됨.

## Test plan

- [ ] CI lint 통과 (.meta, format)
- [ ] CI EditMode 테스트 통과 — 신규 `VitePollDecisionTests` 9개
- [ ] CI E2E 통과 — 기존 dev/production 서버 시작 흐름 무회귀
- [ ] 코드 리뷰
