### PR TITLE
[auto-resolve] 수정: Clean 메뉴 폴더 삭제 실패 시 Sentry 전송 억제 (x3)

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -406,7 +406,10 @@ namespace AppsInToss
                 }
                 else
                 {
-                    Debug.LogError($"AIT: webgl/ 폴더 삭제 실패: {webglPath}");
+                    // 헬퍼(SafeDeleteDirectory)가 이미 sentry-suppressed Warning을 남긴다.
+                    // 여기서 LogError를 띄우면 외부 file lock(IDE/Node/AV 핸들) 같은 사용자 환경 원인이
+                    // Sentry로 전파된다 (APPS-IN-TOSS-UNITY-SDK-RS/V3/V0).
+                    AITLog.Error($"AIT: webgl/ 폴더 삭제 실패: {webglPath}", sentryCapture: false);
                 }
             }
 
@@ -419,7 +422,8 @@ namespace AppsInToss
                 }
                 else
                 {
-                    Debug.LogError($"AIT: ait-build/ 폴더 삭제 실패: {aitBuildPath}");
+                    // 위 webgl/ 블록과 동일 — 헬퍼가 이미 흡수된 Warning을 남기므로 Sentry 전송은 억제.
+                    AITLog.Error($"AIT: ait-build/ 폴더 삭제 실패: {aitBuildPath}", sentryCapture: false);
                 }
             }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/CleanMenuSafetyTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/CleanMenuSafetyTests.cs
@@ -62,6 +62,49 @@ public class CleanMenuSafetyTests
             "AITFileSystemHelper.SafeDeleteDirectory)를 사용해야 한다.");
     }
 
