### PR TITLE
개선: Library/Bee 캐시 SDK 변경 시에만 무효화 (Phase 3)

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -151,6 +151,9 @@ jobs:
         with:
           repository: ${{ inputs.repository || github.repository }}
           ref: ${{ inputs.ref || github.ref }}
+          # Bee 캐시 무효화 판정 시 git diff (push event before SHA → HEAD) 가 필요.
+          # 다중 커밋 푸시도 커버하도록 50 depth — diff 실패 시 보수적으로 Bee 삭제.
+          fetch-depth: 50
 
       # =====================================================
       # Runner 진단 (debug-runner 플래그 활성화 시)
@@ -416,31 +419,95 @@ jobs:
             echo "Cleaning Library cache (requested via input)..."
             rm -rf "${PROJECT_PATH}/Library" 2>/dev/null || true
           else
-            echo "Cleaning Bee build cache to prevent stale ref.dll issues..."
-            echo "Removing: ${PROJECT_PATH}/Library/Bee"
-            rm -rf "${PROJECT_PATH}/Library/Bee" 2>/dev/null || true
+            # Bee는 SDK/asmdef/jslib rename 시 stale ref.dll을 캐시한다
+            # → 해당 변경이 있을 때만 Bee 삭제. 그 외엔 증분 빌드 보존.
+            BEFORE_SHA="${{ github.event.before }}"
+            if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+              BEFORE_REF="HEAD~1"
+            else
+              BEFORE_REF="$BEFORE_SHA"
+            fi
+            CHANGED=""
+            if git rev-parse --verify "$BEFORE_REF" >/dev/null 2>&1; then
+              CHANGED=$(git diff --name-only "$BEFORE_REF" HEAD -- \
+                'Runtime/SDK/' '*.asmdef' '*.jslib' 2>/dev/null || echo "__diff_failed__")
+            else
+              CHANGED="__diff_failed__"
+            fi
+            if [ "$CHANGED" = "__diff_failed__" ] || [ -n "$CHANGED" ]; then
+              if [ "$CHANGED" = "__diff_failed__" ]; then
+                echo "Cannot resolve git diff base — wiping Bee conservatively"
+              else
+                echo "SDK/asmdef/jslib changes detected — wiping Bee to prevent stale ref.dll:"
+                echo "$CHANGED" | sed 's/^/  /'
+              fi
+              rm -rf "${PROJECT_PATH}/Library/Bee" 2>/dev/null || true
+            else
+              echo "No SDK/asmdef/jslib changes — preserving Bee for incremental build"
+            fi
           fi
           echo "Done."
 
+      # Windows: shell 의존성을 피하기 위해 node 로 git/diff/rm 를 직접 호출
+      # (위 BuildConfig 스텝의 WSL/Git-bash 이슈 주석 참조)
       - name: Clean Previous Build Artifacts (Windows)
         if: inputs.os == 'windows' && (inputs.test-level || '2') != '0'
