### PR TITLE
문서: CLAUDE.md/testing.md/generate.md 최근 PR 반영 최신화

### DIFF
--- a/.claude/commands/generate.md
+++ b/.claude/commands/generate.md
@@ -9,7 +9,7 @@ SDK 런타임 코드를 재생성하고 검증합니다.
 3. `pnpm validate` 실행하여 vitest로 생성 코드 속성 검증
 4. `pnpm test` 실행하여 유닛 테스트
 5. 생성된 파일 변경사항 요약: `git diff --stat Runtime/SDK/`
-6. `Runtime/SDK/` 하위 `.cs`/`.jslib` 파일이 rename·add·remove 됐다면 **Library/Bee 캐시 무효화 영향** 사용자에게 안내 (PR #540 정책: SDK 변경 PR은 CI에서 풀 클린 빌드)
+6. `Runtime/SDK/` 하위 `.cs`/`.jslib` 파일이 rename·add·remove 됐다면 **Library/Bee 캐시 무효화 영향** 사용자에게 안내 (SDK 변경 PR은 CI에서 풀 클린 빌드 — `CLAUDE.md`의 "Library/Bee 캐시 동작" 참조)
 7. 결과 보고
 
 ## Arguments

--- a/.claude/commands/generate.md
+++ b/.claude/commands/generate.md
@@ -5,13 +5,20 @@ SDK 런타임 코드를 재생성하고 검증합니다.
 ## Steps
 
 1. `cd sdk-runtime-generator~`
-2. `pnpm generate` 실행하여 TypeScript → C# + jslib 브릿지 생성
+2. `pnpm generate` 실행하여 TypeScript → C# + jslib 브릿지 생성 (~1.5초)
 3. `pnpm validate` 실행하여 vitest로 생성 코드 속성 검증
 4. `pnpm test` 실행하여 유닛 테스트
 5. 생성된 파일 변경사항 요약: `git diff --stat Runtime/SDK/`
-6. 결과 보고
+6. `Runtime/SDK/` 하위 `.cs`/`.jslib` 파일이 rename·add·remove 됐다면 **Library/Bee 캐시 무효화 영향** 사용자에게 안내 (PR #540 정책: SDK 변경 PR은 CI에서 풀 클린 빌드)
+7. 결과 보고
 
 ## Arguments
 
 - `--format`: 생성 후 `pnpm format`도 실행 (CSharpier, dotnet 필요)
 - `$ARGUMENTS`가 있으면 추가 컨텍스트로 사용
+
+## 주의
+
+- `Runtime/SDK/` 의 파일은 절대 직접 수정하지 말 것 (`CLAUDE.md`의 "자동 생성 코드 정책" 참조)
+- 생성기 변경 후 push 전: `./run-local-tests.sh --validate`(~30초)로 invariants 검증 권장
+- pnpm 버전이 변경됐다면 `Editor/AITPackageManagerHelper.cs`의 `PNPM_VERSION`과 3개 `package.json`의 `packageManager` 필드 동기화 확인 (CLAUDE.md "pnpm 버전 핀 동기화" 참조)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,11 @@
   ```bash
   gh api repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs -X POST
   ```
-- **알려진 flaky 패턴**: Unity WebGL Brotli 크래시 (`[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`) — self-hosted runner 동시 빌드 시 리소스 경합으로 발생
+- **알려진 flaky 패턴** (모두 인프라 기인, 코드 변경 없이 재실행으로 해결):
+  - **Unity 라이선스 충돌** — `Code 10 while verifying Licensing Client signature` / handshake / IPC 에러. PR #559에서 self-hosted runner를 `unity-<version>` 라벨로 1:1 핀 고정해 차단 중. 재발 시 라벨이 빠진 머신이 있는지 확인 (`docs/claude/github-actions.md`)
+  - **Windows artifact upload finalize transient** — `actions/upload-artifact@v7`가 `successfully finalized` 메시지 없이 종료 (~1.3% 빈도). PR #560/#562에서 진단 step + `continue-on-error` 적용. 재실행으로 해결
+  - **Unity WebGL Brotli 크래시** — `[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`. self-hosted runner 동시 빌드 시 리소스 경합. CI는 PR #a8e8d31에서 **Gzip으로 전환**하여 신규 발생 차단 — 로컬 재현은 아래 "로컬 CI 재현" 가이드 참조
+- **Sentry 노이즈 패턴 추가**는 자동화(`auto-resolve`)가 처리하므로 수동 PR 불필요 — `Editor/ErrorTracker/AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 자동 흡수됨
 
 ### 테스트 관련
 - E2E 테스트 전 빌드 필요: `./run-local-tests.sh --all` (빌드+테스트) vs `--e2e` (테스트만)
@@ -137,12 +141,15 @@ SDK 생성기 작업을 포함하는 변경사항을 커밋/푸시하기 전, **
    - `.meta` 파일 누락/추가 여부 (Lint 워크플로우에서 검출)
    - 대용량 바이너리/빌드 산출물 혼입 여부
 
-### 로컬 CI 재현 (WebGL Brotli flaky)
+### 로컬 CI 재현 (압축 포맷 / 리소스 경합)
 
-self-hosted runner에서만 재현되는 Brotli 크래시를 로컬에서 좁히려면 `run-local-tests.sh`의 `--compression`과 `--parallel`을 조합:
+CI는 PR #a8e8d31에서 **Gzip 압축으로 전환**되어 신규 빌드에서 Brotli 크래시는 발생하지 않음. 다만 이전 빌드 분석이나 압축별 동작 검증이 필요하면 `--compression`과 `--parallel`을 조합:
 
 ```bash
-# Brotli 압축 강제로 빌드 (CI와 동일 경로)
+# CI와 동일한 Gzip 경로로 빌드
+./run-local-tests.sh --unity-build --compression gzip --unity-version 6000.2
+
+# Brotli 강제 (과거 flaky 재현용)
 ./run-local-tests.sh --unity-build --compression brotli --unity-version 6000.2
 
 # 동시 빌드로 리소스 경합 재현 (모든 버전 병렬)
@@ -151,6 +158,16 @@ self-hosted runner에서만 재현되는 Brotli 크래시를 로컬에서 좁히
 
 **압축 포맷 값**: `auto` | `disabled` | `gzip` | `brotli` (`run-local-tests.sh` 참조).
 **주의**: self-hosted runner의 리소스 경합 자체(CPU/메모리/디스크 경합)는 로컬 머신 스펙에 따라 재현이 보장되지 않음. 로컬에서 통과해도 CI flaky가 재현되지 않을 수 있으며, 이 경우 `rerun-failed-jobs` 경로를 사용 (위 "E2E 테스트 실패 대응" 참조).
+
+### Library/Bee 캐시 동작
+
+PR #540에서 캐시 무효화 정책이 변경됨:
+- **SDK/asmdef/jslib 변경 있음** → `Library/Bee` 삭제 (full rebuild)
+- **변경 없음** → 캐시 보존 (incremental rebuild로 빌드 시간 단축)
+- **fallback** (`git diff` 실패, 얕은 fetch 등) → 보수적으로 Bee 삭제
+- **escape hatch**: workflow_dispatch에서 `clean_library=true`로 강제 풀 클린 가능 (`docs/claude/github-actions.md` 참조)
+
+캐시가 의심되는 빌드 실패가 있으면 먼저 `clean_library=true`로 재트리거 후 재현 여부 확인.
 
 ## 빠른 참조: 주요 명령어
 
@@ -184,4 +201,5 @@ review-fix-loop 등 자동화 skill이 파싱하는 규약 섹션. 각 항목은
 - `docs/claude/testing.md` — 3-Level 테스트 구조, Unity 버전 요구사항, E2E 디렉토리 구조, 실행 명령, CI/CD 통합
 - `docs/claude/sdk-generator.md` — `sdk-runtime-generator~` 워크플로우, 타입 매핑, API 사용 패턴
 - `docs/claude/implementation-details.md` — WebGL 템플릿, 빌드 설정 자동 구성, 내장 Node.js 시스템, 설정 저장소
-- `docs/claude/sentry-known-issues.md` — 무시 가능 Sentry 이슈 목록, 통합 테스트 environment 분리
+- `docs/claude/sentry-known-issues.md` — 무시 가능 Sentry 이슈 목록, 통합 테스트 environment 분리, strict 게이트 + NonSdkMessagePatterns 이중 안전망
+- `docs/claude/build-session-recovery.md` — 빌드 중 도메인 리로드 복원력 (`AITBuildSessionRecovery`) 수동 재현 절차 (`.cs` 저장 / Unity 강제 종료 / Stale 세션 / Idle gate)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,9 @@
   gh api repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs -X POST
   ```
 - **알려진 flaky 패턴** (모두 인프라 기인, 코드 변경 없이 재실행으로 해결):
-  - **Unity 라이선스 충돌** — `Code 10 while verifying Licensing Client signature` / handshake / IPC 에러. PR #559에서 self-hosted runner를 `unity-<version>` 라벨로 1:1 핀 고정해 차단 중. 재발 시 라벨이 빠진 머신이 있는지 확인 (`docs/claude/github-actions.md`)
-  - **Windows artifact upload finalize transient** — `actions/upload-artifact@v7`가 `successfully finalized` 메시지 없이 종료 (~1.3% 빈도). PR #560/#562에서 진단 step + `continue-on-error` 적용. 재실행으로 해결
-  - **Unity WebGL Brotli 크래시** — `[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`. self-hosted runner 동시 빌드 시 리소스 경합. CI는 PR #a8e8d31에서 **Gzip으로 전환**하여 신규 발생 차단 — 로컬 재현은 아래 "로컬 CI 재현" 가이드 참조
+  - **Unity 라이선스 충돌** — `Code 10 while verifying Licensing Client signature` / handshake / IPC 에러. self-hosted runner는 현재 `unity-<version>` 라벨로 1:1 핀 고정되어 차단 중. 재발 시 라벨이 빠진 머신이 있는지 확인 (`docs/claude/github-actions.md`)
+  - **Windows artifact upload finalize transient** — `actions/upload-artifact@v7`가 `successfully finalized` 메시지 없이 종료 (~1.3% 빈도). 진단 step + `continue-on-error`가 적용되어 있고 재실행으로 해결됨
+  - **Unity WebGL Brotli/Gzip 크래시** — `[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`. self-hosted runner 동시 빌드 시 리소스 경합. **현재 E2E CI는 압축 비활성화(`AIT_COMPRESSION_FORMAT="0"`)** 로 압축 단계 자체를 건너뛰므로 신규 발생 없음 (E2E는 vite preview에서만 로드되며 배포되지 않아 압축 불필요). 로컬 재현은 아래 "로컬 CI 재현" 가이드 참조
 - **Sentry 노이즈 패턴 추가**는 자동화(`auto-resolve`)가 처리하므로 수동 PR 불필요 — `Editor/ErrorTracker/AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 자동 흡수됨
 
 ### 테스트 관련
@@ -143,13 +143,14 @@ SDK 생성기 작업을 포함하는 변경사항을 커밋/푸시하기 전, **
 
 ### 로컬 CI 재현 (압축 포맷 / 리소스 경합)
 
-CI는 PR #a8e8d31에서 **Gzip 압축으로 전환**되어 신규 빌드에서 Brotli 크래시는 발생하지 않음. 다만 이전 빌드 분석이나 압축별 동작 검증이 필요하면 `--compression`과 `--parallel`을 조합:
+E2E CI는 현재 압축이 **Disabled**(`AIT_COMPRESSION_FORMAT="0"`)이므로 신규 빌드에서 Brotli/Gzip 크래시는 발생하지 않음. 다만 이전 빌드 분석이나 압축별 동작 검증이 필요하면 `--compression`과 `--parallel`을 조합:
 
 ```bash
-# CI와 동일한 Gzip 경로로 빌드
-./run-local-tests.sh --unity-build --compression gzip --unity-version 6000.2
+# E2E CI와 동일한 경로(압축 비활성화)
+./run-local-tests.sh --unity-build --compression disabled --unity-version 6000.2
 
-# Brotli 강제 (과거 flaky 재현용)
+# Gzip / Brotli 강제 (압축 단계 flaky 재현용)
+./run-local-tests.sh --unity-build --compression gzip --unity-version 6000.2
 ./run-local-tests.sh --unity-build --compression brotli --unity-version 6000.2
 
 # 동시 빌드로 리소스 경합 재현 (모든 버전 병렬)
@@ -161,8 +162,8 @@ CI는 PR #a8e8d31에서 **Gzip 압축으로 전환**되어 신규 빌드에서 B
 
 ### Library/Bee 캐시 동작
 
-PR #540에서 캐시 무효화 정책이 변경됨:
-- **SDK/asmdef/jslib 변경 있음** → `Library/Bee` 삭제 (full rebuild)
+CI Unity 빌드의 `Library/Bee` 캐시 무효화 정책:
+- **SDK/asmdef/jslib 변경 있음** → `Library/Bee` 삭제 (full rebuild — stale ref.dll 차단)
 - **변경 없음** → 캐시 보존 (incremental rebuild로 빌드 시간 단축)
 - **fallback** (`git diff` 실패, 얕은 fetch 등) → 보수적으로 Bee 삭제
 - **escape hatch**: workflow_dispatch에서 `clean_library=true`로 강제 풀 클린 가능 (`docs/claude/github-actions.md` 참조)

--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -70,12 +70,12 @@ npm test
 
 `.github/workflows/test-e2e.yml` 실행 내용 (3-Level 테스트 구조):
 1. EditMode 테스트 (Level 0: C# 순수 로직 검증, 빌드 없이 ~10초) — **self-hosted Unity runner**
-2. Unity WebGL 빌드 + C# 빌드 산출물 검증 (Level 1) — **self-hosted Unity runner**
-3. Playwright E2E 테스트 (Level 2: 5개 테스트) — **ubuntu-latest** (PR #538에서 분리)
+2. Unity WebGL 빌드 + C# 빌드 산출물 검증 (Level 1) — **self-hosted Unity runner** (`build-macos` / `build-windows` 잡)
+3. Playwright E2E 테스트 (Level 2: 5개 테스트) — **ubuntu-latest** (`e2e-macos` / `e2e-windows` 잡)
 4. 벤치마크 결과 아티팩트로 업로드
 5. 성능 메트릭이 포함된 Job summary
 
-**runner 라우팅** (PR #559 이후):
+**runner 라우팅**:
 - self-hosted runner는 `unity-<version>` 라벨로 1:1 핀 — `runs-on: [self-hosted, unity-${{ inputs.unity-version }}]`
 - 라이선스 충돌 차단을 위해 한 머신은 한 Unity 버전 잡만 받음
 - Playwright는 ubuntu에서 artifact 다운로드 → vite preview 서버 → 테스트 실행 (Unity binary 비의존)
@@ -85,4 +85,4 @@ npm test
 - `1`: 빌드+검증, Playwright 스킵 (~8분)
 - `2`: 전체 실행 (~14분, 기본값)
 
-`build-{macos,windows}` matrix는 self-hosted에서 빌드만 수행하고, `e2e-{macos,windows}` matrix가 ubuntu에서 Playwright를 실행. `test_level=0/1`이면 e2e-* 잡은 skipped 처리되고 결과는 build-* 결과로 폴백.
+`test_level=0/1`이면 `e2e-*` 잡은 skipped 처리되고 결과는 `build-*` 결과로 폴백.

--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -69,13 +69,20 @@ npm test
 ## CI/CD 통합
 
 `.github/workflows/test-e2e.yml` 실행 내용 (3-Level 테스트 구조):
-1. EditMode 테스트 (Level 0: C# 순수 로직 검증, 빌드 없이 ~10초)
-2. Unity WebGL 빌드 + C# 빌드 산출물 검증 (Level 1)
-3. Playwright E2E 테스트 (Level 2: 5개 테스트)
+1. EditMode 테스트 (Level 0: C# 순수 로직 검증, 빌드 없이 ~10초) — **self-hosted Unity runner**
+2. Unity WebGL 빌드 + C# 빌드 산출물 검증 (Level 1) — **self-hosted Unity runner**
+3. Playwright E2E 테스트 (Level 2: 5개 테스트) — **ubuntu-latest** (PR #538에서 분리)
 4. 벤치마크 결과 아티팩트로 업로드
 5. 성능 메트릭이 포함된 Job summary
+
+**runner 라우팅** (PR #559 이후):
+- self-hosted runner는 `unity-<version>` 라벨로 1:1 핀 — `runs-on: [self-hosted, unity-${{ inputs.unity-version }}]`
+- 라이선스 충돌 차단을 위해 한 머신은 한 Unity 버전 잡만 받음
+- Playwright는 ubuntu에서 artifact 다운로드 → vite preview 서버 → 테스트 실행 (Unity binary 비의존)
 
 `test-level` 파라미터로 실행 범위 제어:
 - `0`: EditMode만 (~10초)
 - `1`: 빌드+검증, Playwright 스킵 (~8분)
 - `2`: 전체 실행 (~14분, 기본값)
+
+`build-{macos,windows}` matrix는 self-hosted에서 빌드만 수행하고, `e2e-{macos,windows}` matrix가 ubuntu에서 Playwright를 실행. `test_level=0/1`이면 e2e-* 잡은 skipped 처리되고 결과는 build-* 결과로 폴백.


### PR DESCRIPTION
## Summary
- E2E flaky 패턴 3가지로 세분화 (Unity 라이선스 충돌 / Windows artifact upload finalize / Brotli·Gzip 압축 크래시)
- E2E CI 압축 정책을 현재 상태(`AIT_COMPRESSION_FORMAT="0"`, Disabled)로 정정. 로컬 재현 예시에 `--compression disabled` 추가
- Library/Bee 캐시 동작 섹션 신설 — SDK/asmdef/jslib 변경 시에만 무효화, `clean_library=true` escape hatch
- 상세 문서 목록에 누락됐던 `build-session-recovery.md` 추가
- testing.md: Playwright는 ubuntu에서 실행, self-hosted runner는 `unity-<version>` 라벨 1:1 핀, 실제 job명(`build-{macos,windows}` / `e2e-{macos,windows}`) 명시
- generate.md: Bee 캐시 영향 안내, pnpm 핀 동기화 / Runtime/SDK 직접 수정 금지 / `--validate` 권장 보강

## Test plan
- [x] `./run-local-tests.sh --validate` (~30초) 통과 — vitest invariants 18/18 green
- [x] CLAUDE.md 가 참조하는 docs 경로 모두 존재 확인
- [x] 인용 사실(PR #538/#540/#551/#558/#559/#560/#562 등)은 `git log` / `gh api`로 교차 검증
- [ ] PR CI Validate / Lint 통과