### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — cs-compile-error-type-mismatch

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -754,6 +754,18 @@ namespace AppsInToss.Editor.ErrorTracker
             if (message.IndexOf("[AITSentryTransport] Sentry 전송 실패 (HTTP 5", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // 사용자 프로젝트(Assets/) 하위 .cs 파일의 CS0029 암묵 변환 컴파일 에러 (SDK-T2).
+            // Unity 컴파일러가 사용자 코드의 타입 변환 실패를 보고할 때 출력하는 포맷:
+            //   "Assets/.../Foo.cs(L,C): error CS0029: Cannot implicitly convert type 'X' to 'Y'"
+            // 메시지에 SDK 타입명(예: 'AppsInToss.IapProductListItem')이 들어가 AitKeywords 가드가
+            // 발동되므로, SDK 가드보다 먼저 매칭해 노이즈로 드롭한다.
+            // SDK 자체 코드의 컴파일 에러는 'Packages/com.toss.apps-in-toss/...' 또는
+            // 'Library/PackageCache/...' 경로로 출력되어 'Assets/' prefix가 붙지 않으므로 안전.
+            if (message.IndexOf("error CS0029", StringComparison.Ordinal) >= 0
+                && message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용
             if (MessageContainsSdkKeyword(message))
                 return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -808,6 +808,55 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 사용자 코드 CS0029 암묵 변환 컴파일 에러 (SDK-T2)
+
+    [Test]
+    public void UserCodeCS0029_IapProductListItem_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-T2 실측 메시지 — 사용자 IAP 매니저 코드가 SDK 반환 배열을
+        // List<T>에 암묵 변환하려다 발생한 컴파일 에러. SDK 타입명('AppsInToss.IapProductListItem')이
+        // 포함되어 AitKeywords 가드를 발동시키지만, composite AND 가드가 그보다 먼저 매칭되어 노이즈로 드롭됨.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/02_Scripts/02_Manager/IAP/IAPServiceToss.cs(24,29): error CS0029: Cannot implicitly convert type 'AppsInToss.IapProductListItem[]' to 'System.Collections.Generic.List<AppsInToss.IapProductListItem>'"));
+    }
+
+    [Test]
+    public void UserCodeCS0029_OtherUserPath_ReturnsTrue()
+    {
+        // CS0029 + Assets/ + .cs( 조합은 SDK 타입 참조 여부와 무관하게 사용자 코드 컴파일 에러로 분류.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/Scripts/GameLogic.cs(42,10): error CS0029: Cannot implicitly convert type 'int' to 'string'"));
+    }
+
+    [Test]
+    public void Cs0029WithoutAssetsPrefix_AitProtected_ReturnsFalse()
+    {
+        // 'Assets/' 경로가 없으면 composite AND 가드의 한 조건이 빠지므로 매칭되지 않고,
+        // AitKeywords 가드가 정상 동작해 SDK 자체 로그로 간주됨 (필터링 안 함).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] error CS0029 reported from SDK build pipeline"));
+    }
+
+    [Test]
+    public void SdkPackageCS0029_ReturnsFalse()
+    {
+        // SDK 자체 .cs 파일의 컴파일 에러는 'Packages/com.toss.apps-in-toss/...' 경로로 출력되어
+        // 'Assets/' prefix가 붙지 않으므로 composite AND 가드가 매칭되지 않아야 함 (SDK 보호).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/com.toss.apps-in-toss/Runtime/Foo.cs(10,5): error CS0029: Cannot implicitly convert type 'int' to 'string'"));
+    }
+
+    [Test]
+    public void OtherCSErrorInUserAssets_ReturnsFalse()
+    {
+        // CS0029가 아닌 다른 컴파일 에러(CS0103 등)는 composite 가드가 매칭되지 않음.
+        // 필요 시 별도 패턴을 추가하되 본 가드는 'CS0029'에 한정.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/Scripts/GameLogic.cs(42,10): error CS0103: The name 'foo' does not exist in the current context"));
+    }
+
+    #endregion
+
     #region pnpm stdout 패스스루 (SDK-HA, SDK-R6)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-T2

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-T2 | UnityError: Assets/02_Scripts/02_Manager/IAP/IAPServiceToss.cs(24,29): error CS0029: Cannot implicitly convert type 'AppsInToss.IapProductListItem[]' to 'System... |

## 분류 근거

사용자 프로젝트(`Assets/02_Scripts/...`)의 .cs 파일에서 Unity 컴파일러가 출력한 CS0029 암묵 변환 에러. SDK가 반환하는 배열 타입(`AppsInToss.IapProductListItem[]`)을 사용자 코드가 `List<T>`에 변환하려다 발생한 컴파일 에러로, **SDK 버그가 아니라 사용자 코드가 `.ToList()` 등 명시적 변환을 누락**한 것.

메시지에 SDK 타입명(`AppsInToss.IapProductListItem`)이 포함되어 단어 경계 매칭으로 `MessageContainsSdkKeyword` 가드가 발동되기 때문에, 단순히 `NonSdkMessagePatterns`에 substring을 추가해도 필터링되지 않음. 따라서 `ExternalAitPrefixes` 매칭 이후 + `MessageContainsSdkKeyword` 가드 **이전** 위치에 composite AND 조건을 추가해야 가드를 우회할 수 있다.

## 추출 패턴

`Assets/` (사용자 프로젝트 경로) + `error CS0029` (Unity 컴파일러의 암묵 변환 실패 진단) + `.cs(` (라인:컬럼 좌표를 동반한 컴파일러 출력 포맷) — 세 조건을 **모두** 충족하는 메시지만 노이즈로 드롭.

SDK 자체 코드의 컴파일 에러는 `Packages/com.toss.apps-in-toss/...` 또는 `Library/PackageCache/...` 경로로 출력되어 `Assets/` prefix가 붙지 않으므로 보호된다.

## 추가 위치

### `Editor/ErrorTracker/AITEditorErrorTracker.cs`
`IsKnownNonSdkMessage` 내부 — `ExternalAitPrefixes` 매칭 이후, `MessageContainsSdkKeyword` 가드 **이전** 위치에 composite AND 조건 추가. 기존 SDK-T4 (`[AITSentryTransport] HTTP 5xx`) 가드 바로 아래에 배치.

### `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`
새 region `사용자 코드 CS0029 암묵 변환 컴파일 에러 (SDK-T2)` 추가:
- positive: SDK-T2 실측 메시지 (`AppsInToss.IapProductListItem[]` → `List<...>`)
- positive: 다른 사용자 경로 + CS0029 변형
- negative: `Assets/` 없는 경우 (SDK 가드 보호 회귀 방지)
- negative: `Packages/com.toss.apps-in-toss/...` 경로 (SDK 자체 컴파일 에러 보호)
- negative: CS0029가 아닌 다른 CS코드 (가드 범위 한정 확인)

## E2E 결과

이전 attempt에서 전체 success (run [25741897782](https://github.com/toss/apps-in-toss-unity-sdk/actions/runs/25741897782)). 이후 PR #570/#572가 머지되어 최신 origin/main 위로 cherry-pick rebase한 새 head(`34c38b7`)로 E2E 재실행 중: <https://github.com/toss/apps-in-toss-unity-sdk/actions/runs/25779408241>

변경 범위는 `IsKnownNonSdkMessage` 내부 한 군데(composite AND `if` 블록 1개)와 동일 함수의 단위 테스트 5건뿐으로, 빌드 영향이 없는 EditMode-only 변경.

## 사람 머지 검토 필요

자동 생성 PR입니다. squash merge 전 사람 리뷰 + E2E 결과 확인이 필요합니다.