### PR TITLE
개선: Playwright E2E를 ubuntu로 분리 (Phase 1/3)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -192,8 +192,6 @@ jobs:
       os: ${{ matrix.target.os }}
       unity-version: ${{ matrix.target.unity-version }}
       run-build: true
-      run-e2e-test: false
-      run-benchmark: false
     secrets:
       AIT_AD_INTERSTITIAL_ID: ${{ secrets.AIT_AD_INTERSTITIAL_ID }}
       AIT_AD_REWARDED_ID: ${{ secrets.AIT_AD_REWARDED_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,8 +354,6 @@ jobs:
       web-framework-version: ${{ needs.release.outputs.version }}
       sdk-version: ${{ needs.release.outputs.version }}
       run-build: true
-      run-e2e-test: false
-      run-benchmark: false
     secrets:
       AIT_AD_INTERSTITIAL_ID: ${{ secrets.AIT_AD_INTERSTITIAL_ID }}
       AIT_AD_REWARDED_ID: ${{ secrets.AIT_AD_REWARDED_ID }}
@@ -381,8 +379,6 @@ jobs:
       web-framework-version: ${{ needs.release.outputs.version }}
       sdk-version: ${{ needs.release.outputs.version }}
       run-build: true
-      run-e2e-test: false
-      run-benchmark: false
     secrets:
       AIT_AD_INTERSTITIAL_ID: ${{ secrets.AIT_AD_INTERSTITIAL_ID }}
       AIT_AD_REWARDED_ID: ${{ secrets.AIT_AD_REWARDED_ID }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -202,10 +202,11 @@ jobs:
           echo "Reported pending status for commit $SHA"
 
   # =====================================================
-  # E2E Tests - macOS (모든 테스트 실행)
+  # Unity Build - macOS (EditMode 테스트 + WebGL 빌드)
+  # Playwright는 build-* 다음의 e2e-* job(ubuntu)에서 실행
   # =====================================================
-  e2e-test-macos:
-    name: E2E (macOS, Unity ${{ matrix.unity-version }})
+  build-macos:
+    name: Build (macOS, Unity ${{ matrix.unity-version }})
     needs: [setup]
 
     strategy:
@@ -221,8 +222,7 @@ jobs:
       os: macos
       unity-version: ${{ matrix.unity-version }}
       run-build: true
-      run-e2e-test: true
-      run-benchmark: true
+      run-editmode-test: true
       run-unit-test: false
       clean-library: ${{ inputs.clean_library || false }}
       sdk-version-override: ${{ inputs.sdk_version_override || '' }}
@@ -237,10 +237,10 @@ jobs:
       FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
 
   # =====================================================
-  # E2E Tests - Windows (전체 테스트 실행)
+  # Unity Build - Windows (EditMode 테스트 + WebGL 빌드)
   # =====================================================
-  e2e-test-windows:
-    name: E2E (Windows, Unity ${{ matrix.unity-version }})
+  build-windows:
+    name: Build (Windows, Unity ${{ matrix.unity-version }})
     needs: [setup]
 
     strategy:
@@ -255,8 +255,7 @@ jobs:
       os: windows
       unity-version: ${{ matrix.unity-version }}
       run-build: true
-      run-e2e-test: true
-      run-benchmark: true
+      run-editmode-test: true
       run-unit-test: false
       clean-library: ${{ inputs.clean_library || false }}
       sdk-version-override: ${{ inputs.sdk_version_override || '' }}
@@ -271,12 +270,164 @@ jobs:
       FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
 
   # =====================================================
+  # Playwright E2E Tests - macOS 빌드 산출물 (ubuntu-latest)
+  # self-hosted runner 점유를 줄이기 위해 ubuntu에서 실행.
+  # WebGL 산출물은 OS-독립적이라 ubuntu에서 동일하게 동작.
+  # =====================================================
+  e2e-macos:
+    name: E2E (macOS build, Unity ${{ matrix.unity-version }})
+    needs: [setup, build-macos]
+    if: needs.build-macos.result == 'success' && (inputs.test_level || '2') == '2'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        unity-version: ["2021.3", "2022.3", "6000.0", "6000.2", "6000.3"]
+
+    env:
+      MOBILE_EMULATION: "true"
+      TEST_LEVEL: ${{ inputs.test_level || '2' }}
+      AIT_BUILD_DIR: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ needs.setup.outputs.repository }}
+          ref: ${{ needs.setup.outputs.ref }}
+
+      - name: Download AIT Build Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ait-build-macos-${{ matrix.unity-version }}
+          path: ${{ env.AIT_BUILD_DIR }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install AIT Build Dependencies
+        # ait-build/ 안에서 vite preview/dev 서버를 띄우려면 node_modules 필요
+        working-directory: ${{ env.AIT_BUILD_DIR }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Test Dependencies
+        working-directory: Tests~/E2E/tests
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install chromium --with-deps
+
+      - name: Run Playwright E2E
+        working-directory: Tests~/E2E/tests
+        env:
+          UNITY_PROJECT_PATH: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}
+        run: pnpm test
+
+      - name: Upload Benchmark Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results-macos-${{ matrix.unity-version }}
+          path: Tests~/E2E/tests/benchmark-results.json
+          if-no-files-found: ignore
+
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-macos-${{ matrix.unity-version }}
+          path: Tests~/E2E/tests/playwright-report/
+          if-no-files-found: ignore
+          compression-level: 9
+          retention-days: 7
+
+  # =====================================================
+  # Playwright E2E Tests - Windows 빌드 산출물 (ubuntu-latest)
+  # =====================================================
+  e2e-windows:
+    name: E2E (Windows build, Unity ${{ matrix.unity-version }})
+    needs: [setup, build-windows]
+    if: needs.build-windows.result == 'success' && (inputs.test_level || '2') == '2'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        unity-version: ["2021.3", "2022.3", "6000.0", "6000.2", "6000.3"]
+
+    env:
+      TEST_LEVEL: ${{ inputs.test_level || '2' }}
+      AIT_BUILD_DIR: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ needs.setup.outputs.repository }}
+          ref: ${{ needs.setup.outputs.ref }}
+
+      - name: Download AIT Build Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ait-build-windows-${{ matrix.unity-version }}
+          path: ${{ env.AIT_BUILD_DIR }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install AIT Build Dependencies
+        working-directory: ${{ env.AIT_BUILD_DIR }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Test Dependencies
+        working-directory: Tests~/E2E/tests
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install chromium --with-deps
+
+      - name: Run Playwright E2E
+        working-directory: Tests~/E2E/tests
+        env:
+          UNITY_PROJECT_PATH: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}
+        run: pnpm test
+
+      - name: Upload Benchmark Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results-windows-${{ matrix.unity-version }}
+          path: Tests~/E2E/tests/benchmark-results.json
+          if-no-files-found: ignore
+
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-windows-${{ matrix.unity-version }}
+          path: Tests~/E2E/tests/playwright-report/
+          if-no-files-found: ignore
+          compression-level: 9
+          retention-days: 7
+
+  # =====================================================
   # Test Report Summary
   # =====================================================
   test-report:
     name: Test Report Summary
     runs-on: ubuntu-latest
-    needs: [setup, sdk-generator-tests, e2e-test-macos, e2e-test-windows]
+    needs: [setup, sdk-generator-tests, build-macos, build-windows, e2e-macos, e2e-windows]
     if: always()
 
     steps:
@@ -509,9 +660,14 @@ jobs:
           PR_NUMBER="${{ needs.setup.outputs.pr_number }}"
 
           # 테스트 결과 상태 확인
+          # e2e-* job은 test_level=2일 때만 실행되므로, skipped인 경우 build-* 결과를 OS 결과로 사용
           SDK_RESULT="${{ needs.sdk-generator-tests.result }}"
-          MACOS_RESULT="${{ needs.e2e-test-macos.result }}"
-          WINDOWS_RESULT="${{ needs.e2e-test-windows.result }}"
+          BUILD_MACOS_RESULT="${{ needs.build-macos.result }}"
+          BUILD_WINDOWS_RESULT="${{ needs.build-windows.result }}"
+          E2E_MACOS_RESULT="${{ needs.e2e-macos.result }}"
+          E2E_WINDOWS_RESULT="${{ needs.e2e-windows.result }}"
+          MACOS_RESULT=$([ "$E2E_MACOS_RESULT" = "skipped" ] && echo "$BUILD_MACOS_RESULT" || echo "$E2E_MACOS_RESULT")
+          WINDOWS_RESULT=$([ "$E2E_WINDOWS_RESULT" = "skipped" ] && echo "$BUILD_WINDOWS_RESULT" || echo "$E2E_WINDOWS_RESULT")
 
           if [ "$SDK_RESULT" = "success" ] && [ "$MACOS_RESULT" = "success" ] && [ "$WINDOWS_RESULT" = "success" ]; then
             STATUS_EMOJI="✅"
@@ -577,7 +733,7 @@ jobs:
   report-status:
     name: Report Status
     runs-on: ubuntu-latest
-    needs: [setup, sdk-generator-tests, e2e-test-macos, e2e-test-windows]
+    needs: [setup, sdk-generator-tests, build-macos, build-windows, e2e-macos, e2e-windows]
     if: always() && needs.setup.outputs.ref != ''
 
     steps:
@@ -585,8 +741,13 @@ jobs:
         id: status
         run: |
           SDK_RESULT="${{ needs.sdk-generator-tests.result }}"
-          MACOS_RESULT="${{ needs.e2e-test-macos.result }}"
-          WINDOWS_RESULT="${{ needs.e2e-test-windows.result }}"
+          BUILD_MACOS_RESULT="${{ needs.build-macos.result }}"
+          BUILD_WINDOWS_RESULT="${{ needs.build-windows.result }}"
+          E2E_MACOS_RESULT="${{ needs.e2e-macos.result }}"
+          E2E_WINDOWS_RESULT="${{ needs.e2e-windows.result }}"
+          # e2e-* skipped (test_level != 2)이면 build-* 결과를 OS 결과로 사용
+          MACOS_RESULT=$([ "$E2E_MACOS_RESULT" = "skipped" ] && echo "$BUILD_MACOS_RESULT" || echo "$E2E_MACOS_RESULT")
+          WINDOWS_RESULT=$([ "$E2E_WINDOWS_RESULT" = "skipped" ] && echo "$BUILD_WINDOWS_RESULT" || echo "$E2E_WINDOWS_RESULT")
 
           if [ "$SDK_RESULT" = "success" ] && [ "$MACOS_RESULT" = "success" ] && [ "$WINDOWS_RESULT" = "success" ]; then
             echo "state=success" >> $GITHUB_OUTPUT

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -31,13 +31,8 @@ on:
         type: boolean
         required: false
         default: true
-      run-e2e-test:
-        description: 'Run E2E tests after build'
-        type: boolean
-        required: false
-        default: false
-      run-benchmark:
-        description: 'Run benchmark tests'
+      run-editmode-test:
+        description: 'Run Unity EditMode tests before build (was: run-e2e-test). Playwright/benchmark는 별도 ubuntu 워크플로우(test-e2e.yml)로 분리되었음.'
         type: boolean
         required: false
         default: false
@@ -705,7 +700,7 @@ jobs:
       # EditMode 테스트 (Level 0+, 빌드 없이 C# 순수 로직 검증)
       # =====================================================
       - name: Run EditMode Tests (macOS)
-        if: inputs.os == 'macos' && inputs.run-e2e-test
+        if: inputs.os == 'macos' && inputs.run-editmode-test
         run: |
           UNITY_PATH="${{ steps.unity-macos.outputs.UNITY_PATH }}"
           PROJECT_PATH="${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}"
@@ -772,7 +767,7 @@ jobs:
           fi
 
       - name: Probe Windows runner PATH (diagnostic)
-        if: inputs.os == 'windows' && inputs.run-e2e-test
+        if: inputs.os == 'windows' && inputs.run-editmode-test
         shell: powershell
         run: |
           [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
@@ -797,7 +792,7 @@ jobs:
           where.exe git 2>&1 | ForEach-Object { Write-Host "  $_" }
 
       - name: Run EditMode Tests (Windows)
-        if: inputs.os == 'windows' && inputs.run-e2e-test
+        if: inputs.os == 'windows' && inputs.run-editmode-test
         shell: powershell
         run: |
           # Windows PowerShell 5.1 reads scripts using the system code page; non-ASCII
@@ -884,7 +879,7 @@ jobs:
           }
 
       - name: Upload EditMode Test Results
-        if: inputs.run-e2e-test && always()
+        if: inputs.run-editmode-test && always()
         uses: actions/upload-artifact@v7
         with:
           name: editmode-results-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -895,7 +890,7 @@ jobs:
       # EditMode 로그를 통합 분류기에서 grep할 수 있도록 보존
       # (라이선스/Hub/캐시 등 인프라 결함 세분화에 필요).
       - name: Upload EditMode Unity Log (macOS)
-        if: inputs.os == 'macos' && inputs.run-e2e-test && always()
+        if: inputs.os == 'macos' && inputs.run-editmode-test && always()
         uses: actions/upload-artifact@v7
         with:
           name: unity-log-editmode-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -904,7 +899,7 @@ jobs:
           retention-days: 7
 
       - name: Upload EditMode Unity Log (Windows)
-        if: inputs.os == 'windows' && inputs.run-e2e-test && always()
+        if: inputs.os == 'windows' && inputs.run-editmode-test && always()
         uses: actions/upload-artifact@v7
         with:
           name: unity-log-editmode-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -1218,7 +1213,7 @@ jobs:
             }
           }
 
