### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-lifecycle-warning

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -234,6 +234,17 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void SendMessageDuringAwake_OnRectTransformDimensionsChange_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-T6 — 사용자 컴포넌트(ViewPortrait)의
+        // OnRectTransformDimensionsChange에서 발생한 라이프사이클 변형.
+        // 기존 "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate" 패턴이
+        // 후행 컴포넌트/메서드 명시 변형도 부분 매칭으로 커버하는지 fixture로 박아둠.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate (ViewPortrait: OnRectTransformDimensionsChange)"));
+    }
+
+    [Test]
     public void LegacyAnimationClips_ReturnsTrue()
     {
         // Sentry KT/KV — Unity 자체 경고


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-T6

## 묶음 항목

| Source | ID | Title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-T6 | UnityWarning: SendMessage cannot be called during Awake, CheckConsistency, or OnValidate (ViewPortrait: OnRectTransformDimensionsChange) |

## 변경 내용

**프로덕션 코드 변경 없음** — 회귀 방어 fixture만 추가.

T6의 메시지는 사용자 컴포넌트(`ViewPortrait`)의 `OnRectTransformDimensionsChange`에서 발생한 Unity 라이프사이클 경고 변형. 본문 핵심 문구 `"SendMessage cannot be called during Awake, CheckConsistency, or OnValidate"`는 이미 `NonSdkMessagePatterns`(`Editor/ErrorTracker/AITEditorErrorTracker.cs:76`)에 등록되어 있어, T6 메시지도 부분 매칭으로 정상 드롭됨.

이 PR은 T6의 후행 형식 변형(`"... (Component: Method)"`)을 fixture로 박아 향후 필터가 anchored/regex로 tightening되더라도 이 실측 변형을 놓치지 않게 한다.

## 추가 위치

- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`
  - `SendMessageDuringAwake_OnRectTransformDimensionsChange_ReturnsTrue` — T6 실측 메시지 positive 테스트
  - 기존 `SendMessageDuringAwake_WithAitPrefix_NeverFiltered`가 AIT prefix 보호 negative 케이스를 이미 커버

## 추출 패턴

기존 패턴 `"SendMessage cannot be called during Awake, CheckConsistency, or OnValidate"` 유지. 신규 패턴 없음.

## 검증

**동시 빌드 회피로 검증 skip — 사람 확인 필요.**
`pgrep -f run-local-tests`가 6개→9개로 두 차례 충돌이라 `./run-local-tests.sh --validate`를 실행하지 않았다. 변경은 테스트 파일 1개에 fixture 1개 추가만 포함하며 프로덕션 코드는 변경되지 않았다.

리뷰어가 가능하다면 로컬에서 `./run-local-tests.sh --validate`로 신규 EditMode 테스트가 통과하는지 확인 부탁.

---

🤖 Generated with auto-resolve worker
