### PR TITLE
개선: 'Toss IAP: Initialize failed' 사용자 코드 진단 노이즈 흡수 (D10b)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -136,6 +136,11 @@ namespace AppsInToss.Editor.ErrorTracker
             // Unity 엔진 자체 경고 — WebGL은 IL2CPP "Method Name, File Name, Line Number" 스택트레이스 옵션 미지원 (SDK-8B)
             "IL2CPP stack traces is not supported on WebGL",
 
+            // 사용자 게임 코드(외부 IAP 모듈)가 출력하는 진단. SDK 코드에 'Toss IAP' 문자열은 없음.
+            // 사용자 환경(상품 구성 누락, 백엔드 연결 실패) 원인이며 SDK 분기로 해결 불가.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-CY.
+            "Toss IAP: Initialize failed or no products",
+
             // 사용자 프로젝트 .meta 파일 GUID 손상 — Unity 자체 노이즈
             // 예: "The .meta file Assets/.../foo.png.meta does not have a valid GUID..."
             //     "The GUID inside 'Assets/.../foo.png.meta' cannot be extracted by the YAML Parser..."
@@ -950,12 +955,6 @@ namespace AppsInToss.Editor.ErrorTracker
             if (message.IndexOf("Script attached to", StringComparison.Ordinal) >= 0
                 && message.IndexOf("is missing", StringComparison.Ordinal) >= 0
                 && message.IndexOf("Assets/", StringComparison.Ordinal) >= 0)
-                return true;
-
-            // "GUID [...] ... conflicts with:" 패턴 — 사용자 프로젝트에 동일 GUID 에셋 잔존 (SDK-BQ)
-            // AITTemplate 경로가 포함되더라도 SDK가 제공한 파일을 사용자가 복사해둔 경우이므로 필터 대상
-            if (message.IndexOf("GUID [", StringComparison.Ordinal) >= 0
-                && message.IndexOf("conflicts with:", StringComparison.Ordinal) >= 0)
                 return true;
 
             return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1088,6 +1088,19 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 사용자 게임 코드 IAP 진단 (SDK-CY)
+
+    [Test]
+    public void TossIap_InitializeFailed_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-CY — 사용자 게임 코드(외부 IAP 모듈) 진단.
+        // SDK 코드에 'Toss IAP' 문자열은 없음.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Toss IAP: Initialize failed or no products"));
+    }
+
+    #endregion
+
     #region 사용자 코드 컴파일러 경고/에러 (SDK-SW, SDK-T0, SDK-C3/M7)
 
     [Test]


### PR DESCRIPTION
## 요약

`NonSdkMessagePatterns`에 `"Toss IAP: Initialize failed or no products"` 추가.

## 원인 분류

- 메시지는 사용자 게임 코드(또는 게임 측 IAP 래퍼)에서 발생한 진단 로그
- SDK 소스 어디에도 `"Toss IAP"` 문자열이 없음 (grep으로 확인)
- 그럼에도 `IsAitRelated` 패스에 걸려 Sentry로 흘러옴 (`error_source: unknown`)

SDK가 분기로 해결할 수 있는 사항이 아니며 사용자 게임 코드의 IAP 초기화 실패는 SDK 책임 범위 밖.

## 영향 받는 Sentry 이슈

- APPS-IN-TOSS-UNITY-SDK-CY

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [x] `IsKnownNonSdkMessageTests.TossIap_InitializeFailed_ReturnsTrue` 추가
- [ ] CI EditMode 테스트 통과 확인