### PR TITLE
수정: Unity 라이센스 충돌 방지 — 머신 락 + 호출자 ref-cancel 분리

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -180,8 +180,17 @@ jobs:
     name: Build (${{ matrix.target.os }}, Unity ${{ matrix.target.unity-version }})
     needs: parse-targets
 
+    # ref-cancel: 라이센스 직렬화는 reusable workflow 의 머신 락이 담당,
+    # 호출자에서는 같은 ref + 같은 (os, unity-version) 의 이전 호출만 cancel
+    concurrency:
+      group: preview-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.target.os }}-${{ matrix.target.unity-version }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
+      # max-parallel 미설정: matrix 가 macOS/Windows 를 섞어서 가지므로
+      # OS 간 병렬은 허용 (다른 머신). 같은 OS 내 직렬화는 reusable workflow
+      # 의 unity-machine-${os} concurrency 가 담당.
       matrix:
         target: ${{ fromJson(needs.parse-targets.outputs.targets) }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,8 +341,15 @@ jobs:
     name: AIT 빌드 (macOS)
     needs: [release, regenerate-sdk, prepare-build-matrix]
     if: needs.release.outputs.skip != 'true' && needs.prepare-build-matrix.outputs.skip-build != 'true'
+
+    # ref-cancel: 라이센스 직렬화는 reusable workflow 의 머신 락 담당
+    concurrency:
+      group: release-${{ github.workflow }}-${{ needs.regenerate-sdk.outputs.ref }}-macos-${{ matrix.unity-version }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         unity-version: ${{ fromJSON(needs.prepare-build-matrix.outputs.macos-versions) }}
 
@@ -366,8 +373,14 @@ jobs:
     name: AIT 빌드 (Windows)
     needs: [release, regenerate-sdk, prepare-build-matrix]
     if: needs.release.outputs.skip != 'true' && needs.prepare-build-matrix.outputs.skip-windows != 'true'
+
+    concurrency:
+      group: release-${{ github.workflow }}-${{ needs.regenerate-sdk.outputs.ref }}-windows-${{ matrix.unity-version }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         unity-version: ${{ fromJSON(needs.prepare-build-matrix.outputs.windows-versions) }}
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -209,9 +209,17 @@ jobs:
     name: Build (macOS, Unity ${{ matrix.unity-version }})
     needs: [setup]
 
+    # ref-cancel: 같은 ref(브랜치/태그/PR) + 같은 (os, unity-version) 의 이전
+    # 호출을 cancel. reusable workflow 안의 머신 락(unity-build.yml)이 라이센스
+    # 직렬화를 담당하므로, 여기서는 새 푸시 시 이전 잡 정리만 책임진다.
+    concurrency:
+      group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-macos-${{ matrix.unity-version }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
-      max-parallel: 2
+      # 같은 macOS 머신 락에 어차피 큐잉되므로 동시 dispatch 의미 없음
+      max-parallel: 1
       matrix:
         unity-version: ["2021.3", "2022.3", "6000.0", "6000.2", "6000.3"]
 
@@ -243,8 +251,13 @@ jobs:
     name: Build (Windows, Unity ${{ matrix.unity-version }})
     needs: [setup]
 
+    concurrency:
+      group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-windows-${{ matrix.unity-version }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         unity-version: ["2021.3", "2022.3", "6000.0", "6000.2", "6000.3"]
 

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -103,10 +103,16 @@ jobs:
   build:
     name: Build (${{ inputs.os }}, Unity ${{ inputs.unity-version }})
     runs-on: ${{ inputs.os == 'macos' && fromJSON('["self-hosted", "macOS", "ARM64", "enabled"]') || fromJSON('["self-hosted", "Windows", "X64", "enabled"]') }}
-    timeout-minutes: 60
+    timeout-minutes: 90
+    # 라이센스 충돌 방지: Enterprise 라이센스 1개를 같은 머신(OS당 1대)에서
+    # 여러 Unity 프로세스가 동시 점유하면 실패. 따라서 OS 단위로 머신 락을
+    # 걸어 같은 머신에서 한 번에 한 잡만 Unity 를 띄우도록 직렬화한다.
+    # ref 기반 cancel 은 호출자(test-e2e / preview / release)의 잡 concurrency
+    # 가 담당. 호출자가 cancel 되면 reusable workflow 도 cancel 되어 라이센스
+    # 가 즉시 풀린다.
     concurrency:
-      group: unity-build-${{ inputs.ref || github.sha }}-${{ inputs.os }}-${{ inputs.unity-version }}-${{ inputs.sdk-version-override || 'default' }}
-      cancel-in-progress: true
+      group: unity-machine-${{ inputs.os }}
+      cancel-in-progress: false
 
     outputs:
       artifact-name: ${{ steps.artifact.outputs.name }}


### PR DESCRIPTION
## 요약

Enterprise 라이센스 1개 + macOS/Windows 머신 각 1대 환경에서 같은 머신에 여러 runner service 가 등록되어 있어, GitHub Actions 가 같은 머신의 여러 잡에 동시 dispatch 하면 Unity 프로세스 여러 개가 한 라이센스를 점유하려다 충돌하는 문제를 해결합니다.

## 배경

- 라이센스 점유 단위는 **머신 1대 = Unity 프로세스 1개**
- 현재 워크플로우 매트릭스(`max-parallel: 2`)와 reusable workflow concurrency(`unity-build-{ref}-{os}-{version}-{sdk}`)는 같은 OS 머신의 동시 Unity 실행을 막지 못함
- 결과: `No valid Unity Editor license found` / `Access token is unavailable` / `LicensingClient has failed validation` 등 산발적 실패 → 기존 retry 로직으로 가리고 있었음

## 변경 내용

concurrency 를 **두 층으로 분리**합니다.

### 1) `unity-build.yml` — 머신 락 (라이센스 직렬화)

```yaml
concurrency:
  group: unity-machine-${{ inputs.os }}
  cancel-in-progress: false
```

- 같은 OS 머신에서 한 번에 한 잡만 Unity 를 띄우도록 직렬화
- 다른 워크플로우(test-e2e + preview + release) 가 동시 트리거되어도 안전
- `timeout-minutes: 60 → 90` (큐잉 대기 여유)

### 2) 호출자 — ref-cancel

3개 caller (`test-e2e.yml`, `preview.yml`, `release.yml`) 의 build 잡에 ref 기반 concurrency 추가:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ os }}-${{ matrix.unity-version }}
  cancel-in-progress: true
```

- 새 푸시 시 이전 호출을 cancel → reusable workflow 도 cancel → Unity 종료 → 라이센스 즉시 회수
- `matrix max-parallel: 1` (어차피 머신 락에 큐잉되므로 동시 dispatch 의미 없음)
  - 단, `preview.yml` 은 matrix 가 macOS/Windows 를 섞어서 가지므로 미설정 유지 (OS 간 병렬 보존)

## 작동 원리

| 시나리오 | 동작 |
|---|---|
| 같은 머신에 두 잡 도착 | 머신 락이 큐잉, 한 번에 한 Unity |
| 같은 ref 에 새 푸시 | 호출자 concurrency 가 이전 caller cancel → reusable workflow 도 cancel → 라이센스 풀림 → 새 caller 시작 |
| 다른 워크플로우 동시 발생 | 머신 락이 OS 단위로 직렬화 |
| macOS + Windows 잡 | 다른 머신, 머신 락 그룹이 다르므로 병렬 실행 |

## 트레이드오프

- 같은 OS 매트릭스 5잡(Unity 5버전)이 직렬화 → wall clock 증가. 그러나 라이센스 충돌·재시도 비용을 제거하므로 실제 평균 시간은 비슷하거나 줄어들 것
- macOS-Windows 간은 그대로 병렬 (다른 머신)

## PR 충돌 안내

`test-e2e.yml` 을 함께 수정하는 PR #538 (Phase 1 — Playwright 분리) 이 먼저 머지될 경우, 본 PR 은 `e2e-test-{macos,windows}` → `build-{macos,windows}` 잡 이름 변경에 맞춰 rebase 가 필요합니다.

## 검증

- `./run-local-tests.sh --validate` ✓ (3/3)
- `actionlint` 통과 (워크플로 문법 OK)

## 테스트 계획

- [ ] PR 트리거 후 두 잡(같은 OS) 이 동시에 dispatch 되어도 한 쪽이 큐잉되는지 확인
- [ ] 새 푸시 시 이전 잡 cancel → 라이센스가 즉시 회수되어 새 잡이 진행되는지 확인
- [ ] macOS + Windows 매트릭스가 병렬 실행되는지 확인
- [ ] 라이센스 관련 에러 발생 빈도가 감소하는지 며칠간 모니터링