### PR TITLE
개선: E2E 빌드를 Development Build로 전환해 Link_WebGL_wasm 단계 단축

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -338,6 +338,9 @@ jobs:
         working-directory: Tests~/E2E/tests
         env:
           UNITY_PROJECT_PATH: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}
+          # E2E 빌드와 동일한 값으로 전파 — test가 isDevBuild/expectedFormat을 분기.
+          AIT_DEVELOPMENT_BUILD: "true"
+          AIT_COMPRESSION_FORMAT: "0"
         run: pnpm test
 
       - name: Upload Benchmark Results
@@ -412,6 +415,9 @@ jobs:
         working-directory: Tests~/E2E/tests
         env:
           UNITY_PROJECT_PATH: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}
+          # E2E 빌드와 동일한 값으로 전파 — test가 isDevBuild/expectedFormat을 분기.
+          AIT_DEVELOPMENT_BUILD: "true"
+          AIT_COMPRESSION_FORMAT: "0"
         run: pnpm test
 
       - name: Upload Benchmark Results

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1341,11 +1341,13 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: Brotli(q11) 대신 Gzip으로 빌드 — wasm.unityweb 단일 파일 압축이
-          # Brotli q11에서 ~109s 직렬 병목이라 self-hosted runner 점유를 크게 늘린다.
-          # Gzip은 ~3s 수준이라 Build wallclock을 대폭 단축. 파일 크기는 +63%이지만
-          # E2E 아티팩트는 테스트용일 뿐 배포되지 않으므로 무관.
+          # E2E 한정: Brotli(q11) 대신 Gzip으로 빌드.
           AIT_COMPRESSION_FORMAT: "1"
+          # E2E 한정: Development Build 활성화 — Link_WebGL_wasm 단계가 단독 실행
+          # critical path에서 ~163s를 차지(Emscripten 옵티마이저 -O3 풀스피드).
+          # Development Build로 옵티마이저 단축, Build wallclock 대폭 절감 기대.
+          # E2E는 SDK API 동작만 검증하며 런타임 성능을 보지 않으므로 무관.
+          AIT_DEVELOPMENT_BUILD: "true"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30
@@ -1484,8 +1486,9 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: Brotli(q11) 대신 Gzip으로 빌드 — macOS step의 동일 주석 참조.
+          # E2E 한정: macOS step의 동일 주석 참조.
           AIT_COMPRESSION_FORMAT: "1"
+          AIT_DEVELOPMENT_BUILD: "true"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1341,8 +1341,10 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: Brotli(q11) 대신 Gzip으로 빌드.
-          AIT_COMPRESSION_FORMAT: "1"
+          # E2E 한정: 압축 비활성화. E2E는 vite dev/preview 서버에서만 로드되며
+          # 배포되지 않으므로 압축이 불필요. Brotli/Gzip 단계 자체를 건너뛰어
+          # wallclock 절감(~120s).
+          AIT_COMPRESSION_FORMAT: "0"
           # E2E 한정: Development Build 활성화 — Link_WebGL_wasm 단계가 단독 실행
           # critical path에서 ~163s를 차지(Emscripten 옵티마이저 -O3 풀스피드).
           # Development Build로 옵티마이저 단축, Build wallclock 대폭 절감 기대.
@@ -1487,7 +1489,7 @@ jobs:
         env:
           AIT_DEBUG_CONSOLE: "true"
           # E2E 한정: macOS step의 동일 주석 참조.
-          AIT_COMPRESSION_FORMAT: "1"
+          AIT_COMPRESSION_FORMAT: "0"
           AIT_DEVELOPMENT_BUILD: "true"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -288,9 +288,10 @@ namespace AppsInToss.Editor
             // 환경 변수 읽기
             string debugConsoleEnv = System.Environment.GetEnvironmentVariable("AIT_DEBUG_CONSOLE");
             string compressionFormatEnv = System.Environment.GetEnvironmentVariable("AIT_COMPRESSION_FORMAT");
+            string developmentBuildEnv = System.Environment.GetEnvironmentVariable("AIT_DEVELOPMENT_BUILD");
 
             // 오버라이드할 항목이 없으면 원본 반환
