### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — webgl-bee-build-failure (x2)

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1457,6 +1457,23 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void BuildLibraryBee_ReleaseWasmObjFailed_W0_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-W0: release_WebGL_wasm 해시 .o 컴파일 실패.
+        // 기존 "Building Library/Bee/artifacts/WebGL/" 패턴이 커버하는지 evidence로 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/xv9ku506h1iu.o failed with output:"));
+    }
+
+    [Test]
+    public void BuildLibraryBee_ReleaseWasmObjFailed_VZ_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-VZ: 동일 형식의 다른 해시 .o 파일.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/69d9yupbfnl2.o failed with output:"));
+    }
+
+    [Test]
     public void BuildLibraryBee_WithAitPrefix_StillProtected()
     {
         // SDK 보호 가드: SDK가 동일 prefix로 출력하는 가상의 케이스도 필터링 안 되어야 함.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-W0
Fixes APPS-IN-TOSS-UNITY-SDK-VZ

## 배경

webgl-bee-build-failure 카테고리로 묶인 2개 Sentry 이슈를 처리합니다.

| source | id | title |
|--------|-----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-W0 | `UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/xv9ku506h1iu.o failed with output:` |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-VZ | `UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/69d9yupbfnl2.o failed with output:` |

두 이슈 모두 Unity IL2CPP/Bee 빌드 시스템이 WebGL wasm 오브젝트 파일 컴파일 단위별로 직접 출력하는 빌드 실패 메시지입니다. `.o` 해시 파일명이 매번 달라 동일 빌드 실패가 Sentry에서 별도 이슈로 grouping됩니다.

## 분석 결과 — 신규 패턴 추가 불필요

`AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 이미 다음 패턴이 존재합니다 (line 176):

```
"Building Library/Bee/artifacts/WebGL/"
```

W0/VZ 두 메시지 모두 이 부분 문자열을 포함하므로 **이미 필터링되고 있습니다**. action_hint가 제안한 `Building Library/Bee/artifacts/WebGL/.+\.o failed with output` 패턴은 기존 패턴의 부분집합이므로 신규 패턴을 추가하지 않았습니다 (패턴 일반화·중복 방지).

## 변경 내용

`IsKnownNonSdkMessageTests.cs`에 두 이슈의 정확한 evidence 메시지를 positive 회귀 테스트로 추가하여, 기존 패턴이 두 항목을 모두 커버함을 명시적으로 검증합니다.

- `BuildLibraryBee_ReleaseWasmObjFailed_W0_ReturnsTrue`
- `BuildLibraryBee_ReleaseWasmObjFailed_VZ_ReturnsTrue`

기존 AIT prefix 보호 negative 테스트(`BuildLibraryBee_WithAitPrefix_StillProtected`)는 그대로 유지됩니다.

## 검증

`./run-local-tests.sh --validate` 통과 (3 passed, 0 failed — E2E 파일 검증 / Playwright config / SDK invariants 18 tests).

## 비고

코드 동작 변경 없음 (테스트 추가만). **사람 머지 검토 필요.**