### PR TITLE
수정: self-hosted runner를 Unity 버전별로 핀 고정 (license 충돌 차단)

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -102,18 +102,26 @@ on:
 jobs:
   build:
     name: Build (${{ inputs.os }}, Unity ${{ inputs.unity-version }})
-    runs-on: ${{ inputs.os == 'macos' && fromJSON('["self-hosted", "macOS", "ARM64", "enabled"]') || fromJSON('["self-hosted", "Windows", "X64", "enabled"]') }}
+    # Unity 버전별 머신 핀: 같은 self-hosted runner에 두 개 이상의 Unity
+    # LicensingClient가 동시에 살아 있으면 signature/handshake/IPC 충돌이
+    # 발생한다(run #683의 Code 10 등). runner 풀에 unity-<version> 라벨을
+    # 1머신=1버전으로 부여해두고, 매트릭스 잡이 자기 라벨이 붙은 머신으로만
+    # 라우팅되게 해서 LicensingClient가 절대 다른 버전과 마주치지 않게 한다.
+    #
+    # 운영 측 라벨 매핑(필수 선결 조건):
+    #   macos-1-1 / windows-1-1 → unity-2021.3
+    #   macos-1-2 / windows-1-2 → unity-2022.3
+    #   macos-1-3 / windows-1-3 → unity-6000.0
+    #   macos-1-4 / windows-1-4 → unity-6000.2
+    #   macos-1-5 / windows-1-5 → unity-6000.3
+    # 라벨이 누락된 머신/버전이 있으면 해당 매트릭스 잡은 영원히 큐에 남으므로
+    # 즉시 발견된다(silent fallback 없음).
+    runs-on: ${{ inputs.os == 'macos' && fromJSON(format('["self-hosted", "macOS", "ARM64", "enabled", "unity-{0}"]', inputs.unity-version)) || fromJSON(format('["self-hosted", "Windows", "X64", "enabled", "unity-{0}"]', inputs.unity-version)) }}
     timeout-minutes: 90
     # 동시성 정책: 호출자(test-e2e / preview / release)의 잡 concurrency가 ref
     # 기반 cancel을 담당하므로 reusable workflow는 (os, unity-version) 단위로만
     # 이중방어 락을 둔다. 같은 매트릭스 잡이 동시에 두 번 dispatch되는 케이스만
-    # 차단하고, 다른 unity-version 잡끼리는 GitHub Actions의 머신 분배(머신 1대
-    # = 잡 1개 정책)에 맡겨 매트릭스 5개가 병렬 실행되도록 한다.
-    #
-    # 라이센스 시트 제약: enterprise 시트 1개지만 실측상 머신별 토큰 캐시로
-    # 동시 활성화가 작동함을 확인 (run #25487498762: macOS / Windows 동시 빌드
-    # 6.4분 동안 충돌 없음). 만약 동시 N잡에서 라이센스 충돌이 재발하면
-    # `unity-machine-${{ inputs.os }}` 로 OS 단위 락을 복원할 것.
+    # 차단하고, 다른 unity-version 잡끼리는 머신 핀(위)으로 분리된다.
     concurrency:
       group: unity-build-${{ inputs.ref || github.sha }}-${{ inputs.os }}-${{ inputs.unity-version }}-${{ inputs.sdk-version-override || 'default' }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
- `runs-on`에 `unity-${{ inputs.unity-version }}` 라벨을 추가해 매트릭스 잡을 해당 Unity 버전 전용 머신으로만 라우팅
- 같은 self-hosted 머신에 여러 Unity LicensingClient가 동시에 살아 충돌하던 문제(run #683 Code 10) 차단
- 동시성 손실 0 — 5개 매트릭스 잡이 5개 머신에서 그대로 병렬 실행

## ⚠️ 머지 전 선결 조건 (운영 작업 필요)

**라벨 부여가 끝나기 전에 머지하면 모든 매트릭스 잡이 큐에 영원히 남습니다.** 머지 직전에 아래 라벨을 부여한 뒤, 부여 완료를 확인하고 머지해 주세요.

| Runner | 라벨 |
|---|---|
| `macos-1-1` / `windows-1-1` | `unity-2021.3` |
| `macos-1-2` / `windows-1-2` | `unity-2022.3` |
| `macos-1-3` / `windows-1-3` | `unity-6000.0` |
| `macos-1-4` / `windows-1-4` | `unity-6000.2` |
| `macos-1-5` / `windows-1-5` | `unity-6000.3` |

라벨 부여 방법:
- GitHub UI: Settings → Actions → Runners → 각 runner 선택 → Labels에서 추가
- 또는 runner config 파일에 `--labels unity-2021.3` 식으로 추가 후 재시작

각 머신에 해당 Unity 버전 에디터가 실제로 설치돼 있어야 합니다 (이미 매트릭스로 모든 머신에서 모든 버전을 돌리고 있었으니 사실상 모든 머신에 모든 에디터가 깔려 있을 것 — 핀 후에는 1버전만 사용).

## 배경
- run #683에서 self-hosted runner에 2021.3과 2022.3 LicensingClient가 동시에 살아남으면서 `Code 10 while verifying Licensing Client signature` 발생
- 직전 PR #558에서 license retry 패턴을 확장해 회복은 가능하지만, 충돌 자체를 막는 게 더 깔끔
- 5머신 × 5버전 매트릭스 구성에서 1:1 핀이 자연스러운 매핑

## 라벨 누락 시 동작
- 해당 매트릭스 잡은 매칭되는 runner를 못 찾아 큐에 머무름 (silent fallback 없음)
- 즉시 발견되므로 디버깅 용이 — 잘못된 머신에 잡이 떨어져 미묘한 문제를 일으키는 것보다 안전

## Test plan
- [ ] 운영 측에서 모든 runner에 unity-<version> 라벨 부여 완료
- [ ] 라벨 부여 확인 후 머지
- [ ] 머지 후 다음 E2E run에서 모든 매트릭스 잡이 정상 시작하는지 확인 (큐 대기 없이)
- [ ] 후속 몇 회 run에서 license signature/handshake/IPC 에러가 사라지는지 모니터