### PR TITLE
기능: 벤치마크 전용 release 빌드 워크플로우 추가

### DIFF
--- a/.github/workflows/benchmark-build.yml
+++ b/.github/workflows/benchmark-build.yml
@@ -1,0 +1,160 @@
+name: Benchmark Build (release + compression matrix)
+run-name: "Benchmark Build${{ inputs.target_ref && format(' - {0}', inputs.target_ref) || '' }}${{ inputs.compression_format && format(' [{0}]', inputs.compression_format) || '' }}"
+
+# 벤치마크 전용 release 빌드 트리거.
+# - test-e2e.yml은 빌드 속도 최적화를 위해 Development Build + Disabled로 빌드하므로
+#   런타임 성능 측정에 부적합. 이 워크플로우는 release 빌드(IL2CPP=Release,
+#   AIT_DEVELOPMENT_BUILD=false) + 압축 ON/OFF 매트릭스로 5×2=10개 산출물을
+#   업로드해 로컬 벤치마크 측정의 입력으로 쓴다.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: 'PR 번호 또는 브랜치 이름 (예: 23 또는 chore/benchmark-…)'
+        type: string
+        required: false
+      compression_format:
+        description: '압축 포맷 (both = 5×2 모두, disabled / brotli)'
+        type: choice
+        options:
+          - both
+          - disabled
+          - brotli
+        default: both
+      unity_versions:
+        description: 'Unity 버전 (쉼표 구분, 비우면 전체 5개)'
+        type: string
+        required: false
+        default: ''
+      os:
+        description: '빌드 OS (벤치마크 측정용으로는 macos 권장)'
+        type: choice
+        options:
+          - macos
+          - windows
+          - both
+        default: macos
+      clean_library:
+        description: 'Clean Unity Library cache'
+        type: boolean
+        default: false
+
+concurrency:
+  group: benchmark-build-${{ inputs.target_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+      repository: ${{ steps.ref.outputs.repository }}
+      unity-versions: ${{ steps.matrix.outputs.unity-versions }}
+      compressions: ${{ steps.matrix.outputs.compressions }}
+    steps:
+      - name: Resolve Target Ref
+        id: ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TARGET_REF="${{ inputs.target_ref }}"
+          if [ -z "$TARGET_REF" ]; then
+            REF="${{ github.ref_name }}"
+            echo "현재 ref: $REF"
+            echo "ref=$REF" >> $GITHUB_OUTPUT
+            echo "repository=${{ github.repository }}" >> $GITHUB_OUTPUT
+          elif [[ "$TARGET_REF" =~ ^[0-9]+$ ]]; then
+            PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/$TARGET_REF" --jq '{ref: .head.ref, repo: .head.repo.full_name}')
+            REF=$(echo "$PR_DATA" | jq -r '.ref')
+            REPO=$(echo "$PR_DATA" | jq -r '.repo')
+            echo "PR #$TARGET_REF → $REF ($REPO)"
+            echo "ref=$REF" >> $GITHUB_OUTPUT
+            echo "repository=$REPO" >> $GITHUB_OUTPUT
+          else
+            echo "ref=$TARGET_REF" >> $GITHUB_OUTPUT
+            echo "repository=${{ github.repository }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build matrix
+        id: matrix
+        run: |
+          ALL_VERSIONS='["2021.3","2022.3","6000.0","6000.2","6000.3"]'
+          INPUT_VERSIONS="${{ inputs.unity_versions }}"
+          if [ -z "$INPUT_VERSIONS" ]; then
+            VERSIONS="$ALL_VERSIONS"
+          else
+            VERSIONS=$(echo "$INPUT_VERSIONS" | jq -R 'split(",") | map(. | gsub("^\\s+|\\s+$"; ""))')
+          fi
+          echo "unity-versions=$(echo "$VERSIONS" | jq -c .)" >> $GITHUB_OUTPUT
+
+          CMP="${{ inputs.compression_format }}"
+          case "$CMP" in
+            disabled) COMPRESSIONS='["disabled"]' ;;
+            brotli)   COMPRESSIONS='["brotli"]' ;;
+            both|*)   COMPRESSIONS='["disabled","brotli"]' ;;
+          esac
+          echo "compressions=$COMPRESSIONS" >> $GITHUB_OUTPUT
+
+  build-macos:
+    name: Build macOS (Unity ${{ matrix.unity-version }}, ${{ matrix.compression }})
+    needs: [setup]
+    if: inputs.os == 'macos' || inputs.os == 'both'
+    strategy:
+      fail-fast: false
+      matrix:
+        unity-version: ${{ fromJSON(needs.setup.outputs.unity-versions) }}
+        compression: ${{ fromJSON(needs.setup.outputs.compressions) }}
+    uses: ./.github/workflows/unity-build.yml
+    with:
+      repository: ${{ needs.setup.outputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}
+      os: macos
+      unity-version: ${{ matrix.unity-version }}
+      run-build: true
+      run-editmode-test: false
+      run-unit-test: false
+      clean-library: ${{ inputs.clean_library }}
+      test-level: '1'
+      compression-format: ${{ matrix.compression == 'brotli' && '2' || '0' }}
+      development-build: 'false'
+      il2cpp-configuration: 'Release'
+    secrets:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+      FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+      FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
+
+  build-windows:
+    name: Build Windows (Unity ${{ matrix.unity-version }}, ${{ matrix.compression }})
+    needs: [setup]
+    if: inputs.os == 'windows' || inputs.os == 'both'
+    strategy:
+      fail-fast: false
+      matrix:
+        unity-version: ${{ fromJSON(needs.setup.outputs.unity-versions) }}
+        compression: ${{ fromJSON(needs.setup.outputs.compressions) }}
+    uses: ./.github/workflows/unity-build.yml
+    with:
+      repository: ${{ needs.setup.outputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}
+      os: windows
+      unity-version: ${{ matrix.unity-version }}
+      run-build: true
+      run-editmode-test: false
+      run-unit-test: false
+      clean-library: ${{ inputs.clean_library }}
+      test-level: '1'
+      compression-format: ${{ matrix.compression == 'brotli' && '2' || '0' }}
+      development-build: 'false'
+      il2cpp-configuration: 'Release'
+    secrets:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+      FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+      FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -66,6 +66,21 @@ on:
         type: string
         required: false
         default: '2'
+      compression-format:
+        description: 'AIT_COMPRESSION_FORMAT override (0=Disabled, 1=Gzip, 2=Brotli, -1=Auto). Empty = caller default.'
+        type: string
+        required: false
+        default: '0'
+      development-build:
+        description: 'AIT_DEVELOPMENT_BUILD override (true/false). Empty = caller default.'
+        type: string
+        required: false
+        default: 'true'
+      il2cpp-configuration:
+        description: 'AIT_IL2CPP_CONFIGURATION override (Debug/Release/Master). Empty = caller default.'
+        type: string
+        required: false
+        default: 'Debug'
     secrets:
       AIT_AD_INTERSTITIAL_ID:
         description: 'Interstitial ad ID for testing'
@@ -1443,19 +1458,14 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: 압축 비활성화. E2E는 vite dev/preview 서버에서만 로드되며
-          # 배포되지 않으므로 압축이 불필요. Brotli/Gzip 단계 자체를 건너뛰어
-          # wallclock 절감(~120s).
-          AIT_COMPRESSION_FORMAT: "0"
-          # E2E 한정: Development Build 활성화 — Link_WebGL_wasm 단계가 단독 실행
-          # critical path에서 ~163s를 차지(Emscripten 옵티마이저 -O3 풀스피드).
-          # Development Build로 옵티마이저 단축, Build wallclock 대폭 절감 기대.
-          # E2E는 SDK API 동작만 검증하며 런타임 성능을 보지 않으므로 무관.
-          AIT_DEVELOPMENT_BUILD: "true"
-          # E2E 한정: IL2CPP 컴파일러 옵티마이저 레벨도 Debug로 강제. developmentBuild
-          # 플래그는 Player 측 설정이라 IL2CPP 옵티마이저(C_WebGL_wasm/Link_WebGL_wasm)에는
-          # 영향이 없어 별도 변수로 페어링. -O3 → -O0/-Og 수준으로 wasm 컴파일/링크 단축.
-          AIT_IL2CPP_CONFIGURATION: "Debug"
+          # 기본값은 E2E 최적화(압축 비활성화 + Development Build + Debug IL2CPP)이며
+          # caller에서 override 가능 (예: benchmark-build.yml은 release + 압축 ON/OFF로 호출).
+          # 압축: 0=Disabled로 Brotli/Gzip 단계 스킵(~120s 절감).
+          # 개발빌드: Link_WebGL_wasm critical path ~163s 단축.
+          # IL2CPP Debug: wasm 컴파일/링크 -O0/-Og.
+          AIT_COMPRESSION_FORMAT: ${{ inputs.compression-format }}
+          AIT_DEVELOPMENT_BUILD: ${{ inputs.development-build }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.il2cpp-configuration }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30
@@ -1596,10 +1606,10 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: macOS step의 동일 주석 참조.
-          AIT_COMPRESSION_FORMAT: "0"
-          AIT_DEVELOPMENT_BUILD: "true"
-          AIT_IL2CPP_CONFIGURATION: "Debug"
+          # macOS step의 동일 주석 참조. caller에서 override 가능.
+          AIT_COMPRESSION_FORMAT: ${{ inputs.compression-format }}
+          AIT_DEVELOPMENT_BUILD: ${{ inputs.development-build }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.il2cpp-configuration }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30


### PR DESCRIPTION
## Summary
- `unity-build.yml`에 `compression-format` / `development-build` / `il2cpp-configuration` workflow_call input 3개 추가. 기본값은 기존 E2E 최적화값(Disabled / Development Build / Debug IL2CPP)이라 **기존 호출부 동작은 불변**.
- `benchmark-build.yml` 신규: `workflow_dispatch`로 release 빌드(IL2CPP=Release, Development Build=false) + 압축 ON/OFF 매트릭스를 트리거. 5 Unity × 2 compression 산출물을 업로드해 로컬 로딩 시간 벤치마크의 입력으로 사용.

## 배경
`test-e2e.yml`은 빌드 속도를 위해 Development Build + Disabled 압축 + Debug IL2CPP로 빌드하므로 런타임 성능 측정에 부적합. 벤치마크는 release 빌드 + 압축 매트릭스가 필요해 별도 워크플로우를 둔다. 하드코딩돼 있던 3개 환경변수를 input으로 노출해 caller가 override할 수 있게 했다.

## Test plan
- [ ] `unity-build.yml` 기존 호출부(test-e2e.yml 등)가 input 미지정 시 기존 동작(Disabled/Development/Debug) 유지하는지 확인
- [ ] `benchmark-build.yml` workflow_dispatch 트리거 → 5x2 매트릭스 빌드 + artifact 업로드 확인
- [ ] release artifact가 압축 ON(Brotli `.unityweb`) / OFF로 올바르게 생성되는지 확인