### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-webgl-il2cpp-warning

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -129,6 +129,9 @@ namespace AppsInToss.Editor.ErrorTracker
             // 예: "Exec> git show -s --pretty=%D HEAD", "Exec> git log -1 --pretty=format:%h"
             // Sentry APPS-IN-TOSS-UNITY-SDK-NX, APPS-IN-TOSS-UNITY-SDK-NW
             "Exec> git ",
+
+            // Unity 엔진 자체 경고 — WebGL은 IL2CPP "Method Name, File Name, Line Number" 스택트레이스 옵션 미지원 (SDK-8B)
+            "IL2CPP stack traces is not supported on WebGL",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -713,6 +713,24 @@ public class IsKnownNonSdkMessageTests
             "[AIT] [Worker2] Import Error Code:(4)"));
     }
 
+    [Test]
+    public void Il2CppStackTracesNotSupportedOnWebGL_ReturnsTrue()
+    {
+        // Sentry SDK-8B — Unity 엔진 자체 경고. WebGL 빌드는 IL2CPP의 "Method Name, File Name, Line Number"
+        // 스택트레이스 옵션을 지원하지 않으므로 PlayerSettings에 해당 옵션이 켜져 있을 때 Unity가 직접 출력.
+        // SDK 코드와 무관하므로 노이즈로 분류.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "The \"Method Name, File Name, and Line Number\" option for IL2CPP stack traces is not supported on WebGL."));
+    }
+
+    [Test]
+    public void Il2CppStackTracesNotSupportedOnWebGL_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] The \"Method Name, File Name, and Line Number\" option for IL2CPP stack traces is not supported on WebGL."));
+    }
+
     #endregion
 
     #region SDK 관련 메시지는 통과 (negative cases)


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-8B

## 대상 Sentry 이슈

- **Item ID**: `APPS-IN-TOSS-UNITY-SDK-8B`
- **Title**: `UnityWarning: The "Method Name, File Name, and Line Number" option for IL2CPP stack traces is not supported on WebGL.`
- **분석 근거**: WebGL 빌드는 IL2CPP의 "Method Name, File Name, Line Number" 스택트레이스 옵션을 지원하지 않으며, PlayerSettings에 해당 옵션이 켜져 있을 때 Unity 엔진이 직접 출력하는 경고입니다. SDK 코드 경로와 무관한 사용자 프로젝트 설정 이슈로 노이즈에 해당합니다.

## 변경 사항

### 추출 패턴
- `"IL2CPP stack traces is not supported on WebGL"`
  - Unity 메시지 본문의 불변 핵심 문구 (PlayerSettings 옵션명/플랫폼 부분은 버전별로 출력 미세 차이 가능)

### 추가 위치
- `Editor/ErrorTracker/AITEditorErrorTracker.cs` `NonSdkMessagePatterns` 배열 (1개 패턴 추가)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`
  - positive: `Il2CppStackTracesNotSupportedOnWebGL_ReturnsTrue`
  - AIT prefix 보호 negative: `Il2CppStackTracesNotSupportedOnWebGL_WithAitPrefix_NeverFiltered`

## 검증

- `./run-local-tests.sh --validate`: ✅ 통과 (E2E Test Files / Playwright Config / SDK Generator Unit Tests 18 passed)

## 주의

**사람 머지 검토 필요** — auto-resolve 브랜치는 자동 생성되었으나 머지는 리뷰어 판단으로 진행해 주세요.