### PR TITLE
빌드: lockfile 자동 재생성 워크플로 추가

### DIFF
--- a/.github/workflows/regen-lockfiles.yml
+++ b/.github/workflows/regen-lockfiles.yml
@@ -1,0 +1,109 @@
+name: Regenerate Lockfiles
+
+on:
+  schedule:
+    - cron: "0 18 * * 0"
+  workflow_dispatch:
+    inputs:
+      auto_merge:
+        description: "PR 자동 머지 여부"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+jobs:
+  regen:
+    name: Regenerate pnpm lockfiles
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org/"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Force public registry
+        run: |
+          mkdir -p ~/.config/pnpm
+          cat > ~/.npmrc <<'EOF'
+          registry=https://registry.npmjs.org/
+          EOF
+          pnpm config set registry https://registry.npmjs.org/
+
+      - name: Regenerate E2E lockfile
+        working-directory: Tests~/E2E/tests
+        run: |
+          rm -f pnpm-lock.yaml
+          pnpm install --lockfile-only --registry=https://registry.npmjs.org/
+
+      - name: Regenerate BuildConfig lockfile
+        working-directory: WebGLTemplates/AITTemplate/BuildConfig~
+        run: |
+          rm -f pnpm-lock.yaml
+          pnpm install --lockfile-only --registry=https://registry.npmjs.org/
+
+      - name: Verify no internal registry leak
+        run: |
+          set -e
+          BAD=0
+          for f in Tests~/E2E/tests/pnpm-lock.yaml WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml; do
+            if grep -q "nexus.toss.bz\|toss.bz" "$f"; then
+              echo "::error file=$f::Internal registry URL detected in regenerated lockfile"
+              grep -nE "nexus.toss.bz|toss.bz" "$f" | head -5
+              BAD=1
+            fi
+          done
+          if [ "$BAD" = "1" ]; then exit 1; fi
+          echo "lockfiles clean"
+
+      - name: Open PR if changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTO_MERGE: ${{ inputs.auto_merge || 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Tests~/E2E/tests/pnpm-lock.yaml WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml
+          if git diff --staged --quiet; then
+            echo "lockfiles unchanged"
+            exit 0
+          fi
+          BRANCH="chore/regen-lockfiles-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git commit -m "빌드: pnpm lockfile 자동 재생성 (public registry)"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "빌드: pnpm lockfile 자동 재생성" \
+            --body "주기적 lockfile 재생성 — public registry(npmjs.org) 기반으로 새로 만들어 내부 nexus 레지스트리 URL 누출을 방지합니다." \
+            --base main \
+            --head "$BRANCH"
+          if [ "$AUTO_MERGE" != "true" ]; then
+            echo "auto_merge=false — PR open 상태로 둠"
+            exit 0
+          fi
+          MERGED=false
+          for attempt in 1 2 3; do
+            sleep 5
+            echo "머지 시도 ${attempt}/3..."
+            if gh pr merge --squash --delete-branch; then
+              MERGED=true
+              break
+            fi
+          done
+          if [ "$MERGED" != "true" ]; then
+            echo "::warning::자동 머지 실패 — PR 수동 머지 필요"
+          fi

--- a/.github/workflows/regen-lockfiles.yml
+++ b/.github/workflows/regen-lockfiles.yml
@@ -56,11 +56,17 @@ jobs:
           rm -f pnpm-lock.yaml
           pnpm install --lockfile-only --registry=https://registry.npmjs.org/
 
+      - name: Regenerate SDK Generator lockfile
+        working-directory: sdk-runtime-generator~
+        run: |
+          rm -f pnpm-lock.yaml
+          pnpm install --lockfile-only --registry=https://registry.npmjs.org/
+
       - name: Verify no internal registry leak
         run: |
           set -e
           BAD=0
-          for f in Tests~/E2E/tests/pnpm-lock.yaml WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml; do
+          for f in Tests~/E2E/tests/pnpm-lock.yaml WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml sdk-runtime-generator~/pnpm-lock.yaml; do
             if grep -q "nexus.toss.bz\|toss.bz" "$f"; then
               echo "::error file=$f::Internal registry URL detected in regenerated lockfile"
               grep -nE "nexus.toss.bz|toss.bz" "$f" | head -5
@@ -77,7 +83,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Tests~/E2E/tests/pnpm-lock.yaml WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml
+          git add Tests~/E2E/tests/pnpm-lock.yaml WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml sdk-runtime-generator~/pnpm-lock.yaml
           if git diff --staged --quiet; then
             echo "lockfiles unchanged"
             exit 0
@@ -95,15 +101,8 @@ jobs:
             echo "auto_merge=false — PR open 상태로 둠"
             exit 0
           fi
-          MERGED=false
-          for attempt in 1 2 3; do
-            sleep 5
-            echo "머지 시도 ${attempt}/3..."
-            if gh pr merge --squash --delete-branch; then
-              MERGED=true
-              break
-            fi
-          done
-          if [ "$MERGED" != "true" ]; then
-            echo "::warning::자동 머지 실패 — PR 수동 머지 필요"
+          # --auto: required check 통과 후 자동 squash merge 예약
+          # check 대기 없이 즉시 머지하면 lint/validate가 pending인 상태로 main에 들어갈 수 있어 위험
+          if ! gh pr merge --squash --delete-branch --auto; then
+            echo "::warning::auto-merge 예약 실패 — PR 수동 머지 필요"
           fi


### PR DESCRIPTION
## Summary

- 매주 일요일 03:00 KST에 다음 3개 lockfile을 public npm registry 기준으로 재생성:
  - `Tests~/E2E/tests/pnpm-lock.yaml`
  - `WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml`
  - `sdk-runtime-generator~/pnpm-lock.yaml`
- 결과 변경분만 PR로 자동 제출
- **기본값 `auto_merge=true`**: `gh pr merge --squash --delete-branch --auto`로 GitHub auto-merge 예약 → required check(lint/validate) 통과 후 자동 squash merge (`auto_merge=false`로 옵션 끌 수 있음)
- 재생성 시 `REDACTED` 누출 가드 단계 포함 — 내부 URL이 검출되면 워크플로 실패

## Why

PR #543 머지 시 lockfile에 toss 내부 nexus 레지스트리 URL이 89개 박혀있던 사건 재발 방지. 로컬에서 toss network 환경으로 lockfile을 만들면 nexus URL이 박히는데, ubuntu github-hosted runner에서는 public registry로만 접근하므로 깨끗한 lockfile을 보장한다.

`sdk-runtime-generator~/pnpm-lock.yaml`도 현재 nexus URL이 342개 누출된 상태이므로 동일 정책 적용 필요.

## Test plan

- [ ] PR 머지 후 `Actions → Regenerate Lockfiles → Run workflow`로 수동 실행, 결과 PR 확인
- [ ] 자동 머지가 required check 통과 후에만 트리거되는지 확인 (즉시 머지되지 않음)
- [ ] 다음 일요일 정기 실행 후 PR 자동 생성/머지 확인