### PR TITLE
수정: WebGLTemplateMismatchWarningTests를 Debug.Log 강등 코드에 맞춤

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/WebGLTemplateMismatchWarningTests.cs
@@ -1,21 +1,28 @@
 // -----------------------------------------------------------------------
 // WebGLTemplateMismatchWarningTests.cs
-// Sentry APPS-IN-TOSS-UNITY-SDK-R9 회귀 가드.
+// Sentry APPS-IN-TOSS-UNITY-SDK-R9 / R8 회귀 가드.
 //
-// `webglPath/Runtime` 폴더가 없을 때 WebGLBuildCopier가 출력하는 두 줄의
-// 진단 경고는 "사용자가 AITTemplate 외 템플릿으로 빌드한 경우"의 폴백 경로
+// `webglPath/Runtime` 폴더가 없을 때 WebGLBuildCopier가 출력하는 진단
+// 메시지는 "사용자가 AITTemplate 외 템플릿으로 빌드한 경우"의 폴백 경로
 // 알림이지 SDK 결함이 아니다. 따라서 콘솔에는 남기되 Sentry로는 캡처되지
-// 않아야 한다 — 즉 `Debug.LogWarning`이 아니라 `AITLog.Warning(..., sentryCapture: false)`
-// 호출이어야 한다.
+// 않아야 한다.
 //
-// 이 테스트는 `WebGLBuildCopier.cs` 소스를 읽어 그 두 줄이 회귀하지 않도록
-// 텍스트 수준에서 가드한다 — `CopyWebGLToPublic`을 통째로 호출하면
-// AITPackagePathResolver, AITTemplateManager, BuildMarker 등 의존 그래프가
-// 너무 커서 EditMode 단위 테스트로 격리하기 어렵다.
+// 허용 형태:
+//   - `Debug.Log(...)` (LogWarning이 아니므로 ErrorTracker가 Sentry로 보내지 않음)
+//   - `AITLog.Warning(..., sentryCapture: false)` (명시적 노이즈 차단)
 //
-// 제약: 검증은 라인 단위로 수행하므로 두 경고 호출은 **단일 라인**에
-// `AITLog.Warning(..., sentryCapture: false)` 형태를 유지해야 한다.
-// named argument를 다음 줄로 줄바꿈하면 false negative가 발생한다.
+// 금지 형태:
+//   - `Debug.LogWarning(...)` 직접 호출 — Sentry로 캡처되어 노이즈 발생
+//   - `AITLog.Warning(..., sentryCapture: true)` 또는 sentryCapture 기본값 호출
+//
+// 이 테스트는 `WebGLBuildCopier.cs` 소스를 읽어 회귀를 텍스트 수준에서
+// 가드한다 — `CopyWebGLToPublic`을 통째로 호출하면 AITPackagePathResolver,
+// AITTemplateManager, BuildMarker 등 의존 그래프가 너무 커서 EditMode
+// 단위 테스트로 격리하기 어렵다.
+//
+// 제약: 검증은 라인 단위로 수행하므로 메시지가 포함된 호출은 **단일
+// 라인**에 위 허용 형태 중 하나로 유지해야 한다. named argument를 다음
+// 줄로 줄바꿈하면 false negative가 발생한다.
 // -----------------------------------------------------------------------
 
 using System.IO;
