### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — worker-import-error (x3)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -119,6 +119,12 @@ namespace AppsInToss.Editor.ErrorTracker
             // 사용자 Unity 설치에 WebGL 모듈 미설치 — SDK-DD
             "Build target 'WebGL' not supported",
 
+            // Unity AssetImporter 내부 워커 에러 — SDK 외부 출처
+            // 예: "[Worker2] Import Error Code:(4)", "[Worker3] Import Error Code:(4)", "[Worker4] Import Error Code:(4)"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-RC, APPS-IN-TOSS-UNITY-SDK-RD, APPS-IN-TOSS-UNITY-SDK-RE
+            // 워커 번호와 코드 숫자가 가변이지만 "] Import Error Code:(" 부분 문자열로 모두 매칭됨
+            "] Import Error Code:(",
+
             // 서브프로세스 실행 브레드크럼 — SDK가 아닌 외부(Unity Collab/CCD/사용자 도구)가 출력
             // 예: "Exec> git show -s --pretty=%D HEAD", "Exec> git log -1 --pretty=format:%h"
             // Sentry APPS-IN-TOSS-UNITY-SDK-NX, APPS-IN-TOSS-UNITY-SDK-NW

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -651,6 +651,31 @@ public class IsKnownNonSdkMessageTests
             "[AIT] Addressable content build failure (duration : 0:00:16.61)"));
     }
 
+    [TestCase(
+        "[Worker2] Import Error Code:(4)",
+        TestName = "WorkerImportError_Worker2_ReturnsTrue")]
+    [TestCase(
+        "[Worker3] Import Error Code:(4)",
+        TestName = "WorkerImportError_Worker3_ReturnsTrue")]
+    [TestCase(
+        "[Worker4] Import Error Code:(4)",
+        TestName = "WorkerImportError_Worker4_ReturnsTrue")]
+    public void WorkerImportError_RealisticVariants_ReturnsTrue(string message)
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-RC/RD/RE — Unity AssetImporter 내부 워커 에러.
+        // 워커 번호(2/3/4)가 가변이지만 "] Import Error Code:(" 부분 문자열로 모두 매칭.
+        // SDK 코드에는 "Worker"/"Import Error Code" 문자열이 존재하지 않음 (grep으로 확인).
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(message));
+    }
+
+    [Test]
+    public void WorkerImportError_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙으면 SDK 자체 로그로 간주되어 필터링되지 않아야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] [Worker2] Import Error Code:(4)"));
+    }
+
     #endregion
 
     #region SDK 관련 메시지는 통과 (negative cases)


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-RE
Fixes APPS-IN-TOSS-UNITY-SDK-RD
Fixes APPS-IN-TOSS-UNITY-SDK-RC

## 묶음 항목 (auto-resolve box: worker-import-error, N=3)

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-RE | UnityWarning: [Worker4] Import Error Code:(4) |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-RD | UnityWarning: [Worker2] Import Error Code:(4) |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-RC | UnityWarning: [Worker3] Import Error Code:(4) |

세 항목 모두 `[Worker<N>] Import Error Code:(<N>)` 형태의 Unity AssetImporter 내부 워커 에러로 SDK 외부 출처입니다.

## 추출 패턴

워커 번호와 에러 코드 숫자가 가변이므로 공통 부분 문자열 한 개로 일반화:

```
"] Import Error Code:("
```

세 항목 (`[Worker2]`, `[Worker3]`, `[Worker4]`) 모두 이 부분 문자열을 포함하므로 단일 substring 매칭으로 커버됩니다. `IndexOf` 기반 매칭 정책에 맞춰 정규식 대신 부분 문자열로 등록.

### 안전성

- SDK 코드(`Editor/`, `Runtime/`, `Tests~/`)에 `Worker` / `Import Error Code` 문자열이 출력되지 않음을 grep으로 확인
- `AitKeywords` 보호 가드는 그대로 유지되므로 `[AIT] [Worker2] Import Error Code:(4)` 형태의 SDK 자체 출력은 필터링되지 않음 (negative 테스트로 회귀 방지)

## 추가 위치

1. `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열에 패턴 1개 추가
2. `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`:
   - positive 테스트 3개 (`[TestCase]` 파라미터화) — `[Worker2/3/4] Import Error Code:(4)`
   - AIT prefix 보호 negative 테스트 1개

## 검증 결과

`./run-local-tests.sh --validate` 통과 (exit 0):
- E2E Test Files Validation ✓
- Playwright Config Validation ✓
- SDK Generator Unit Tests ✓ (18 tests passed)

## 머지 주의

**사람 머지 검토 필요** — auto-resolve worker가 자동 생성한 PR입니다. 추가된 패턴이 SDK가 출력하는 다른 정상 로그를 의도치 않게 필터링하지 않는지 리뷰 부탁드립니다.

squash merge 후 본문의 `Fixes APPS-IN-TOSS-UNITY-SDK-{RE,RD,RC}` 키워드로 Sentry 이슈 3개가 자동 resolve됩니다.