-          # 첫 번째 EditMode(run-e2e-test)에서 이미 통과한 경우, 이 step 실패를 무시
+          # 첫 번째 EditMode(run-editmode-test)에서 이미 통과한 경우, 이 step 실패를 무시
           $firstEditModeResults = "${{ github.workspace }}\Tests~\E2E\SampleUnityProject-${{ inputs.unity-version }}\editmode-results.xml"
           if (Test-Path $firstEditModeResults) {
             $firstContent = Get-Content $firstEditModeResults -Raw
@@ -1674,108 +1669,3 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      # =====================================================
-      # E2E 테스트 (선택적)
-      # =====================================================
-      - name: Setup Node.js
-        if: inputs.run-e2e-test && (inputs.test-level || '2') == '2'
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Install Playwright Dependencies (macOS)
-        if: inputs.os == 'macos' && inputs.run-e2e-test && (inputs.test-level || '2') == '2'
-        working-directory: Tests~/E2E/tests
-        run: |
-          # package.json 변경 시에만 node_modules 재설치 (self-hosted 캐시 활용)
-          EXPECTED_HASH=$(shasum -a 256 package.json | cut -d' ' -f1)
-          CACHED_HASH=""
-          if [ -f node_modules/.package-hash ]; then
-            CACHED_HASH=$(cat node_modules/.package-hash)
-          fi
-
-          if [ "$EXPECTED_HASH" != "$CACHED_HASH" ]; then
-            echo "package.json changed, reinstalling dependencies..."
-            rm -rf node_modules package-lock.json pnpm-lock.yaml
-            pnpm install
-            echo "$EXPECTED_HASH" > node_modules/.package-hash
-          else
-            echo "Dependencies up to date (cached)"
-          fi
-
-          # Playwright 브라우저 설치 (이미 설치된 버전이면 빠르게 스킵됨)
-          pnpm exec playwright install chromium --with-deps
-          pnpm exec playwright --version
-
-      - name: Install Playwright Dependencies (Windows)
-        if: inputs.os == 'windows' && inputs.run-e2e-test && (inputs.test-level || '2') == '2'
-        working-directory: Tests~/E2E/tests
-        shell: powershell
-        env:
-          # Use job-local Playwright cache to avoid race conditions between parallel runners
-          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}\.playwright-browsers
-        run: |
-          # package.json 변경 시에만 node_modules 재설치 (self-hosted 캐시 활용)
-          $expectedHash = (Get-FileHash -Algorithm SHA256 package.json).Hash
-          $cachedHash = ""
-          if (Test-Path "node_modules\.package-hash") {
-            $cachedHash = Get-Content "node_modules\.package-hash" -Raw
-            $cachedHash = $cachedHash.Trim()
-          }
-
-          if ($expectedHash -ne $cachedHash) {
-            Write-Host "package.json changed, reinstalling dependencies..."
-            if (Test-Path node_modules) { Remove-Item -Recurse -Force node_modules }
-            if (Test-Path package-lock.json) { Remove-Item -Force package-lock.json }
-            if (Test-Path pnpm-lock.yaml) { Remove-Item -Force pnpm-lock.yaml }
-            pnpm install
-            Set-Content "node_modules\.package-hash" -Value $expectedHash -NoNewline
-          } else {
-            Write-Host "Dependencies up to date (cached)"
-          }
-
-          # Playwright 브라우저: 캐시 유지 (버전 변경 시에만 재설치)
-          pnpm exec playwright install chromium --with-deps
-          pnpm exec playwright --version
-
-      - name: Run E2E Tests (macOS - Full)
-        if: inputs.os == 'macos' && inputs.run-e2e-test && (inputs.test-level || '2') == '2'
-        working-directory: Tests~/E2E/tests
-        env:
-          UNITY_PROJECT_PATH: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}
-          MOBILE_EMULATION: "true"
-          TEST_LEVEL: ${{ inputs.test-level || '2' }}
-        run: pnpm test
-
-      - name: Run E2E Tests (Windows - Full)
-        if: inputs.os == 'windows' && inputs.run-e2e-test && (inputs.test-level || '2') == '2'
-        working-directory: Tests~/E2E/tests
-        shell: powershell
-        env:
-          UNITY_PROJECT_PATH: ${{ github.workspace }}\Tests~\E2E\SampleUnityProject-${{ inputs.unity-version }}
-          MOBILE_EMULATION: "true"
-          TEST_LEVEL: ${{ inputs.test-level || '2' }}
-          # Use job-local Playwright cache to avoid race conditions between parallel runners
-          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}\.playwright-browsers
-        run: pnpm test
-
-      # =====================================================
-      # 벤치마크 결과 업로드 (선택적)
-      # =====================================================
-      - name: Upload Benchmark Results
-        if: inputs.run-benchmark && (inputs.test-level || '2') == '2'
-        uses: actions/upload-artifact@v7
-        with:
-          name: benchmark-results-${{ inputs.os }}-${{ inputs.unity-version }}
-          path: Tests~/E2E/tests/benchmark-results.json
-          if-no-files-found: ignore
-
-      - name: Upload Playwright Report
-        if: inputs.run-e2e-test && (inputs.test-level || '2') == '2' && always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-report-${{ inputs.os }}-${{ inputs.unity-version }}
-          path: Tests~/E2E/tests/playwright-report/
-          if-no-files-found: ignore
-          compression-level: 9
-          retention-days: 7


