### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — addressable-build-report

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -194,6 +194,23 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void UnableToLoadBuildReport_AddressablesBuildLayout_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-RP — Unity Addressables가 빌드 리포트 파일이 없을 때 출력하는 표준 경고.
+        // Library/com.unity.addressables/BuildReports/ 하위 timestamped 파일명까지 매칭되는지 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Unable to load build report at Library/com.unity.addressables/BuildReports/buildlayout_2026.05.12.07.23.02.json."));
+    }
+
+    [Test]
+    public void UnableToLoadBuildReport_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 보호 가드: AIT prefix가 붙은 동일 본문은 SDK 자체 로그로 보호되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Unable to load build report at Library/com.unity.addressables/BuildReports/foo.json"));
+    }
+
+    [Test]
     public void CannotReadBuildLayout_ReturnsTrue()
     {
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage("Cannot read BuildLayout header"));


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-RP

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-RP | UnityWarning: Unable to load build report at Library/com.unity.addressables/BuildReports/buildlayout_2026.05.12.07.23.02.json. |

## 분석

Sentry APPS-IN-TOSS-UNITY-SDK-RP의 메시지 본문은 Unity Addressables가 빌드 리포트 파일이 없을 때 출력하는 표준 경고로, SDK 코드와 무관합니다.

이 메시지에 매칭될 수 있는 패턴이 **이미 존재**합니다:

- `Editor/ErrorTracker/AITEditorErrorTracker.cs:70` — `"Unable to load build report at Library/"`

새 입력 메시지(`"Unable to load build report at Library/com.unity.addressables/BuildReports/buildlayout_*.json"`)는 위 prefix를 부분 문자열로 포함하므로 `IsKnownNonSdkMessage`에서 이미 정상 드롭됩니다. 따라서 `NonSdkMessagePatterns`에 새 패턴을 추가할 필요는 없습니다.

다만 기존 회귀 테스트(`UnableToLoadBuildReport_ReturnsTrue`)는 `Library/LastBuild.buildreport` 변형만 검증하므로, addressables 경로 변형까지 안전하게 매칭되는지 보호하기 위해 회귀 테스트 2개를 추가했습니다.

## 추가된 테스트

`Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`

- `UnableToLoadBuildReport_AddressablesBuildLayout_ReturnsTrue` — Sentry RP에 보고된 정확한 메시지 변형이 노이즈로 분류되는지 검증 (positive)
- `UnableToLoadBuildReport_WithAitPrefix_NeverFiltered` — `[AIT]` prefix가 붙은 동일 본문은 SDK 보호 가드로 필터링되지 않는지 검증 (negative)

## 변경 파일

- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` (+17/-0)

`Editor/ErrorTracker/AITEditorErrorTracker.cs`는 수정 없음.

## 검증 결과

⚠️ **`./run-local-tests.sh --validate` 미실행 — 동시 빌드 회피로 검증 skip**

PR 생성 시점에 같은 SDK repo에서 다른 worker 10개가 동시에 `run-local-tests`를 실행 중이었습니다. 정책에 따라 30초 대기 후 재확인했으나 여전히 충돌 상태로 검증을 건너뛰었습니다. 변경 범위가 테스트 코드에만 한정되고(C# 프로덕션 코드 무수정), 추가된 어설션이 기존 패턴의 동작을 확인하는 것이라 안전성은 높지만, **사람 머지 검토 시 로컬에서 `./run-local-tests.sh --validate` 한 번 실행해주세요**.

---

자동 생성된 PR (auto-resolve worker)
**사람 머지 검토 필요**
