### PR TITLE
수정: pnpm install/실행 실패 cascade Sentry 차단

### DIFF
--- a/Editor/AITNpmRunner.cs
+++ b/Editor/AITNpmRunner.cs
@@ -324,14 +324,18 @@ namespace AppsInToss.Editor
                     }
                     else
                     {
-                        Debug.LogError($"[{pmName}] 명령 실패 (Exit Code: {process.ExitCode}): {pmName} {arguments}");
+                        // npm/pnpm exit != 0 — lockfile drift, 네트워크, AV scan, registry 정책 등
+                        // 사용자 환경 원인. 호출자는 FAIL_NPM_BUILD로 결과 인지 후 상위에서
+                        // 컨텍스트 있는 메시지로 보고하므로 여기서는 Console 진단만 남기고
+                        // Sentry는 차단 (SDK-HA/HB/R6/PM cascade 흡수).
+                        AITLog.Error($"[{pmName}] 명령 실패 (Exit Code: {process.ExitCode}): {pmName} {arguments}", sentryCapture: false);
                         if (!string.IsNullOrEmpty(output))
                         {
-                            Debug.LogError($"[{pmName}] 출력:\n{output}");
+                            AITLog.Error($"[{pmName}] 출력:\n{output}", sentryCapture: false);
                         }
                         if (!string.IsNullOrEmpty(error))
                         {
-                            Debug.LogError($"[{pmName}] 오류:\n{error}");
+                            AITLog.Error($"[{pmName}] 오류:\n{error}", sentryCapture: false);
                         }
                         return AITConvertCore.AITExportError.FAIL_NPM_BUILD;
                     }
@@ -343,7 +347,9 @@ namespace AppsInToss.Editor
             catch (Exception e)
             {
                 EditorUtility.ClearProgressBar();
-                Debug.LogError($"[{pmName}] 명령 실행 오류: {e}");
+                // 동기 npm 실행 예외 — 호출자가 NODE_NOT_FOUND로 인지 후 상위 가이드 출력.
+                // 예외 본문에 명령줄/path가 들어가 fingerprint가 폭주하므로 Sentry 차단.
+                AITLog.Error($"[{pmName}] 명령 실행 오류: {e}", sentryCapture: false);
                 return AITConvertCore.AITExportError.NODE_NOT_FOUND;
             }
         }
@@ -399,10 +405,12 @@ namespace AppsInToss.Editor
                     }
                     else
                     {
-                        Debug.LogWarning($"[{pmName}] 비동기 명령 실패 (Exit Code: {result.ExitCode}): {pmName} {arguments}");
+                        // 비동기 변형 — 동기 경로와 동일하게 사용자 환경 원인이며
+                        // onComplete가 상위로 결과 전파. Sentry는 차단.
+                        AITLog.Warning($"[{pmName}] 비동기 명령 실패 (Exit Code: {result.ExitCode}): {pmName} {arguments}", sentryCapture: false);
                         if (!string.IsNullOrEmpty(result.Error))
                         {
-                            Debug.LogWarning($"[{pmName}] 오류:\n{result.Error}");
+                            AITLog.Warning($"[{pmName}] 오류:\n{result.Error}", sentryCapture: false);
                         }
                         onComplete?.Invoke(AITConvertCore.AITExportError.FAIL_NPM_BUILD);
                     }

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -176,7 +176,9 @@ namespace AppsInToss.Editor
             string pnpmPath = AITNpmRunner.FindPnpmPath();
             if (string.IsNullOrEmpty(pnpmPath))
             {
-                Debug.LogError("[AIT] [병렬] pnpm 설치에 실패했습니다.");
+                // pnpm 부재는 환경 원인 — 다이얼로그로 사용자에게 안내되고 빌드 흐름이
+                // FAIL_NPM_BUILD로 결과 인지. Sentry는 fingerprint 가치가 없어 차단.
+                AITLog.Error("[AIT] [병렬] pnpm 설치에 실패했습니다.", sentryCapture: false);
                 AITPackageManagerHelper.ShowInstallationFailureDialog();
                 return (null, AITConvertCore.AITExportError.FAIL_NPM_BUILD);
             }
