### PR TITLE
수정: powershell Win32Exception + 외부 WebGL 템플릿 Sentry 차단

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -196,6 +196,12 @@ namespace AppsInToss.Editor.ErrorTracker
             // 예: "Building webgl/Build/204ccce7cc46e2cd9bd7212e664b4738.data.unityweb failed with output:"
             // 실 SDK 빌드 실패는 "[AIT] WebGL 빌드가 실패했습니다." (SDK-8E)로 별도 캡처되므로 안전.
             "Building webgl/Build/",
+
+            // 사용자 프로젝트가 사용하는 다른 WebGL 템플릿(Fill 등)이 출력하는 진단. SDK 영역 아님.
+            // 예: "[WebGL] unity-webview.js source not found: /Users/.../Assets/WebGLTemplates/Fill/TemplateData/unity-webview.js"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-VJ.
+            // SDK는 "[WebGL]" prefix를 출력하지 않으므로(grep 확인) AitKeywords 보호 가드와 충돌 없음.
+            "[WebGL] unity-webview.js source not found",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.
@@ -950,6 +956,17 @@ namespace AppsInToss.Editor.ErrorTracker
             // 메시지에 'AppsInToss'/'AIT' 토큰이 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
             // Sentry APPS-IN-TOSS-UNITY-SDK-RT.
             if (message.IndexOf("Unknown error occurred while loading 'Library/", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // AITAsyncCommandRunner의 Windows powershell 실행 실패 — 사용자 환경(PATH/실행 정책) 원인.
+            // 예: "[AIT Async] 명령 실행 예외: System.ComponentModel.Win32Exception (0x80004005):
+            //       ApplicationName='powershell.exe', CommandLine='-ExecutionPolicy Bypass ...'"
+            // [AIT Async] prefix가 SDK 키워드 가드("[AIT")에 막히므로 가드보다 먼저 매칭한다.
+            // 사용자 환경 문제이며 SDK 코드 분기로 해결 불가. 합성 AND로 일반 [AIT Async] 메시지와 충돌 방지.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-VE, APPS-IN-TOSS-UNITY-SDK-VC.
+            if (message.IndexOf("[AIT Async] 명령 실행 예외", StringComparison.Ordinal) >= 0
+                && message.IndexOf("Win32Exception", StringComparison.Ordinal) >= 0
+                && message.IndexOf("ApplicationName='powershell.exe'", StringComparison.Ordinal) >= 0)
                 return true;
 
             // AppsInTossMenu의 'ait deploy' 실패 경로가 redirect한 stdout/stderr 본문 중

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1261,6 +1261,59 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region AITAsyncCommandRunner Windows powershell 실행 실패 (SDK-VE, SDK-VC)
+
+    [Test]
+    public void AsyncCommand_Win32Exception_PowershellMissing_ReturnsTrue()
+    {
+        // Sentry SDK-VE/VC — 사용자 Windows 환경에서 powershell.exe 실행 실패. PATH/실행 정책 문제.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT Async] 명령 실행 예외: System.ComponentModel.Win32Exception (0x80004005): " +
+            "ApplicationName='powershell.exe', CommandLine='-ExecutionPolicy Bypass -NoProfile -NoLogo -Command \"...\"'"));
+    }
+
+    [Test]
+    public void AsyncCommand_OtherException_NotFiltered()
+    {
+        // Win32Exception이 아닌 일반 [AIT Async] 예외는 SDK 디버깅에 가치가 있으므로 보호.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT Async] 명령 실행 예외: System.InvalidOperationException: pipe closed"));
+    }
+
+    [Test]
+    public void AsyncCommand_Win32Exception_NonPowershell_NotFiltered()
+    {
+        // powershell.exe 외 다른 ApplicationName의 Win32Exception은 패턴 좁히기 위해 통과.
+        // (현재는 pnpm/git/node 등은 별도 진단 경로가 있어 SDK 가치 보존)
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT Async] 명령 실행 예외: System.ComponentModel.Win32Exception (0x80004005): " +
+            "ApplicationName='node.exe', CommandLine='...'"));
+    }
+
+    #endregion
+
+    #region 외부 WebGL 템플릿 (SDK-VJ)
+
+    [Test]
+    public void ExternalWebGLTemplate_UnityWebviewSourceNotFound_ReturnsTrue()
+    {
+        // Sentry SDK-VJ — 사용자 프로젝트가 사용하는 다른 WebGL 템플릿(Fill)이 출력한 진단.
+        // SDK는 "[WebGL]" prefix를 사용하지 않음.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[WebGL] unity-webview.js source not found: " +
+            "/Users/ad03148361/jenkins_workspace/attack-web/Assets/WebGLTemplates/Fill/TemplateData/unity-webview.js"));
+    }
+
+    [Test]
+    public void WebGL_OtherWarning_NotFiltered()
+    {
+        // 다른 "[WebGL]" prefix 메시지는 패턴이 좁혀 있어 통과 (unity-webview source 한정).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[WebGL] unity-webview.js compiled successfully"));
+    }
+
+    #endregion
+
     #region IL2CPP/Bee 빌드 단위별 실패 (SDK-SA~SV, T7, TV)
 
     [Test]


