### PR TITLE
개선: E2E 빌드 IL2CPP를 Debug로 강제해 추가 wallclock 단축

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1350,6 +1350,10 @@ jobs:
           # Development Build로 옵티마이저 단축, Build wallclock 대폭 절감 기대.
           # E2E는 SDK API 동작만 검증하며 런타임 성능을 보지 않으므로 무관.
           AIT_DEVELOPMENT_BUILD: "true"
+          # E2E 한정: IL2CPP 컴파일러 옵티마이저 레벨도 Debug로 강제. developmentBuild
+          # 플래그는 Player 측 설정이라 IL2CPP 옵티마이저(C_WebGL_wasm/Link_WebGL_wasm)에는
+          # 영향이 없어 별도 변수로 페어링. -O3 → -O0/-Og 수준으로 wasm 컴파일/링크 단축.
+          AIT_IL2CPP_CONFIGURATION: "Debug"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30
@@ -1491,6 +1495,7 @@ jobs:
           # E2E 한정: macOS step의 동일 주석 참조.
           AIT_COMPRESSION_FORMAT: "0"
           AIT_DEVELOPMENT_BUILD: "true"
+          AIT_IL2CPP_CONFIGURATION: "Debug"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -147,6 +147,23 @@ namespace AppsInToss.Editor
             Il2CppCompilerConfiguration il2cppConfig = editorConfig.il2cppConfiguration >= 0
                 ? (Il2CppCompilerConfiguration)editorConfig.il2cppConfiguration
                 : AITDefaultSettings.GetDefaultIl2CppConfiguration();
+
+            // E2E CI 한정 오버라이드: IL2CPP 컴파일러 옵티마이저 레벨을 줄여 Link_WebGL_wasm 단축.
+            // developmentBuild 플래그는 Player 측 옵션이며 IL2CPP 옵티마이저와 별개라 별도 변수 필요.
+            string il2cppConfigEnv = System.Environment.GetEnvironmentVariable("AIT_IL2CPP_CONFIGURATION");
+            if (!string.IsNullOrEmpty(il2cppConfigEnv))
+            {
+                if (System.Enum.TryParse<Il2CppCompilerConfiguration>(il2cppConfigEnv, ignoreCase: true, out var parsed))
+                {
+                    il2cppConfig = parsed;
+                    Debug.Log($"[AIT] 환경 변수 오버라이드: AIT_IL2CPP_CONFIGURATION={parsed}");
+                }
+                else
+                {
+                    Debug.LogWarning($"[AIT] AIT_IL2CPP_CONFIGURATION 환경 변수 값이 올바르지 않습니다: '{il2cppConfigEnv}' (Debug/Release/Master 필요)");
+                }
+            }
+
 #if UNITY_6000_0_OR_NEWER
             PlayerSettings.SetIl2CppCompilerConfiguration(NamedBuildTarget.WebGL, il2cppConfig);
 #else
@@ -190,7 +207,7 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - 예외 처리: {exceptionSupport}{(editorConfig.exceptionSupport < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Stack Trace Log Type (Error/Assert/Warning/Log/Exception): {PlayerSettings.GetStackTraceLogType(LogType.Error)} (WebGL 자동)");
             Debug.Log($"[AIT]   - Stripping Level: {strippingLevel}{(profile?.managedStrippingLevel < 0 || profile == null ? " (자동)" : " (프로필)")}");
-            Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
+            Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
 #if UNITY_2023_3_OR_NEWER


### PR DESCRIPTION
## 요약

PR #551 후속. traceevents 분석에서 발견된 누락분 보정.

#551에서 `AIT_DEVELOPMENT_BUILD=true`를 적용했지만 빌드 로그에 `[AIT]   - IL2CPP 설정: Release (자동)` 으로 출력. `developmentBuild` 플래그는 Player 측 옵션이라 IL2CPP 컴파일러 옵티마이저와 무관 — `Il2CppCompilerConfiguration`을 별도로 Debug로 설정해야 `C_WebGL_wasm` (-O3 → -O0/-Og) 및 `Link_WebGL_wasm` 단축 효과가 실제로 발생.

## 변경

- `Editor/AITBuildInitializer.cs`: `AIT_IL2CPP_CONFIGURATION` 환경 변수 도입 (`Debug` | `Release` | `Master`). PlayerSettings에 직접 set. 미설정 시 기존 동작 유지.
- `.github/workflows/unity-build.yml`: E2E 빌드 step(macOS/Windows)에 `AIT_IL2CPP_CONFIGURATION="Debug"` 추가, 기존 `AIT_DEVELOPMENT_BUILD`와 페어링.

## 측정 근거

run #659 (squashed #551 최종) 빌드 로그:
- macOS 6000.0 (~6m): Link_WebGL_wasm 26s (단일 BUSY 노드)
- Windows 6000.3 (~9m): Link_WebGL_wasm 46s + C_WebGL_wasm 5개 (34/20/14/13/12s) + UnityLinker 16s + IL2CPP_CodeGen 8s

두 케이스 모두 IL2CPP가 여전히 Release로 컴파일 중이라 추가 단축 여지 ~1~3분 예상.

## Test plan

- [ ] CI E2E 워크플로 통과
- [ ] 빌드 로그에 `[AIT]   - IL2CPP 설정: Debug (환경 변수)` 출력 확인
- [ ] wallclock 단축 측정 (#659 baseline 대비)
- [ ] 배포 빌드(release.yml 등)는 환경 변수 미설정이므로 영향 없음 확인