-            if (string.IsNullOrEmpty(debugConsoleEnv) && string.IsNullOrEmpty(compressionFormatEnv))
+            if (string.IsNullOrEmpty(debugConsoleEnv) && string.IsNullOrEmpty(compressionFormatEnv) && string.IsNullOrEmpty(developmentBuildEnv))
                 return profile;
 
             // 복사본 생성 (새 필드 추가 시 누락 방지)
@@ -322,6 +323,21 @@ namespace AppsInToss.Editor
                 else
                 {
                     Debug.LogWarning($"[AIT] AIT_COMPRESSION_FORMAT 환경 변수 값이 올바르지 않습니다: '{compressionFormatEnv}' (-1/0/1/2 필요)");
+                }
+            }
+
+            // AIT_DEVELOPMENT_BUILD 오버라이드
+            // E2E CI에서 Emscripten 옵티마이저 단축으로 Link_WebGL_wasm 단계 시간 절감 목적.
+            if (!string.IsNullOrEmpty(developmentBuildEnv))
+            {
+                if (bool.TryParse(developmentBuildEnv, out bool developmentBuild))
+                {
+                    overriddenProfile.developmentBuild = developmentBuild;
+                    Debug.Log($"[AIT] 환경 변수 오버라이드: AIT_DEVELOPMENT_BUILD={developmentBuild}");
+                }
+                else
+                {
+                    Debug.LogWarning($"[AIT] AIT_DEVELOPMENT_BUILD 환경 변수 값이 올바르지 않습니다: '{developmentBuildEnv}' (true/false 필요)");
                 }
             }
 

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -480,11 +480,10 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
         validation.warnings.forEach(w => console.log(`     ⚠️ ${w}`));
       }
 
-      const expectedCompressionFormat = process.env.AIT_COMPRESSION_FORMAT === '0'
-        ? 'disabled'
-        : process.env.AIT_COMPRESSION_FORMAT === '1'
-          ? 'gzip'
-          : 'brotli';
+      // AIT_COMPRESSION_FORMAT 매핑: 0=disabled, 1=gzip, 2=brotli, -1=auto(brotli),
+      // 미설정 시 사용자 PlayerSettings 따름 — null로 기록.
+      const compressionFormatEnvMap = { '0': 'disabled', '1': 'gzip', '2': 'brotli', '-1': 'brotli' };
+      const expectedCompressionFormat = compressionFormatEnvMap[process.env.AIT_COMPRESSION_FORMAT] ?? null;
 
       testResults.tests['1_build_validation'] = {
         passed: validation.passed,

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -72,12 +72,16 @@ const AIT_BUILD = path.resolve(SAMPLE_PROJECT, 'ait-build');
 const DIST_WEB = path.resolve(AIT_BUILD, 'dist/web');
 
 // 벤치마크 기준
+// MAX_BUILD_SIZE_MB가 80인 이유: E2E CI는 AIT_DEVELOPMENT_BUILD=true로 빌드하여
+// Emscripten 옵티마이저를 줄여 Link_WebGL_wasm 단계 시간을 단축한다(unity-build.yml 참조).
+// Development Build는 wasm 크기가 Release 대비 2-3배 커지므로 한도 상향 필요.
+// 배포 빌드에는 영향 없음 (production 워크플로우는 사용자 PlayerSettings 따름).
 const BENCHMARKS = isMobileEmulation ? {
   MAX_LOAD_TIME_MS: 30000,
-  MAX_BUILD_SIZE_MB: 50,
+  MAX_BUILD_SIZE_MB: 80,
 } : {
   MAX_LOAD_TIME_MS: 10000,
-  MAX_BUILD_SIZE_MB: 50,
+  MAX_BUILD_SIZE_MB: 80,
 };
 
 // 결과 저장용

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -72,16 +72,17 @@ const AIT_BUILD = path.resolve(SAMPLE_PROJECT, 'ait-build');
 const DIST_WEB = path.resolve(AIT_BUILD, 'dist/web');
 
 // 벤치마크 기준
-// MAX_BUILD_SIZE_MB가 80인 이유: E2E CI는 AIT_DEVELOPMENT_BUILD=true로 빌드하여
-// Emscripten 옵티마이저를 줄여 Link_WebGL_wasm 단계 시간을 단축한다(unity-build.yml 참조).
-// Development Build는 wasm 크기가 Release 대비 2-3배 커지므로 한도 상향 필요.
-// 배포 빌드에는 영향 없음 (production 워크플로우는 사용자 PlayerSettings 따름).
+// E2E CI는 AIT_DEVELOPMENT_BUILD=true + AIT_COMPRESSION_FORMAT=0(Disabled)로 빌드하여
+// 빌드 wallclock을 단축한다(unity-build.yml 참조).
+// Dev Build는 wasm 크기가 Release 대비 2-3배 커지고 압축도 비활성화되므로
+// MAX_BUILD_SIZE_MB 단언을 사용할 수 없어 isDevBuild일 때 스킵한다.
+const isDevBuild = process.env.AIT_DEVELOPMENT_BUILD === 'true';
 const BENCHMARKS = isMobileEmulation ? {
   MAX_LOAD_TIME_MS: 30000,
-  MAX_BUILD_SIZE_MB: 80,
+  MAX_BUILD_SIZE_MB: 50,
 } : {
   MAX_LOAD_TIME_MS: 10000,
-  MAX_BUILD_SIZE_MB: 80,
+  MAX_BUILD_SIZE_MB: 50,
 };
 
 // 결과 저장용
@@ -479,6 +480,12 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
         validation.warnings.forEach(w => console.log(`     ⚠️ ${w}`));
       }
 