-        shell: cmd
+        shell: node {0}
+        env:
+          UNITY_VERSION: ${{ inputs.unity-version }}
+          CLEAN_LIBRARY: ${{ inputs.clean-library }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          @echo off
-          set "PROJECT_PATH=Tests~\E2E\SampleUnityProject-${{ inputs.unity-version }}"
-          set "CLEAN_LIBRARY=${{ inputs.clean-library }}"
-          echo Cleaning previous build artifacts...
-          if exist "%PROJECT_PATH%\ait-build" rmdir /s /q "%PROJECT_PATH%\ait-build"
-          if exist "%PROJECT_PATH%\webgl" rmdir /s /q "%PROJECT_PATH%\webgl"
-          if "%CLEAN_LIBRARY%"=="true" (
-            echo Cleaning Library cache requested via input...
-            if exist "%PROJECT_PATH%\Library" rmdir /s /q "%PROJECT_PATH%\Library"
-          ) else (
-            echo Cleaning Bee build cache to prevent stale ref.dll issues...
-            echo Removing: %PROJECT_PATH%\Library\Bee
-            if exist "%PROJECT_PATH%\Library\Bee" rmdir /s /q "%PROJECT_PATH%\Library\Bee"
-          )
-          echo Done.
+          const fs = require('fs');
+          const path = require('path');
+          const { execFileSync } = require('child_process');
+
+          const projectPath = path.join('Tests~', 'E2E', `SampleUnityProject-${process.env.UNITY_VERSION}`);
+          const rm = (rel) => {
+            const p = path.join(projectPath, rel);
+            if (fs.existsSync(p)) {
+              fs.rmSync(p, { recursive: true, force: true });
+              console.log(`  removed: ${p}`);
+            }
+          };
+
+          console.log('Cleaning previous build artifacts...');
+          rm('ait-build');
+          rm('webgl');
+
+          if (process.env.CLEAN_LIBRARY === 'true') {
+            console.log('Cleaning Library cache (requested via input)...');
+            rm('Library');
+            console.log('Done.');
+            return;
+          }
+
+          let beforeRef = process.env.BEFORE_SHA;
+          if (!beforeRef || /^0+$/.test(beforeRef)) beforeRef = 'HEAD~1';
+
+          let changed = null;
+          let diffFailed = false;
+          try {
+            execFileSync('git', ['rev-parse', '--verify', beforeRef], { stdio: 'ignore' });
+            changed = execFileSync('git', [
+              'diff', '--name-only', beforeRef, 'HEAD', '--',
+              'Runtime/SDK/', '*.asmdef', '*.jslib',
+            ], { encoding: 'utf8' }).trim();
+          } catch {
+            diffFailed = true;
+          }
+
+          if (diffFailed) {
+            console.log('Cannot resolve git diff base — wiping Bee conservatively');
+            rm(path.join('Library', 'Bee'));
+          } else if (changed && changed.length > 0) {
+            console.log('SDK/asmdef/jslib changes detected — wiping Bee to prevent stale ref.dll:');
+            for (const line of changed.split(/\r?\n/)) console.log('  ' + line);
+            rm(path.join('Library', 'Bee'));
+          } else {
+            console.log('No SDK/asmdef/jslib changes — preserving Bee for incremental build');
+          }
+          console.log('Done.');
 
       # =====================================================
       # Unity 설치 감지

--- a/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
+++ b/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
@@ -101,8 +101,8 @@ public class E2EBuildRunner
         // 4. SDK의 빌드 & 패키징 실행
         Debug.Log("[4/5] Building WebGL and packaging with SDK...");
 
-        // Library/Bee/는 CI에서 매 빌드 전 삭제됨 (stale ref.dll 방지)
-        // 로컬 환경에서는 캐시 문제 발생 시 Library/Bee/ 수동 삭제 필요
+        // Library/Bee/는 CI에서 SDK/asmdef/jslib 변경이 감지될 때만 삭제됨 (stale ref.dll 방지)
+        // 로컬 환경에서는 SDK 재생성 후 캐시 문제 발생 시 Library/Bee/ 수동 삭제 필요
         // cleanBuild: false로 설정하여 Unity 측 증분 빌드 캐시 재사용
         // 전체 Library 삭제가 필요한 경우 workflow_dispatch에서 clean_library=true로 실행
         // E2E 테스트에서는 프로덕션 환경을 시뮬레이션하기 위해 productionProfile 사용


### PR DESCRIPTION
## 요약

CI Unity 빌드의 `Library/Bee` 캐시를 항상 삭제하던 동작을 **SDK/asmdef/jslib 변경 시에만 삭제**하도록 변경합니다. SDK 변경이 없는 대부분의 PR에서 Unity 증분 빌드 캐시를 보존해 빌드 시간을 줄입니다.

## 배경

`e15a799` (이후 `de52e2f`로 강화)에서 stale ref.dll 문제 해결을 위해 매 빌드마다 `Library/Bee` 전체를 삭제하기 시작함. 근본 원인은:

- SDK 재생성 시 `Runtime/SDK/`의 `.cs`/`.jslib` 파일이 rename·add·remove 됨
- 예: `cbc8397` (SDK v2.4.5)에서 `AnonKey.jslib` → `AppsInToss-GetAnonymousKey.jslib`
- Unity Bee 빌드는 이전 ref.dll 출력을 캐시에 유지 → 사라진 심볼 참조로 CS0246

하지만 `Runtime/SDK/`를 건드리는 커밋은 드물다 (origin/main 최근 30개 SDK 변경 커밋이 100+ 일에 분산). 매번 풀 빌드는 비대한 비용.

## 변경 내용

### `.github/workflows/unity-build.yml`
- `actions/checkout`에 `fetch-depth: 50` 추가 — 다중 커밋 푸시 diff 확보
- macOS Clean 단계 (bash):
  - `github.event.before..HEAD` 또는 `HEAD~1..HEAD`에서 `Runtime/SDK/`, `*.asmdef`, `*.jslib` 변경 검사
  - 변경 감지 시에만 `Library/Bee` 삭제, 그 외엔 보존
- Windows Clean 단계: 같은 로직을 `node` 로 재구현 (위쪽 BuildConfig 스텝 패턴 참조 — WSL/Git-bash 환경 차이 회피)
- **fallback**: `git diff` 실패 또는 SHA 미해석 시 보수적으로 Bee 삭제 (false negative 방지)
- `clean_library=true` workflow_dispatch escape hatch 그대로 유지

### `Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs`
- 주석을 새 정책에 맞게 갱신

## 안전 장치

| 시나리오 | 동작 |
|---|---|
| SDK/asmdef/jslib 변경 있음 | Bee 삭제 (기존과 동일) |
| 변경 없음 | Bee 보존 (신규 — 시간 절감) |
| `git diff` 실패 (얕은 fetch 등) | Bee 삭제 (보수적) |
| `before` SHA가 0 (PR 첫 푸시) | `HEAD~1` fallback |
| `clean_library=true` 입력 | 전체 Library 삭제 |

## 검증

- `./run-local-tests.sh --validate` ✓ (3/3)
- `actionlint` ✓ (워크플로 문법 OK)

## 테스트 계획

- [ ] CI 트리거 후 Clean 단계 로그에서 "preserving Bee" 또는 "wiping Bee" 분기 확인
- [ ] SDK 변경이 없는 PR에서 Bee 보존 → Unity 빌드 시간 단축 측정
- [ ] SDK 업데이트 PR에서 Bee 삭제 → 기존과 동일한 풀 빌드 동작 확인