### PR TITLE
수정: Unity 라이선스 retry 분기에 signature/handshake/IPC 패턴 추가

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1466,8 +1466,10 @@ jobs:
               fi
 
               # 라이선스 관련 오류 감지 (retry 액션이 자동 재시도)
+              # signature/handshake/IPC 실패는 같은 self-hosted runner에서 다른 Unity 버전의
+              # LicensingClient가 살아있어 충돌하는 케이스 — retry로 회복 가능.
               LICENSE_ERROR=false
-              if grep -qE "No valid Unity Editor license found|Unsupported protocol version|ResponseCode: 505" "$LOG_FILE" 2>/dev/null; then
+              if grep -qE "No valid Unity Editor license found|Unsupported protocol version|ResponseCode: 505|Access token is unavailable|Code 10 while verifying Licensing Client signature|LicensingClient has failed validation|Failed to handshake to channel|IPC channel to LicensingClient doesn't exist" "$LOG_FILE" 2>/dev/null; then
                 LICENSE_ERROR=true
               fi
               if [ $EXIT_CODE -eq 199 ]; then
@@ -1601,10 +1603,12 @@ jobs:
               }
 
               # 라이선스 관련 오류 감지 (retry 액션이 자동 재시도)
+              # signature/handshake/IPC 실패는 같은 self-hosted runner에서 다른 Unity 버전의
+              # LicensingClient가 살아있어 충돌하는 케이스 — retry로 회복 가능.
               $licenseError = $false
               if (Test-Path $logFile) {
                 $logContent = Get-Content $logFile -Raw -ErrorAction SilentlyContinue
-                if ($logContent -match "No valid Unity Editor license found|Unsupported protocol version|ResponseCode: 505|Access token is unavailable") {
+                if ($logContent -match "No valid Unity Editor license found|Unsupported protocol version|ResponseCode: 505|Access token is unavailable|Code 10 while verifying Licensing Client signature|LicensingClient has failed validation|Failed to handshake to channel|IPC channel to LicensingClient doesn't exist") {
                   $licenseError = $true
                 }
               }


### PR DESCRIPTION
## 요약

같은 self-hosted runner에서 다른 Unity 버전 job이 동시에 도는 경우 발생하는 LicensingClient signature/handshake 충돌을 retry 분기에 포함시킵니다.

## 관찰

E2E run #683 `Build (Windows, Unity 2022.3)` 실패 로그:

```
[Licensing::Client] Code 10 while verifying Licensing Client signature
  (process Id: 63892, path: ".../2021.3.45f2/.../Unity.Licensing.Client.exe")
[Licensing::Module] LicensingClient has failed validation; ignoring
[Licensing::Module] Error: Failed to handshake to channel: "LicenseClient-dave"
IPC channel to LicensingClient doesn't exist; aborting
Exiting without the bug reporter. Application will terminate with return code 199
```

`return code 199`는 라이선스 에러로 분류되어 있으나, 이번 케이스에서는 Unity가 ExitCode를 반환하지 않은 채 종료(`ExitCode is null`) → 빌드 산출물 부재 검증 경로로 빠져 `exitCode = 1`로 강제 설정 → retry 분기를 못 탔습니다.

## 수정

라이선스 에러 패턴 grep/match에 다음 4종 추가 (Windows + macOS 양쪽):
- `Code 10 while verifying Licensing Client signature`
- `LicensingClient has failed validation`
- `Failed to handshake to channel`
- `IPC channel to LicensingClient doesn't exist`

기존 recovery 액션(Hub headless + LicensingClient 프로세스 정리 + sleep)을 그대로 발동시켜 다음 attempt에서 회복 시도.

## 한계

근본 해결(다른 Unity 버전이 동시에 같은 머신에서 안 도는 concurrency 강화)은 별도 PR로 분리합니다. 본 PR은 회복 가능성을 retry로 확보하는 1차 안전장치입니다.

## Test plan

- [ ] 머지 후 cold cache run을 한두 차례 돌려 동일 패턴 발생 시 retry 동작 확인