### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — webgl-template-missing

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -199,7 +199,8 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 사용자 프로젝트가 사용하는 다른 WebGL 템플릿(Fill 등)이 출력하는 진단. SDK 영역 아님.
             // 예: "[WebGL] unity-webview.js source not found: /Users/.../Assets/WebGLTemplates/Fill/TemplateData/unity-webview.js"
-            // Sentry APPS-IN-TOSS-UNITY-SDK-VJ.
+            //     "UnityWarning: [WebGL] unity-webview.js source not found: /Users/.../unity-webview.js"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-VJ ("UnityWarning: " prefix 변형 포함 — 부분 문자열 매칭).
             // SDK는 "[WebGL]" prefix를 출력하지 않으므로(grep 확인) AitKeywords 보호 가드와 충돌 없음.
             "[WebGL] unity-webview.js source not found",
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1357,6 +1357,26 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void ExternalWebGLTemplate_UnityWarningPrefix_ReturnsTrue()
+    {
+        // Sentry SDK-VJ — "UnityWarning: " prefix가 붙은 실측 변형.
+        // 매칭은 부분 문자열(IndexOf) 기반이므로 기존 "[WebGL] unity-webview.js source not found"
+        // 패턴이 prefix 유무와 무관하게 그대로 매칭한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [WebGL] unity-webview.js source not found: " +
+            "/Users/ad03148361/jenkins_workspace/attack-web/Assets/WebGLTemplates/Fill/TemplateData/unity-webview.js"));
+    }
+
+    [Test]
+    public void ExternalWebGLTemplate_UnityWebviewSourceNotFound_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 자체 로그("[AIT" prefix)는 AitKeywords 가드로 보호되어 절대 필터링하지 않음.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] [WebGL] unity-webview.js source not found: " +
+            "/Users/foo/Assets/WebGLTemplates/AITTemplate/TemplateData/unity-webview.js"));
+    }
+
+    [Test]
     public void WebGL_OtherWarning_NotFiltered()
     {
         // 다른 "[WebGL]" prefix 메시지는 패턴이 좁혀 있어 통과 (unity-webview source 한정).


### PR DESCRIPTION
`Fixes APPS-IN-TOSS-UNITY-SDK-VJ`

## 묶음 항목 (N=1)

| source | id | title |
|--------|----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-VJ | `UnityWarning: [WebGL] unity-webview.js source not found: .../Assets/WebGLTemplates/Fill/TemplateData/unity-webview.js` |

## 분석 결과 — 기존 패턴이 이미 커버

이번 Sentry 이슈 `APPS-IN-TOSS-UNITY-SDK-VJ`는 사용자 프로젝트가 사용하는 외부 WebGL 템플릿(`Fill`)이 출력하는 진단으로, SDK 영역이 아닌 노이즈입니다.

`AITEditorErrorTracker.IsKnownNonSdkMessage`의 매칭은 **부분 문자열(`IndexOf`) 기반**입니다. PR #626에서 추가된 `NonSdkMessagePatterns` 항목:

```
"[WebGL] unity-webview.js source not found"
```

이 패턴은 `UnityWarning: ` prefix가 붙은 신규 변형 메시지에도 그대로 포함되어 **이미 매칭**됩니다. action_hint가 제안한 `^UnityWarning: \[WebGL\]` 정규식 앵커는 이 엔진이 정규식이 아닌 substring 매칭을 쓰므로 적용 불가하며, 별도 패턴 추가도 불필요합니다(중복).

## 변경 내용

신규 패턴 추가 없이 **회귀 테스트만 추가**해 신규 fingerprint 커버리지를 명시적으로 검증:

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — 기존 SDK-VJ 패턴 주석에 `UnityWarning: ` prefix 변형 명시 (코드 동작 변경 없음)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`:
  - `ExternalWebGLTemplate_UnityWarningPrefix_ReturnsTrue` — 신규 Sentry 실측 메시지(`UnityWarning: ` prefix) positive 케이스
  - `ExternalWebGLTemplate_UnityWebviewSourceNotFound_WithAitPrefix_NeverFiltered` — `[AIT` prefix 보호 negative 케이스

## 검증

`./run-local-tests.sh --validate` 통과 (3/3 — 파일 구조 검증 + Playwright 설정 + SDK 유닛 테스트 18/18).

EditMode C# 테스트는 `--validate` 범위 밖이나, 변경이 순수 추가형 테스트 케이스 + 주석이며 매칭 로직 자체는 불변입니다.

---

⚠️ **사람 머지 검토 필요** — auto-resolve worker가 생성한 PR입니다.
