### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — external-tool-noise (x2)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -150,10 +150,13 @@ namespace AppsInToss.Editor.ErrorTracker
             "does not have a valid GUID",
             "' cannot be extracted by the YAML Parser",
 
-            // pnpm stdout 패스스루 노이즈 — 본문 없는 "[pnpm] 출력:" 라인 (SDK-HA, SDK-R6).
+            // pnpm stdout/stderr 패스스루 노이즈 — Unity가 외부 pnpm 프로세스 출력을 래핑한 라인.
+            // "[pnpm] 출력:"(SDK-HA, SDK-R6)은 stdout, "[pnpm] 오류:"(SDK-VF, SDK-VA)는 stderr를
+            // Unity가 UnityWarning으로 래핑한 것. 둘 다 SDK 외부(pnpm 프로세스) 출처.
             // AitKeywords에 "[pnpm]"이 없어 SDK 보호 가드는 우회되며,
             // SDK 자체 로그는 "[AIT...]" prefix와 함께 출력되므로 보호된다.
             "[pnpm] 출력:",
+            "[pnpm] 오류:",
 
             // 사용자 코드 using 중복 — Unity 컴파일러가 직접 출력하는 CS0105.
             // 예: "warning CS0105: The using directive for 'AppsInToss' appeared previously in this namespace"

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -940,7 +940,7 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
-    #region pnpm stdout 패스스루 (SDK-HA, SDK-R6)
+    #region pnpm stdout/stderr 패스스루 (SDK-HA, SDK-R6, SDK-VF, SDK-VA)
 
     [Test]
     public void PnpmStdoutPassthrough_TrailingAnchor_ReturnsTrue()
@@ -958,11 +958,34 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void PnpmStderrPassthrough_TrailingAnchor_ReturnsTrue()
+    {
+        // Sentry SDK-VF — Unity가 외부 pnpm 프로세스 stderr를 래핑한 "[pnpm] 오류:" 라인
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage("[pnpm] 오류:"));
+    }
+
+    [Test]
+    public void PnpmStderrPassthrough_UnityWrapped_ReturnsTrue()
+    {
+        // Sentry SDK-VA — UnityWarning prefix로 래핑된 "[pnpm] 오류:" 본문 (후행 내용 포함)
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[pnpm] 오류: ERR_PNPM_FETCH_404 GET https://registry.npmjs.org/foo"));
+    }
+
+    [Test]
     public void PnpmStdoutPassthrough_WithAitPrefix_NeverFiltered()
     {
         // SDK가 직접 출력한 "[AIT...]" prefix가 붙으면 SDK 보호 가드로 필터링되지 않아야 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AIT] [pnpm] 출력: build failed"));
+    }
+
+    [Test]
+    public void PnpmStderrPassthrough_WithAitPrefix_NeverFiltered()
+    {
+        // SDK가 직접 출력한 "[AIT...]" prefix가 붙으면 SDK 보호 가드로 필터링되지 않아야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] [pnpm] 오류: 빌드 의존성 설치 실패"));
     }
 
     #endregion


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-VF
Fixes APPS-IN-TOSS-UNITY-SDK-VA

## 요약

auto-resolve가 묶은 `external-tool-noise` 카테고리 2개 항목을 한 PR로 처리.

## 묶음 항목

| source | id | title |
|--------|----|----|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-VF | UnityWarning: [pnpm] 오류: |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-VA | UnityWarning: [pnpm] 오류: |

두 항목 모두 동일 노이즈 — Unity가 외부 pnpm 프로세스의 stderr 경고를 `UnityWarning`으로 래핑해 Console로 전달한 SDK 외부 출처 출력.

## 추출 패턴

`Editor/ErrorTracker/AITEditorErrorTracker.cs` 의 `NonSdkMessagePatterns`에 패턴 **1개** 추가:

- `"[pnpm] 오류:"` — pnpm stderr 패스스루 (메시지 본문 부분 문자열)

action_hint가 `'[pnpm]'` / `'UnityWarning: [pnpm]'`로 갈렸으나, `UnityWarning:`은 Unity가 붙이는 LogType 래퍼 prefix이고 실제 메시지 본문은 `[pnpm] 오류:`로 시작하므로 본문 부분 문자열 1개로 두 항목을 모두 커버. 기존 `"[pnpm] 출력:"`(stdout, SDK-HA/R6)과 동일한 형식.

### 안전성

- `AitKeywords`에 `[pnpm]`이 없어 `MessageContainsSdkKeyword` 보호 가드를 우회하므로 패턴이 동작.
- SDK 자체 로그는 `[AIT...]` prefix와 함께 출력되며, 해당 가드가 먼저 발동해 절대 필터링되지 않음 (negative 테스트로 검증).
- `grep` 확인: SDK 코드(`Editor/`, `Runtime/`)는 `[pnpm]` 문자열을 직접 출력하지 않음.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 2개(trailing anchor / UnityWarning 래핑 본문) + AIT prefix 보호 negative 1개 추가

## 검증

`./run-local-tests.sh --validate` — ✅ 통과 (3 passed, 0 failed)

---

⚠️ **사람 머지 검토 필요** — auto-resolve가 생성한 PR입니다.