### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — user-action-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -938,6 +938,13 @@ namespace AppsInToss.Editor.ErrorTracker
                 && !message.StartsWith("[AIT]", StringComparison.Ordinal))
                 return true;
 
+            // 사용자가 직접 WebGL 빌드를 취소한 정보성 경고 — SDK의 의도된 동작 경로.
+            // 신규 SDK 버전은 #591에서 origin(AITLog sentryCapture:false)으로 차단되지만,
+            // 이전 버전 사용자 빌드에서는 여전히 Sentry로 도달하므로 message-filter로도 흡수.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-TX.
+            if (message.IndexOf("사용자에 의해 WebGL 빌드가 취소", StringComparison.Ordinal) >= 0)
+                return true;
+
             // 사용자 프로젝트(Assets/) 하위 .cs 파일의 CS0029 암묵 변환 컴파일 에러 (SDK-T2).
             // Unity 컴파일러가 사용자 코드의 타입 변환 실패를 보고할 때 출력하는 포맷:
             //   "Assets/.../Foo.cs(L,C): error CS0029: Cannot implicitly convert type 'X' to 'Y'"

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1765,6 +1765,25 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void UserCancelledWebGLBuild_ReturnsTrue()
+    {
+        // Sentry SDK-TX — 사용자가 직접 WebGL 빌드를 취소한 정보성 경고.
+        // #591에서 origin(AITLog sentryCapture:false)으로 차단되지만, 이전 SDK 버전
+        // 사용자 빌드에서 도달하는 케이스를 message-filter로도 흡수.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다."));
+    }
+
+    [Test]
+    public void GenericAitBuildFailed_NotFiltered()
+    {
+        // negative — 일반 [AIT] WebGL 빌드 실패 메시지는 SDK 보호 가드로 통과해야 한다.
+        // "사용자에 의해 ... 취소" 부분 문자열이 없으면 영향 없음.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] WebGL 빌드가 실패했습니다."));
+    }
+
+    [Test]
     public void SdkPolicyFetch_NotMatching_GenericMessage_NotFiltered()
     {
         // negative — 단순 'sdk-policy' 문자열만 포함된 다른 메시지는 영향받지 않아야 함.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-TX

## Summary

사용자가 직접 WebGL 빌드를 취소했을 때 SDK가 정보성으로 출력하는 `[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.` 경고가 Sentry에 노이즈로 수집되던 케이스를 message-filter로 흡수.

## 묶음 항목

| Source | ID | Title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-TX | UnityWarning: [AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다. |

## 추가 패턴

`Editor/ErrorTracker/AITEditorErrorTracker.cs::IsKnownNonSdkMessage` 내 inline pre-guard에 1개 패턴 추가:

- `"사용자에 의해 WebGL 빌드가 취소"` — 부분 문자열 매칭

### 왜 inline pre-guard인가

메시지가 `[AIT]` prefix로 시작해 `AitKeywords` SDK-보호 가드에 걸리므로 단순히 `NonSdkMessagePatterns`에 추가하면 차단되지 않음. 기존 `[AIT] Git 명령 타임아웃`, `[AIT] sdk-policy.json fetch 실패` 등과 동일한 위치/구조로 처리.

### 기존 처리와의 관계

- #591에서 origin(`Editor/AITConvertCore.cs:997`의 `AITLog.Warning(..., sentryCapture:false)`)으로 차단됨 — **신규 SDK 버전에서만** 효과
- 본 PR은 **이전 SDK 버전 사용자 빌드**에서 동일 메시지가 Sentry로 도달하는 경로를 message-filter로 추가 차단

## 추가된 테스트 (`IsKnownNonSdkMessageTests.cs`)

- `UserCancelledWebGLBuild_ReturnsTrue` — positive: 정확한 origin 메시지
- `GenericAitBuildFailed_NotFiltered` — negative: 일반 `[AIT] WebGL 빌드가 실패했습니다.`가 SDK 보호 가드를 통과함을 검증 (패턴이 빌드 실패 경로에 영향 없음 확인)

## 검증

- `./run-local-tests.sh --validate` — **동시 빌드 회피로 검증 skip (사람 확인 필요)**: 다른 worker 9개가 동시에 빌드 중이어서 락 충돌 회피를 위해 로컬 검증 생략. CI에서 자동 검증 + 사람 머지 검토 시 필요시 로컬 재검증 권장.

## 사람 머지 검토 필요

자동 생성 PR이므로 squash merge 전 한 번 검토 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)