### PR TITLE
수정: 사용자 코드 CS0103/CS0117 컴파일 에러 Sentry 차단

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -913,7 +913,31 @@ namespace AppsInToss.Editor.ErrorTracker
             // SDK 자체 코드의 컴파일 에러는 'Packages/com.toss.apps-in-toss/...' 또는
             // 'Library/PackageCache/...' 경로로 출력되어 'Assets/' prefix가 붙지 않으므로 안전.
             if (message.IndexOf("error CS0029", StringComparison.Ordinal) >= 0
-                && message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 코드의 식별자 미발견 컴파일 에러 (CS0103) — Unity 컴파일러가 직접 출력.
+            // 예: "Assets\Scripts\AppsInTossCompatibilityChecker.cs(31,9): error CS0103:
+            //       The name 'CheckIncompatibleComponents' does not exist in the current context"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-CR, APPS-IN-TOSS-UNITY-SDK-MN.
+            // 사용자 식별자가 가변이라 일반화된 형태로 좁힌다(Assets/ 경로 + .cs(L,C) 패턴).
+            // SDK 자체 코드는 Packages/ 또는 Library/PackageCache/ 경로로 출력되어 안전.
+            if (message.IndexOf("error CS0103", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 코드의 멤버 미정의 컴파일 에러 (CS0117) — Unity 컴파일러가 직접 출력.
+            // 예: "Assets\98_Tools\BuildTool\Editor\BuildToolEditorWindow.cs(484,43): error CS0117:
+            //       'AppsInTossMenu' does not contain a definition for 'Package'"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-80.
+            // SDK 타입명을 잘못 참조한 경우라도 사용자 코드가 잘못 사용한 것이며 SDK 분기로 해결 불가.
+            if (message.IndexOf("error CS0117", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
                 return true;
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -932,10 +932,62 @@ public class IsKnownNonSdkMessageTests
     [Test]
     public void OtherCSErrorInUserAssets_ReturnsFalse()
     {
-        // CS0029가 아닌 다른 컴파일 에러(CS0103 등)는 composite 가드가 매칭되지 않음.
-        // 필요 시 별도 패턴을 추가하되 본 가드는 'CS0029'에 한정.
+        // 가드가 등록되지 않은 다른 CS 에러 코드(예: CS0535)는 composite 가드가 매칭되지 않아 통과해야 함.
+        // 본 SDK는 CS0029/CS0103/CS0105/CS0117/CS0246/CS1503 한정으로 가드.
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "Assets/Scripts/GameLogic.cs(42,10): error CS0103: The name 'foo' does not exist in the current context"));
+            "Assets/Scripts/GameLogic.cs(42,10): error CS0535: 'X' does not implement interface member 'Y'"));
+    }
+
+    #endregion
+
+    #region 사용자 코드 CS0103/CS0117 컴파일 에러 (SDK-CR, SDK-MN, SDK-80)
+
+    [Test]
+    public void UserCodeCS0103_AssetsBackslashPath_ReturnsTrue()
+    {
+        // Sentry SDK-CR — Windows 경로 + 사용자 식별자 미발견.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\Scripts\\AppsInTossCompatibilityChecker.cs(31,9): error CS0103: The name 'CheckIncompatibleComponents' does not exist in the current context"));
+    }
+
+    [Test]
+    public void UserCodeCS0103_AssetsForwardSlashPath_ReturnsTrue()
+    {
+        // Sentry SDK-MN POSIX 변형.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/AppsInToss/01_Script/CreateObstacle.cs(22,54): error CS0103: The name 'touchPos' does not exist in the current context"));
+    }
+
+    [Test]
+    public void UserCodeCS0117_AppsInTossMenu_ReturnsTrue()
+    {
+        // Sentry SDK-80 — 사용자 BuildTool 코드가 SDK 타입의 존재하지 않는 멤버 참조.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\98_Tools\\BuildTool\\Editor\\BuildToolEditorWindow.cs(484,43): error CS0117: 'AppsInTossMenu' does not contain a definition for 'Package'"));
+    }
+
+    [Test]
+    public void Cs0103WithoutAssetsPrefix_AitProtected_ReturnsFalse()
+    {
+        // SDK 자체 진단 라인(Assets/ 경로 미포함)은 [AIT] prefix로 보호됨.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] diag: error CS0103 reported in SDK fallback path"));
+    }
+
+    [Test]
+    public void Cs0103_SdkPackagePath_NotFiltered()
+    {
+        // SDK 자체 .cs의 CS0103은 Packages/com.toss.apps-in-toss 경로로 출력되어 Assets/ prefix 미포함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/com.toss.apps-in-toss/Editor/Foo.cs(10,5): error CS0103: The name 'bar' does not exist in the current context"));
+    }
+
+    [Test]
+    public void Cs0117_SdkPackagePath_NotFiltered()
+    {
+        // CS0117도 동일 — SDK 자체 코드 보호.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/com.toss.apps-in-toss/Editor/Foo.cs(10,5): error CS0117: 'Bar' does not contain a definition for 'baz'"));
     }
 
     #endregion


### PR DESCRIPTION
## 요약

`AITEditorErrorTracker.IsKnownNonSdkMessage`에 사용자 .cs 컴파일 에러 가드 두 개를 추가하고, 기존 CS0029 가드를 Windows 경로(`Assets\\`)도 인식하도록 확장.

## 추가 가드

### CS0103 (식별자 미발견)

```
Assets\Scripts\AppsInTossCompatibilityChecker.cs(31,9): error CS0103:
  The name 'CheckIncompatibleComponents' does not exist in the current context
```

- Sentry SDK-CR (4 events, Windows path)
- Sentry SDK-MN (2 events, POSIX variant)

### CS0117 (멤버 미정의)

```
Assets\98_Tools\BuildTool\Editor\BuildToolEditorWindow.cs(484,43): error CS0117:
  'AppsInTossMenu' does not contain a definition for 'Package'
```

- Sentry SDK-80 (2 events)

## 분류 근거

세 패턴 모두 Unity 컴파일러가 직접 출력하는 형태이고, 사용자 코드의 식별자/멤버 참조 오류이며 SDK 분기로 해결 불가. 동일한 4-way 합성 가드(에러 코드 + `Assets/` POSIX + `Assets\\` Windows + `.cs(` 위치 마커)로 SDK 패키지 코드의 컴파일 에러(`Packages/com.toss.apps-in-toss/...`)와 충돌 없이 좁힘.

## 부수 개선

CS0029 가드도 Windows 경로 인식 추가 — 이전엔 POSIX(`Assets/`)만 매칭하던 한계를 보강.

## Negative 보호

| 테스트 | 메시지 | 보호 메커니즘 |
|--------|--------|--------------|
| `OtherCSErrorInUserAssets_ReturnsFalse` (수정) | `error CS0535` | 등록되지 않은 에러 코드 |
| `Cs0103WithoutAssetsPrefix_AitProtected_ReturnsFalse` | `[AIT] diag: error CS0103 ...` (Assets/ 미포함) | 합성 false → SDK 키워드 가드 보호 |
| `Cs0103_SdkPackagePath_NotFiltered` | `Packages/com.toss.apps-in-toss/...` | Assets/ 조건 false |
| `Cs0117_SdkPackagePath_NotFiltered` | `Packages/com.toss.apps-in-toss/...` | Assets/ 조건 false |

## 영향 받는 Sentry 이슈

- CR (4 events) - CS0103 CompatibilityChecker
- MN (2 events) - CS0103 CreateObstacle
- 80 (2 events) - CS0117 AppsInTossMenu.Package

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E EditMode (3 positive + 3 negative + 기존 CS0029 케이스 재검증)