### PR TITLE
수정: AITSentryTransport self-loop Sentry 차단 (D7)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -828,10 +828,16 @@ namespace AppsInToss.Editor.ErrorTracker
                     return true;
             }
 
-            // SDK 자체 로그이지만 원인이 외부 서비스의 일시적 장애(5xx)인 메시지는
-            // SDK 가드 도달 전에 노이즈로 드롭한다. 5xx만 매칭하므로 4xx(인증/페이로드)는 영향 없음.
+            // Sentry 전송 모듈 자체의 실패를 다시 Sentry로 보내면 self-loop이 발생한다.
+            // 현재 main에서는 source 단에서 sentryCapture:false로 차단하지만(AITSentryTransport),
+            // 이전 SDK 버전이 만든 envelope이 후속 빌드에서 흘러올 수 있어 cascade 필터도 함께 유지.
+            // 4xx(인증/페이로드)와 5xx(서비스 장애) 모두 SDK 코드로 분기할 정보가 아니므로 동일 처리.
             // Sentry APPS-IN-TOSS-UNITY-SDK-T4 — [AITSentryTransport] Sentry 전송 실패 (HTTP 503)
-            if (message.IndexOf("[AITSentryTransport] Sentry 전송 실패 (HTTP 5", StringComparison.Ordinal) >= 0)
+            if (message.IndexOf("[AITSentryTransport] Sentry 전송 실패 (HTTP ", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 동기 전송(에디터 종료 시 FlushSync) 실패도 self-loop 위험. 동일 정책으로 차단.
+            if (message.IndexOf("[AITSentryTransport] 동기 전송 실패", StringComparison.Ordinal) >= 0)
                 return true;
 
             // AITSentryTransport 자체의 네트워크 오류(ConnectionError) — 사용자 환경 일시 장애.

--- a/Editor/ErrorTracker/AITSentryTransport.cs
+++ b/Editor/ErrorTracker/AITSentryTransport.cs
@@ -271,7 +271,9 @@ namespace AppsInToss.Editor.ErrorTracker
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"[AITSentryTransport] 동기 전송 실패: {e}");
+                // Sentry 전송 모듈 자체의 실패를 다시 Sentry로 보내면 self-loop이 발생.
+                // SubmitResult.Fail로 호출자에게 결과가 전달되므로 가시성은 유지됨.
+                AITLog.Warning($"[AITSentryTransport] 동기 전송 실패: {e}", sentryCapture: false);
                 if (_requestEnvelopes.TryGetValue(request, out var env))
                 {
                     _requestEnvelopes.Remove(request);
@@ -315,9 +317,11 @@ namespace AppsInToss.Editor.ErrorTracker
                 if (request.isNetworkError)
 #endif
                 {
-                    Debug.LogWarning(
-                        $"[AITSentryTransport] 네트워크 오류: {request.error}"
-                    );
+                    // Sentry 전송 모듈 자체의 네트워크 오류를 다시 Sentry로 보내면 self-loop.
+                    // SubmitResult.Fail로 호출자에게 결과가 전달되므로 가시성은 유지됨.
+                    AITLog.Warning(
+                        $"[AITSentryTransport] 네트워크 오류: {request.error}",
+                        sentryCapture: false);
                     result = SubmitResult.Fail(request.error ?? "네트워크 오류");
                     return;
                 }
@@ -333,9 +337,12 @@ namespace AppsInToss.Editor.ErrorTracker
 
                 if (statusCode >= 400)
                 {
-                    Debug.LogWarning(
-                        $"[AITSentryTransport] Sentry 전송 실패 (HTTP {statusCode})"
-                    );
+                    // Sentry 전송 실패를 다시 Sentry로 보내면 self-loop.
+                    // 4xx(인증/페이로드)도 5xx(서비스 장애)도 SDK 코드로 분기할 정보가 없고,
+                    // SubmitResult.Fail로 호출자에게 결과가 전달되므로 가시성은 유지됨.
+                    AITLog.Warning(
+                        $"[AITSentryTransport] Sentry 전송 실패 (HTTP {statusCode})",
+                        sentryCapture: false);
                     result = SubmitResult.Fail($"HTTP {statusCode}", (int)statusCode);
                     return;
                 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -967,13 +967,13 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
-    #region 외부 서비스 일시적 장애 (Sentry transport 5xx)
+    #region Sentry transport 자기참조 노이즈 (4xx/5xx + 네트워크 + 동기)
 
     [Test]
     public void SentryTransport_Http503_ReturnsTrue()
     {
         // Sentry APPS-IN-TOSS-UNITY-SDK-T4 — Sentry 서버의 일시적 503 응답.
-        // SDK 자체 로그이지만 원인이 외부 서비스 transient 장애이므로 노이즈로 드롭.
+        // Transport 자체의 실패를 다시 Sentry로 보내면 self-loop이 발생하므로 드롭.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AITSentryTransport] Sentry 전송 실패 (HTTP 503)"));
     }
@@ -981,7 +981,6 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void SentryTransport_Http500_ReturnsTrue()
     {
-        // 5xx 일반화 — 500/502/504 등도 동일한 외부 transient 장애로 분류
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AITSentryTransport] Sentry 전송 실패 (HTTP 500)"));
     }
@@ -1001,19 +1000,28 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
-    public void SentryTransport_Http400_NotFiltered()
+    public void SentryTransport_Http400_ReturnsTrue()
     {
-        // 4xx(인증/페이로드 오류)는 SDK가 알아야 하는 진짜 에러이므로 5xx 패턴에 매칭되지 않아야 함
-        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+        // 4xx도 self-loop 방지 정책에 따라 동일하게 차단. SDK 분기 정보가 없고
+        // SubmitResult.Fail로 호출자에게 결과가 전달되므로 가시성 손실 없음.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AITSentryTransport] Sentry 전송 실패 (HTTP 400)"));
     }
 
     [Test]
-    public void SentryTransport_Http401_NotFiltered()
+    public void SentryTransport_Http401_ReturnsTrue()
     {
-        // DSN 오설정 등 — SDK 측 수정이 필요한 진짜 에러
-        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+        // DSN 오설정도 사용자 가시성은 콘솔에 유지되므로 self-loop 방지를 우선.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AITSentryTransport] Sentry 전송 실패 (HTTP 401)"));
+    }
+
+    [Test]
+    public void SentryTransport_SyncSendFailure_ReturnsTrue()
+    {
+        // 에디터 종료 FlushSync 경로의 예외도 self-loop 방지를 위해 차단.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentryTransport] 동기 전송 실패: System.Net.WebException: ..."));
     }
 
     [Test]


### PR DESCRIPTION
## 요약

AITSentryTransport는 Sentry envelope을 전송하는 모듈이지만 실패 시 `Debug.LogWarning`을 호출했고, 이 출력이 `AITEditorErrorTracker.OnLogMessageReceived`를 거쳐 다시 Sentry로 캡처되어 self-loop noise를 만들었다. 카테고리 D7.

## 소스 차단 (3개 지점)

AITSentryTransport.cs의 `Debug.LogWarning` → `AITLog.Warning(sentryCapture: false)`:

- 동기 전송 실패(`FlushSync` 경로 예외, line 274)
- 네트워크 오류(ConnectionError, line 318) — SDK-CZ/KA/RR 흡수
- HTTP 4xx/5xx 응답(line 336) — SDK-T4 흡수

Console 진단은 그대로 유지되고, `SubmitResult.Fail`로 호출자(AITLog, FlushSentryEnvelope 등)에 결과가 전달되므로 가시성 손실은 없다.

## 필터 보강 (backward compat)

이전 SDK 버전이 만든 envelope이 후속 빌드에서 흘러올 경우를 대비해 `IsKnownNonSdkMessage`도 강화:

- HTTP 패턴을 `"(HTTP 5"`에서 `"(HTTP "`로 일반화 — 4xx도 동일하게 self-loop 위험 → 차단
- `"동기 전송 실패"` 변형 추가

## 영향 받는 Sentry 이슈

- APPS-IN-TOSS-UNITY-SDK-T4 (HTTP 503 self-loop, 3 events, 24분 전 마지막)
- APPS-IN-TOSS-UNITY-SDK-CZ (네트워크 오류 Unknown, 10 events)
- APPS-IN-TOSS-UNITY-SDK-KA (네트워크 오류 Request timeout, 7 events)
- APPS-IN-TOSS-UNITY-SDK-RR (네트워크 오류 Unable to read data, 2 events)

현재 release `2.4.7`은 `#572`/`#591` 필터 머지 이전 빌드라 필터가 작동하지 않았다. 다음 SDK bump부터 source 차단 + cascade 흡수가 동시에 작동한다.

## Test plan

- [x] `IsKnownNonSdkMessageTests`에 positive case 3개 갱신 (4xx, 401, 동기 전송 실패)
- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI EditMode 테스트에서 4xx → true 정책 변경이 반영되는지 확인