### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — transient-network-error

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -842,7 +842,9 @@ namespace AppsInToss.Editor.ErrorTracker
             // AITSentryTransport 자체의 네트워크 오류(ConnectionError) — 사용자 환경 일시 장애.
             // Transport가 스스로의 출력을 다시 Sentry로 보내면 캐스케이드 위험이 있고,
             // 실제로 SubmitResult.Fail로 호출자에게 결과가 전달되므로 가시성도 유지됨.
-            // Sentry APPS-IN-TOSS-UNITY-SDK-CZ, APPS-IN-TOSS-UNITY-SDK-KA.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-CZ, APPS-IN-TOSS-UNITY-SDK-KA, APPS-IN-TOSS-UNITY-SDK-RR.
+            // UnityWebRequest.error 텍스트(예: "Connection refused", "Unknown Error", "Request timeout",
+            // "Unable to read data")가 suffix로 붙는 다양한 변형이 동일 패턴으로 모두 매칭된다.
             if (message.IndexOf("[AITSentryTransport] 네트워크 오류", StringComparison.Ordinal) >= 0)
                 return true;
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1042,6 +1042,15 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void SentryTransport_NetworkErrorUnableToReadData_ReturnsTrue()
+    {
+        // Sentry SDK-RR — UnityWebRequest.error 변형 "Unable to read data" (transient I/O 실패).
+        // 기존 일반 패턴이 suffix 변형을 모두 흡수함을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] 네트워크 오류: Unable to read data"));
+    }
+
+    [Test]
     public void SentryTransport_OtherDiagnostic_NotFiltered()
     {
         // Transport의 다른 진단 메시지(예: 큐 가득 참, 동기 전송 등)는 영향받지 않아야 함.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-RR

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-RR | UnityWarning: [AITSentryTransport] 네트워크 오류: Unable to read data |

## 분석

`AITSentryTransport`가 `UnityWebRequest.error` 텍스트를 그대로 메시지에 포함시키므로 transient 네트워크 실패는 다양한 suffix 변형으로 출력된다:

- `Connection refused` (SDK-CZ)
- `Unknown Error` (SDK-CZ)
- `Request timeout` (SDK-KA)
- `Unable to read data` (SDK-RR ← 본 PR 신규 변형)

이미 `Editor/ErrorTracker/AITEditorErrorTracker.cs:846`의 일반 패턴 `"[AITSentryTransport] 네트워크 오류"`(IndexOf substring)가 모든 suffix 변형을 흡수하므로 **신규 패턴은 추가하지 않음**. 회귀 방어 목적의 테스트 케이스만 추가하고 주석에 신규 sentry id를 기록.

## 변경

- `Editor/ErrorTracker/AITEditorErrorTracker.cs`: 주석에 `APPS-IN-TOSS-UNITY-SDK-RR`와 `Unable to read data` 변형 추가 (코드 로직 무변경)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`: `SentryTransport_NetworkErrorUnableToReadData_ReturnsTrue` 추가

## 검증

`./run-local-tests.sh --validate` **검증 skip — 사람 확인 필요**

— PR 생성 시점에 같은 SDK repo에서 다른 worker 5개가 동시에 `run-local-tests`를 실행 중이어서 worker 동시 빌드 회피 정책에 따라 검증 단계를 건너뜀. 추가된 테스트는 기존 패턴이 substring match로 새 변형을 흡수하는지만 검증하며 코드 동작은 변경되지 않음.

## 사람 머지 검토 필요