### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-addressables-build-failure

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -113,6 +113,8 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 사용자 Addressable 설정
             "does not have any associated AddressableAssetGroupSchemas",
+            // 사용자 Addressables 콘텐츠 빌드 실패 — Unity Addressables 시스템 자체 오류 (SDK-H2)
+            "Addressable content build failure",
 
             // 사용자 Unity 설치에 WebGL 모듈 미설치 — SDK-DD
             "Build target 'WebGL' not supported",

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -610,6 +610,22 @@ public class IsKnownNonSdkMessageTests
             "[AIT] Exec> git show -s --pretty=%D HEAD"));
     }
 
+    [Test]
+    public void AddressableContentBuildFailure_ReturnsTrue()
+    {
+        // Sentry SDK-H2 — Unity Addressables 콘텐츠 빌드 실패 (SDK와 무관한 사용자 프로젝트 문제)
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Addressable content build failure (duration : 0:00:16.61)"));
+    }
+
+    [Test]
+    public void AddressableContentBuildFailure_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙으면 SDK 자체 로그로 간주
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Addressable content build failure (duration : 0:00:16.61)"));
+    }
+
     #endregion
 
     #region SDK 관련 메시지는 통과 (negative cases)


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-H2

## 대상 Sentry 이슈
- **Item ID**: APPS-IN-TOSS-UNITY-SDK-H2
- **Title**: UnityError: Addressable content build failure (duration : 0:00:16.61)

## 분석 근거
`Addressable content build failure`는 Unity Addressables 시스템 자체에서 발생하는 콘텐츠 빌드 실패 메시지로, 사용자 프로젝트의 Addressable 설정/에셋 문제에서 비롯되며 SDK 코드와 무관한 노이즈다. SDK 어디에도 해당 문자열이 출력되지 않음 (grep 확인 완료).

## 추출 패턴
- `"Addressable content build failure"` — Unity Addressables 콘텐츠 빌드 단계 자체 오류

## 추가 위치
- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열 (기존 Addressable 패턴 옆 그룹)

## AitKeywords 보호 가드
`[AIT` / `AppsInToss` / `apps-in-toss` 등 AitKeywords가 포함된 메시지는 패턴이 매칭되더라도 SDK 자체 로그로 간주되어 절대 필터링되지 않음. positive 케이스와 함께 negative(`[AIT]` prefix 시 통과) 회귀 테스트 추가.

## 검증
- `./run-local-tests.sh --validate` ✅ All tests passed (3/3, SDK Generator Unit Tests 18/18 invariants 통과)

## 검토 요청
**사람 머지 검토 필요** — 자동 생성된 PR이지만, 패턴이 SDK 자체 로그를 가릴 위험이 없는지 한 번 더 확인 부탁드립니다.