### PR TITLE
개선: Sentry 노이즈 패턴 추가 (Bee/.o 빌드 실패, cmd /c "git")

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -160,6 +160,20 @@ namespace AppsInToss.Editor.ErrorTracker
             // 즉시 파괴를 시도할 때 직접 출력. 사용자 게임 코드 호출 흐름.
             // Sentry APPS-IN-TOSS-UNITY-SDK-T0.
             "Destroying GameObjects immediately is not permitted during",
+
+            // Unity IL2CPP / Bee 빌드 시스템이 직접 출력하는 컴파일 단위별 빌드 실패.
+            // .o 해시 파일명이 매번 달라 Sentry에서 동일 빌드 실패가 수십 개 별도 이슈로 grouping 됨.
+            // 예: "Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/abcdef.o failed with output:"
+            //     "Building Library/Bee/artifacts/WebGL/ManagedStripped failed with output:"
+            //     "Building Library/Bee/artifacts/WebGL/build/debug_WebGL_wasm/build.js failed with output:"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-SA~SV, T7, TV 등 다수.
+            // 실 SDK 빌드 실패는 "[AIT] WebGL 빌드가 실패했습니다." (SDK-8E)로 별도 캡처되므로 안전.
+            "Building Library/Bee/artifacts/WebGL/",
+
+            // git 호출 trace의 cmd wrapper 변형 — 기존 "Exec> git " 패턴이 잡지 못하는 형태.
+            // 예: "Exec> cmd /c \"git\" show -s --pretty=%D HEAD", "Exec> cmd /c \"git\" log -1 ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-TE, APPS-IN-TOSS-UNITY-SDK-TF.
+            "Exec> cmd /c \"git\"",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1101,6 +1101,77 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region IL2CPP/Bee 빌드 단위별 실패 (SDK-SA~SV, T7, TV)
+
+    [Test]
+    public void BuildLibraryBee_ObjFailed_ReturnsTrue()
+    {
+        // Sentry SDK-SV: 매번 다른 해시 파일명 — "Building Library/Bee/artifacts/WebGL/" 부분 문자열로 일괄 매칭
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Building Library/Bee/artifacts/WebGL/GameAssembly/master_WebGL_wasm/uqx36jn5evd9.o failed with output:"));
+    }
+
+    [Test]
+    public void BuildLibraryBee_ReleaseObjFailed_ReturnsTrue()
+    {
+        // Sentry SDK-SQ
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/287iqgly6k3x.o failed with output:"));
+    }
+
+    [Test]
+    public void BuildLibraryBee_ManagedStripped_ReturnsTrue()
+    {
+        // Sentry SDK-T7
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Building Library/Bee/artifacts/WebGL/ManagedStripped failed with output:"));
+    }
+
+    [Test]
+    public void BuildLibraryBee_BuildJs_ReturnsTrue()
+    {
+        // Sentry SDK-TV
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Building Library/Bee/artifacts/WebGL/build/debug_WebGL_wasm/build.js failed with output:"));
+    }
+
+    [Test]
+    public void BuildLibraryBee_WithAitPrefix_StillProtected()
+    {
+        // SDK 보호 가드: SDK가 동일 prefix로 출력하는 가상의 케이스도 필터링 안 되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/xxx.o failed"));
+    }
+
+    #endregion
+
+    #region git wrapper trace (SDK-TE, SDK-TF)
+
+    [Test]
+    public void ExecCmdGit_ShowVariant_ReturnsTrue()
+    {
+        // Sentry SDK-TF: Unity Collab/CCD 등이 cmd 래핑으로 git 호출
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Exec> cmd /c \"git\" show -s --pretty=%D HEAD"));
+    }
+
+    [Test]
+    public void ExecCmdGit_LogVariant_ReturnsTrue()
+    {
+        // Sentry SDK-TE
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Exec> cmd /c \"git\" log -1 --pretty=format:%h"));
+    }
+
+    [Test]
+    public void ExecCmdGit_WithAitPrefix_StillProtected()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Exec> cmd /c \"git\" show -s --pretty=%D HEAD"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
## Summary

- `Building Library/Bee/artifacts/WebGL/` 부분 문자열을 `NonSdkMessagePatterns`에 추가 — Unity IL2CPP/Bee가 컴파일 단위별로 출력하는 빌드 실패는 `.o` 해시 파일명이 매번 달라 Sentry에서 동일 사고가 수십 개 이슈로 분산되어 잡힘 (SDK-SA, SB, SC, SD, SE, SF, SG, SH, SJ, SM, SN, SP, SQ, SR, SS, ST, SV, S8, S9, T7, TV)
- `Exec> cmd /c "git"` 패턴을 추가 — 기존 `Exec> git `이 잡지 못하던 Unity Collab/CCD의 cmd wrapper 호출 변형 (SDK-TE, SDK-TF)
- IsKnownNonSdkMessageTests에 positive 6개 + AIT 키워드 보호 negative 2개 추가

## 안전성

- AitKeywords (`[AIT`, `AIT:`, `AppsInToss`, `apps-in-toss`, `ait-build`, ...)와 두 패턴 모두 충돌하지 않음 — SDK 보호 가드가 그대로 동작
- 실 SDK 빌드 실패 경로는 `[AIT] WebGL 빌드가 실패했습니다.` (SDK-8E)로 별도 캡처되므로 가시성 유지
- SDK 코드에서 두 패턴 문자열이 직접 출력되지 않음을 grep으로 확인

## Test plan

- [x] `./run-local-tests.sh --validate` (3/3 통과)
- [ ] CI: Check Unity .meta files
- [ ] CI: scan
- [ ] CI: SDK Generator Unit Tests