### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — user-build-config

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -81,6 +81,9 @@ namespace AppsInToss.Editor.ErrorTracker
             "cannot be used in the State \"",
             // Unity 빌드 — 미컴파일 코드 변경 상태에서 빌드 시도 시 Unity가 직접 출력 (SDK-NE)
             "You are building a player, but you have uncompiled code changes",
+            // Unity 빌드 — 사용자가 Development 옵션 없이 ConnectWithProfiler를 설정해 발생하는 Unity 표준 예외 (SDK-T3)
+            // 사용자 BuildPlayerOptions 구성 문제이며 SDK 버그 아님. Unity 버전/언어와 무관하게 영문 메시지 본문이 동일.
+            "Non-development build cannot allow auto-connecting the profiler",
 
             // 사용자 프로젝트 에셋 문제
             "matches more than one built-in atlases",

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -288,6 +288,32 @@ public class IsKnownNonSdkMessageTests
             "[AIT] You are building a player, but you have uncompiled code changes."));
     }
 
+    [Test]
+    public void NonDevelopmentBuildAutoConnectingProfiler_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-T3 — 사용자가 Development 옵션 없이 ConnectWithProfiler를 설정해
+        // Unity가 직접 던지는 ArgumentException. 사용자 BuildPlayerOptions 구성 문제이며 SDK 버그 아님.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: 변환 중 오류가 발생했습니다: System.ArgumentException: Non-development build cannot allow auto-connecting the profiler. Either add the Development build option,"));
+    }
+
+    [Test]
+    public void NonDevelopmentBuildAutoConnectingProfiler_PlainException_ReturnsTrue()
+    {
+        // Unity가 영문 환경 또는 다른 호출 경로에서 ArgumentException 본문만 그대로 출력하는 변형.
+        // "Non-development build cannot allow auto-connecting the profiler" 부분 문자열이 핵심 불변 문구.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "ArgumentException: Non-development build cannot allow auto-connecting the profiler. Either add the Development build option, or unset ConnectWithProfiler."));
+    }
+
+    [Test]
+    public void NonDevelopmentBuildAutoConnectingProfiler_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙으면 SDK 자체 로그로 간주되어야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Non-development build cannot allow auto-connecting the profiler"));
+    }
+
     #endregion
 
     #region 사용자 프로젝트 에셋 문제


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-T3

## 묶음 항목

| Source | ID | Title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-T3 | `UnityError: 변환 중 오류가 발생했습니다: System.ArgumentException: Non-development build cannot allow auto-connecting the profiler. Either add the Development build option,` |

## 분석

Unity 표준 `ArgumentException`. 사용자가 `BuildPlayerOptions`에서 `Development` 옵션을 켜지 않은 채 `ConnectWithProfiler`를 설정해 발생하는 **사용자 빌드 구성 문제**이며 SDK 버그 아님. Unity 엔진이 빌드 검증 단계에서 직접 던지는 예외라 SDK 코드 변경과 무관하게 재현됨.

SDK 코드에는 `Non-development build`, `auto-connecting the profiler`, `ConnectWithProfiler` 문자열이 존재하지 않음을 grep으로 확인 (SDK가 같은 메시지를 직접 출력할 가능성 없음).

## 추출 패턴

`Editor/ErrorTracker/AITEditorErrorTracker.cs` `NonSdkMessagePatterns`:

- `"Non-development build cannot allow auto-connecting the profiler"`

핵심 불변 문구만 추출. Unity가 영문 메시지 본문은 환경/언어/버전과 무관하게 동일하게 출력하므로 한국어 prefix("변환 중 오류가 발생했습니다:") 변형이나 단순 `ArgumentException:` 변형 모두 동일 패턴으로 매칭됨.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns`의 Unity 빌드 섹션 (uncompiled code changes 다음)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 2개 (Sentry 실측 fixture + plain ArgumentException 변형) + AIT prefix 보호 negative 1개

## 검증

⚠️ **동시 빌드 회피로 검증 skip — 사람 확인 필요**

`./run-local-tests.sh --validate` 실행 직전 `pgrep -f run-local-tests` 결과가 11개(초기) → 10개(30초 후 재확인)로 다른 worker가 다수 동시 실행 중이었음. 작업 지침의 "동시 빌드 회피" 정책에 따라 검증 단계를 건너뛰고 PR 생성. 리뷰어가 머지 전 로컬에서 `./run-local-tests.sh --validate` 또는 EditMode 테스트 실행 권장.

추가된 변경은 텍스트 패턴 문자열 1개와 단위 테스트 3개로 격리되어 있어 회귀 위험은 낮음.

## 사람 머지 검토 필요

자동 생성 PR이며 머지 전 사람 검토 필수.