+      const expectedCompressionFormat = process.env.AIT_COMPRESSION_FORMAT === '0'
+        ? 'disabled'
+        : process.env.AIT_COMPRESSION_FORMAT === '1'
+          ? 'gzip'
+          : 'brotli';
+
       testResults.tests['1_build_validation'] = {
         passed: validation.passed,
         buildSizeMB: validation.buildSizeMB,
@@ -486,12 +493,16 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
         fileCount: validation.fileCount,
         compressionValidation: {
           detectedFormat: validation.compressionFormat,
-          expectedFormat: 'brotli'
+          expectedFormat: expectedCompressionFormat
         }
       };
 
       expect(validation.passed, 'Build validation should pass').toBe(true);
-      expect(validation.buildSizeMB).toBeLessThanOrEqual(BENCHMARKS.MAX_BUILD_SIZE_MB);
+      // Dev Build + 압축 비활성화 조합에서는 산출물이 50MB 한도를 초과하므로 size 단언 스킵.
+      // 배포 빌드에는 영향 없음 (production 워크플로우는 사용자 PlayerSettings/압축 따름).
+      if (!isDevBuild) {
+        expect(validation.buildSizeMB).toBeLessThanOrEqual(BENCHMARKS.MAX_BUILD_SIZE_MB);
+      }
     } else {
       // build-validation.json이 없는 경우 직접 검증 (이전 버전 호환)
       console.log('⚠️ build-validation.json not found, performing direct validation...');

--- a/run-local-tests.sh
+++ b/run-local-tests.sh
@@ -436,21 +436,23 @@ test_e2e_playwright() {
     echo "Installing Playwright Chromium..."
     pnpx playwright install chromium
 
-    # EXPECTED_COMPRESSION 환경변수 설정 (압축 포맷 검증용)
-    local expected_compression=""
-    if [ -n "$COMPRESSION_FORMAT" ] && [ "$COMPRESSION_FORMAT" != "auto" ]; then
-        expected_compression="$COMPRESSION_FORMAT"
-        echo "Expected compression: $expected_compression"
-    elif [ -n "$COMPRESSION_FORMAT" ] && [ "$COMPRESSION_FORMAT" = "auto" ]; then
-        expected_compression="brotli"
-        echo "Expected compression: $expected_compression (auto → brotli)"
+    # 빌드 단계에서 사용한 AIT_COMPRESSION_FORMAT을 test에도 전파 — test가 expectedFormat을 분기.
+    local compression_env_for_test=""
+    if [ -n "$COMPRESSION_FORMAT" ]; then
+        case "$COMPRESSION_FORMAT" in
+            auto)     compression_env_for_test="-1" ;;
+            disabled) compression_env_for_test="0" ;;
+            gzip)     compression_env_for_test="1" ;;
+            brotli)   compression_env_for_test="2" ;;
+        esac
+        echo "Expected compression: $COMPRESSION_FORMAT (AIT_COMPRESSION_FORMAT=$compression_env_for_test)"
     fi
 
     # 테스트 실행 시 프로젝트 경로를 환경변수로 전달
     echo "Running E2E tests..."
     local e2e_env="UNITY_PROJECT_PATH=$project_path"
