### PR TITLE
수정: Unity Addressables/AssetDatabase 노이즈 Sentry 차단

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -202,6 +202,31 @@ namespace AppsInToss.Editor.ErrorTracker
             // Sentry APPS-IN-TOSS-UNITY-SDK-VJ.
             // SDK는 "[WebGL]" prefix를 출력하지 않으므로(grep 확인) AitKeywords 보호 가드와 충돌 없음.
             "[WebGL] unity-webview.js source not found",
+
+            // Unity Addressables linker 누락 — 사용자 프로젝트의 Addressables 그룹 설정 문제. SDK 영역 아님.
+            // 예: "BuildFailedException: Missing Addressables linker file. ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-QE.
+            // SDK는 "Addressables linker" 문자열을 출력하지 않으므로(grep 확인) 안전.
+            "Missing Addressables linker",
+
+            // Unity AssetDatabase가 import 중 SaveAssets 호출 시 직접 출력 — 사용자 코드/플러그인이 import 중에 SaveAssets를 호출.
+            // 예: "Calls to \"AssetDatabase.SaveAssets\" are restricted during asset importing."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-P4.
+            // SDK는 이 문자열을 출력하지 않으므로(grep 확인) 안전.
+            "\"AssetDatabase.SaveAssets\" are restricted during asset importing",
+
+            // Unity AssetDatabase Refresh 루프 중 발생 — 사용자 프로젝트의 import 충돌. Unity 자체 진단.
+            // 예: "The asset at ProjectSettings/ProjectSettings.asset has been scheduled for reimport during the Refresh loop ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-P6.
+            // SDK는 이 문자열을 출력하지 않으므로(grep 확인) 안전.
+            "scheduled for reimport during the Refresh loop",
+
+            // Unity PackageManager가 immutable 패키지 변경 감지 시 직접 출력 — SDK 자동 업데이트 또는 사용자 변경.
+            // 예: "The following asset(s) located in immutable packages were unexpectedly altered. ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-CH.
+            // 기존 LogType.Warning 가드는 별도로 유지되며(line 432-436), 이 패턴은 Error/Exception LogType 변형도 흡수.
+            // SDK 자체 코드는 이 메시지를 출력하지 않으며(주석으로만 참조) Unity 엔진이 직접 출력.
+            "immutable packages were unexpectedly altered",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1314,6 +1314,62 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region Unity Addressables / AssetDatabase 노이즈 (SDK-QE, SDK-P4, SDK-P6, SDK-CH)
+
+    [Test]
+    public void Addressables_MissingLinker_ReturnsTrue()
+    {
+        // Sentry SDK-QE — 사용자 프로젝트의 Addressables 그룹/링커 설정 누락. SDK 영역 아님.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "BuildFailedException: Missing Addressables linker file. " +
+            "Please ensure the linker file is present in your project."));
+    }
+
+    [Test]
+    public void AssetDatabase_SaveAssetsRestricted_ReturnsTrue()
+    {
+        // Sentry SDK-P4 — 사용자 코드/플러그인이 import 중에 SaveAssets 호출.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Calls to \"AssetDatabase.SaveAssets\" are restricted during asset importing."));
+    }
+
+    [Test]
+    public void AssetDatabase_ScheduledForReimport_ReturnsTrue()
+    {
+        // Sentry SDK-P6 — Refresh 루프 중 import 충돌. Unity 자체 진단.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "The asset at ProjectSettings/ProjectSettings.asset has been scheduled for reimport " +
+            "during the Refresh loop and will be reimported."));
+    }
+
+    [Test]
+    public void ImmutablePackages_UnexpectedlyAltered_ReturnsTrue()
+    {
+        // Sentry SDK-CH — Unity PackageManager가 immutable 패키지 변경 감지 시 직접 출력.
+        // LogType.Warning 가드(line 432-436)와 별개로 Error/Exception LogType 변형도 흡수.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "The following asset(s) located in immutable packages were unexpectedly altered. " +
+            "These assets should be reverted to their original state."));
+    }
+
+    [Test]
+    public void Addressables_GenericMessage_NotFiltered()
+    {
+        // "Missing Addressables linker"가 없는 일반 Addressables 메시지는 통과.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Addressables: catalog cache miss"));
+    }
+
+    [Test]
+    public void AssetDatabase_GenericRestriction_NotFiltered()
+    {
+        // "SaveAssets" 토큰이 없으면 통과.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Calls to AssetDatabase.Refresh are restricted during asset importing."));
+    }
+
+    #endregion
+
     #region IL2CPP/Bee 빌드 단위별 실패 (SDK-SA~SV, T7, TV)
 
     [Test]


### PR DESCRIPTION
## 요약

`AITEditorErrorTracker.NonSdkMessagePatterns`에 Unity Addressables/AssetDatabase 노이즈 4개 패턴을 추가. 모두 Unity 엔진/PackageManager가 직접 출력하며 SDK 코드 분기로 해결 불가.

## 추가 패턴

| 패턴 | Sentry 이슈 | 원본 메시지 |
|------|-------------|-------------|
| `Missing Addressables linker` | QE | `BuildFailedException: Missing Addressables linker file. ...` |
| `"AssetDatabase.SaveAssets" are restricted during asset importing` | P4 | `Calls to "AssetDatabase.SaveAssets" are restricted during asset importing.` |
| `scheduled for reimport during the Refresh loop` | P6 | `The asset at ProjectSettings/ProjectSettings.asset has been scheduled for reimport during the Refresh loop ...` |
| `immutable packages were unexpectedly altered` | CH | `The following asset(s) located in immutable packages were unexpectedly altered. ...` |

## 안전성 확인

- SDK 자체 코드(`Editor/`, `Runtime/`, `Tests~/`)에 위 4개 패턴 출력 없음 — grep 확인 완료.
- CH는 기존 `LogType.Warning` 가드(`AITEditorErrorTracker.cs` line 432-436)와 **별개**로 Error/Exception LogType 변형도 흡수. 두 가드는 충돌 없이 공존.
- 모든 패턴은 충분히 unique한 substring이므로 composite AND 가드 불필요.

## Negative 보호

| 테스트 | 메시지 | 보호 메커니즘 |
|--------|--------|--------------|
| `Addressables_GenericMessage_NotFiltered` | `Addressables: catalog cache miss` | `Missing Addressables linker` substring 미포함 |
| `AssetDatabase_GenericRestriction_NotFiltered` | `AssetDatabase.Refresh are restricted ...` | `SaveAssets` 토큰 미포함 |

## 영향 받는 Sentry 이슈

- QE - Missing Addressables linker
- P4 - AssetDatabase.SaveAssets restricted
- P6 - scheduled for reimport during Refresh loop
- CH - immutable packages unexpectedly altered

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E EditMode (4 positive + 2 negative)