### PR TITLE
수정: Windows pnpm/Node.js 설치 실패 Sentry cascade 흡수

### DIFF
--- a/Editor/AITNodeJSDownloader.cs
+++ b/Editor/AITNodeJSDownloader.cs
@@ -159,7 +159,9 @@ namespace AppsInToss.Editor
                         }
                         catch (Exception e)
                         {
-                            Debug.LogWarning($"[NodeJS] 다운로드 실패 ({url}): {e}");
+                            // 네트워크/프록시/방화벽 등 사용자 환경 원인. 재시도/폴백 미러로
+                            // 회복되므로 Sentry로 매 시도마다 fingerprint를 흘릴 가치가 없음.
+                            AITLog.Warning($"[NodeJS] 다운로드 실패 ({url}): {e}", sentryCapture: false);
                             lastException = e;
 
                             // 다운로드 실패 시 임시 파일 삭제
@@ -196,7 +198,7 @@ namespace AppsInToss.Editor
                 if (!checksumValid)
                 {
                     // 체크섬 실패 시 다른 미러에서 재시도
-                    Debug.LogWarning("[NodeJS] 체크섬 불일치! 다른 미러에서 재다운로드를 시도합니다...");
+                    AITLog.Warning("[NodeJS] 체크섬 불일치! 다른 미러에서 재다운로드를 시도합니다...", sentryCapture: false);
                     AITFileSystemHelper.SafeDelete(tempFile, logPrefix: "[NodeJS]");
 
                     // 나머지 미러들로 재시도
@@ -218,13 +220,13 @@ namespace AppsInToss.Editor
                             }
                             else
                             {
-                                Debug.LogWarning($"[NodeJS] 대체 미러도 체크섬 실패: {mirrorUrl}");
+                                AITLog.Warning($"[NodeJS] 대체 미러도 체크섬 실패: {mirrorUrl}", sentryCapture: false);
                                 AITFileSystemHelper.SafeDelete(tempFile, logPrefix: "[NodeJS]");
                             }
                         }
                         catch (Exception e)
                         {
-                            Debug.LogWarning($"[NodeJS] 대체 미러 다운로드 실패: {e}");
+                            AITLog.Warning($"[NodeJS] 대체 미러 다운로드 실패: {e}", sentryCapture: false);
                             AITFileSystemHelper.SafeDelete(tempFile, logPrefix: "[NodeJS]");
                         }
                     }
@@ -304,12 +306,20 @@ namespace AppsInToss.Editor
                 }
                 else
                 {
-                    Debug.LogWarning($"[NodeJS] ✓ Node.js {NODE_VERSION} 설치 완료. pnpm 설치 실패 (빌드 시 재시도됨)");
+                    // pnpm 설치 실패는 빌드 시 재시도되며 사용자 환경(네트워크/PATH) 원인.
+                    // Sentry로 fingerprint를 흘리지 않음 (SDK-TG/TP/TN 등 흡수).
+                    AITLog.Warning(
+                        $"[NodeJS] ✓ Node.js {NODE_VERSION} 설치 완료. pnpm 설치 실패 (빌드 시 재시도됨)",
+                        sentryCapture: false);
                 }
             }
             catch (Exception e)
             {
-                Debug.LogError($"[NodeJS] 다운로드 실패: {e}");
+                // 사용자 환경(네트워크 차단, ZIP 추출 시 PowerShell 인용 충돌, 디스크 권한)
+                // 원인이며 SDK에서 분기/수정할 수 있는 정보가 아니다. 다이얼로그로 사용자에게는
+                // 안내하되, Sentry로는 fingerprint가 폭주하던 본문이 흘러가지 않도록 차단.
+                // Sentry SDK-RX/RZ 등 흡수. 호출자(Initializer)는 throw로 결과 인지 가능.
+                AITLog.Error($"[NodeJS] 다운로드 실패: {e}", sentryCapture: false);
 
                 // CI/배치 모드에서는 다이얼로그 스킵
                 AITPlatformHelper.ShowInfoDialog("다운로드 실패",
@@ -536,7 +546,8 @@ namespace AppsInToss.Editor
                     }
                     catch (Exception e)
                     {
-                        Debug.LogWarning($"[NodeJS] 임시 폴더 삭제 실패 (무시됨): {e}");
+                        // cleanup 경로 — 사용자 환경 잠금(AV/handle) 원인. Sentry 차단.
+                        AITLog.Warning($"[NodeJS] 임시 폴더 삭제 실패 (무시됨): {e}", sentryCapture: false);
                     }
                 }
             }
@@ -563,11 +574,13 @@ namespace AppsInToss.Editor
             }
             catch (UnauthorizedAccessException)
             {
-                Debug.LogWarning($"[NodeJS] 드라이브 루트 접근 권한 없음 ({driveRoot}), 표준 임시 디렉토리로 폴백");
+                // 드라이브 루트 권한 부족은 사용자 정책(BitLocker, 회사 정책) 원인.
+                // 폴백 경로가 있으므로 Sentry로 보고할 필요 없음.
+                AITLog.Warning($"[NodeJS] 드라이브 루트 접근 권한 없음 ({driveRoot}), 표준 임시 디렉토리로 폴백", sentryCapture: false);
             }
             catch (IOException ex)
             {
-                Debug.LogWarning($"[NodeJS] 드라이브 루트 접근 실패 ({ex}), 표준 임시 디렉토리로 폴백");
+                AITLog.Warning($"[NodeJS] 드라이브 루트 접근 실패 ({ex}), 표준 임시 디렉토리로 폴백", sentryCapture: false);
             }
 
             // 2순위: 표준 임시 디렉토리 사용 (권한 보장)
