### PR TITLE
수정: E2E build job concurrency group을 PR/브랜치별로 분리

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -211,8 +211,11 @@ jobs:
 
     # ref-cancel: 같은 ref(브랜치/태그/PR) + 같은 (os, unity-version) 의 이전
     # 호출을 cancel. 새 푸시 시 이전 잡 정리만 담당한다.
+    # workflow_dispatch에서는 github.event.pull_request.number가 비어 있고
+    # github.ref가 항상 dispatch한 ref(보통 main)라 PR 간 분리가 안 됨 →
+    # needs.setup.outputs.ref(target_ref 해석 결과)를 우선 사용해 PR/브랜치별 격리.
     concurrency:
-      group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-macos-${{ matrix.unity-version }}
+      group: e2e-${{ github.workflow }}-${{ needs.setup.outputs.ref || github.event.pull_request.number || github.ref }}-macos-${{ matrix.unity-version }}
       cancel-in-progress: true
 
     strategy:
@@ -250,7 +253,7 @@ jobs:
     needs: [setup]
 
     concurrency:
-      group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-windows-${{ matrix.unity-version }}
+      group: e2e-${{ github.workflow }}-${{ needs.setup.outputs.ref || github.event.pull_request.number || github.ref }}-windows-${{ matrix.unity-version }}
       cancel-in-progress: true
 
     strategy:


### PR DESCRIPTION
## 요약

`test-e2e.yml`의 build-macos / build-windows job concurrency group이 `workflow_dispatch` 시 모든 PR을 같은 그룹으로 묶어, 다른 PR을 동시 dispatch하면 직전 build가 cancel되는 버그를 수정합니다.

## 원인

```yaml
group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-{os}-${{ matrix.unity-version }}
```

`workflow_dispatch` 이벤트에서:
- `github.event.pull_request.number` = 빈 값 (PR 이벤트 아님)
- `github.ref` = dispatch한 ref (보통 `main`)

→ 모든 dispatch가 `e2e-E2E Tests-refs/heads/main-{os}-{ver}` 한 group에 빠짐. `cancel-in-progress: true`이므로 다른 PR을 dispatch하면 직전 run이 즉사.

## 관찰된 영향

5월 9일 09:39~09:47 사이 #669~#678 (PR 518/520/523/536/541/556 라운드로빈) 모두 1~3분 내 cancel되어 IL2CPP 효과 측정이 불가했음.

## 수정

`needs.setup.outputs.ref` (target_ref 해석 결과: PR head 브랜치 또는 직접 지정 브랜치)를 group key 최우선 항목으로 추가. workflow_dispatch와 PR/푸시 이벤트 모두에서 PR/브랜치별로 정확히 격리됩니다.

기존 의도(같은 PR + 같은 OS/Unity 버전 새 push 시 직전 잡 cancel)는 그대로 보존됩니다.

## Test plan

- [ ] PR 머지 후 동시에 여러 PR을 dispatch하여 서로 cancel하지 않는지 확인
- [ ] 같은 PR에 새 push 시 직전 build가 cancel되는 기존 동작은 유지되는지 확인