### PR TITLE
실험: Unity 빌드 매트릭스 5병렬 실행으로 wallclock 단축

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,14 +342,13 @@ jobs:
     needs: [release, regenerate-sdk, prepare-build-matrix]
     if: needs.release.outputs.skip != 'true' && needs.prepare-build-matrix.outputs.skip-build != 'true'
 
-    # ref-cancel: 라이센스 직렬화는 reusable workflow 의 머신 락 담당
+    # ref-cancel: 같은 ref의 이전 호출만 정리. 머신 분배는 GH Actions 자체가 담당.
     concurrency:
       group: release-${{ github.workflow }}-${{ needs.regenerate-sdk.outputs.ref }}-macos-${{ matrix.unity-version }}
       cancel-in-progress: true
 
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         unity-version: ${{ fromJSON(needs.prepare-build-matrix.outputs.macos-versions) }}
 
@@ -380,7 +379,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         unity-version: ${{ fromJSON(needs.prepare-build-matrix.outputs.windows-versions) }}
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -210,16 +210,14 @@ jobs:
     needs: [setup]
 
     # ref-cancel: 같은 ref(브랜치/태그/PR) + 같은 (os, unity-version) 의 이전
-    # 호출을 cancel. reusable workflow 안의 머신 락(unity-build.yml)이 라이센스
-    # 직렬화를 담당하므로, 여기서는 새 푸시 시 이전 잡 정리만 책임진다.
+    # 호출을 cancel. 새 푸시 시 이전 잡 정리만 담당한다.
     concurrency:
       group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-macos-${{ matrix.unity-version }}
       cancel-in-progress: true
 
     strategy:
       fail-fast: false
-      # 같은 macOS 머신 락에 어차피 큐잉되므로 동시 dispatch 의미 없음
-      max-parallel: 1
+      # OS당 enabled 머신 5대(macos-1-1~1-5)에서 매트릭스 5개를 병렬 실행
       matrix:
         unity-version: ["2021.3", "2022.3", "6000.0", "6000.2", "6000.3"]
 
@@ -257,7 +255,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 1
+      # OS당 enabled 머신 5대(windows-1-1~1-5)에서 매트릭스 5개를 병렬 실행
       matrix:
         unity-version: ["2021.3", "2022.3", "6000.0", "6000.2", "6000.3"]
 

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -104,14 +104,18 @@ jobs:
     name: Build (${{ inputs.os }}, Unity ${{ inputs.unity-version }})
     runs-on: ${{ inputs.os == 'macos' && fromJSON('["self-hosted", "macOS", "ARM64", "enabled"]') || fromJSON('["self-hosted", "Windows", "X64", "enabled"]') }}
     timeout-minutes: 90
-    # 라이센스 충돌 방지: Enterprise 라이센스 1개를 같은 머신(OS당 1대)에서
-    # 여러 Unity 프로세스가 동시 점유하면 실패. 따라서 OS 단위로 머신 락을
-    # 걸어 같은 머신에서 한 번에 한 잡만 Unity 를 띄우도록 직렬화한다.
-    # ref 기반 cancel 은 호출자(test-e2e / preview / release)의 잡 concurrency
-    # 가 담당. 호출자가 cancel 되면 reusable workflow 도 cancel 되어 라이센스
-    # 가 즉시 풀린다.
+    # 동시성 정책: 호출자(test-e2e / preview / release)의 잡 concurrency가 ref
+    # 기반 cancel을 담당하므로 reusable workflow는 (os, unity-version) 단위로만
+    # 이중방어 락을 둔다. 같은 매트릭스 잡이 동시에 두 번 dispatch되는 케이스만
+    # 차단하고, 다른 unity-version 잡끼리는 GitHub Actions의 머신 분배(머신 1대
+    # = 잡 1개 정책)에 맡겨 매트릭스 5개가 병렬 실행되도록 한다.
+    #
+    # 라이센스 시트 제약: enterprise 시트 1개지만 실측상 머신별 토큰 캐시로
+    # 동시 활성화가 작동함을 확인 (run #25487498762: macOS / Windows 동시 빌드
+    # 6.4분 동안 충돌 없음). 만약 동시 N잡에서 라이센스 충돌이 재발하면
+    # `unity-machine-${{ inputs.os }}` 로 OS 단위 락을 복원할 것.
     concurrency:
