### PR TITLE
수정: CS1503 + 'ait deploy' stdout ANSI escape Sentry 차단

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -933,11 +933,35 @@ namespace AppsInToss.Editor.ErrorTracker
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // 사용자 코드의 SDK 타입 인자 오용(CS1503) — Unity 컴파일러가 직접 출력.
+            // 예: "Assets\Scripts\Manager\TossManager.cs(192,91): error CS1503: Argument 1: cannot convert from 'AppsInToss.GetUserKeyForGameResult' to 'string'"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-VM/PV/PW/DA.
+            // 메시지에 'AppsInToss.*' 타입명이 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
+            // 'AppsInToss.' 점(.)을 포함해 namespace prefix를 정확히 요구하므로 단독 토큰 'AppsInToss'만 있는 SDK 빌드 메시지와 충돌 없음.
+            if (message.IndexOf("error CS1503", StringComparison.Ordinal) >= 0
+                && message.IndexOf("'AppsInToss.", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
             // Unity AssetDatabase가 Library/ 경로의 SDK 외부 캐시 로딩 실패 시 직접 출력.
             // 예: "Unknown error occurred while loading 'Library/AppsInToss/AITBuildSession.asset'."
             // 메시지에 'AppsInToss'/'AIT' 토큰이 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
             // Sentry APPS-IN-TOSS-UNITY-SDK-RT.
             if (message.IndexOf("Unknown error occurred while loading 'Library/", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // AppsInTossMenu의 'ait deploy' 실패 경로가 redirect한 stdout/stderr 본문 중
+            // pnpm/npm progress bar의 ANSI escape 시퀀스(\x1b[?25l, \x1b[?25h 등 커서 hide/show)만 들어간 라인.
+            // 예: "AIT: [stdout] \x1b[?25l│", "AIT: [stdout] \x1b[?25h"
+            // 신규 SDK는 deploy 경로를 sentryCapture: false로 차단(D10a)했지만, 구버전 SDK 사용자는 여전히
+            // 동일 메시지를 다수 fingerprint(VK/BD/T5)로 전송한다. 컨텐츠 기반 backstop.
+            // 'AIT: [stdout]'/'AIT: [stderr]' prefix는 SDK 키워드 가드("AIT:")에 막히므로 가드보다 먼저 매칭.
+            // ANSI escape "[?25" + "AIT: [std" 합성으로 좁혀 일반 stdout/stderr 진단 메시지와 충돌 방지.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-VK/BD/T5.
+            if (message.IndexOf("AIT: [std", StringComparison.Ordinal) >= 0
+                && message.IndexOf("[?25", StringComparison.Ordinal) >= 0)
                 return true;
 
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1176,6 +1176,91 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region SDK 타입 인자 오용 컴파일 에러 CS1503 (SDK-VM, SDK-PV, SDK-PW, SDK-DA)
+
+    [Test]
+    public void UserCode_Cs1503_AppsInTossTypeMisuse_ReturnsTrue()
+    {
+        // Sentry SDK-VM — TossManager.cs에서 GetUserKeyForGameResult를 string으로 잘못 사용.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\Scripts\\Manager\\TossManager.cs(192,91): error CS1503: Argument 1: cannot convert from 'AppsInToss.GetUserKeyForGameResult' to 'string'"));
+    }
+
+    [Test]
+    public void UserCode_Cs1503_AppsInTossTypeMisuse_PosixPath_ReturnsTrue()
+    {
+        // Sentry SDK-PV — POSIX 경로 변형 (IapProductListItem 잘못 사용).
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/02.Script/Platform/AIT/AITBridge.IAP.cs(17,26): error CS1503: Argument 1: cannot convert from 'AppsInToss.IapProductListItem' to 'string'"));
+    }
+
+    [Test]
+    public void UserCode_Cs1503_AitException_ReturnsTrue()
+    {
+        // Sentry SDK-PW — modules 경로의 사용자 코드, AITException 잘못 사용.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/modules/unity-trident/Runtime/FeatureService/Billing/Billing.cs(398,42): error CS1503: Argument 1: cannot convert from 'AppsInToss.AITException' to 'string'"));
+    }
+
+    [Test]
+    public void Cs1503_WithoutAppsInTossNamespace_NotFiltered()
+    {
+        // CS1503 단독은 SDK와 무관한 컴파일 에러도 잡을 수 있으므로 'AppsInToss.' namespace prefix가
+        // 동반될 때만 노이즈로 분류. 'AppsInToss.' 점(.) 위치가 중요 (단독 토큰 'AppsInToss'는 통과).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/Foo.cs(1,1): error CS1503: Argument 1: cannot convert from 'System.Int32' to 'string'"));
+    }
+
+    [Test]
+    public void Cs1503_AppsInTossTypeMisuse_WithAitPrefix_StillProtected()
+    {
+        // SDK 보호 가드: 합성 가드(error CS1503 + 'AppsInToss.' + Assets/ + .cs()를 모두 만족하지 않으면
+        // 다음 단계인 SDK 키워드 가드에서 [AIT] prefix로 보호된다. 여기서는 Assets/와 .cs( 없이
+        // SDK가 진단/리포트로 같은 토큰을 출력하는 케이스를 검증.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] diag: error CS1503 fallback: 'AppsInToss.Result' conversion mismatch detected"));
+    }
+
+    #endregion
+
+    #region 'ait deploy' stdout/stderr ANSI escape 노이즈 (SDK-VK, SDK-BD, SDK-T5)
+
+    [Test]
+    public void DeployStdout_AnsiCursorHide_ReturnsTrue()
+    {
+        // Sentry SDK-VK/BD/T5 — pnpm progress bar의 커서 hide(\x1b[?25l) escape가 stdout에 새는 경우.
+        // 구버전 SDK 사용자가 deploy 실행 시 다수의 별도 fingerprint로 캡처되던 메시지.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: [stdout] \x1b[?25l│"));
+    }
+
+    [Test]
+    public void DeployStderr_AnsiCursorShow_ReturnsTrue()
+    {
+        // 동일 패턴의 stderr 변형 — 커서 show(\x1b[?25h) escape 포함.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: [stderr] \x1b[?25h│"));
+    }
+
+    [Test]
+    public void DeployStdout_WithoutAnsiEscape_NotFiltered()
+    {
+        // 실제 진단 가치가 있는 stdout 메시지는 보호되어야 한다 — ANSI escape "[?25" 미포함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: [stdout] Building project... done in 12.3s"));
+    }
+
+    [Test]
+    public void DeployStdout_AnsiEscape_WithAitPrefix_StillProtected()
+    {
+        // SDK 보호 가드: [AIT...] prefix가 붙은 동일 패턴은 SDK 자체 진단 로그로 간주.
+        // 합성 가드의 "AIT: [std" 토큰을 우회하기 위해 [AIT] prefix가 먼저 와야 보호 가능.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] deploy diag: stdout snapshot contains \x1b[?25l progress bar fragment"));
+    }
+
+    #endregion
+
     #region IL2CPP/Bee 빌드 단위별 실패 (SDK-SA~SV, T7, TV)
 
     [Test]


### PR DESCRIPTION
## 요약

`AITEditorErrorTracker.IsKnownNonSdkMessage`에 두 가지 합성 가드를 추가해 SDK 키워드 가드(`MessageContainsSdkKeyword`)에 막혀 흘러가던 사용자 코드 노이즈와 구버전 deploy stdout 노이즈를 흡수한다.

직전 D7~D10b 시리즈 머지 후 Sentry 라이브 상태 조사에서 발견된 노이즈 패턴을 처리.

## 추가 가드

### 1) CS1503 + 'AppsInToss.' (SDK-VM/PV/PW/DA)

사용자 코드가 SDK 타입을 잘못된 인자로 사용한 경우 Unity 컴파일러가 출력:

```
Assets\Scripts\Manager\TossManager.cs(192,91): error CS1503:
  Argument 1: cannot convert from 'AppsInToss.GetUserKeyForGameResult' to 'string'
```

기존 CS0246/CS0105 가드와 동일한 4-way AND 구조:

```csharp
if (message.IndexOf("error CS1503", StringComparison.Ordinal) >= 0
    && message.IndexOf("'AppsInToss.", StringComparison.Ordinal) >= 0
    && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
        || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
    && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
    return true;
```

`'AppsInToss.` 점(.)을 포함해 namespace prefix를 정확히 요구하므로 단독 토큰 `'AppsInToss'`만 있는 SDK 빌드 메시지와 충돌하지 않는다.

### 2) AIT: [std…] + ANSI escape "[?25" (SDK-VK/BD/T5)

`AppsInTossMenu` deploy 경로의 stdout/stderr redirect 본문에 pnpm progress bar ANSI escape(`\x1b[?25l`, `\x1b[?25h` 등 cursor hide/show)가 새는 경우:

```
AIT: [stdout] \x1b[?25l│
```

D10a(#607)가 신규 SDK에서 `sentryCapture: false`로 차단했지만 구버전 SDK 사용자는 여전히 매번 다른 escape 변형으로 별도 fingerprint를 만들어 다수의 single-event 이슈로 누적됨. 컨텐츠 기반 backstop:

```csharp
if (message.IndexOf("AIT: [std", StringComparison.Ordinal) >= 0
    && message.IndexOf("[?25", StringComparison.Ordinal) >= 0)
    return true;
```

`AIT: [std` + `[?25` 합성으로 좁혀 일반 stdout/stderr 진단 메시지와 충돌 없음.

## Negative 보호

| 테스트 | 메시지 | 보호 메커니즘 |
|--------|--------|--------------|
| `Cs1503_WithoutAppsInTossNamespace_NotFiltered` | `'System.Int32'` to `'string'` | namespace 조건 false |
| `Cs1503_AppsInTossTypeMisuse_WithAitPrefix_StillProtected` | `[AIT] diag` (Assets/, .cs( 미포함) | 합성 false → SDK 키워드 가드 보호 |
| `DeployStdout_WithoutAnsiEscape_NotFiltered` | `AIT: [stdout] Building project... done in 12.3s` | ANSI escape 조건 false |
| `DeployStdout_AnsiEscape_WithAitPrefix_StillProtected` | `[AIT] deploy diag: ...` (`AIT:` 미포함) | 합성 false → SDK 키워드 가드 보호 |

## 영향 받는 Sentry 이슈

- VM (2 events) - CS1503 TossManager
- PV (3 events) - CS1503 IapProductListItem
- PW (2 events) - CS1503 AITException
- DA (2 events) - CS1503 LoadAdMobOptions
- VK/BD/T5 (각 1-2 events) - AIT: [stdout] ANSI escape

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E EditMode 통과 (4 positive + 4 negative)