### PR DESCRIPTION
## 배경

CI 진단 결과, E2E Tests 워크플로우의 wall clock(~140분) 중 핵심 병목은 self-hosted Unity runner 점유였다. 매트릭스 10개(macOS×5 + Windows×5)가 self-hosted runner 4대를 두고 큐잉되며, 각 매트릭스 안에서 Unity-독립적인 Playwright 단계(~60s)도 함께 점유 중이다.

이 PR은 **CI 개선 Phase 1**: Unity가 실제로 필요한 단계(EditMode + WebGL 빌드)와 OS-독립적인 Playwright E2E를 분리한다.

## 변경 요약

**unity-build.yml** — self-hosted에서 도는 작업만 남김:
- `run-e2e-test` → `run-editmode-test`로 rename (이름이 실제 동작과 맞도록)
- `run-benchmark` 제거 (Playwright와 함께 ubuntu로 이동)
- Playwright 관련 단계 5개 삭제 (Setup Node, Install Playwright Deps mac/win, Run E2E mac/win, Upload Benchmark/Playwright Report)
- 110줄 감소

**test-e2e.yml** — Playwright를 ubuntu matrix로 이동:
- 기존 `e2e-test-{macos,windows}` matrix → `build-{macos,windows}` (Unity 빌드만)
- 신규 `e2e-{macos,windows}` matrix on `ubuntu-latest`: artifact 다운로드 → pnpm install → Playwright
- `test-report` / `report-status`가 e2e-* 결과를 OS 결과로 쓰되, test_level≠2로 e2e-*가 skipped면 build-* 결과로 폴백

