### PR TITLE
개선: Sentry 노이즈 자체 출력 억제 (카테고리 B - Git/빌드취소/Transport)

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -994,7 +994,7 @@ namespace AppsInToss
                 // 이것은 사용자 의사이므로 SDK 결함 보고 대상이 아니다.
                 if (result.summary.result == UnityEditor.Build.Reporting.BuildResult.Cancelled)
                 {
-                    Debug.LogWarning("[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.");
+                    AITLog.Warning("[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.", sentryCapture: false);
                     return AITExportError.CANCELLED;
                 }
 

--- a/Editor/AITGitGuard.cs
+++ b/Editor/AITGitGuard.cs
@@ -394,7 +394,7 @@ namespace AppsInToss.Editor
                         {
                             Debug.LogWarning($"[AIT] Git stdout/stderr 수집 실패: {ex.GetType().Name}: {ex.Message}");
                         }
-                        Debug.LogWarning($"[AIT] Git 명령 타임아웃 ({timeoutMs / 1000}초): git {arguments}");
+                        AITLog.Warning($"[AIT] Git 명령 타임아웃 ({timeoutMs / 1000}초): git {arguments}", sentryCapture: false);
                         return null;
                     }
 

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -817,6 +817,13 @@ namespace AppsInToss.Editor.ErrorTracker
             if (message.IndexOf("[AITSentryTransport] Sentry 전송 실패 (HTTP 5", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // AITSentryTransport 자체의 네트워크 오류(ConnectionError) — 사용자 환경 일시 장애.
+            // Transport가 스스로의 출력을 다시 Sentry로 보내면 캐스케이드 위험이 있고,
+            // 실제로 SubmitResult.Fail로 호출자에게 결과가 전달되므로 가시성도 유지됨.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-CZ, APPS-IN-TOSS-UNITY-SDK-KA.
+            if (message.IndexOf("[AITSentryTransport] 네트워크 오류", StringComparison.Ordinal) >= 0)
+                return true;
+
             // 사용자 프로젝트(Assets/) 하위 .cs 파일의 CS0029 암묵 변환 컴파일 에러 (SDK-T2).
             // Unity 컴파일러가 사용자 코드의 타입 변환 실패를 보고할 때 출력하는 포맷:
             //   "Assets/.../Foo.cs(L,C): error CS0029: Cannot implicitly convert type 'X' to 'Y'"

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1017,11 +1017,36 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
-    public void SentryTransport_NetworkError_NotFiltered()
+    public void SentryTransport_NetworkError_ReturnsTrue()
     {
-        // 다른 transport 로그(네트워크 오류, 동기 전송 실패 등)는 영향 없음
-        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+        // Sentry SDK-CZ, KA — ConnectionError 등 transport 네트워크 일시 장애는 SDK 가드 우회로 드롭.
+        // Transport가 자기 출력을 다시 Sentry로 보내면 캐스케이드 위험.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AITSentryTransport] 네트워크 오류: Connection refused"));
+    }
+
+    [Test]
+    public void SentryTransport_NetworkErrorUnknown_ReturnsTrue()
+    {
+        // Sentry SDK-CZ
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] 네트워크 오류: Unknown Error"));
+    }
+
+    [Test]
+    public void SentryTransport_NetworkErrorTimeout_ReturnsTrue()
+    {
+        // Sentry SDK-KA
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] 네트워크 오류: Request timeout"));
+    }
+
+    [Test]
+    public void SentryTransport_OtherDiagnostic_NotFiltered()
+    {
+        // Transport의 다른 진단 메시지(예: 큐 가득 참, 동기 전송 등)는 영향받지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] 큐가 가득 차서 가장 오래된 이벤트를 버립니다"));
     }
 
     #endregion


### PR DESCRIPTION
## Summary

카테고리 B Sentry 노이즈 3종을 origin에서 차단. 사용자 코드가 아닌 SDK 자체가 정상 흐름에서 출력하는 `Debug.LogWarning`이 Sentry로 전송되던 케이스.

| Sentry Issue | 메시지 | 처리 |
|---|---|---|
| `APPS-IN-TOSS-UNITY-SDK-QC` | `[AIT] Git 명령 타임아웃 ({sec}초): git ...` | `Editor/AITGitGuard.cs:397` `Debug.LogWarning` → `AITLog.Warning(sentryCapture:false)` |
| `APPS-IN-TOSS-UNITY-SDK-TX` | `[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.` | `Editor/AITConvertCore.cs:997` 동일 처리 |
| `APPS-IN-TOSS-UNITY-SDK-CZ`, `KA` | `[AITSentryTransport] 네트워크 오류: ...` | `Editor/ErrorTracker/AITEditorErrorTracker.cs` `IsKnownNonSdkMessage` 내 inline pre-guard (기존 5xx 패턴과 동일 구조) |

### 왜 Transport는 inline pre-guard인가
`AITSentryTransport`가 자기 출력을 다시 Sentry로 보내면 캐스케이드 위험이 있고, `[AITSentryTransport]` 프리픽스가 `AitKeywords` SDK-보호 가드에 걸려 단순히 `NonSdkMessagePatterns`에 추가하는 방식으로는 차단되지 않음. 5xx 응답을 처리하는 기존 pre-guard와 동일한 위치에 한 줄 추가. `SubmitResult.Fail`로 호출자에게 결과가 전달되므로 가시성은 유지됨.

### 영향
- 지난 7일 기준 17건의 이벤트가 origin 차단됨
- 사용자가 이미 배포한 빌드에서 발생하는 동일 메시지는 `IsKnownNonSdkMessage` 필터를 통과해야 차단되므로, transport 케이스만 즉시 효과 (다른 두 케이스는 신규 SDK 버전에서만 효과)

## Test plan
- [x] `./run-local-tests.sh --validate` — 3/3 통과
- [x] 신규 테스트 케이스 4종 (`SentryTransport_NetworkError_ReturnsTrue`, `_NetworkErrorUnknown_ReturnsTrue`, `_NetworkErrorTimeout_ReturnsTrue`, `_OtherDiagnostic_NotFiltered`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
