### PR TITLE
수정: ait-build artifact에 dev server 필수 파일 포함

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1718,6 +1718,8 @@ jobs:
           name: ${{ steps.artifact.outputs.name }}
           path: |
             Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/ait-build/dist/
+            Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/ait-build/public/
+            Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/ait-build/index.html
             Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/ait-build/*.ait
             Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/ait-build/package.json
             Tests~/E2E/SampleUnityProject-${{ inputs.unity-version }}/ait-build/pnpm-lock.yaml


### PR DESCRIPTION
## Summary

E2E 잡 분리(병렬화) 후 모든 macOS/Windows 매트릭스 10개 잡에서 Test 2 "AIT dev server should start and load Unity"가 **deterministic ~21초만에 fail**. 후속 retry/spawn cascade로 worker SIGKILL → 전체 E2E 실패.

## Root Cause

성공·실패 run 비교를 통해 확인:
- 마지막 성공: run #25439211975 @ `c71af9a` — Test 2 = **1.9s PASS**
- 첫 실패: run #25440535850 @ **같은 커밋** `c71af9a` — Test 2 = **~21s FAIL**

차이는 **잡 구조**. 성공 시기는 단일 잡(`Build / E2E` 결합)이라 `ait-build/` 디렉토리가 그대로 보였지만, 분리 후에는 `actions/upload-artifact`의 path 패턴이 dev server에 필요한 파일들을 누락:

| 파일 | dev에 필요 | 기존 upload | dev 동작 |
|---|---|---|---|
| `dist/` | ❌ (preview만) | ✅ | preview Test 3-7 정상 |
| `index.html` (root) | ✅ Vite root | ❌ | **HEAD `/` 200 안 줌** → polling 실패 |
| `public/Build,Runtime,TemplateData` | ✅ Unity loader | ❌ | dev mode loader 자원 없음 |

`vite ready in 197ms`은 vite 자체는 시작했지만 root entry가 없어 Test 2의 `fetch(HEAD /).ok` 30회 polling이 모두 false → throw → retry → 다음 spec까지 cascading SIGKILL.

## Fix

`unity-build.yml` artifact upload path에 누락된 파일 추가:
- `ait-build/index.html` (Vite root entry)
- `ait-build/public/` (Unity loader가 참조하는 Build/Runtime/TemplateData)

## Test plan

- [ ] PR push 후 자동 트리거되는 E2E run에서 Test 2가 PASS하는지 확인
- [ ] 후속 worker SIGKILL이 함께 사라지는지 확인 (root cause만 해결하면 cascade도 자동 해소될 것)
- [ ] artifact 크기 증가 폭이 합리적인지 (public/ 추가로 build artifact 약 50~60MB → 60~70MB 예상)