**release.yml, preview.yml** — 제거된 input 라인 정리.

## 동작 호환성

- ait-build artifact 구성(`dist/`, `*.ait`, `package.json`, `pnpm-lock.yaml`, `granite.config.ts`, `build-validation.json`)은 ubuntu에서 vite preview로 동일하게 동작 (테스트가 Unity binary를 호출하지 않고 vite/preview 서버만 spawn).
- macOS는 `MOBILE_EMULATION=true` 유지, Windows는 desktop chromium 그대로.
- `test_level=0/1` 동작 보존: e2e-* job은 `if: test_level == '2'`로 게이트.

## 예상 효과

- self-hosted runner 점유 매트릭스당 ~60s 단축 (10 × 60s = 누적 10분)
- ubuntu에서 5+5 매트릭스가 즉시 병렬 실행되어 큐 압박 완화
- Phase 2/3와 결합 시 wall clock ~140분 → ~50–60분 목표

## 검증

- 로컬: `./run-local-tests.sh --validate` 통과
- actionlint: 변경 파일 모두 통과 (잔여 shellcheck info는 기존 코드)

## 후속

- **Phase 2**: Unity 버전별 self-hosted runner 라벨 분리 → 큐 대기 50%+ 단축
- **Phase 3**: Library/Bee 캐시 정책 완화 → 빌드당 1–3분 단축

## Test plan

- [ ] PR CI에서 Validate / Lint 통과
- [ ] 수동으로 E2E Tests 워크플로우를 이 PR 번호로 트리거, build-* 5×2 매트릭스가 self-hosted에서 빌드만 수행하는지 확인
- [ ] e2e-* 매트릭스가 ubuntu에서 artifact 다운로드 → Playwright 통과하는지 확인
- [ ] Test Report Summary가 정상 생성되는지 확인