### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — cs-warning-user-code

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -142,10 +142,14 @@ namespace AppsInToss.Editor.ErrorTracker
         //   - SDK-D2: [AIT Login][src=AIT_MOCK_OR_TIMEOUT] ...
         //   - SDK-D3: [AIT Login] InitSession failed: FORBIDDEN_ORIGIN
         //   - SDK-CF: [Toss Firebase] 게임로그인 실패: ... (사용자 게임 백엔드 통합 레이어)
+        //   - SDK-PK/PJ/PF/PC/PB/QA/Q9/Q8/Q7/Q6/Q5/Q4: Assets/FTR_AppsInToss/... CS#### 사용자 코드 경고
+        //     (Unity 컴파일러가 사용자 프로젝트 파일 경로 prefix로 출력 — SDK 자체 코드는 Runtime/ 또는 Editor/ 하위)
         private static readonly string[] ExternalAitPrefixes =
         {
             "[AIT Login]",
             "[Toss Firebase]",
+            "Assets\\FTR_AppsInToss\\",
+            "Assets/FTR_AppsInToss/",
         };
 
         #endregion

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -66,17 +66,19 @@ public class IsKnownNonSdkMessageTests
     public void ExternalFtrAppsInTossPath_BackslashPrefix_ReturnsTrue()
     {
         // Sentry SDK-PK/PJ/PF/PC/PB — Windows 경로 변형. 사용자 프로젝트 경로 prefix는
-        // SDK 보호 가드를 우회하여 노이즈로 드롭한다 (CS0414 외 경고에도 동일하게 적용).
+        // ExternalAitPrefixes를 통해 SDK 보호 가드보다 먼저 매칭되어 노이즈로 드롭된다.
+        // CS0414/NonSdkMessagePatterns에 의존하지 않는 입력으로 ExternalAitPrefixes 코드 경로를 직접 검증.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "Assets\\FTR_AppsInToss\\Optimization\\Platform\\PlatformMemoryManager.cs(19,36): warning CS0414: The field 'PlatformMemoryManager.iosMemoryCheckInterval' is assigned but its value is never used"));
+            "Assets\\FTR_AppsInToss\\Optimization\\Platform\\PlatformMemoryManager.cs(19,36): some unrelated diagnostic"));
     }
 
     [Test]
     public void ExternalFtrAppsInTossPath_ForwardSlashPrefix_ReturnsTrue()
     {
-        // Sentry SDK-QA/Q9/Q8/Q7/Q6/Q5/Q4 — POSIX 경로 변형
+        // Sentry SDK-QA/Q9/Q8/Q7/Q6/Q5/Q4 — POSIX 경로 변형. NonSdkMessagePatterns 키워드 없이도
+        // ExternalAitPrefixes만으로 노이즈 분류되어야 함.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "Assets/FTR_AppsInToss/Optimization/Platform/PlatformOptimizer.cs(17,35): warning CS0414: The field 'PlatformOptimizer.disableShadowsOnWebGL' is assigned but its value is never used"));
+            "Assets/FTR_AppsInToss/Optimization/Platform/PlatformOptimizer.cs(17,35): some unrelated diagnostic"));
     }
 
     [Test]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -62,6 +62,41 @@ public class IsKnownNonSdkMessageTests
             "[Toss Firebase] 게임로그인 실패: Object reference not set to an instance of an object"));
     }
 
+    [Test]
+    public void ExternalFtrAppsInTossPath_BackslashPrefix_ReturnsTrue()
+    {
+        // Sentry SDK-PK/PJ/PF/PC/PB — Windows 경로 변형. 사용자 프로젝트 경로 prefix는
+        // SDK 보호 가드를 우회하여 노이즈로 드롭한다 (CS0414 외 경고에도 동일하게 적용).
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\FTR_AppsInToss\\Optimization\\Platform\\PlatformMemoryManager.cs(19,36): warning CS0414: The field 'PlatformMemoryManager.iosMemoryCheckInterval' is assigned but its value is never used"));
+    }
+
+    [Test]
+    public void ExternalFtrAppsInTossPath_ForwardSlashPrefix_ReturnsTrue()
+    {
+        // Sentry SDK-QA/Q9/Q8/Q7/Q6/Q5/Q4 — POSIX 경로 변형
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/FTR_AppsInToss/Optimization/Platform/PlatformOptimizer.cs(17,35): warning CS0414: The field 'PlatformOptimizer.disableShadowsOnWebGL' is assigned but its value is never used"));
+    }
+
+    [Test]
+    public void ExternalFtrAppsInTossPath_WithAitKeyword_StillFiltered()
+    {
+        // ExternalAitPrefixes는 AitKeywords 가드보다 먼저 매칭되어야 한다.
+        // 사용자 코드에 AppsInToss 식별자가 섞여도 FTR_AppsInToss 경로 prefix가 우선해 드롭된다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/FTR_AppsInToss/Foo.cs(1,1): warning CS0123: AppsInToss reference unresolved"));
+    }
+
+    [Test]
+    public void SdkAssetsPath_NotFtrAppsInToss_StillProtected()
+    {
+        // SDK 자체 경로(Runtime/, Editor/) 또는 일반 Assets/ 경로는
+        // FTR_AppsInToss prefix와 무관하므로 SDK 보호 가드가 정상 동작해야 한다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Assets/Other/Foo.cs error: AppsInToss runtime issue"));
+    }
+
     #endregion
 
     #region SDK 보호: AIT 키워드 포함 시 절대 필터링 안 함


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-PK, APPS-IN-TOSS-UNITY-SDK-PJ, APPS-IN-TOSS-UNITY-SDK-PF, APPS-IN-TOSS-UNITY-SDK-PC, APPS-IN-TOSS-UNITY-SDK-PB, APPS-IN-TOSS-UNITY-SDK-QA, APPS-IN-TOSS-UNITY-SDK-Q9, APPS-IN-TOSS-UNITY-SDK-Q8, APPS-IN-TOSS-UNITY-SDK-Q7, APPS-IN-TOSS-UNITY-SDK-Q6, APPS-IN-TOSS-UNITY-SDK-Q5, APPS-IN-TOSS-UNITY-SDK-Q4

