### PR TITLE
빌드: String Check 워크플로 추가 및 Regenerate Lockfiles 단순화

### DIFF
--- a/.github/workflows/regen-lockfiles.yml
+++ b/.github/workflows/regen-lockfiles.yml
@@ -2,7 +2,7 @@ name: Regenerate Lockfiles
 
 on:
   schedule:
-    - cron: "0 18 * * 0"
+    - cron: "0 18 * * *"
   workflow_dispatch:
     inputs:
       auto_merge:
@@ -62,20 +62,6 @@ jobs:
           rm -f pnpm-lock.yaml
           pnpm install --lockfile-only --registry=https://registry.npmjs.org/
 
-      - name: Verify no internal registry leak
-        run: |
-          set -e
-          BAD=0
-          for f in Tests~/E2E/tests/pnpm-lock.yaml WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml sdk-runtime-generator~/pnpm-lock.yaml; do
-            if grep -q "nexus.toss.bz\|toss.bz" "$f"; then
-              echo "::error file=$f::Internal registry URL detected in regenerated lockfile"
-              grep -nE "nexus.toss.bz|toss.bz" "$f" | head -5
-              BAD=1
-            fi
-          done
-          if [ "$BAD" = "1" ]; then exit 1; fi
-          echo "lockfiles clean"
-
       - name: Open PR if changed
         env:
           GH_TOKEN: ${{ github.token }}
@@ -94,7 +80,7 @@ jobs:
           git push -u origin "$BRANCH"
           gh pr create \
             --title "빌드: pnpm lockfile 자동 재생성" \
-            --body "주기적 lockfile 재생성 — public registry(npmjs.org) 기반으로 새로 만들어 내부 nexus 레지스트리 URL 누출을 방지합니다." \
+            --body "주기적 lockfile 재생성 — public registry(npmjs.org) 기반." \
             --base main \
             --head "$BRANCH"
           if [ "$AUTO_MERGE" != "true" ]; then

