### PR TITLE
[auto-resolve] 수정: HTML 마커 fallback 경고를 Sentry에서 제외

### DIFF
--- a/Editor/AITTemplateManager.cs
+++ b/Editor/AITTemplateManager.cs
@@ -324,7 +324,9 @@ namespace AppsInToss.Editor
 
             if (startIdx == -1 || endIdx == -1)
             {
-                Debug.LogWarning($"[AIT] HTML 마커를 찾을 수 없습니다: {startMarker}");
+                // 사용자 환경 차이(빌드 출력에서 마커 누락, 사용자가 마커를 임의로 제거 등)로
+                // 발생하는 fallback. SDK 결함이 아니므로 Sentry 전송은 억제하고 콘솔 경고만 남긴다.
+                AITLog.Warning($"[AIT] HTML 마커를 찾을 수 없습니다: {startMarker}", sentryCapture: false);
                 return content;
             }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITTemplateManagerHtmlMarkerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITTemplateManagerHtmlMarkerTests.cs
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------
+// AITTemplateManagerHtmlMarkerTests.cs - HTML 마커 머지 회귀 테스트
+// Level 0: ReplaceHtmlUserSection이 마커 미발견 시 Sentry로 노이즈를 보내지 않는지 검증
+//          (Sentry 이슈 APPS-IN-TOSS-UNITY-SDK-RA / -RB)
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss.Editor;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+public class AITTemplateManagerHtmlMarkerTests
+{
+    private static int GetSuppressDepth()
+    {
+        var field = typeof(AITEditorErrorTracker).GetField(
+            "_suppressLogCaptureCount",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.IsNotNull(field, "_suppressLogCaptureCount field should exist on AITEditorErrorTracker");
+        return (int)field.GetValue(null);
+    }
+
+    [Test]
+    public void ReplaceHtmlUserSection_MissingStartMarker_ReturnsContentUnchanged()
+    {
+        const string content = "<html><head></head><body></body></html>";
+        const string newSection = "<!-- USER_HEAD_START -->custom<!-- USER_HEAD_END -->";
+
+        // 마커가 없으므로 콘솔에 fallback 경고가 한 번 발생해야 한다.
+        LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\] HTML 마커를 찾을 수 없습니다: <!-- USER_HEAD_START"));
+
+        string result = AITTemplateManager.ReplaceHtmlUserSection(
+            content,
+            AITTemplateManager.HTML_USER_HEAD_START,
+            AITTemplateManager.HTML_USER_HEAD_END,
+            newSection);
+
+        // 입력 콘텐츠는 그대로 반환되어야 한다 (사용자 환경 차이 fallback).
+        Assert.AreEqual(content, result);
+    }
+
+    [Test]
+    public void ReplaceHtmlUserSection_MissingMarker_DoesNotCaptureToSentry()
+    {
+        // 회귀 검증: 사용자 환경 차이(빌드 산출물에 마커 누락 등)로 발생하는 fallback warning은
+        // Sentry로 전송되지 않아야 한다 (sentryCapture: false). 이를 위해
+        // AITLog.SuppressScope 가 BeginSuppressLogCapture/EndSuppressLogCapture 를 호출하면서
+        // Debug.LogWarning 이 발생하는 동안 _suppressLogCaptureCount 가 1 이상이어야 한다.
+        //
+        // logMessageReceived 콜백은 메인 스레드에서 동기적으로 호출되므로, 콜백 시점의
+        // suppress depth 를 캡처해 검증한다.
+
+        int observedDepth = -1;
+        Application.LogCallback handler = (msg, stack, type) =>
+        {
+            if (type == LogType.Warning && msg != null && msg.Contains("[AIT] HTML 마커를 찾을 수 없습니다"))
+            {
+                observedDepth = GetSuppressDepth();
+            }
+        };
+
+        Application.logMessageReceived += handler;
+        try
+        {
+            LogAssert.Expect(LogType.Warning, new Regex(@"\[AIT\] HTML 마커를 찾을 수 없습니다: <!-- USER_BODY_END_START"));
+
+            AITTemplateManager.ReplaceHtmlUserSection(
+                "<html></html>",
+                AITTemplateManager.HTML_USER_BODY_END_START,
+                AITTemplateManager.HTML_USER_BODY_END_END,
+                "<!-- USER_BODY_END_START -->x<!-- USER_BODY_END_END -->");
+        }
+        finally
+        {
+            Application.logMessageReceived -= handler;
+        }
+
+        Assert.GreaterOrEqual(
+            observedDepth, 1,
+            "fallback warning이 Sentry로 캡처되지 않도록 SuppressScope 가 활성 상태여야 함 (sentryCapture: false)");
+        // 호출이 끝난 뒤 suppress depth 는 원상복귀 되어야 한다.
+        Assert.AreEqual(0, GetSuppressDepth(), "ReplaceHtmlUserSection 종료 후 suppress depth 는 0이어야 함");
+    }
+
+    [Test]
+    public void ReplaceHtmlUserSection_MarkerPresent_ReplacesUserSection()
+    {
+        // 정상 경로: 마커가 있으면 경고 없이 사용자 섹션이 교체되어야 한다.
+        string content =
+            "<html><head>"
+            + AITTemplateManager.HTML_USER_HEAD_START + " -->old"
+            + AITTemplateManager.HTML_USER_HEAD_END
+            + "</head></html>";
+        string newSection = AITTemplateManager.HTML_USER_HEAD_START + " -->new" + AITTemplateManager.HTML_USER_HEAD_END;
+
+        string result = AITTemplateManager.ReplaceHtmlUserSection(
+            content,
+            AITTemplateManager.HTML_USER_HEAD_START,
+            AITTemplateManager.HTML_USER_HEAD_END,
+            newSection);
+
+        StringAssert.Contains("new", result);
+        StringAssert.DoesNotContain("old", result);
+        // LogAssert.NoUnexpectedReceived 는 Error 만 감시하므로, 패턴 누락 검증은 Expect 없이 기본 동작.
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITTemplateManagerHtmlMarkerTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITTemplateManagerHtmlMarkerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1653ace4e4804eb584fb776ce8d05637
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-RB, APPS-IN-TOSS-UNITY-SDK-RA

## 대상 Sentry 이슈

- `APPS-IN-TOSS-UNITY-SDK-RB`: `[AIT] HTML 마커를 찾을 수 없습니다: <!-- USER_HEAD_START`
- `APPS-IN-TOSS-UNITY-SDK-RA`: `[AIT] HTML 마커를 찾을 수 없습니다: <!-- USER_BODY_END_START`

## 재현 절차

`Editor/AITTemplateManager.cs:320` `ReplaceHtmlUserSection`은 입력 콘텐츠에서 `startMarker`/`endMarker`를 찾지 못하면 `Debug.LogWarning`을 호출한다. 이 함수는 두 경로에서 호출된다:

1. `MergeHtmlTemplates` (line 159-170) — `ExtractHtmlUserSection(projectContent, ...)`이 non-empty일 때 SDK 콘텐츠에서 마커 교체.
2. `WebGLBuildCopier.cs:243-256` — 프로젝트 `index.html`에 마커가 있을 때 Unity가 출력한 빌드 결과 `index.html`에서 마커 교체.

두 경로 모두 호출 대상 콘텐츠(SDK 템플릿 또는 Unity 빌드 출력)에 마커가 없을 때 경고를 발생시킨다. 이는 다음과 같은 **사용자 환경 차이**로 정상 발생할 수 있다:

- 사용자가 자신의 `Assets/WebGLTemplates/AITTemplate/index.html`의 마커를 임의로 제거/변형
- Unity가 WebGL 빌드 출력 시 일부 환경에서 HTML 주석 처리
- AITTemplate이 아닌 다른 템플릿으로 빌드되어 Unity 출력에 마커가 없음

회귀 테스트(`AITTemplateManagerHtmlMarkerTests`)에서 마커가 없는 콘텐츠로 직접 `ReplaceHtmlUserSection`을 호출해 두 시나리오를 모두 재현했다.

## 원인

`docs/claude/sentry-known-issues.md` §"정상 흐름 fallback warning 컨벤션"에 따르면 사용자 환경 차이로 발생하는 fallback warning은 `AITLog.Warning(msg, sentryCapture: false)` 사용이 권장된다. 본 경고는 SDK 결함이 아닌 사용자 환경 fallback이지만 `Debug.LogWarning`으로 직접 호출되어 Sentry로 전송되고 있었다.

## Fix 요약

`Editor/AITTemplateManager.cs:327`의 `Debug.LogWarning(...)`을 `AITLog.Warning(..., sentryCapture: false)`로 교체:

- 콘솔 경고는 동일하게 유지 → 사용자 디버깅 단서 보존
- Sentry 캡처는 `SuppressScope`로 억제 → 노이즈 제거
- 변경 범위 최소화 (한 줄 + 의도 설명 주석)

## 회귀 테스트

`Tests~/E2E/SharedScripts/Editor/EditModeTests/AITTemplateManagerHtmlMarkerTests.cs`:

1. `ReplaceHtmlUserSection_MissingStartMarker_ReturnsContentUnchanged` — 마커 부재 시 입력 콘텐츠 그대로 반환되는지 검증.
2. `ReplaceHtmlUserSection_MissingMarker_DoesNotCaptureToSentry` — `Application.logMessageReceived` 콜백 시점에 `_suppressLogCaptureCount >= 1`임을 reflection으로 확인. 호출 종료 후 0으로 복귀.
3. `ReplaceHtmlUserSection_MarkerPresent_ReplacesUserSection` — 정상 경로에서 사용자 섹션이 새 내용으로 교체되는지 검증.

## 검증 결과

`./run-local-tests.sh --validate` ✓ All tests passed (3 passed, 0 failed)

- E2E Test Files Validation ✓
- Playwright Config Validation ✓
- SDK Generator Unit Tests ✓ (18 invariants passed)

## 사람 머지 검토 필요

- 변경 범위가 한 줄 + 회귀 테스트로 최소화되어 있고 콘솔 경고 동작은 보존됨.
- 동일한 fallback 컨벤션 점진 적용 대상인 다른 `Debug.LogWarning` 호출(예: `ReplaceMarkerSection` SDK 마커 경고)은 본 PR 범위에서 제외 (한 PR에 한 issue).