-      group: unity-machine-${{ inputs.os }}
+      group: unity-build-${{ inputs.ref || github.sha }}-${{ inputs.os }}-${{ inputs.unity-version }}-${{ inputs.sdk-version-override || 'default' }}
       cancel-in-progress: false
 
     outputs:


### PR DESCRIPTION
## 배경

#542에서 Enterprise 라이센스 1시트 제약으로 OS당 머신 락(`unity-machine-${os}`)을 도입했지만, 이는 OS당 enabled 머신이 5대로 늘어난 환경에서 idle 자원을 만들어내고 있었다.

run #25487498762에서 **macOS·Windows가 동시 빌드한 6.4분 동안 라이센스 충돌이 없었던 점**을 근거로, 머신별 토큰 캐시가 실제로는 시트 1개여도 동시 활성화를 허용한다고 가정하고 매트릭스 5개를 병렬화한다.

## 변경

- `unity-build.yml`: concurrency를 OS 머신 락에서 `(ref, os, unity-version, sdk)` 키로 환원. 같은 매트릭스 잡이 두 번 dispatch되는 것만 차단하고, 다른 unity-version 잡끼리는 GitHub Actions 머신 분배에 맡긴다.
- `test-e2e.yml`: `build-{macos,windows}`의 `max-parallel: 1` 제거.
- `release.yml`: `build-ait-{macos,windows}`의 `max-parallel: 1` 제거.

호출자 ref-cancel concurrency는 그대로 유지되어 새 푸시 시 이전 잡 정리.

## 인프라 변경 (코드 외)

자체호스팅 runner의 `enabled` 라벨을 OS당 5대 모두에 추가:
- macOS: macos-1-3, macos-1-4, macos-1-5
- Windows: windows-1-3, windows-1-4, windows-1-5

(이전엔 OS당 1-1, 1-2만 활성화)

`gh api repos/.../actions/runners/{id}/labels` POST로 적용 완료. 머지 전에 모든 머신 online 상태 확인됨.

## 예상 효과

| 메트릭 | 이전 | 예상 |
|---|---|---|
| macOS 매트릭스 wallclock | ~32분 (직렬) | **~7분** (병렬) |
| Windows 매트릭스 wallclock | ~41분 (직렬) | **~9분** (병렬) |
| 총 E2E run wallclock | ~112분 | **~20-30분** |

## 롤백 절차

라이센스 충돌이 재발하면:
1. `unity-build.yml`의 concurrency를 `unity-machine-${{ inputs.os }}` 로 복원
2. `test-e2e.yml`/`release.yml`에 `max-parallel: 1` 다시 추가
3. (선택) 새로 추가된 6대 runner의 `enabled` 라벨 제거 — 이는 코드 변경 불필요, gh api로 처리

## 위험 평가

- **라이센스 충돌 재발 위험**: 중간. macOS·Windows 동시 활성화가 작동했다는 점에서 동시 N잡도 작동할 가능성이 높지만, 다른 OS와 같은 OS는 라이센스 토큰 핸들링이 다를 수 있음.
- **충돌 감지**: 빌드 잡이 `Licensing::HandshakeResponse` 에러나 `LicenseClient channel disconnected`로 실패. 빠르게 1-2분 안에 드러남.
- **첫 검증**: PR 머지 후 main에 E2E 트리거하여 매트릭스 5병렬이 라이센스 충돌 없이 통과하는지 관찰.

## 검증

- [x] `./run-local-tests.sh --validate` 통과 (3/3)
- [x] `actionlint` 구조 에러 0건
- [ ] 머지 후 main E2E 트리거 — 매트릭스 5잡 동시 dispatch 확인 + 라이센스 충돌 없음 확인