### PR TITLE
개선: Unity AssetDatabase GUID 충돌 경고 노이즈 흡수 (D8)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -877,6 +877,21 @@ namespace AppsInToss.Editor.ErrorTracker
             if (message.IndexOf("[AIT] Git 명령 타임아웃", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // Unity AssetDatabase가 출력하는 GUID 충돌 경고. 사용자가 SDK를 UPM이 아닌
+            // Assets/ 하위로 import한 환경에서 동일 자산이 Packages/와 Assets/ 양쪽에 존재하면
+            // Unity 엔진이 자동으로 새 GUID를 부여하며 이 경고를 출력한다.
+            // 형식:
+            //   "GUID [<hash>] for asset '<assetPath>' conflicts with:
+            //     '<otherAssetPath>' (current owner)
+            //   Assigning a new guid."
+            // composite AND 조건으로 다른 GUID 진단 메시지와 거짓양성 충돌을 방지한다.
+            // SDK 패키지 경로가 message에 들어가 AitKeywords 가드가 발동되므로 가드보다 먼저 매칭.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-BQ.
+            if (message.IndexOf("GUID [", StringComparison.Ordinal) >= 0
+                && message.IndexOf("] for asset '", StringComparison.Ordinal) >= 0
+                && message.IndexOf("' conflicts with:", StringComparison.Ordinal) >= 0)
+                return true;
+
             // 사용자 프로젝트(Assets/) 하위 .cs 파일의 CS0029 암묵 변환 컴파일 에러 (SDK-T2).
             // Unity 컴파일러가 사용자 코드의 타입 변환 실패를 보고할 때 출력하는 포맷:
             //   "Assets/.../Foo.cs(L,C): error CS0029: Cannot implicitly convert type 'X' to 'Y'"

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -886,10 +886,12 @@ namespace AppsInToss.Editor.ErrorTracker
             //   Assigning a new guid."
             // composite AND 조건으로 다른 GUID 진단 메시지와 거짓양성 충돌을 방지한다.
             // SDK 패키지 경로가 message에 들어가 AitKeywords 가드가 발동되므로 가드보다 먼저 매칭.
+            // [AIT] prefix가 붙은 SDK 자체 로그는 절대 필터링하지 않으므로 별도 가드.
             // Sentry APPS-IN-TOSS-UNITY-SDK-BQ.
             if (message.IndexOf("GUID [", StringComparison.Ordinal) >= 0
                 && message.IndexOf("] for asset '", StringComparison.Ordinal) >= 0
-                && message.IndexOf("' conflicts with:", StringComparison.Ordinal) >= 0)
+                && message.IndexOf("' conflicts with:", StringComparison.Ordinal) >= 0
+                && !message.StartsWith("[AIT]", StringComparison.Ordinal))
                 return true;
 
             // 사용자 프로젝트(Assets/) 하위 .cs 파일의 CS0029 암묵 변환 컴파일 에러 (SDK-T2).

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1059,6 +1059,35 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region Unity AssetDatabase GUID 충돌 (SDK-BQ)
+
+    [Test]
+    public void GuidConflict_SdkAssetImported_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-BQ — 사용자가 SDK를 UPM이 아닌 Assets/ 하위로 import.
+        // Unity 엔진이 출력하는 GUID 충돌 경고로, SDK 코드에서 차단 불가.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "GUID [ab2202024c4c0485e9a366792ed7605d] for asset 'Assets/WebGLTemplates/AITTemplate/TemplateData/unity-logo-dark.png' conflicts with:\n  'Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/TemplateData/unity-logo-dark.png' (current owner)\nAssigning a new guid.\n"));
+    }
+
+    [Test]
+    public void GuidConflict_StyleCss_ReturnsTrue()
+    {
+        // BQ의 다른 변형 — style.css에서도 동일 패턴
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "GUID [d097f2670df9e41ff90dd9bda7da052c] for asset 'Assets/WebGLTemplates/AITTemplate/TemplateData/style.css' conflicts with:\n  'Packages/im.toss.apps-in-toss-unity-sdk/WebGLTemplates/AITTemplate/TemplateData/style.css' (current owner)\nAssigning a new guid.\n"));
+    }
+
+    [Test]
+    public void GuidDiagnostic_WithoutConflict_NotFiltered()
+    {
+        // composite AND 가드: "GUID ["만 있고 "conflicts with:"는 없는 다른 메시지는 통과
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "GUID [abc123] computed for asset; nothing else to report."));
+    }
+
+    #endregion
+
     #region 사용자 코드 컴파일러 경고/에러 (SDK-SW, SDK-T0, SDK-C3/M7)
 
     [Test]


### PR DESCRIPTION
## 요약

사용자가 SDK를 UPM이 아닌 `Assets/` 하위로 import한 환경에서 동일 자산이 `Packages/`와 `Assets/` 양쪽에 존재하면 Unity 엔진이 새 GUID를 자동 부여하며 다음 경고를 직접 출력한다:

```
GUID [<hash>] for asset 'Assets/.../foo.png' conflicts with:
  'Packages/im.toss.apps-in-toss-unity-sdk/.../foo.png' (current owner)
Assigning a new guid.
```

SDK 코드에서 차단 불가하므로 `NonSdkMessagePatterns`에 composite AND 조건으로 추가한다.

## 매칭 조건

세 토큰이 모두 매칭되어야 노이즈로 드롭:

- `"GUID ["`
- `"] for asset '"`
- `"' conflicts with:"`

단일 부분 문자열이 아닌 composite 조건으로 다른 GUID 진단 메시지(예: `GUID [abc123] computed for asset; ...`)와 거짓양성 충돌을 방지한다.

SDK 키워드(`Packages/im.toss.apps-in-toss-unity-sdk`)가 메시지에 포함되어 `AitKeywords` 가드를 통과하므로 SDK 보호 가드(`MessageContainsSdkKeyword`)보다 먼저 매칭한다.

## 영향 받는 Sentry 이슈

- APPS-IN-TOSS-UNITY-SDK-BQ: 31 events, last seen 1시간 전, release `2.1.0`+ 다수 환경에서 발생

## Test plan

- [x] `IsKnownNonSdkMessageTests`에 positive 2개(unity-logo, style.css) + negative 1개 추가
- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI EditMode 테스트 통과 확인