### PR TITLE
수정: AitKeywords 매칭에 단어 경계 정책 적용 (Sentry T6 거짓양성 차단)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -609,10 +609,16 @@ namespace AppsInToss.Editor.ErrorTracker
         {
             for (int i = 0; i < AitKeywords.Length; i++)
             {
-                if (message != null && message.IndexOf(AitKeywords[i], StringComparison.OrdinalIgnoreCase) >= 0)
+                string keyword = AitKeywords[i];
+
+                // 메시지 본문은 단어 경계 정책으로 매칭 — "Portrait:" 안의 "ait:"처럼
+                // 일반 영어 단어 일부와 case-insensitive substring 충돌하는 거짓양성을 차단.
+                // 스택트레이스는 namespace prefix(예: "AppsInToss.Editor.Foo") 매칭이 자연스럽고
+                // 거짓양성 가능성이 낮으므로 기존 substring 동작 유지.
+                if (message != null && KeywordMatchesAtBoundary(message, keyword))
                     return true;
 
-                if (stackTrace != null && stackTrace.IndexOf(AitKeywords[i], StringComparison.OrdinalIgnoreCase) >= 0)
+                if (stackTrace != null && stackTrace.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) >= 0)
                     return true;
             }
 
@@ -637,19 +643,48 @@ namespace AppsInToss.Editor.ErrorTracker
                 return false;
 
             // AitKeywords를 그대로 재사용하여 IsAitRelated와 가드의 키워드 set drift를 방지.
-            // 식별자형 키워드(영숫자/언더스코어/하이픈)는 단어 경계를 요구해
-            // 사용자 경로(예: Assets/FTR_AppsInToss/...)에 부분 문자열로 들어가도
-            // SDK 가드가 잘못 발동하지 않게 한다. prefix형 키워드("[AIT", "AIT:")는
-            // 비식별자 문자를 포함하므로 substring 매치한다 ("[AITWarn]"처럼
-            // 다른 토큰의 시작 prefix로 사용되어야 함).
+            // 식별자형 키워드("AppsInToss"/"ait-build" 등)는 양쪽 단어 경계를 요구하고,
+            // prefix형 키워드("[AIT", "AIT:")는 키워드 자체가 letter로 시작하는 경우에 한해
+            // 왼쪽 단어 경계만 요구한다. 후자는 "Portrait:" 안의 "ait:"처럼 일반 영어 단어
+            // 일부와 case-insensitive 충돌하는 거짓양성을 차단하기 위함이다 (Sentry T6 회귀 방지).
             for (int i = 0; i < AitKeywords.Length; i++)
             {
-                string keyword = AitKeywords[i];
-                bool match = IsIdentifierToken(keyword)
-                    ? ContainsKeywordAtBoundary(message, keyword)
-                    : message.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) >= 0;
-                if (match)
+                if (KeywordMatchesAtBoundary(message, AitKeywords[i]))
                     return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// AitKeywords의 단일 키워드가 메시지에 단어 경계 정책에 맞게 등장하는지 검사한다.
+        /// 식별자형 키워드는 양쪽 경계, prefix형 키워드(첫 문자가 비식별자)는 substring 매치,
+        /// 첫 문자가 letter인 prefix형 키워드("AIT:")는 왼쪽 경계만 요구한다.
+        /// </summary>
+        private static bool KeywordMatchesAtBoundary(string text, string keyword)
+        {
+            if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(keyword))
+                return false;
+
+            if (IsIdentifierToken(keyword))
+                return ContainsKeywordAtBoundary(text, keyword);
+
+            // prefix형 키워드: 키워드 첫 문자가 비식별자(예: '[')면 자연스럽게 왼쪽 경계가 형성되어
+            // substring 매치로 충분. letter로 시작하면("AIT:") 왼쪽 경계 검사로 좁힘.
+            if (!IsBoundaryWordChar(keyword[0]))
+                return text.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) >= 0;
+
+            int searchFrom = 0;
+            while (searchFrom <= text.Length - keyword.Length)
+            {
+                int idx = text.IndexOf(keyword, searchFrom, StringComparison.OrdinalIgnoreCase);
+                if (idx < 0)
+                    return false;
+
+                bool leftOk = idx == 0 || !IsBoundaryWordChar(text[idx - 1]);
+                if (leftOk)
+                    return true;
+
+                searchFrom = idx + 1;
             }
             return false;
         }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -192,6 +192,24 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void AitColonPrefix_MidSentence_LeadingNonWordBoundary_NeverFiltered()
