### PR TITLE
수정: 프로젝트 pnpm-lock.yaml 폴백 경고 Sentry 차단 (D9)

### DIFF
--- a/Editor/Package/BuildConfigMerger.cs
+++ b/Editor/Package/BuildConfigMerger.cs
@@ -91,15 +91,20 @@ namespace AppsInToss.Editor.Package
                     }
                     else
                     {
-                        Debug.LogWarning(
+                        // 의도된 폴백 경로(SDK lockfile 사용). Console 가시성은 유지하되
+                        // 사용자 환경 의존 메시지(불일치 specifier 목록)가 Sentry fingerprint를
+                        // 흩어놓아 노이즈를 만들므로 Sentry 전송은 차단. Sentry SDK-Q1/S2.
+                        AITLog.Warning(
                             "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml이 package.json과 정합되지 않아 SDK lockfile로 폴백합니다. " +
-                            "불일치: " + mismatchSummary);
+                            "불일치: " + mismatchSummary,
+                            sentryCapture: false);
                     }
                 }
                 else
                 {
-                    Debug.LogWarning(
-                        "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml은 있지만 package.json이 없어 검증 불가. SDK lockfile로 폴백합니다.");
+                    AITLog.Warning(
+                        "[AIT]   ⚠ 프로젝트 pnpm-lock.yaml은 있지만 package.json이 없어 검증 불가. SDK lockfile로 폴백합니다.",
+                        sentryCapture: false);
                 }
             }
 


### PR DESCRIPTION
## 요약

`BuildConfigMerger.CopyPnpmLockfileWithFallback`의 두 `Debug.LogWarning`을 `AITLog.Warning(sentryCapture:false)`로 교체.

이 경로는 SDK가 의도한 폴백(프로젝트 lockfile이 package.json과 불일치하거나 package.json이 없을 때 SDK lockfile 사용)이며 빌드는 정상 진행된다. 하지만 `mismatchSummary`에 사용자 환경별 specifier 목록(예: `vite 8.0.10 vs 8.0.8`, `typescript 6.0.3 vs 6.0.2`)이 포함되어 Sentry에서 동일 폴백이 수십 개의 별도 issue로 fingerprint된다.

## 가시성 유지

Console 경고는 그대로 출력되어 사용자/지원팀 가시성은 손실 없음. SDK가 결정한 폴백 동작이며 사용자가 actionable한 사항도 없으므로 Sentry 캡처가 불필요한 케이스다.

## 영향 받는 Sentry 이슈

- APPS-IN-TOSS-UNITY-SDK-Q1: 38 events, 14일 전 first seen
- APPS-IN-TOSS-UNITY-SDK-S2: 7 events, 5일 전 first seen

각각 release `2.4.x` 빌드에서 발생. 다음 SDK bump부터 source 차단 작동.

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI EditMode 테스트 통과 확인