@@ -283,7 +285,9 @@ namespace AppsInToss.Editor
             var installResult = earlyCtx.PnpmInstallResult ?? AITConvertCore.AITExportError.FAIL_NPM_BUILD;
             if (installResult != AITConvertCore.AITExportError.SUCCEED)
             {
-                Debug.LogError($"[AIT] [병렬] pnpm install 실패: {installResult}");
+                // pnpm install 결과 코드만 노출 — onComplete가 빌드 흐름으로 결과를
+                // 전파해 상위에서 보고. 환경 원인이라 Sentry fingerprint 가치 없음.
+                AITLog.Error($"[AIT] [병렬] pnpm install 실패: {installResult}", sentryCapture: false);
                 earlyCtx.CancelAndDisposePnpm();
                 try { snapshot.Restore(); }
                 finally { AITBuildSession.EndBuild(); }

--- a/Editor/Package/PnpmRunner.cs
+++ b/Editor/Package/PnpmRunner.cs
@@ -130,7 +130,9 @@ namespace AppsInToss.Editor.Package
                                     {
                                         process.Kill();
                                         process.WaitForExit(5000);
-                                        Debug.LogError($"[AIT] [병렬] pnpm {label} 시간 초과 ({maxWaitMs / 1000}초)");
+                                        // 5분 타임아웃은 환경(네트워크/registry) 원인이며 다음 폴백
+                                        // 단계로 진행됨. Sentry로 fingerprint를 흘리지 않음.
+                                        AITLog.Error($"[AIT] [병렬] pnpm {label} 시간 초과 ({maxWaitMs / 1000}초)", sentryCapture: false);
                                         break; // 다음 단계로
                                     }
 
@@ -164,7 +166,8 @@ namespace AppsInToss.Editor.Package
                     }
                     catch (Exception e)
                     {
-                        Debug.LogError($"[AIT] [병렬] pnpm {label} 실행 오류: {e}");
+                        // 프로세스 시작/IO 예외 — 다음 폴백 단계로 진행. 환경 원인 cascade이므로 Sentry 차단.
+                        AITLog.Error($"[AIT] [병렬] pnpm {label} 실행 오류: {e}", sentryCapture: false);
                     }
 
                     Debug.Log($"[AIT] [병렬] pnpm install ({label}) 실패, 다음 단계로...");


### PR DESCRIPTION
## Summary
- 사용자 환경(lockfile drift, 네트워크, registry 정책, AV scan) 원인의 npm/pnpm exit != 0 실패가 fingerprint 변형으로 Sentry에 폭주하던 cascade 차단
- 결과 코드는 호출자(빌드 흐름)가 FAIL_NPM_BUILD/NODE_NOT_FOUND로 인지하고 상위에서 컨텍스트 있는 가이드 메시지를 출력하므로 사용자 경험은 그대로
- Console 진단(메시지 본문)은 유지, Sentry만 차단

## 변경 사항
- `AITNpmRunner.RunNpmCommandWithCacheSync`: `명령 실패 / 출력 / 오류 / 명령 실행 오류` 4개 site 모두 `AITLog.Error(sentryCapture: false)` (SDK-HA/HB/R6/PM)
- `AITNpmRunner.RunNpmCommandWithCacheAsync`: 비동기 변형 2개 site `AITLog.Warning(sentryCapture: false)`
- `AITPackageBuilder.RunEarlyPackagePreparation`: pnpm 경로 부재 `Debug.LogError` → `AITLog.Error(sentryCapture: false)` (SDK-F1 변형)
- `AITPackageBuilder.OnPnpmInstallReady`: install 결과 실패 `Debug.LogError` → `AITLog.Error(sentryCapture: false)` (SDK-F1)
- `Editor/Package/PnpmRunner.cs`: 타임아웃 / 실행 예외 `AITLog.Error(sentryCapture: false)`

## 영향
- Sentry: D4 클러스터(HA/HB/R6/PM/F1/R5, 252+ events) untilEscalating ignore + 신규 발생 차단
- Unity Console: 메시지 본문 변경 없음

## Test plan
- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI: Lint, Validation, E2E (자동)