## 요약

12건 묶음(`cs-warning-user-code` 카테고리). 사용자 프로젝트 `Assets/FTR_AppsInToss/...` 경로에서 Unity 컴파일러가 출력하는 CS0414(unused field) 등 사용자 코드 경고가 SDK 노이즈로 잡혀 Sentry에 올라오던 패턴.

## 대상 Sentry 이슈 (각 1 event 묶음, 12건)

| ID | 메시지 핵심 |
|---|---|
| APPS-IN-TOSS-UNITY-SDK-PK | `PlatformMemoryManager.iosMemoryCheckInterval` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-PJ | `PlatformOptimizer.useTiledRendering` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-PF | `PlatformOptimizer.enableGPUInstancing` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-PC | `PlatformOptimizer.enableMetalOptimization` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-PB | `PlatformOptimizer.useMetalPerformanceShaders` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-QA | `PlatformOptimizer.disableShadowsOnWebGL` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-Q9 | `PlatformMemoryManager.androidGCInterval` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-Q8 | `PlatformOptimizer.disableShadowsOnLowEnd` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-Q7 | `PlatformOptimizer.adaptiveResolutionAndroid` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-Q6 | `PlatformMemoryManager.androidAdaptiveGC` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-Q5 | `PlatformMemoryManager.androidMemoryGrowthThreshold` CS0414 |
| APPS-IN-TOSS-UNITY-SDK-Q4 | `PlatformMemoryManager.listenLowMemory` CS0414 |

모든 이슈 메시지가 `Assets\FTR_AppsInToss\...` 또는 `Assets/FTR_AppsInToss/...` 경로 prefix를 공유.

## 추출 패턴

`ExternalAitPrefixes`에 두 패턴 추가:

```csharp
"Assets\\FTR_AppsInToss\\",
"Assets/FTR_AppsInToss/",
```

- `ExternalAitPrefixes`는 `AitKeywords` 보호 가드보다 **먼저** 매칭되어 노이즈로 드롭됨 (`IsKnownNonSdkMessage` 내부).
- SDK 코드(`Runtime/`, `Editor/`)에는 `FTR_AppsInToss` 문자열이 출력되지 않음을 grep으로 확인 (주석/문서 참조뿐).
- 기존 `NonSdkMessagePatterns`의 `"warning CS0414"` 매칭과 별개 경로로, CS0414 외 다른 경고에도 동일하게 작동.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `ExternalAitPrefixes` 배열에 2개 prefix 추가 + 주석에 대상 SDK 이슈 ID 기록
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 2개(backslash/forward slash 경로) + AIT 키워드 보호 우선순위 1개 + SDK 자체 경로 보호 negative 1개

## 검증 결과

`./run-local-tests.sh --validate` 통과 (3 passed / 0 failed):
- File Structure 검증
- Playwright 설정 검증
- SDK Generator unit tests (vitest invariants 18 passed)

## 사람 머지 검토 필요

자동 생성 PR입니다. 머지 전에 다음 검토 부탁드립니다:
- 추가된 prefix가 SDK 자체 출력과 충돌하지 않는지 (확인 완료, 위 참조)
- 테스트 케이스가 SDK 보호 가드(AitKeywords) 우회를 합리적인 범위로 유지하는지

Sentry 자동 resolve는 squash 머지 후 PR body의 `Fixes ...` 키워드가 squash commit message로 들어가면서 동작합니다.