### PR TITLE
수정: main E2E 실패 복구 — 'AppsInToss' SDK 키워드 가드 우회 보장

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -191,11 +191,6 @@ namespace AppsInToss.Editor.ErrorTracker
             // 예: "Building webgl/Build/204ccce7cc46e2cd9bd7212e664b4738.data.unityweb failed with output:"
             // 실 SDK 빌드 실패는 "[AIT] WebGL 빌드가 실패했습니다." (SDK-8E)로 별도 캡처되므로 안전.
             "Building webgl/Build/",
-
-            // Unity AssetDatabase가 SDK 외부 캐시(Library/) 로딩 실패 시 직접 출력 (SDK-RT)
-            // 예: "Unknown error occurred while loading 'Library/AppsInToss/AITBuildSession.asset'."
-            // SDK가 띄우는 라이프사이클 경고가 아니라 Unity 자체 stderr 캡처.
-            "Unknown error occurred while loading 'Library/",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.
@@ -888,6 +883,35 @@ namespace AppsInToss.Editor.ErrorTracker
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // 사용자 코드의 'AppsInToss' 미발견 컴파일 에러 — SDK 미설치 또는 asmdef 참조 누락.
+            // 예: "Assets/.../Foo.cs(L,C): error CS0246: The type or namespace name 'AppsInToss' could not be found ..."
+            // 메시지에 'AppsInToss' 토큰이 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-C3, APPS-IN-TOSS-UNITY-SDK-M7 등.
+            // CS0246 단독은 SDK 빌드 메시지와 충돌 위험이 있어 "'AppsInToss'"와 합성 AND + Assets/ 경로 가드로 좁힌다.
+            if (message.IndexOf("error CS0246", StringComparison.Ordinal) >= 0
+                && message.IndexOf("'AppsInToss'", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 코드의 'AppsInToss' using 중복(CS0105) — Unity 컴파일러가 직접 출력.
+            // 예: "Assets/.../Foo.cs(L,C): warning CS0105: The using directive for 'AppsInToss' appeared previously in this namespace"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-SW.
+            if (message.IndexOf("warning CS0105", StringComparison.Ordinal) >= 0
+                && message.IndexOf("'AppsInToss'", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // Unity AssetDatabase가 Library/ 경로의 SDK 외부 캐시 로딩 실패 시 직접 출력.
+            // 예: "Unknown error occurred while loading 'Library/AppsInToss/AITBuildSession.asset'."
+            // 메시지에 'AppsInToss'/'AIT' 토큰이 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-RT.
+            if (message.IndexOf("Unknown error occurred while loading 'Library/", StringComparison.Ordinal) >= 0)
+                return true;
+
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용
             if (MessageContainsSdkKeyword(message))
                 return false;
@@ -909,14 +933,6 @@ namespace AppsInToss.Editor.ErrorTracker
             // AITTemplate 경로가 포함되더라도 SDK가 제공한 파일을 사용자가 복사해둔 경우이므로 필터 대상
             if (message.IndexOf("GUID [", StringComparison.Ordinal) >= 0
                 && message.IndexOf("conflicts with:", StringComparison.Ordinal) >= 0)
-                return true;
-
-            // 사용자 코드의 'AppsInToss' 미발견 컴파일 에러 — SDK 미설치 또는 asmdef 참조 누락.
-            // 예: "error CS0246: The type or namespace name 'AppsInToss' could not be found ..."
-            // Sentry APPS-IN-TOSS-UNITY-SDK-C3, APPS-IN-TOSS-UNITY-SDK-M7 등 다수.
-            // CS0246 단독은 SDK 빌드 메시지와 충돌 위험이 있어, "'AppsInToss'"와 합성 AND로 좁힌다.
-            if (message.IndexOf("error CS0246", StringComparison.Ordinal) >= 0
-                && message.IndexOf("'AppsInToss'", StringComparison.Ordinal) >= 0)
                 return true;
 
             return false;


### PR DESCRIPTION
## 요약

PR #593에서 추가된 4개 테스트 케이스가 현재 main의 E2E EditMode에서 실패하고 있습니다.

실패 테스트:
- `UnityAssetDb_LibraryLoad_ReturnsTrue`
- `UserCode_AppsInTossNamespaceMissing_ReturnsTrue`
- `UserCode_AppsInTossNamespaceMissing_PosixPath_ReturnsTrue`
- `UsingDirectiveAppearedPreviously_AppsInToss_ReturnsTrue`

## 원인

4개 테스트의 메시지는 모두 `'AppsInToss'` 토큰을 포함합니다. `IsKnownNonSdkMessage`는 다음 순서로 검사합니다:

1. ExternalAitPrefixes
2. AITSentryTransport 5xx / ConnectionError
3. sdk-policy/Vite/Dev server/git 등 합성 가드들
4. CS0029 + Assets/ + `.cs(`
5. **`MessageContainsSdkKeyword(message)` → SDK 보호 가드 (true 시 false 반환)**
6. NonSdkMessagePatterns 순회
7. Script attached to ... is missing
8. GUID [...] conflicts with:
9. (구) CS0246 + 'AppsInToss'

5단계에서 `AppsInToss` 키워드 가드에 막혀 false 반환되므로 6~9단계의 매칭 코드(라인 198 `Unknown error occurred while loading 'Library/`, 라인 157 `warning CS0105`, CS0246 합성 가드)가 모두 dead code.

## 해결

SDK 키워드 가드 **이전**에 다음 3개 합성 가드를 추가:

```csharp
// CS0246 + 'AppsInToss' + Assets/ 경로 + .cs(  (SDK-C3, SDK-M7)
if (message.IndexOf("error CS0246", StringComparison.Ordinal) >= 0
    && message.IndexOf("'AppsInToss'", StringComparison.Ordinal) >= 0
    && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
        || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
    && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
    return true;

// CS0105 + 'AppsInToss' + Assets/ 경로 + .cs(  (SDK-SW)
if (message.IndexOf("warning CS0105", StringComparison.Ordinal) >= 0
    && message.IndexOf("'AppsInToss'", StringComparison.Ordinal) >= 0
    && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
        || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
    && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
    return true;

// Unknown error occurred while loading 'Library/  (SDK-RT)
if (message.IndexOf("Unknown error occurred while loading 'Library/", StringComparison.Ordinal) >= 0)
    return true;
```

그리고 dead code 정리:
- NonSdkMessagePatterns의 `"Unknown error occurred while loading 'Library/"` 제거 (새 합성 가드가 흡수)
- 마지막 CS0246 + 'AppsInToss' 합성 가드 제거 (SDK 가드 이후라 도달 불가)

## Negative 보호

- `UsingDirectiveAppearedPreviously_AitKeywordProtected` — `"[AIT] internal: warning CS0105 collision"`: `.cs(` 없어서 새 가드 통과 → SDK 키워드 가드가 false 반환 (보호)
- `Cs0246_WithoutAppsInTossToken_NotFiltered` — `'SomethingElse'` 메시지: 새 가드의 `'AppsInToss'` 조건이 false → 통과
- UnityAssetDb 새 가드는 `'Library/'` 경로 제한으로 SDK 다른 로딩 실패 메시지와 충돌 없음 (SDK 자체 로그는 "[AIT...]" prefix를 가진다)

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E EditMode (4개 실패 → 통과 전환 + 2개 negative 보호 + 1개 CS0246 negative 보호)

## 후속

이 PR이 머지된 후 D 카테고리 7개 PR(#602/603/604/605/606/607/608)을 main에 rebase하고 E2E 재검증.