### PR TITLE
수정: 'ait deploy' CLI exit/timeout Sentry 차단 (D10a)

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -745,18 +745,22 @@ namespace AppsInToss
                 {
                     if (result.ExitCode == -1)
                     {
-                        Debug.LogError("AIT: 배포 타임아웃 (5분 초과)");
+                        // 사용자 환경(네트워크/원격 응답 지연) 원인 — 다이얼로그로 가시화하며 Sentry는 차단.
+                        AITLog.Error("AIT: 배포 타임아웃 (5분 초과)", sentryCapture: false);
                         AITPlatformHelper.ShowInfoDialog("타임아웃", "배포 시간이 초과되었습니다.", "확인");
                     }
                     else
                     {
-                        // 에러 메시지 추출 (stdout과 stderr에서)
+                        // 'ait deploy' CLI exit != 0 — 원인은 인증 실패(401/403), 서버 오류,
+                        // 네트워크, 사용자 환경 등 사용자에게 actionable한 외부 요인. 다이얼로그에서
+                        // 인증/서버 분기로 가이드를 보여주므로 Sentry로 흘리면 stdout/stderr 변형이
+                        // 다수의 별도 fingerprint(SDK-B9, SDK-RF cascade)를 만든다.
                         string errorDetail = ExtractDeployErrorMessage(result.Output, result.Error);
-                        Debug.LogError($"AIT: 배포 실패 (Exit Code: {result.ExitCode})");
+                        AITLog.Error($"AIT: 배포 실패 (Exit Code: {result.ExitCode})", sentryCapture: false);
                         if (!string.IsNullOrEmpty(result.Output))
-                            Debug.LogError($"AIT: [stdout] {result.Output}");
+                            AITLog.Error($"AIT: [stdout] {result.Output}", sentryCapture: false);
                         if (!string.IsNullOrEmpty(result.Error))
-                            Debug.LogError($"AIT: [stderr] {result.Error}");
+                            AITLog.Error($"AIT: [stderr] {result.Error}", sentryCapture: false);
 
                         bool isAuthError = !string.IsNullOrEmpty(errorDetail) &&
                             (errorDetail.Contains("403") || errorDetail.Contains("401") ||


### PR DESCRIPTION
## 요약

`AppsInTossMenu`의 deploy 실패 경로(timeout, exit != 0)의 4개 `Debug.LogError`를 `AITLog.Error(sentryCapture: false)`로 교체.

## 원인 분류

이 메시지들의 underlying cause는 모두 사용자에게 actionable한 외부 요인:

- 인증 실패(401/403) — 사용자 환경, 배포 키 오설정
- 서버 오류 — Apps in Toss 백엔드 일시 장애
- 네트워크 — 사용자 환경
- `ait` CLI 미설치 — 사용자 환경, PATH/번들 누락
- 타임아웃 — 네트워크/백엔드 응답 지연

SDK 코드에서 분기로 해결할 수 있는 사항이 없다.

## 가시성

- `isAuthError` 분기로 다이얼로그에 'Apps in Toss 콘솔에서 키 관리 확인' 등 actionable 가이드를 사용자에게 보여줌
- Console 로그(메인 메시지 + stdout + stderr)는 그대로 유지되어 지원팀 진단 가능

Sentry로 흘리면 stdout/stderr 변형이 다수의 별도 fingerprint를 만들며 fingerprint마다 sentry에서 분류로 분기할 SDK 정보가 없다.

## 영향 받는 Sentry 이슈

- APPS-IN-TOSS-UNITY-SDK-B9: 31 events, 'AIT: 배포 실패 (Exit Code: 1)'
- APPS-IN-TOSS-UNITY-SDK-RF: 8 events, 'AIT: [stderr] ''ait'' is not recognized'

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI EditMode 테스트 통과 확인