### PR TITLE
개선: Sentry 노이즈 패턴 추가 (사용자 코드 컴파일/라이프사이클)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -149,6 +149,17 @@ namespace AppsInToss.Editor.ErrorTracker
             // AitKeywords에 "[pnpm]"이 없어 SDK 보호 가드는 우회되며,
             // SDK 자체 로그는 "[AIT...]" prefix와 함께 출력되므로 보호된다.
             "[pnpm] 출력:",
+
+            // 사용자 코드 using 중복 — Unity 컴파일러가 직접 출력하는 CS0105.
+            // 예: "warning CS0105: The using directive for 'AppsInToss' appeared previously in this namespace"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-SW.
+            // SDK는 컴파일러 경고 메시지를 직접 출력하지 않으므로 안전.
+            "warning CS0105",
+
+            // 사용자 MonoBehaviour 라이프사이클 위반 — Unity 엔진이 OnValidate/animation event 등에서
+            // 즉시 파괴를 시도할 때 직접 출력. 사용자 게임 코드 호출 흐름.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-T0.
+            "Destroying GameObjects immediately is not permitted during",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.
@@ -825,6 +836,14 @@ namespace AppsInToss.Editor.ErrorTracker
             // AITTemplate 경로가 포함되더라도 SDK가 제공한 파일을 사용자가 복사해둔 경우이므로 필터 대상
             if (message.IndexOf("GUID [", StringComparison.Ordinal) >= 0
                 && message.IndexOf("conflicts with:", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 코드의 'AppsInToss' 미발견 컴파일 에러 — SDK 미설치 또는 asmdef 참조 누락.
+            // 예: "error CS0246: The type or namespace name 'AppsInToss' could not be found ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-C3, APPS-IN-TOSS-UNITY-SDK-M7 등 다수.
+            // CS0246 단독은 SDK 빌드 메시지와 충돌 위험이 있어, "'AppsInToss'"와 합성 AND로 좁힌다.
+            if (message.IndexOf("error CS0246", StringComparison.Ordinal) >= 0
+                && message.IndexOf("'AppsInToss'", StringComparison.Ordinal) >= 0)
                 return true;
 
             return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1019,6 +1019,81 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 사용자 코드 컴파일러 경고/에러 (SDK-SW, SDK-T0, SDK-C3/M7)
+
+    [Test]
+    public void UsingDirectiveAppearedPreviously_AppsInToss_ReturnsTrue()
+    {
+        // Sentry SDK-SW — 사용자 코드의 using AppsInToss; 중복 (CS0105).
+        // Unity 컴파일러가 직접 출력하므로 SDK 외부 메시지로 드롭한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\Script\\AITIAPManager.cs(11,7): warning CS0105: The using directive for 'AppsInToss' appeared previously in this namespace"));
+    }
+
+    [Test]
+    public void UsingDirectiveAppearedPreviously_AitKeywordProtected()
+    {
+        // SDK 자체 로그가 "[AIT ...] warning CS0105 ..." 형태로 캡처될 가능성 보호.
+        // AitKeywords 가드로 필터링되지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] internal: warning CS0105 collision"));
+    }
+
+    [Test]
+    public void DestroyingGameObjectsImmediately_ReturnsTrue()
+    {
+        // Sentry SDK-T0 — 사용자 MonoBehaviour의 OnValidate/animation event 등에서 즉시 파괴 시도.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Destroying GameObjects immediately is not permitted during physics trigger/contact, animation event callbacks, rendering callbacks or OnValidate. You must use Destroy instead."));
+    }
+
+    [Test]
+    public void DestroyingGameObjects_AitKeywordProtected()
+    {
+        // SDK가 동일 문구를 진단/리포트로 출력하더라도 [AIT] prefix가 붙으면 보호되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] diag: Destroying GameObjects immediately is not permitted during teardown"));
+    }
+
+    #endregion
+
+    #region 'AppsInToss' 식별자 미발견 컴파일 에러 (SDK-C3, SDK-M7, SDK-PV)
+
+    [Test]
+    public void UserCode_AppsInTossNamespaceMissing_ReturnsTrue()
+    {
+        // Sentry SDK-C3 — 사용자 스크립트가 AppsInToss namespace를 import하지 못함.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\Script\\Tutorial_Howtoplay.cs(4,7): error CS0246: The type or namespace name 'AppsInToss' could not be found (are you missing a using directive or an assembly reference?)"));
+    }
+
+    [Test]
+    public void UserCode_AppsInTossNamespaceMissing_PosixPath_ReturnsTrue()
+    {
+        // Sentry SDK-M7 — POSIX 경로 변형
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/CommonScripts/AdManager.cs(3,7): error CS0246: The type or namespace name 'AppsInToss' could not be found (are you missing a using directive or an assembly reference?)"));
+    }
+
+    [Test]
+    public void Cs0246_WithoutAppsInTossToken_NotFiltered()
+    {
+        // CS0246 단독은 SDK 빌드 메시지/다른 namespace 미발견과 충돌할 수 있으므로
+        // 'AppsInToss' 식별자가 동반될 때만 노이즈로 분류한다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/Foo.cs(1,1): error CS0246: The type or namespace name 'SomethingElse' could not be found"));
+    }
+
+    [Test]
+    public void Cs0246_AppsInTossToken_WithAitPrefix_StillProtected()
+    {
+        // SDK 보호 가드: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] diag: error CS0246: The type or namespace name 'AppsInToss' could not be found in fallback build"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
## Summary

Sentry에서 활성 release(2.4.5/6/7)로도 계속 들어오는 노이즈성 이슈를 캡처 단에서 드롭하기 위해 `NonSdkMessagePatterns`와 `IsKnownNonSdkMessage` 합성 조건을 보강합니다. 모두 사용자 게임 코드 또는 Unity 엔진이 직접 출력하는 메시지이며, SDK 자체 로그는 `[AIT...]` 보호 가드로 영향이 없습니다.

## 추가된 패턴

- **`warning CS0105`** — `using AppsInToss;` 중복 (`SDK-SW`).
- **`Destroying GameObjects immediately is not permitted during`** — 사용자 MonoBehaviour의 OnValidate / animation event에서 즉시 파괴 시도 (`SDK-T0`).
- **`error CS0246` AND `'AppsInToss'`** (합성 AND) — 사용자 스크립트가 SDK namespace 미발견 (`SDK-C3`, `SDK-M7`, `SDK-PV` 외). CS0246 단독은 SDK 빌드 실패 메시지와 충돌 위험이 있어, `'AppsInToss'` 토큰과의 합성 조건으로 좁혔습니다.

## SDK 안전성 점검

- `grep`으로 SDK 코드(Editor/, Runtime/, sdk-runtime-generator~)에 `CS0246/CS0105/CS1503/CS0103`, `Destroying GameObjects immediately`, `'AppsInToss' could not be found` 등 동일 문구가 출력되지 않음을 확인.
- 추가 패턴은 모두 `MessageContainsSdkKeyword` 가드 이후 검사되므로, `[AIT...]` prefix가 붙은 SDK 자체 로그는 영향 없음.

## 관련 작업

이번 PR 직전, lastSeen ≥ 14일 기준 9건(SDK-CF/D2/D3/8A/H6-H9/HE)을 untilEscalating 모드로 ignore 처리. 본 PR은 활성 release에서도 계속 발생하는 노이즈 그룹을 코드 레벨에서 정리합니다.

## Test plan

- [x] `./run-local-tests.sh --validate` 통과 (SDK Generator unit + Playwright config + E2E 파일 구조)
- [x] `IsKnownNonSdkMessageTests`에 positive/negative 8개 추가 — CI EditMode에서 자동 실행