-    if [ -n "$expected_compression" ]; then
-        e2e_env="$e2e_env EXPECTED_COMPRESSION=$expected_compression"
+    if [ -n "$compression_env_for_test" ]; then
+        e2e_env="$e2e_env AIT_COMPRESSION_FORMAT=$compression_env_for_test"
     fi
     if env $e2e_env pnpm test; then
         print_success "E2E Playwright Tests ($version_pattern)"


### PR DESCRIPTION
## Summary

**Pivot: Gzip 전환(#549) → 압축 완전 비활성화 + Development Build 병행**

### Pivot 배경
- E2E CI는 vite로 local serve하여 배포가 없음 → 압축 파일을 실제로 사용하지 않음
- Brotli/Gzip 압축 단계 자체가 불필요한 wallclock 낭비였음
- 압축 비활성화로 Brotli(최대 109s) + Gzip 단계를 완전히 건너뜀

### 두 가지 env-var 오버라이드 (E2E CI 전용)
| 환경변수 | 값 | 효과 |
|---|---|---|
| `AIT_COMPRESSION_FORMAT` | `"0"` (Disabled) | Brotli/Gzip 압축 단계 건너뜀 |
| `AIT_DEVELOPMENT_BUILD` | `"true"` | Emscripten 옵티마이저 단축 → Link_WebGL_wasm 대폭 감소 |

### traceevents 분석 (기반: CI log unity-build-6000.2.log)

BUSY 마커 시퀀스로 critical path 식별:

| 노드 | 시간 | 단독/병렬 | 이 PR 처리 |
|------|------|----------|-----------|
| **Link_WebGL_wasm** | **163s** | **단독** ★ | Dev Build로 대폭 단축 기대 |
| Brotli wasm.unityweb | 109s | data와 병렬 | **Disabled로 건너뜀** |
| Brotli data.unityweb | 45s | wasm와 병렬 | **Disabled로 건너뜀** |
| Brotli symbols | 12s | 단독 | **Disabled로 건너뜀** |

## 변경 사항

- `Editor/AITBuildInitializer.cs`: `AIT_DEVELOPMENT_BUILD` 환경변수 처리 추가
- `.github/workflows/unity-build.yml`: macOS/Windows E2E 빌드 step에 두 env-var 설정
- `Tests~/E2E/tests/e2e-full-pipeline.test.js`:
  - `MAX_BUILD_SIZE_MB` assertion을 Dev Build + Disabled 시 skip (Dev Build는 wasm 크기 +2-3배, 압축 미적용으로 더 큼)
  - `expectedCompressionFormat` 매핑 일원화 + dead var 제거

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E 워크플로우 통과 (이 PR이 트리거)
- [ ] 빌드 wallclock 비교: #549 baseline vs #551 (Build job 단일 시간 비교)
- [x] 사용자 PlayerSettings 영향 없음 (clone 후 환경변수만 오버라이드)
- [x] production 빌드(release/preview/bulk-release) 영향 없음

## 호환성

- `AITConvertCore.cs`에서 `BuildOptions.Development` 정상 적용
- E2E 테스트는 SDK API 동작만 검증, 런타임 성능 미감지
- 사용자 워크플로우(`AIT > Configuration` UI에서 Production 빌드)는 그대로
- production: 압축 기본값 Brotli 유지, Dev Build 미적용