### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — missing-script-user-scene

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -713,7 +713,8 @@ namespace AppsInToss.Editor.ErrorTracker
                     return true;
             }
 
-            // "Script attached to ... is missing" 패턴은 Assets/ 경로가 포함된 경우에만 사용자 프로젝트로 분류
+            // "Script attached to ... is missing" 패턴은 Assets/ 경로가 포함된 경우에만 사용자 프로젝트로 분류.
+            // "in Assets/..." 직접 경로 형태와 "in scene 'Assets/...'" 변형(SDK-H0/GX/GW) 모두 매칭한다.
             if (message.IndexOf("Script attached to", StringComparison.Ordinal) >= 0
                 && message.IndexOf("is missing", StringComparison.Ordinal) >= 0
                 && message.IndexOf("Assets/", StringComparison.Ordinal) >= 0)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -256,6 +256,31 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    [TestCase(
+        "Script attached to '_iOSUpdate' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached.",
+        TestName = "ScriptMissingInUserScene_iOSUpdate_ReturnsTrue")]
+    [TestCase(
+        "Script attached to 'Image_Popup' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached.",
+        TestName = "ScriptMissingInUserScene_ImagePopup_ReturnsTrue")]
+    [TestCase(
+        "Script attached to '_AdManager' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached.",
+        TestName = "ScriptMissingInUserScene_AdManager_ReturnsTrue")]
+    public void ScriptMissingInUserScene_RealisticVariants_ReturnsTrue(string message)
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-H0/GX/GW — 사용자 씬의 missing script 경고.
+        // "in scene 'Assets/...'" 형태도 기존 composite 가드(Script attached to + is missing + Assets/)가 매칭한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(message));
+    }
+
+    [Test]
+    public void ScriptMissingInUserScene_WithAitPrefix_NeverFiltered()
+    {
+        // AIT 키워드가 섞이면 SDK 보호 가드가 우선 — composite missing-script 가드를 우회하지 않는다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Script attached to '_iOSUpdate' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached."));
+    }
+
+    [Test]
     public void AudioClipImportWarning_ReturnsTrue()
     {
         // Sentry GT/GV — 사용자 프로젝트 에셋 import 경고

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -275,7 +275,8 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void ScriptMissingInUserScene_WithAitPrefix_NeverFiltered()
     {
-        // AIT 키워드가 섞이면 SDK 보호 가드가 우선 — composite missing-script 가드를 우회하지 않는다.
+        // composite missing-script 가드의 세 조건(Script attached to + is missing + Assets/)을 모두 만족하지만,
+        // "[AIT" 키워드가 MessageContainsSdkKeyword 가드에 먼저 매칭되어 composite 가드 도달 전에 return false 한다.
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AIT] Script attached to '_iOSUpdate' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached."));
     }


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-H0, APPS-IN-TOSS-UNITY-SDK-GX, APPS-IN-TOSS-UNITY-SDK-GW

## 대상 Sentry 이슈

| Item ID | Events | 메시지 (요약) |
|---|---|---|
| APPS-IN-TOSS-UNITY-SDK-H0 | n/a | `UnityWarning: Script attached to '_iOSUpdate' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached.` |
| APPS-IN-TOSS-UNITY-SDK-GX | n/a | `UnityWarning: Script attached to 'Image_Popup' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached.` |
| APPS-IN-TOSS-UNITY-SDK-GW | n/a | `UnityWarning: Script attached to '_AdManager' in scene 'Assets/Scenes/Main.unity' is missing or no valid script is attached.` |

## 분석

세 이슈 모두 **사용자 씬(`Assets/Scenes/Main.unity`)** 의 GameObject에 attach된 스크립트가 missing/invalid 상태일 때 Unity가 출력하는 경고이며, SDK 외부의 사용자 프로젝트 자산 문제다. SDK 동작과 무관하므로 노이즈로 분류해 드롭한다.

## 추출 패턴 / 추가 위치

기존 composite 가드(`AITEditorErrorTracker.IsKnownNonSdkMessage`)가 이미 다음 세 부분 문자열을 모두 포함하면 매칭한다:
- `Script attached to`
- `is missing`
- `Assets/`

세 이슈 메시지(`... in scene 'Assets/Scenes/Main.unity' ...`) 모두 위 세 조건을 만족하므로 **로직 변경 없이 매칭**된다. 본 PR은 다음 변경만 포함:

1. **`Editor/ErrorTracker/AITEditorErrorTracker.cs`**: composite 가드 주석에 `in scene 'Assets/...'` 변형도 매칭됨을 명시 (Sentry 이슈 ID 참조 추가).
2. **`Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`**:
   - Positive: `ScriptMissingInUserScene_RealisticVariants_ReturnsTrue` — 세 Sentry 이슈의 정확한 메시지 형태(_iOSUpdate / Image_Popup / _AdManager)를 케이스로 추가.
   - Negative (AIT prefix 보호): `ScriptMissingInUserScene_WithAitPrefix_NeverFiltered` — `[AIT]` prefix가 섞인 동일 메시지는 SDK 보호 가드로 인해 필터되지 않음을 검증.

## 검증

- `./run-local-tests.sh --validate` ✅ Passed: 3 / Failed: 0 / Skipped: 0
  - File Structure Validation, E2E Test Files Validation, Playwright Config Validation 통과
  - SDK Generator Unit Tests (`vitest run tests/unit/invariants.test.ts`) — 18 passed

## 변경 범위

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` (주석 1줄 보강)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` (테스트 4건 추가)

---

⚠️ **사람 머지 검토 필요** — 본 PR은 자동 분류 노이즈 패턴 정리 흐름으로 생성되었습니다. squash merge 시 PR body의 `Fixes ...` 키워드가 머지 커밋에 포함되어 Sentry가 해당 이슈들을 자동 resolve합니다.