### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — user-action-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1030,6 +1030,18 @@ namespace AppsInToss.Editor.ErrorTracker
                 && message.IndexOf("[?25", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // 사용자가 WebGL 빌드를 직접 취소한 정상 액션 — 에러가 아닌 의도된 사용자 동작 노이즈.
+            // 예: "[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다." (AITConvertCore.cs, AITLog.Warning)
+            //     "[AIT] 빌드가 취소되었습니다." (AITConvertCore.cs, Debug.LogWarning 변형)
+            // 신규 SDK는 취소 경로를 sentryCapture: false로 차단했지만, 구버전 SDK 사용자는 여전히
+            // 동일 Warning을 전송한다. 컨텐츠 기반 backstop.
+            // "[AIT]" prefix가 SDK 키워드 가드("[AIT")에 막히므로 가드보다 먼저 매칭한다.
+            // "[AIT" + "빌드가 취소되었습니다" 합성으로 좁혀 일반 빌드 실패 메시지와 충돌 방지.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-TX.
+            if (message.IndexOf("[AIT", StringComparison.Ordinal) >= 0
+                && message.IndexOf("빌드가 취소되었습니다", StringComparison.Ordinal) >= 0)
+                return true;
+
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용
             if (MessageContainsSdkKeyword(message))
                 return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1608,6 +1608,35 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 사용자 WebGL 빌드 취소 (SDK-TX)
+
+    [Test]
+    public void UserCancelledWebGLBuild_ReturnsTrue()
+    {
+        // Sentry SDK-TX — 사용자가 WebGL 빌드를 직접 취소한 정상 액션. AITConvertCore.cs의
+        // AITLog.Warning("[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.")가 출력한 본문.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다."));
+    }
+
+    [Test]
+    public void UserCancelledBuild_ShortVariant_ReturnsTrue()
+    {
+        // AITConvertCore.cs의 Debug.LogWarning("[AIT] 빌드가 취소되었습니다.") 변형도 동일 노이즈.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 빌드가 취소되었습니다."));
+    }
+
+    [Test]
+    public void BuildFailure_NotCancellation_NotFiltered()
+    {
+        // 실제 빌드 실패는 SDK 진단 가치가 있으므로 보호 — "취소" 문구가 없으면 매칭되지 않음.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] WebGL 빌드가 실패했습니다."));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1635,6 +1635,15 @@ public class IsKnownNonSdkMessageTests
             "[AIT] WebGL 빌드가 실패했습니다."));
     }
 
+    [Test]
+    public void Cancellation_WithoutAitPrefix_NotFiltered()
+    {
+        // composite AND 가드의 반대 축 검증 — "[AIT" prefix 없이 "빌드가 취소되었습니다"만
+        // 포함하는 메시지는 가드에 걸리지 않아야 한다(외부 코드의 다른 빌드 시스템 로그 보호).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Addressables 빌드가 취소되었습니다."));
+    }
+
     #endregion
 
     #region SDK 관련 메시지는 통과 (negative cases)


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-TX

## 묶음 항목

| source | id | title |
|--------|----|----|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-TX | UnityWarning: [AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다. |

## 배경

`[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.` 는 사용자가 WebGL 빌드를 직접 취소한 **정상 액션**으로, SDK 버그가 아닌 의도된 사용자 동작 노이즈다.

신규 SDK(`AITConvertCore.cs:997`)는 이미 `AITLog.Warning(..., sentryCapture: false)` 로 source 단에서 차단하지만, 구버전 SDK 사용자는 여전히 동일 Warning을 Sentry로 전송한다. 또한 `AITConvertCore.cs` 의 여러 경로(`Debug.LogWarning("[AIT] 빌드가 취소되었습니다.")`)는 `sentryCapture` 인자가 없어 `OnLogMessageReceived` 가 캡처할 수 있다. 컨텐츠 기반 backstop 가드가 필요하다.

## 추출 패턴

`[AIT]` prefix가 붙은 SDK 자체 로그라 `MessageContainsSdkKeyword` 가드(`NonSdkMessagePatterns`)를 우회한다. 따라서 `IsKnownNonSdkMessage` 내 SDK 키워드 가드 **앞**에 명시적 composite AND 가드를 추가:

```
message contains "[AIT"  AND  message contains "빌드가 취소되었습니다"
```

- `사용자에 의해 WebGL 빌드가 취소되었습니다.` (AITLog.Warning) 와 `빌드가 취소되었습니다.` (Debug.LogWarning) 변형을 공통 핵심 문구 하나로 모두 흡수.
- `[AIT` + `취소` 합성으로 좁혀 일반 빌드 실패 메시지(`[AIT] WebGL 빌드가 실패했습니다.`)와 충돌 방지.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `IsKnownNonSdkMessage` 명시적 가드 1개 추가 (`AIT: [std` ANSI 가드 뒤, SDK 키워드 가드 앞)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 2개(긴 변형/짧은 변형) + negative 1개(실제 빌드 실패는 보호)

## 검증

`./run-local-tests.sh --validate` — 3 passed / 0 failed (E2E 파일 구조 + Playwright 설정 + SDK 유닛 18 invariants)

---

⚠️ **사람 머지 검토 필요** — auto-resolve worker가 자동 생성한 PR입니다. squash merge로 병합 시 PR body의 `Fixes` 키워드가 머지 커밋에 포함되어 Sentry 이슈가 자동 resolve됩니다.