### PR TITLE
개선: E2E 빌드 Gzip 전환으로 self-hosted runner 점유 단축

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1341,6 +1341,11 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
+          # E2E 한정: Brotli(q11) 대신 Gzip으로 빌드 — wasm.unityweb 단일 파일 압축이
+          # Brotli q11에서 ~109s 직렬 병목이라 self-hosted runner 점유를 크게 늘린다.
+          # Gzip은 ~3s 수준이라 Build wallclock을 대폭 단축. 파일 크기는 +63%이지만
+          # E2E 아티팩트는 테스트용일 뿐 배포되지 않으므로 무관.
+          AIT_COMPRESSION_FORMAT: "1"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30
@@ -1479,6 +1484,8 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
+          # E2E 한정: Brotli(q11) 대신 Gzip으로 빌드 — macOS step의 동일 주석 참조.
+          AIT_COMPRESSION_FORMAT: "1"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30


### PR DESCRIPTION
## Summary

- Unity Brotli q11 단일 파일 직렬 병목(wasm.unityweb ~109초)을 회피하기 위해 E2E CI 빌드만 Gzip으로 전환
- 이미 구현된 `AIT_COMPRESSION_FORMAT` 환경변수 활용 — 사용자 PlayerSettings는 그대로
- 예상 wallclock 절감 ~150초 (Build job 전체 Brotli 단계 ~160초 → ~10초)

## 측정 근거 (M4 Max 로컬, 93MB raw wasm)

| 압축 | 시간 | 출력 크기 | vs raw |
|------|------|----------|--------|
| Brotli q11 (Unity 기본) | 250s | 9.69 MB | 10.4% |
| Brotli q9 | 8.5s | 11.62 MB | 12.5% |
| Gzip -6 | 2.9s | 15.83 MB | 17.0% |

CI 로그(unity-build-6000.2.log)에서 wasm.unityweb 단일 파일이 109초 직렬 병목으로 확인됨.

## 왜 q9가 아니라 Gzip인가

Unity는 Brotli quality를 공개 API로 노출하지 않는다. q9 강제 적용은 PostBuild 재압축이 유일한데, Unity의 q11 압축이 이미 끝난 뒤라 시간 절감 효과가 없다. Unity 내부 압축을 회피(compressionFormat=Disabled)한 뒤 PostBuild에서 q9로 재압축하는 우회는 loader.js 호환성 검증 등 변경 면적이 크다. Gzip 전환은 환경변수 한 줄로 거의 동일한 절감을 즉시 얻는다.

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E 워크플로우 통과 (이 PR이 트리거)
- [x] `BuildOutputValidator.cs`가 `.gz` 파일을 gzip으로 인식하는지 코드 확인
- [x] vite plugin이 `.gz` 확장자에 Content-Encoding: gzip 헤더 설정하는지 확인 (`vite.config.ts:82-88`)
- [x] MAX_BUILD_SIZE_MB=50 한도 내 (Gzip 환산 ~41MB)
- [x] production 빌드/release/preview 워크플로우 영향 없음

## 호환성

- `run-local-tests.sh --compression brotli` 시나리오 보존 — 워크플로우 하드코딩과 독립적으로 인자 처리
- Production 빌드(release/preview/bulk-release)는 사용자 PlayerSettings 따라 Brotli 유지