@@ -27,31 +34,45 @@ using AppsInToss.Editor;
 [Category("Unit")]
 public class WebGLTemplateMismatchWarningTests
 {
-    private const string WarningMessage1Substring = "WebGL 빌드에 Runtime 폴더가 없습니다";
-    private const string WarningMessage2Substring = "AITTemplate이 아닌 다른 템플릿으로 빌드되었을 수 있습니다";
+    private const string TemplateMismatchMessageSubstring = "WebGL 빌드에 Runtime 폴더가 없";
 
     [Test]
-    public void TemplateMismatchWarnings_AreSuppressedFromSentry()
+    public void TemplateMismatchWarning_IsSuppressedFromSentry()
     {
         string source = ReadCopierSource();
 
-        AssertWarningSentryCaptureFalse(source, WarningMessage1Substring);
-        AssertWarningSentryCaptureFalse(source, WarningMessage2Substring);
+        bool foundCorrect = false;
+        foreach (string line in source.Split('\n'))
+        {
+            if (!line.Contains(TemplateMismatchMessageSubstring)) continue;
+
+            // 허용 형태 1: Debug.Log (LogWarning 아님 → ErrorTracker가 Sentry로 송신 안 함)
+            // 허용 형태 2: AITLog.Warning(..., sentryCapture: false) (명시적 노이즈 차단)
+            bool isPlainDebugLog = line.Contains("Debug.Log(") && !line.Contains("Debug.LogWarning");
+            bool isSuppressedAitLog = line.Contains("AITLog.Warning") && line.Contains("sentryCapture: false");
+            if (isPlainDebugLog || isSuppressedAitLog)
+            {
+                foundCorrect = true;
+                break;
+            }
+        }
+
+        Assert.IsTrue(
+            foundCorrect,
+            $"\"{TemplateMismatchMessageSubstring}...\" 메시지는 Debug.Log 또는 AITLog.Warning(..., sentryCapture: false) 로 호출되어야 합니다. " +
+            "Debug.LogWarning이나 sentryCapture: true 로의 회귀가 발생하면 Sentry APPS-IN-TOSS-UNITY-SDK-R8/R9 노이즈가 다시 잡힙니다.");
     }
 
     [Test]
-    public void TemplateMismatchWarnings_DoNotUseRawDebugLogWarning()
+    public void TemplateMismatchWarning_DoesNotUseRawDebugLogWarning()
     {
         // Debug.LogWarning은 ErrorTracker 로그 핸들러를 그대로 통과해 Sentry로
-        // 캡처된다. 이 두 메시지에 대해서는 절대 Debug.LogWarning을 직접 호출하면 안 된다.
+        // 캡처된다. 이 메시지에 대해서는 절대 Debug.LogWarning을 직접 호출하면 안 된다.
         string source = ReadCopierSource();
 
         Assert.IsFalse(
-            ContainsLineWith(source, "Debug.LogWarning", WarningMessage1Substring),
-            $"Debug.LogWarning(...\"{WarningMessage1Substring}...\") 직접 호출 금지 — Sentry 노이즈 발생.");
-        Assert.IsFalse(
-            ContainsLineWith(source, "Debug.LogWarning", WarningMessage2Substring),
-            $"Debug.LogWarning(...\"{WarningMessage2Substring}...\") 직접 호출 금지 — Sentry 노이즈 발생.");
+            ContainsLineWith(source, "Debug.LogWarning", TemplateMismatchMessageSubstring),
+            $"Debug.LogWarning(...\"{TemplateMismatchMessageSubstring}...\") 직접 호출 금지 — Sentry 노이즈 발생.");
     }
 
     private static string ReadCopierSource()
@@ -74,26 +95,5 @@ public class WebGLTemplateMismatchWarningTests
                 return true;
         }
         return false;
-    }
-
-    private static void AssertWarningSentryCaptureFalse(string source, string messageSubstring)
-    {
-        bool foundCorrect = false;
-        foreach (string line in source.Split('\n'))
-        {
-            if (!line.Contains(messageSubstring)) continue;
-
-            // 메시지를 담는 호출 라인은 AITLog.Warning이고 sentryCapture: false 여야 한다.
-            if (line.Contains("AITLog.Warning") && line.Contains("sentryCapture: false"))
-            {
-                foundCorrect = true;
-                break;
-            }
-        }
-
-        Assert.IsTrue(
-            foundCorrect,
-            $"\"{messageSubstring}\" 경고는 AITLog.Warning(..., sentryCapture: false) 로 호출되어야 합니다. " +
-            "Debug.LogWarning이나 sentryCapture: true 로의 회귀가 발생하면 Sentry APPS-IN-TOSS-UNITY-SDK-R9 노이즈가 다시 잡힙니다.");
     }
 }


### PR DESCRIPTION
## Summary

- PR #535이 Runtime 폴더 폴백 경고를 `Debug.LogWarning` → 단일 `Debug.Log`로 강등했으나, PR #517에서 추가된 회귀 가드(`WebGLTemplateMismatchWarningTests`)가 여전히 `AITLog.Warning(..., sentryCapture: false)` 두 줄짜리 옛 형태만 통과시킴 → main에서 EditMode 일관 실패
- 테스트가 두 가지 허용 형태(`Debug.Log` 또는 `AITLog.Warning(..., sentryCapture: false)`)를 모두 받도록 수정. `Debug.LogWarning` 직접 호출 금지(=Sentry R8/R9 노이즈 가드)는 유지
- 메시지 substring을 두 개 → 현재 합쳐진 단일 라인에 맞는 하나로 정리

## Why

[Run 25497063584](https://github.com/toss/apps-in-toss-unity-sdk/actions/runs/25497063584)에서 macOS+Windows 10잡 모두 동일 EditMode 회귀로 실패. 라이센스/lockfile/병렬 매트릭스와 무관한 코드/테스트 mismatch.

## Test plan

- [x] `./run-local-tests.sh --validate` 통과 (vitest invariants + SDK 유닛 테스트)
- [ ] PR 머지 후 E2E 워크플로 재트리거하여 EditMode 통과 + Phase 1 5병렬 매트릭스 검증