+    {
+        // "AIT:" prefix는 줄 시작이 아니어도 토큰 경계(공백 등) 직후이면 SDK 자체 로그로 보호되어야 한다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[WARN] AIT: Ignoring locale en-US"));
+    }
+
+    [Test]
+    public void PortraitColonSubstring_NotMatchingAitColon_FilteredAsNoise()
+    {
+        // 회귀 가드: "Portrait:" 내부의 "ait:" substring은 "AIT:"와 case-insensitive로
+        // 충돌하지만 왼쪽이 letter라 단어 경계 정책에 의해 SDK 키워드로 인정하지 않는다.
+        // 따라서 SDK 보호 가드가 발동하지 않고 NonSdkMessagePatterns로 정상 필터된다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate (ViewPortrait: OnFoo)"));
+    }
+
+    [Test]
     public void AitBuildKeyword_NeverFiltered()
     {
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
@@ -258,6 +276,21 @@ public class IsKnownNonSdkMessageTests
         // SDK 보호 가드: AIT prefix 붙으면 필터 안 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AIT] SendMessage cannot be called during Awake, CheckConsistency, or OnValidate."));
+    }
+
+    [Test]
+    public void SendMessageDuringAwake_OnRectTransformDimensionsChange_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-T6 — 사용자 컴포넌트(ViewPortrait)의
+        // OnRectTransformDimensionsChange에서 발생한 라이프사이클 변형.
+        //
+        // 회귀 가드: "Portrait:" 안의 "ait:"가 AitKeywords의 "AIT:"와 case-insensitive로
+        // substring 충돌하던 거짓양성을 단어 경계 정책으로 차단했음을 검증한다.
+        // 거짓양성이 차단되면 SDK 보호 가드가 발동하지 않고 NonSdkMessagePatterns의
+        // "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate" 패턴이
+        // 정상 매칭되어 노이즈로 드롭된다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SendMessage cannot be called during Awake, CheckConsistency, or OnValidate (ViewPortrait: OnRectTransformDimensionsChange)"));
     }
 
     [Test]


### PR DESCRIPTION
## Summary

`AitKeywords`의 `"AIT:"` prefix가 `Portrait:` 같은 일반 영어 단어 안의 `"ait:"` substring과 case-insensitive 충돌하던 거짓양성을 단어 경계 정책으로 차단한다.

PR #569 (closed) 의 후속 작업. T6의 ViewPortrait 메시지가 패턴 추가만으로 해결되지 않은 근본 원인을 SDK 본체에서 수정.

Fixes APPS-IN-TOSS-UNITY-SDK-T6

## 문제

Sentry T6 메시지:
```
UnityWarning: SendMessage cannot be called during Awake, CheckConsistency, or OnValidate (ViewPortrait: OnRectTransformDimensionsChange)
```

흐름 분석 (이전):
1. `OnLogMessageReceived` → `IsAitRelated` (메시지의 `Portrait:` 안 `ait:`가 `AIT:`와 case-insensitive 매칭) → true
2. `IsKnownNonSdkMessage` 진입 → `MessageContainsSdkKeyword`도 동일 substring 매칭으로 true
3. SDK 보호 가드 발동 → `IsKnownNonSdkMessage`가 false 반환
4. `NonSdkMessagePatterns`의 기존 `"SendMessage cannot be called during Awake, CheckConsistency, or OnValidate"` 패턴이 매칭될 기회를 못 얻음
5. 결과적으로 SDK 노이즈로 잘못 분류되어 Sentry에 캡처

## 변경

`Editor/ErrorTracker/AITEditorErrorTracker.cs`

- `IsAitRelated`의 메시지 본문 매칭과 `MessageContainsSdkKeyword`를 공통 `KeywordMatchesAtBoundary`로 통합.
- 키워드 분류별 매칭 정책:
  - **식별자형**(`AppsInToss`, `ait-build` 등): 양쪽 단어 경계 — 기존 동작 유지.
  - **prefix형 + 비식별자 시작**(`[AIT`): substring 매치 — 기존 동작 유지 (`[`가 자연스럽게 왼쪽 경계 형성).
  - **prefix형 + letter 시작**(`AIT:`): 왼쪽 단어 경계 추가 요구 — **신규**. `Portrait:` 같은 일반 단어와의 충돌 차단.
- **스택트레이스**: 기존 substring 동작 유지. namespace prefix(`AppsInToss.Editor.Foo`) 매칭이 자연스럽고 거짓양성 위험이 낮음.

## 추가 위치

`Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`

- `SendMessageDuringAwake_OnRectTransformDimensionsChange_ReturnsTrue` — T6 실측 메시지가 정책 적용 후 정상 노이즈로 분류됨을 검증.
- `AitColonPrefix_MidSentence_LeadingNonWordBoundary_NeverFiltered` — `"AIT:"`이 줄 시작 외에도 토큰 경계 직후이면 SDK 보호 발동함을 회귀 방어 (기존 동작 보존).
- `PortraitColonSubstring_NotMatchingAitColon_FilteredAsNoise` — substring 충돌이 더 이상 SDK 보호 가드를 발동시키지 않음을 명시.

## 검증

`./run-local-tests.sh --validate` — All tests passed (3/3, 18/18 invariants).

E2E EditMode 매트릭스로 실 Unity 환경에서 통과 여부 확인 필요.

## Test plan

- [ ] CI EditMode 매트릭스 (macOS/Windows × 5 Unity 버전) 통과
- [ ] T6 회귀 fixture 통과 확인
- [ ] 기존 SDK 보호 가드 회귀 테스트 100% 통과 (`AitColonPrefix_*`, `AppsInTossKeyword_*` 등)
- [ ] 사람 리뷰: SDK 분류 전반에 영향이 가는 변경이므로 다른 패턴이 깨지지 않는지 코드 리뷰
