### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — sprite-atlas (x2)

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -391,6 +391,13 @@ public class IsKnownNonSdkMessageTests
     [TestCase(
         "Sprite 'player idle frame' matches more than one built-in atlases (fallback applied).",
         TestName = "SpriteAtlas_QuotedNameAndTrailingParen_ReturnsTrue")]
+    // Sentry APPS-IN-TOSS-UNITY-SDK-RM / RN — "UnityWarning: " prefix가 붙은 실측 변형.
+    [TestCase(
+        "UnityWarning: Sprite object_03_07 matches more than one built-in atlases. Default to use the first available atlas.",
+        TestName = "SpriteAtlas_UnityWarningPrefix_ObjectName_ReturnsTrue")]
+    [TestCase(
+        "UnityWarning: Sprite background_theme1_3 matches more than one built-in atlases. Default to use the first available atlas.",
+        TestName = "SpriteAtlas_UnityWarningPrefix_UnderscoredName_ReturnsTrue")]
     public void SpriteAtlasDuplicate_RealisticVariants_ReturnsTrue(string message)
     {
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(message));


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-RM
Fixes APPS-IN-TOSS-UNITY-SDK-RN

## 묶음 항목

| source | id | title |
|--------|----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-RM | UnityWarning: Sprite object_03_07 matches more than one built-in atlases. Default to use the first available atlas. |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-RN | UnityWarning: Sprite background_theme1_3 matches more than one built-in atlases. Default to use the first available atlas. |

## 분석

두 이슈 모두 Unity 내장 Sprite atlas 중복 경고 — SDK 외부(Unity 엔진 자체) 출처. action_hint들의 공통 substring은 `"matches more than one built-in atlases"`.

**해당 substring은 이미 `NonSdkMessagePatterns`에 존재** — `Editor/ErrorTracker/AITEditorErrorTracker.cs:86`:

```csharp
// 사용자 프로젝트 에셋 문제
"matches more than one built-in atlases",
```

따라서 패턴 자체는 **추가 변경 불필요**. 실측 입력 형태인 `"UnityWarning: "` prefix 변형이 누락되지 않는지 회귀 방지 테스트만 추가한다.

## 변경

- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`
  - `SpriteAtlasDuplicate_RealisticVariants_ReturnsTrue`에 2개 `TestCase` 추가:
    - `UnityWarning: Sprite object_03_07 matches more than one built-in atlases. Default to use the first available atlas.` (RM 실측)
    - `UnityWarning: Sprite background_theme1_3 matches more than one built-in atlases. Default to use the first available atlas.` (RN 실측)

  현재 필터는 `IndexOf` 부분 매칭이라 둘 다 통과하지만, 필터가 향후 anchored/regex로 tightening될 때 실측 변형을 놓치지 않게 박아둔다.

## 검증

```
$ ./run-local-tests.sh --validate
✓ E2E Test Files Validation
✓ Playwright Config Validation
✓ SDK Generator Unit Tests (18 invariants passed)
Passed: 3 / Failed: 0
```

C# `IsKnownNonSdkMessageTests`는 Unity EditMode 영역으로 `--validate`가 직접 실행하지 않음 — CI lint/EditMode 워크플로우가 검증. 추가된 TestCase는 기존 패턴(line 86)에 매칭되므로 통과가 보장됨.

## 사람 머지 검토 필요

자동 생성 PR. 머지 정책에 따라 사람 승인 후 squash merge.
