### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — external-service-transient-error

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -744,6 +744,12 @@ namespace AppsInToss.Editor.ErrorTracker
                     return true;
             }
 
+            // SDK 자체 로그이지만 원인이 외부 서비스의 일시적 장애(5xx)인 메시지는
+            // SDK 가드 도달 전에 노이즈로 드롭한다. 5xx만 매칭하므로 4xx(인증/페이로드)는 영향 없음.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-T4 — [AITSentryTransport] Sentry 전송 실패 (HTTP 503)
+            if (message.IndexOf("[AITSentryTransport] Sentry 전송 실패 (HTTP 5", StringComparison.Ordinal) >= 0)
+                return true;
+
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용
             if (MessageContainsSdkKeyword(message))
                 return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -808,6 +808,65 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 외부 서비스 일시적 장애 (Sentry transport 5xx)
+
+    [Test]
+    public void SentryTransport_Http503_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-T4 — Sentry 서버의 일시적 503 응답.
+        // SDK 자체 로그이지만 원인이 외부 서비스 transient 장애이므로 노이즈로 드롭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] Sentry 전송 실패 (HTTP 503)"));
+    }
+
+    [Test]
+    public void SentryTransport_Http500_ReturnsTrue()
+    {
+        // 5xx 일반화 — 500/502/504 등도 동일한 외부 transient 장애로 분류
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] Sentry 전송 실패 (HTTP 500)"));
+    }
+
+    [Test]
+    public void SentryTransport_Http502_ReturnsTrue()
+    {
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] Sentry 전송 실패 (HTTP 502)"));
+    }
+
+    [Test]
+    public void SentryTransport_Http504_ReturnsTrue()
+    {
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] Sentry 전송 실패 (HTTP 504)"));
+    }
+
+    [Test]
+    public void SentryTransport_Http400_NotFiltered()
+    {
+        // 4xx(인증/페이로드 오류)는 SDK가 알아야 하는 진짜 에러이므로 5xx 패턴에 매칭되지 않아야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] Sentry 전송 실패 (HTTP 400)"));
+    }
+
+    [Test]
+    public void SentryTransport_Http401_NotFiltered()
+    {
+        // DSN 오설정 등 — SDK 측 수정이 필요한 진짜 에러
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] Sentry 전송 실패 (HTTP 401)"));
+    }
+
+    [Test]
+    public void SentryTransport_NetworkError_NotFiltered()
+    {
+        // 다른 transport 로그(네트워크 오류, 동기 전송 실패 등)는 영향 없음
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] 네트워크 오류: Connection refused"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-T4

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-T4 | UnityWarning: [AITSentryTransport] Sentry 전송 실패 (HTTP 503) |

## 분석

- 메시지 `[AITSentryTransport] Sentry 전송 실패 (HTTP 503)` 자체는 SDK 코드(`Editor/ErrorTracker/AITSentryTransport.cs:337`)가 직접 `Debug.LogWarning`으로 출력함 → AitKeywords의 `[AIT` prefix에 매칭되어 SDK 보호 가드가 발동.
- 그러나 **원인은 외부 Sentry 서버의 일시적 5xx 응답**(transient outage)이므로 SDK 코드 변경으로 해결할 수 없는 노이즈.
- 4xx(인증/페이로드)는 SDK가 인지해야 하는 진짜 에러이므로 5xx에만 한정해서 드롭.

## 추출 패턴

`[AITSentryTransport] Sentry 전송 실패 (HTTP 5` (substring) — 500/502/503/504 등 5xx 응답에만 매칭.

## 추가 위치

`Editor/ErrorTracker/AITEditorErrorTracker.cs` — `IsKnownNonSdkMessage` 내부, `ExternalAitPrefixes` 직후 / `MessageContainsSdkKeyword` SDK 보호 가드 **이전**에 명시적 composite 조건으로 추가. 일반적인 `NonSdkMessagePatterns` 배열은 SDK 가드 다음에 평가되므로 이 케이스를 잡을 수 없어 가드 위에 명시적 분기로 처리.

`Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — 새 region `외부 서비스 일시적 장애 (Sentry transport 5xx)` 추가. positive(500/502/503/504) + negative(400/401, 네트워크 오류) 검증.

## --validate 결과

⚠️ **동시 빌드 회피로 검증 skip — 사람 확인 필요.** push 직전 `pgrep -f run-local-tests` 결과가 다른 worker 다수가 동시 실행 중이라 셀프 종료 가드 규칙(30초 대기 후 재확인, 두 번 다 충돌이면 skip)에 따라 로컬 validate를 실행하지 않고 PR을 만듦. 변경은 두 파일에 국한되며 substring 매칭 한 줄 + 단위 테스트만 추가했으나 사람 리뷰어가 `./run-local-tests.sh --validate`로 한 번 확인 부탁드림.

## 사람 머지 검토 필요

`auto-resolve` 워커가 생성한 PR입니다. 코드 변경의 부작용(특히 4xx/네트워크 오류 케이스가 그대로 SDK 에러로 캡처되는지)을 사람 리뷰어가 확인한 후 squash merge 부탁드립니다.