@@ -593,7 +606,9 @@ namespace AppsInToss.Editor
                 string npmPath = GetNpmExecutablePath(nodePath);
                 if (!File.Exists(npmPath))
                 {
-                    Debug.LogError($"[NodeJS] npm을 찾을 수 없습니다: {npmPath}");
+                    // 설치 직후 npm이 없는 케이스 — ZIP 추출/복사 race 또는 디스크 정리.
+                    // 사용자 환경 원인이며 호출자(빌드 흐름)가 fallback 처리 가능.
+                    AITLog.Error($"[NodeJS] npm을 찾을 수 없습니다: {npmPath}", sentryCapture: false);
                     return false;
                 }
 
@@ -618,14 +633,18 @@ namespace AppsInToss.Editor
                 }
                 else
                 {
-                    Debug.LogWarning("[NodeJS] pnpm 설치 실패");
+                    // pnpm 설치 실패는 사용자 환경(공백 PATH, PowerShell 정책, 네트워크) 원인.
+                    // 호출자가 빌드 시 재시도하므로 Sentry로 전송하지 않음.
+                    AITLog.Warning("[NodeJS] pnpm 설치 실패", sentryCapture: false);
                 }
 
                 return success;
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[NodeJS] pnpm 설치 중 예외 발생: {e}");
+                // 예외 본문에 PowerShell 호출 명령줄이 포함되어 fingerprint가 폭주하던 경로.
+                // 사용자 환경 원인이며 빌드 시 재시도되므로 Sentry 차단.
+                AITLog.Warning($"[NodeJS] pnpm 설치 중 예외 발생: {e}", sentryCapture: false);
                 return false;
             }
         }

--- a/Editor/AITNpmRunner.cs
+++ b/Editor/AITNpmRunner.cs
@@ -138,7 +138,11 @@ namespace AppsInToss.Editor
 
             if (!result.Success)
             {
-                Debug.LogError($"[AIT] pnpm 설치 실패: {result.Error}");
+                // 사용자 환경(공백 미인용 PATH, PowerShell 정책, 네트워크 차단 등)에서 발생하는
+                // npm 호출 실패 — 콘솔에는 진단 메시지를 남기되 Sentry로 전송하지 않는다.
+                // result.Error에 전체 명령줄/PowerShell 호출 본문이 들어가 fingerprint가 폭주하던
+                // 케이스(Sentry SDK-TQ/TM/TR 등) 방지.
+                AITLog.Error($"[AIT] pnpm 설치 실패: {result.Error}", sentryCapture: false);
                 return false;
             }
             return true;

--- a/Editor/AITPackageManagerHelper.cs
+++ b/Editor/AITPackageManagerHelper.cs
@@ -133,18 +133,21 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// pnpm/Node.js 설치 실패 에러를 로그에 출력
+        /// pnpm/Node.js 설치 실패 에러를 로그에 출력. 사용자 환경(네트워크/방화벽/디스크 권한)
+        /// 원인이며 SDK에서 분기할 정보가 없으므로 콘솔에만 가이드를 남기고 Sentry로 보내지 않는다.
+        /// Sentry SDK-TP/RH/SZ 등 다수 fingerprint 변형 흡수.
         /// </summary>
         public static void LogInstallationFailure(string tag)
         {
             string nodejsPath = GetNodejsPathDescription();
-            Debug.LogError(
+            AITLog.Error(
                 $"[{tag}] ✗ pnpm을 설치할 수 없습니다.\n"
                 + $"내장 Node.js 다운로드 또는 pnpm 설치에 실패했습니다.\n"
                 + $"해결 방법:\n"
                 + $"  1. 네트워크 연결을 확인하세요.\n"
                 + $"  2. {nodejsPath} 폴더를 삭제 후 Unity를 재시작하세요.\n"
-                + $"  3. 방화벽/프록시가 nodejs.org를 차단하고 있는지 확인하세요."
+                + $"  3. 방화벽/프록시가 nodejs.org를 차단하고 있는지 확인하세요.",
+                sentryCapture: false
             );
         }
 


### PR DESCRIPTION
## Summary
- 사용자 환경(공백 PATH, PowerShell 정책, 네트워크 차단, AV 잠금) 원인의 pnpm/Node.js 설치 실패가 fingerprint 변형으로 Sentry에 폭주하던 경로를 차단
- 콘솔에는 동일한 진단/가이드 메시지를 유지하고, Sentry로만 전송을 막아 사용자 경험은 그대로
- 호출자 throw 체인은 그대로 두어 빌드 흐름에서 결과 인지 가능

## 변경 사항
- `AITNpmRunner.InstallPnpmWithNpm`: pnpm 설치 실패 로그 `Debug.LogError` → `AITLog.Error(sentryCapture: false)` (SDK-TQ/TM/TR)
- `AITPackageManagerHelper.LogInstallationFailure`: 설치 실패 가이드 로그 `Debug.LogError` → `AITLog.Error(sentryCapture: false)` (SDK-TP/RH/SZ)
- `AITNodeJSDownloader`: 다운로드/체크섬/임시폴더 정리/드라이브 루트 fallback/pnpm 설치 경로 전반 `Debug.LogWarning|LogError` → `AITLog.Warning|Error(sentryCapture: false)` (SDK-RX/RZ/TG/TN/TJ/TK 등)

## 영향
- Sentry: D3 클러스터(14개 이슈) untilEscalating ignore + 신규 발생 차단
- Unity Console: 메시지 본문 변경 없음

## Test plan
- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI: Lint, Validation, E2E (자동)