### PR TITLE
개선: Sentry 노이즈 흡수 (카테고리 D - Addressables/Vite/git/정책 fetch/Unity 자체)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -174,6 +174,28 @@ namespace AppsInToss.Editor.ErrorTracker
             // 예: "Exec> cmd /c \"git\" show -s --pretty=%D HEAD", "Exec> cmd /c \"git\" log -1 ..."
             // Sentry APPS-IN-TOSS-UNITY-SDK-TE, APPS-IN-TOSS-UNITY-SDK-TF.
             "Exec> cmd /c \"git\"",
+
+            // Unity Addressables / ScriptableBuildPipeline이 직접 출력하는 빌드 실패 메시지.
+            // 사용자 프로젝트의 Addressables 그룹/스키마 설정 문제이며 SDK 영역 아님.
+            // 예: "SBP ErrorError" (SDK-H4), "BuildFailedException: Failed to build Addressables content..." (SDK-S4)
+            // Addressables는 동일 메시지를 다양한 prefix로 반복 출력하므로 핵심 토큰만 매칭.
+            "SBP ErrorError",
+            "Failed to build Addressables content",
+            // Cannot read BuildLayout의 변형 — "BuildLayout has not open for a file" (SDK-EX)
+            "BuildLayout has not open",
+
+            // Unity 오디오 시스템 — 빌드/플레이 중 오디오 장치 전환 발생 시 출력 (SDK-TW)
+            "Default audio device was changed",
+
+            // Unity emscripten 압축 단계 직접 출력 — SDK 코드가 띄우는 메시지가 아님 (SDK-RV)
+            // 예: "Building webgl/Build/204ccce7cc46e2cd9bd7212e664b4738.data.unityweb failed with output:"
+            // 실 SDK 빌드 실패는 "[AIT] WebGL 빌드가 실패했습니다." (SDK-8E)로 별도 캡처되므로 안전.
+            "Building webgl/Build/",
+
+            // Unity AssetDatabase가 SDK 외부 캐시(Library/) 로딩 실패 시 직접 출력 (SDK-RT)
+            // 예: "Unknown error occurred while loading 'Library/AppsInToss/AITBuildSession.asset'."
+            // SDK가 띄우는 라이프사이클 경고가 아니라 Unity 자체 stderr 캡처.
+            "Unknown error occurred while loading 'Library/",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.
@@ -822,6 +844,36 @@ namespace AppsInToss.Editor.ErrorTracker
             // 실제로 SubmitResult.Fail로 호출자에게 결과가 전달되므로 가시성도 유지됨.
             // Sentry APPS-IN-TOSS-UNITY-SDK-CZ, APPS-IN-TOSS-UNITY-SDK-KA.
             if (message.IndexOf("[AITSentryTransport] 네트워크 오류", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 외부 정책 파일 fetch의 일시적 네트워크 오류 — SDK가 외부 호스트에 띄운 메시지이지만
+            // SubmitResult/콘솔로 사용자 가시성은 유지되고, 재시도 시 자연 회복되는 케이스.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-M9.
+            if (message.IndexOf("[AIT] sdk-policy.json fetch 실패", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // Vite dev 서버 포트 polling 타임아웃 — 단순 폴링 종료 알림이며 실제로는 곧 브라우저가 열림.
+            // SDK 흐름상 fatal하지 않고 사용자에게 안내 후 진행.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-QN.
+            if (message.IndexOf("[AIT] Vite 포트 5173 대기 타임아웃", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 환경 포트 점유 / 외부 프로세스 비정상 종료 — actionable 가이드는 콘솔에 이미 출력.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-KP, APPS-IN-TOSS-UNITY-SDK-Q3.
+            if (message.IndexOf("AIT: Dev 서버 시작 실패", StringComparison.Ordinal) >= 0
+                || message.IndexOf("AIT: Production 서버 시작 실패", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 git 환경 문제(Author identity 미설정, git 프로세스 실패 등) — SDK 자동 커밋 보조 흐름.
+            // 실패 시 SDK는 계속 진행하며 사용자가 수동 커밋 가능.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-SK, APPS-IN-TOSS-UNITY-SDK-TZ.
+            if (message.IndexOf("[AIT] 자동 커밋 실패", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // git 명령 타임아웃 — 짧은 타임아웃(5초)은 #591에서 source 차단(AITLog sentryCapture:false).
+            // 긴 타임아웃(예: 300초 commit) 변형도 동일하게 사용자 환경 응답 지연이므로 차단.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-TY, QC.
+            if (message.IndexOf("[AIT] Git 명령 타임아웃", StringComparison.Ordinal) >= 0)
                 return true;
 
             // 사용자 프로젝트(Assets/) 하위 .cs 파일의 CS0029 암묵 변환 컴파일 에러 (SDK-T2).

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1197,6 +1197,121 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 카테고리 D 노이즈 (Addressables / Vite / git / 정책 fetch / Unity 자체)
+
+    [Test]
+    public void Addressables_SbpError_ReturnsTrue()
+    {
+        // Sentry SDK-H4: "SBP ErrorError"는 ScriptableBuildPipeline 출력 자체.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage("SBP ErrorError"));
+    }
+
+    [Test]
+    public void Addressables_FailedToBuildContent_ReturnsTrue()
+    {
+        // Sentry SDK-S4
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "BuildFailedException: BuildFailedException: Failed to build Addressables content, content not included in Player Build. \"SBP ErrorError\""));
+    }
+
+    [Test]
+    public void BuildLayout_HasNotOpen_ReturnsTrue()
+    {
+        // Sentry SDK-EX
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Cannot read BuildLayout header, BuildLayout has not open for a file"));
+    }
+
+    [Test]
+    public void DefaultAudioDevice_Changed_ReturnsTrue()
+    {
+        // Sentry SDK-TW
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Default audio device was changed, but the audio system failed to initialize it. Attempting to reset sound system."));
+    }
+
+    [Test]
+    public void EmscriptenBuild_WebGlBuildFailed_ReturnsTrue()
+    {
+        // Sentry SDK-RV
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Building webgl/Build/204ccce7cc46e2cd9bd7212e664b4738.data.unityweb failed with output:"));
+    }
+
+    [Test]
+    public void UnityAssetDb_LibraryLoad_ReturnsTrue()
+    {
+        // Sentry SDK-RT
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Unknown error occurred while loading 'Library/AppsInToss/AITBuildSession.asset'."));
+    }
+
+    [Test]
+    public void SdkPolicyFetchFailed_ReturnsTrue()
+    {
+        // Sentry SDK-M9
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] sdk-policy.json fetch 실패: System.Net.WebException: The operation has timed out."));
+    }
+
+    [Test]
+    public void VitePortTimeout_ReturnsTrue()
+    {
+        // Sentry SDK-QN
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Vite 포트 5173 대기 타임아웃 (15초), 브라우저를 엽니다"));
+    }
+
+    [Test]
+    public void DevServerStartFailed_PortBusy_ReturnsTrue()
+    {
+        // Sentry SDK-KP
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: Dev 서버 시작 실패 - 포트가 이미 사용 중입니다. 다른 서버가 실행 중인지 확인하세요."));
+    }
+
+    [Test]
+    public void ProductionServerStartFailed_ReturnsTrue()
+    {
+        // Sentry SDK-Q3
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: Production 서버 시작 실패 - 프로세스가 비정상 종료되었습니다 (Exit Code: 1)"));
+    }
+
+    [Test]
+    public void AutoCommit_AuthorIdentity_ReturnsTrue()
+    {
+        // Sentry SDK-SK
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 자동 커밋 실패: Author identity unknown"));
+    }
+
+    [Test]
+    public void AutoCommit_GitProcessTimeout_ReturnsTrue()
+    {
+        // Sentry SDK-TZ
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 자동 커밋 실패: Git 프로세스를 시작할 수 없거나 타임아웃이 발생했습니다."));
+    }
+
+    [Test]
+    public void GitCommandTimeout_300Seconds_ReturnsTrue()
+    {
+        // Sentry SDK-TY (300초 변형) — 5초 케이스(SDK-QC)는 #591에서 source 차단됨.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Git 명령 타임아웃 (300초): git commit --quiet -m \"정리: .gitignore 보호 패턴 추가\""));
+    }
+
+    [Test]
+    public void SdkPolicyFetch_NotMatching_GenericMessage_NotFiltered()
+    {
+        // negative — 단순 'sdk-policy' 문자열만 포함된 다른 메시지는 영향받지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] sdk-policy.json 적용 완료"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
## Summary

지난 7일간 발생한 71개 unresolved Sentry 이슈 중 외부 환경/사용자 프로젝트 원인인 노이즈 7종 그룹(약 69건)을 origin에서 차단.

| Sentry Issue | 메시지 prefix | 위치 |
|---|---|---|
| SDK-H4, S4 | `SBP ErrorError`, `Failed to build Addressables content` | NonSdkMessagePatterns |
| SDK-EX | `BuildLayout has not open` | NonSdkMessagePatterns |
| SDK-TW | `Default audio device was changed` | NonSdkMessagePatterns |
| SDK-RV | `Building webgl/Build/` | NonSdkMessagePatterns |
| SDK-RT | `Unknown error occurred while loading 'Library/` | NonSdkMessagePatterns |
| SDK-M9 | `[AIT] sdk-policy.json fetch 실패` | inline pre-guard |
| SDK-QN | `[AIT] Vite 포트 5173 대기 타임아웃` | inline pre-guard |
| SDK-KP, Q3 | `AIT: Dev/Production 서버 시작 실패` | inline pre-guard |
| SDK-SK, TZ | `[AIT] 자동 커밋 실패` | inline pre-guard |
| SDK-TY, QC | `[AIT] Git 명령 타임아웃` | inline pre-guard |

### 분류 기준
- **SDK 키워드(`[AIT`/`AIT:`/`AppsInToss`) 미포함 메시지** → `NonSdkMessagePatterns` 배열에 추가. `MessageContainsSdkKeyword` 가드보다 뒤에 매칭되어도 SDK 보호와 충돌 없음.
- **SDK 키워드 포함 메시지** → `IsKnownNonSdkMessage` 내 inline pre-guard. SDK 보호 가드(`MessageContainsSdkKeyword`)보다 먼저 매칭되어 노이즈로 드롭. 기존 5xx, ConnectionError 패턴과 동일 구조.

### 분리 처리 (별도 PR 예정)
- **D1** ait-build/ 삭제 실패 (Windows gen-mapping access denied, ~57건) — 실제 SDK 버그. retry-with-backoff + readonly bit 클리어 필요.
- **D2** WebGL 빌드 실패 일반 메시지 (~75건) — 메시지 컨텍스트 부족. BuildResult.summary 등 보강 필요.
- **D3** Windows pnpm 설치 실패 (경로 인용/PowerShell ZIP, ~14건) — 실제 SDK 버그.

## Test plan
- [x] `./run-local-tests.sh --validate` — 3/3 통과
- [x] 신규 테스트 13건 (positive 12 + negative 1) 추가
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
