### PR TITLE
수정: 디버그/리포트 artifact upload에 continue-on-error 적용 (transient 실패 차단)

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -963,8 +963,12 @@ jobs:
             exit 1
           }
 
+      # 디버그/리포트 artifact: actions/upload-artifact의 finalize transient 실패가
+      # 빌드 자체를 fail로 만들지 않도록 continue-on-error로 격리
+      # (run #682, #695에서 windows-1-5 머신의 finalize 단계가 0.87s 만에 무성한 실패).
       - name: Upload EditMode Test Results
         if: inputs.run-editmode-test && always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: editmode-results-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -976,6 +980,7 @@ jobs:
       # (라이선스/Hub/캐시 등 인프라 결함 세분화에 필요).
       - name: Upload EditMode Unity Log (macOS)
         if: inputs.os == 'macos' && inputs.run-editmode-test && always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: unity-log-editmode-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -985,6 +990,7 @@ jobs:
 
       - name: Upload EditMode Unity Log (Windows)
         if: inputs.os == 'windows' && inputs.run-editmode-test && always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: unity-log-editmode-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -1314,6 +1320,7 @@ jobs:
 
       - name: Upload Test Results
         if: inputs.run-unit-test && always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: unit-test-results-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -1325,6 +1332,7 @@ jobs:
 
       - name: Upload Unit Test Unity Log (macOS)
         if: inputs.os == 'macos' && inputs.run-unit-test && always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: unity-log-unit-test-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -1334,6 +1342,7 @@ jobs:
 
       - name: Upload Unit Test Unity Log (Windows)
         if: inputs.os == 'windows' && inputs.run-unit-test && always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: unity-log-unit-test-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -1761,6 +1770,7 @@ jobs:
       # 빌드 실패의 인프라 원인을 grep으로 세분화하기 위함.
       - name: Upload Build Unity Log (macOS)
         if: inputs.os == 'macos' && inputs.run-build && (inputs.test-level || '2') != '0' && always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: unity-log-build-${{ inputs.os }}-${{ inputs.unity-version }}
@@ -1770,6 +1780,7 @@ jobs:
 
       - name: Upload Build Unity Log (Windows)
         if: inputs.os == 'windows' && inputs.run-build && (inputs.test-level || '2') != '0' && always()
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: unity-log-build-${{ inputs.os }}-${{ inputs.unity-version }}


### PR DESCRIPTION
## Summary
- 디버그/리포트 성격의 `actions/upload-artifact@v7` step에 `continue-on-error: true` 추가
- finalize 단계의 transient infrastructure 실패가 빌드 잡 전체를 fail로 만드는 현상 차단
- 빌드 산출물(AIT Build artifact)은 E2E 후속 잡이 의존하므로 그대로 유지

## 배경
- run #682: Windows 6000.3 (windows-1-5)의 `Upload Build Artifact` finalize 실패로 잡 fail
- run #695: 같은 머신에서 `Upload EditMode Unity Log` finalize가 0.87s 만에 무성하게 종료, 잡 fail
- 두 케이스 모두 빌드/테스트는 정상 완료, artifact 업로드 단계만 인프라 transient 이슈
- 같은 머신에서 반복되는 패턴이라 GitHub Actions 일반 문제보다 windows-1-5 머신 특정 문제로 의심됨 (별도 조사 필요)

## 적용 대상 step
- Upload EditMode Test Results
- Upload EditMode Unity Log (macOS / Windows)
- Upload Test Results
- Upload Unit Test Unity Log (macOS / Windows)
- Upload Build Unity Log (macOS / Windows)

## 적용 안 함
- **Upload AIT Build**: E2E 후속 잡(playwright)이 이 artifact를 다운로드해서 사용. transient 실패도 잡을 fail시키는 게 맞음.

## 효과
- artifact upload 실패 시 step은 yellow(skipped-like)로 표시되지만 잡 자체는 success
- 디버깅용 로그 한 번 손실은 감수 (다음 run에서 재현 가능)
- 빌드/테스트 결과의 진짜 신호와 인프라 노이즈가 분리됨

## Test plan
- [ ] 머지 후 cold cache E2E run 실행
- [ ] artifact upload step이 fail해도 잡이 success로 끝나는지 확인
- [ ] AIT Build artifact는 여전히 fail 시 잡 fail시키는지 확인 (회귀 방지)