### PR DESCRIPTION
## 요약

`AITEditorErrorTracker.IsKnownNonSdkMessage`에 두 가지 가드를 추가해 사용자 환경 의존성에서 발생하는 노이즈와 SDK 외부 WebGL 템플릿 출력을 흡수한다.

PR #624 머지 후 남은 Sentry 라이브 노이즈 정리 2탄.

## 추가 가드

### 1) [AIT Async] Win32Exception + ApplicationName='powershell.exe' (SDK-VE/VC)

`AITAsyncCommandRunner`가 Windows에서 powershell.exe 실행 실패 시 출력:

```
[AIT Async] 명령 실행 예외: System.ComponentModel.Win32Exception (0x80004005):
  ApplicationName='powershell.exe', CommandLine='-ExecutionPolicy Bypass ...'
```

사용자 환경(PATH 미설정, 실행 정책 차단, 안티바이러스 격리 등)이 원인이며 SDK 코드 분기로 해결 불가. `[AIT Async]` prefix가 SDK 키워드 가드(`[AIT`)에 막히므로 가드보다 먼저 매칭:

```csharp
if (message.IndexOf("[AIT Async] 명령 실행 예외", StringComparison.Ordinal) >= 0
    && message.IndexOf("Win32Exception", StringComparison.Ordinal) >= 0
    && message.IndexOf("ApplicationName='powershell.exe'", StringComparison.Ordinal) >= 0)
    return true;
```

3-way AND로 일반 [AIT Async] 진단과 충돌 방지.

### 2) [WebGL] unity-webview.js source not found (SDK-VJ)

사용자 프로젝트가 SDK가 아닌 다른 WebGL 템플릿(예: Fill)을 사용 중인 경우 해당 템플릿이 출력하는 진단:

```
[WebGL] unity-webview.js source not found: /Users/.../Assets/WebGLTemplates/Fill/...
```

SDK는 `[WebGL]` prefix를 사용하지 않으므로(grep 확인) `NonSdkMessagePatterns`에 직접 추가. unity-webview source 한정으로 좁혀 향후 SDK가 동일 prefix를 도입할 경우의 충돌 위험도 최소화.

## Negative 보호

| 테스트 | 메시지 | 보호 메커니즘 |
|--------|--------|--------------|
| `AsyncCommand_OtherException_NotFiltered` | `InvalidOperationException` | Win32Exception 조건 false |
| `AsyncCommand_Win32Exception_NonPowershell_NotFiltered` | `ApplicationName='node.exe'` | powershell.exe 조건 false |
| `WebGL_OtherWarning_NotFiltered` | `[WebGL] unity-webview.js compiled successfully` | source not found 부분 문자열 미포함 |

## 영향 받는 Sentry 이슈

- VE/VC (각 1 event) - [AIT Async] Win32Exception powershell.exe
- VJ (3 events) - [WebGL] unity-webview.js source not found

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E EditMode (3 positive + 3 negative)