### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — aitpromotion-log-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -220,6 +220,7 @@ namespace AppsInToss.Editor.ErrorTracker
         //   - SDK-S1/SX: <color=Yellow>AITPromotion</color>: ... (사용자 게임 프로모션 로직 로그)
         //     SDK 어디에도 "AITPromotion" 문자열이 출력되지 않으며 (grep 확인),
         //     AitKeywords의 "[AIT"/"AIT:"와도 매칭되지 않으므로 ExternalAitPrefixes로 안전하게 분류.
+        //     "UnityWarning:" prefix가 덧붙은 변형(SDK-S1 재발)도 IndexOf 부분 매칭으로 동일하게 드롭.
         private static readonly string[] ExternalAitPrefixes =
         {
             "[AIT Login]",

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -126,6 +126,17 @@ public class IsKnownNonSdkMessageTests
             "<color=Yellow>AITPromotion</color>: AppsInToss helper called"));
     }
 
+    [Test]
+    public void ExternalAitPromotionPrefix_WithUnityWarningPrefix_ReturnsTrue()
+    {
+        // Sentry SDK-S1 회귀 — Unity 로그 핸들러가 "UnityWarning:" prefix를 덧붙여
+        // 캡처한 변형도 동일한 ExternalAitPrefixes 패턴("AITPromotion</color>")으로 드롭됨을 검증.
+        // IndexOf 부분 문자열 매칭이므로 prefix 유무와 무관하지만, 실제 보고된 메시지 포맷이
+        // 미래 변경(예: prefix-anchored 매칭으로 회귀)에서도 계속 매칭되도록 회귀 케이스로 고정.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [17:07:22:329] <color=Yellow>AITPromotion</color>: CaptureEntryPoint skipped on non-WebGL"));
+    }
+
     #endregion
 
     #region SDK 보호: AIT 키워드 포함 시 절대 필터링 안 함


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-S1

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-S1 | `UnityWarning: [17:07:22:329] <color=Yellow>AITPromotion</color>: CaptureEntryPoint skipped on non-WebGL` |

## 분석

- 보고된 메시지는 `UnityWarning:` prefix가 덧붙은 SDK-S1 재발 변형.
- `ExternalAitPrefixes`에 이미 `"AITPromotion</color>"` 패턴이 등록되어 있고, `IsKnownNonSdkMessage`가 `IndexOf` 부분 문자열 매칭을 사용하므로 **prefix 유무와 무관하게 기존 패턴이 메시지를 드롭**한다.
- 신규 패턴 추가가 불필요하다고 판단 — 대신 회귀 테스트와 주석을 보강해 미래 변경(예: prefix-anchored 매칭으로의 회귀)에서도 같은 메시지가 계속 매칭되도록 고정.

## 추출 패턴

기존 `ExternalAitPrefixes`의 `"AITPromotion</color>"` 재사용 (신규 패턴 없음).

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs`: `ExternalAitPrefixes` 위 주석에 `UnityWarning:` prefix 변형도 동일하게 드롭됨을 명시.
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`: `ExternalAitPromotionPrefix_WithUnityWarningPrefix_ReturnsTrue` 회귀 테스트 추가 (보고된 메시지 문자열 그대로 사용).

## --validate 결과

⚠️ **검증 skip — 사람 확인 필요**

`./run-local-tests.sh --validate`를 실행했으나 다른 worker(transient-network-error 카테고리)의 동시 실행으로 자원 경합이 발생해 37분 이상 지연됨. 셀프 종료 가드의 30분 wall-clock cap에 따라 검증을 중단하고 PR을 생성. 변경 범위가 매우 작고(주석 1줄 + 단위 테스트 1개) 기존 패턴을 재사용하는 회귀 테스트이므로 정상 동작 기대.

## 사람 머지 검토 필요

- 회귀 테스트만 추가하는 작은 변경이지만, `--validate` 통과 여부를 머지 전 한 번 확인해주세요.