+    /// <summary>
+    /// 회귀 가드: Clean() 본문의 삭제 실패 보고 경로가 `Debug.LogError`를 사용하면
+    /// 외부 file lock(다른 프로세스가 ait-build 핸들을 잡고 있는 사용자 환경 원인)이
+    /// Sentry로 전파된다. 헬퍼(SafeDeleteDirectory)가 이미 sentry-suppressed Warning을
+    /// 남기므로 호출자는 `AITLog.Error(..., sentryCapture: false)`를 사용해야 한다.
+    ///
+    /// 회귀 대상 Sentry 이슈:
+    ///   - APPS-IN-TOSS-UNITY-SDK-RS: "ait-build/ 폴더 삭제 실패: C:\UNITY\Projects\HolmesOrchard\ait-build"
+    ///   - APPS-IN-TOSS-UNITY-SDK-V3: "ait-build/ 폴더 삭제 실패: D:\New folder\BALANCE\..." (공백 포함 경로)
+    ///   - APPS-IN-TOSS-UNITY-SDK-V0: "ait-build/ 폴더 삭제 실패: C:\project\Match in Dream_1.0.21_web\ait-build"
+    /// 모두 read-only가 아닌 file lock에 의한 실패로, 메시지에 예외 타입이 없는 변형.
+    /// </summary>
+    [Test]
+    public void Clean_DeleteFailureUsesSentrySuppressedLog()
+    {
+        string sourcePath = LocateAppsInTossMenuSource();
+        Assert.IsNotNull(sourcePath, "AppsInTossMenu.cs 소스 경로를 찾을 수 없음.");
+
+        string source = File.ReadAllText(sourcePath);
+        string cleanBody = ExtractMethodBody(source, "public static void Clean()");
+        Assert.IsNotNull(cleanBody, "AppsInTossMenu.Clean() 메서드를 소스에서 찾을 수 없음.");
+
+        // 핵심 가드 #1: Clean() 본문에 Debug.LogError 직호출이 없어야 함.
+        //   `Debug.LogError`는 AITLog의 SuppressScope를 거치지 않으므로 Sentry로 전송된다.
+        bool callsDebugLogError = cleanBody.Contains("Debug.LogError(");
+        Assert.IsFalse(callsDebugLogError,
+            "AppsInTossMenu.Clean()은 Debug.LogError()를 직접 호출하면 안 됨. " +
+            "외부 file lock(IDE/Node/AV)에 의한 삭제 실패가 Sentry로 전파된다 " +
+            "(Sentry APPS-IN-TOSS-UNITY-SDK-RS/V3/V0). " +
+            "AITLog.Error(..., sentryCapture: false)를 사용할 것.");
+
+        // 핵심 가드 #2: 삭제 실패 분기가 명시적으로 sentryCapture: false를 사용해야 함.
+        //   이중 안전망 — Clean() 본문에 "폴더 삭제 실패" 문구를 출력하는 라인이 있다면
+        //   같은 라인 근처에 `sentryCapture: false`가 함께 있어야 한다.
+        bool reportsFailure = cleanBody.Contains("폴더 삭제 실패");
+        if (reportsFailure)
+        {
+            Assert.IsTrue(cleanBody.Contains("sentryCapture: false"),
+                "AppsInTossMenu.Clean()이 '폴더 삭제 실패'를 출력한다면 sentryCapture: false로 " +
+                "Sentry 전송을 억제해야 함. 헬퍼(SafeDeleteDirectory)가 이미 흡수된 Warning을 남긴다.");
+        }
+    }
+
     private static string LocateAppsInTossMenuSource()
     {
         // 1) 가장 견고한 방법: AssetDatabase에서 MonoScript를 검색해 자산 경로를 얻는다.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-RS
Fixes APPS-IN-TOSS-UNITY-SDK-V3
Fixes APPS-IN-TOSS-UNITY-SDK-V0

## 묶음 항목

| Sentry | 경로 | 비고 |
|--------|------|------|
| APPS-IN-TOSS-UNITY-SDK-RS | `C:\UNITY\Projects\HolmesOrchard\ait-build` | Windows, 예외 정보 없음 |
| APPS-IN-TOSS-UNITY-SDK-V3 | `D:\New folder\BALANCE\THEBALANCE_HEISHERE_TOSS - 2\ait-build` | Windows, 공백 포함 경로 |
| APPS-IN-TOSS-UNITY-SDK-V0 | `C:\project\Match in Dream_1.0.21_web\ait-build` | Windows, 예외 정보 없음 |

세 항목 모두 동일한 메시지 형식 `AIT: ait-build/ 폴더 삭제 실패: <Windows path>`이며 메시지에 **예외 타입이 포함되지 않음** (이전에 fix된 SDK-CA — `UnauthorizedAccessException ... gen-mapping` — 와는 다른 변형).

## 원인

`AppsInTossMenu.Clean()` 의 webgl/ 및 ait-build/ 폴더 삭제 분기:

```csharp
if (AITFileUtils.DeleteDirectory(aitBuildPath)) { ... }
else
{
    Debug.LogError($"AIT: ait-build/ 폴더 삭제 실패: {aitBuildPath}");  // ← Sentry로 전송됨
}
```

- 헬퍼 `AITFileSystemHelper.SafeDeleteDirectory`는 read-only 속성을 선제 해제하고 실패 시 **이미 `AITLog.Warning(..., sentryCapture: false)`** 로 흡수된 Warning을 남긴 뒤 false를 반환한다.
- 그런데 호출자(Clean menu)가 추가로 `Debug.LogError`를 출력 → AITLog의 SuppressScope를 거치지 않으므로 **Sentry로 전파**된다.
- read-only는 이미 처리되므로 남은 실패 원인은 외부 프로세스의 file lock (IDE/Node/AV가 핸들을 잡고 있음) — 사용자 환경 원인이며 SDK가 해결할 수 없다.

## Fix

`Debug.LogError` → `AITLog.Error(..., sentryCapture: false)` 두 곳 (webgl/, ait-build/).

콘솔 Error 가시성은 그대로 유지되어 사용자는 실패를 인지할 수 있고, 헬퍼의 Warning이 상세 예외 정보를 함께 출력한다. Sentry로의 자동 전파만 차단된다.

## 재현 시도

| 단계 | 결과 |
|------|------|
| EditMode 회귀 테스트 | 실패 — 기존 `SafeDelete_LockedFile_*` 테스트는 `[Platform("Win")]` 제한. macOS에서는 mandatory file lock이 없어 재현 불가 |
| 로컬 E2E | 실패 — file lock은 외부 프로세스 의존, macOS 환경에서 재현 불가 |
| CI E2E | 무리 — Windows runner도 외부 lock holder가 없어 재현 불가 |

재현은 실패했지만 **근본 원인은 코드에서 명확히 식별 가능**: SafeDeleteDirectory의 sentry 흡수 망을 호출자 `Debug.LogError`가 우회하는 구조. 추측 수정이 아닌 정적 분석으로 확인되는 문제.

## 회귀 테스트

`CleanMenuSafetyTests.Clean_DeleteFailureUsesSentrySuppressedLog` 추가 — 정적 소스 분석으로 두 가지 가드:

1. `Clean()` 본문에 `Debug.LogError(` 직호출 없음 (Sentry 흡수 망 우회 방지)
2. "폴더 삭제 실패" 출력 라인 근처에 `sentryCapture: false` 토큰 존재

같은 파일의 기존 `Clean_SourceDoesNotCall_DirectoryDelete` 패턴을 따른다.

## 검증

`./run-local-tests.sh --validate` 실행을 시도했으나 **동시 실행 중인 다른 worker 14개와 충돌**이 두 번 확인되어 가이드(셀프 종료 가드 — "두 번 충돌이면 검증 skip + PR 본문에 명시")에 따라 로컬 검증을 스킵.

- 변경 범위가 작고 (`Debug.LogError` → `AITLog.Error(..., sentryCapture: false)` 2곳)
- `AITLog`는 같은 파일 내 다른 라인(261, 280, 352, ...)에서 이미 사용 중이라 using 추가 불필요
- 회귀 테스트는 정적 소스 분석이라 컴파일 의존 없음
- 검증은 CI lint/EditMode 워크플로우에 위임

## Test plan

- [ ] CI lint 통과 (`.meta` 검증 등)
- [ ] CI EditMode 통과 — 새 회귀 테스트 `Clean_DeleteFailureUsesSentrySuppressedLog` 포함
- [ ] CI E2E 통과 — `--unity-build` 경로의 Clean 메뉴 호출 무영향 확인