--- a/.github/workflows/string-check.yml
+++ b/.github/workflows/string-check.yml
@@ -1,0 +1,64 @@
+name: String Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+
+jobs:
+  scan:
+    name: scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PATTERN: ${{ secrets.STRING_CHECK_PATTERN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Guard
+        run: |
+          if [ -z "$PATTERN" ]; then
+            echo "::error::STRING_CHECK_PATTERN repository secret이 설정되지 않았습니다."
+            exit 1
+          fi
+          echo "::add-mask::$PATTERN"
+
+      - name: Scan tree
+        run: |
+          set +e
+          FOUND=$(grep -rIn \
+            --exclude-dir=".git" \
+            --exclude-dir="node_modules" \
+            --exclude-dir="Library" \
+            --exclude-dir="Temp" \
+            -E "$PATTERN" . 2>/dev/null)
+          RC=$?
+          set -e
+          if [ "$RC" = "0" ] && [ -n "$FOUND" ]; then
+            echo "::error::금지된 패턴이 감지되었습니다."
+            echo "$FOUND" | awk -F: '{print "::error file=" $1 ",line=" $2 "::redacted"}'
+            exit 1
+          fi
+          echo "scan OK"
+
+      - name: Scan lockfiles
+        run: |
+          set -e
+          BAD=0
+          for f in \
+            "Tests~/E2E/tests/pnpm-lock.yaml" \
+            "WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml" \
+            "sdk-runtime-generator~/pnpm-lock.yaml"
+          do
+            [ -f "$f" ] || continue
+            if grep -qE "$PATTERN" "$f"; then
+              echo "::error file=$f::redacted"
+              BAD=1
+            fi
+          done
+          [ "$BAD" = "0" ] || exit 1
+          echo "lockfile scan OK"

--- a/.github/workflows/string-check.yml
+++ b/.github/workflows/string-check.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Scan tree
         run: |
           set +e
-          FOUND=$(grep -rIln \
+          FOUND=$(grep -rIn \
             --exclude-dir=".git" \
             --exclude-dir="node_modules" \
             --exclude-dir="Library" \
@@ -40,12 +40,7 @@ jobs:
           set -e
           if [ "$RC" = "0" ] && [ -n "$FOUND" ]; then
             echo "::error::금지된 패턴이 감지되었습니다."
-            # 디버그: 매치 파일 경로의 sha256 12자 + 파일 크기 (경로 자체는 노출 안 함)
-            echo "$FOUND" | sort -u | while IFS= read -r f; do
-              H=$(printf '%s' "$f" | sha256sum | cut -c1-12)
-              SIZE=$(wc -c < "$f" 2>/dev/null || echo "?")
-              echo "::error::match file (sha256:$H, size:$SIZE bytes)"
-            done
+            echo "$FOUND" | awk -F: '{print "::error file=" $1 ",line=" $2 "::redacted"}'
             exit 1
           fi
           echo "scan OK"

--- a/.github/workflows/string-check.yml
+++ b/.github/workflows/string-check.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Scan tree
         run: |
           set +e
-          FOUND=$(grep -rIn \
+          FOUND=$(grep -rIln \
             --exclude-dir=".git" \
             --exclude-dir="node_modules" \
             --exclude-dir="Library" \
@@ -40,7 +40,12 @@ jobs:
           set -e
           if [ "$RC" = "0" ] && [ -n "$FOUND" ]; then
             echo "::error::금지된 패턴이 감지되었습니다."
-            echo "$FOUND" | awk -F: '{print "::error file=" $1 ",line=" $2 "::redacted"}'
+            # 디버그: 매치 파일 경로의 sha256 12자 + 파일 크기 (경로 자체는 노출 안 함)
+            echo "$FOUND" | sort -u | while IFS= read -r f; do
+              H=$(printf '%s' "$f" | sha256sum | cut -c1-12)
+              SIZE=$(wc -c < "$f" 2>/dev/null || echo "?")
+              echo "::error::match file (sha256:$H, size:$SIZE bytes)"
+            done
             exit 1
           fi
           echo "scan OK"


### PR DESCRIPTION
## Summary

- 신규 워크플로 `.github/workflows/string-check.yml` — PR/push 시점에 금지 패턴을 즉시 차단
- `.github/workflows/regen-lockfiles.yml` 단순화 — 검사 step 제거, cron 매주 일요일 → 매일, PR body 어휘 정리
- 검사 정규식은 repository secret `STRING_CHECK_PATTERN` 으로 주입 → 워크플로 yaml/job/step/secret 이름 어디에도 검사 대상 문자열이 노출되지 않음

## Why

- 기존 방어막은 `regen-lockfiles.yml` 의 주 1회 cron 단계 안의 grep 한 줄뿐 — PR/push 시점에 즉시 차단되지 않고, 그 grep 라인 자체가 검사 대상 문자열을 평문으로 노출
- 검사 책임을 별도 워크플로(`string-check.yml`)로 이관하고 패턴을 secret 으로 분리하면, 재생성 루틴은 깔끔해지고 yaml 어디에도 평문이 남지 않음

## 머지 전 필수 작업 (사용자가 GitHub UI에서)

1. **Repository Secret 등록** — 머지 전 반드시 선행:
   - Settings → Secrets and variables → Actions → New repository secret
   - Name: `STRING_CHECK_PATTERN`
   - Value: 검사 정규식 (`grep -E` POSIX ERE 문법)
   - 미설정 상태로 머지 시 Guard step 이 모든 PR/push 에서 fail
2. **Required check 등록** (선택, 차단 강화):
   - Settings → Rules → Rulesets → main branch ruleset
   - `String Check / scan` 추가

## 검증

- `.github/` 디렉토리 grep — 변경 후 평문 `toss.bz` / `nexus` 잔존 0건
- regen-lockfiles 다음 cron run / workflow_dispatch 에서 검사 step 없이 정상 종료 확인 필요
- String Check red-path 재현: throwaway 브랜치에서 임의 매치 라인 추가 → 워크플로 fail 확인 (PR 만들지 말 것)
- 로컬 `./run-local-tests.sh --validate` 는 SDK 유닛 테스트 + 파일 구조 검증이라 워크플로 yaml 변경과는 직교 — CI 에서 검증

## 후속 작업 (별도)

- 과거 머지된 commit history 의 평문 정리 (`git filter-repo` + force push + 백업 태그 정리) — 위험 작업이므로 사용자 명시적 승인 후 별도 진행

## Test plan

- [ ] secret 등록 후 이 PR 의 String Check job 이 green 인지
- [ ] regen-lockfiles workflow_dispatch 1회 실행 결과가 정상 종료
- [ ] required check 등록 (선택)