### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-import-warning (x1)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -122,11 +122,12 @@ namespace AppsInToss.Editor.ErrorTracker
             // 사용자 Unity 설치에 WebGL 모듈 미설치 — SDK-DD
             "Build target 'WebGL' not supported",
 
-            // Unity AssetImporter 내부 워커 에러 — SDK 외부 출처
-            // 예: "[Worker2] Import Error Code:(4)", "[Worker3] Import Error Code:(4)", "[Worker4] Import Error Code:(4)"
-            // Sentry APPS-IN-TOSS-UNITY-SDK-RC, APPS-IN-TOSS-UNITY-SDK-RD, APPS-IN-TOSS-UNITY-SDK-RE
-            // 워커 번호와 코드 숫자가 가변이지만 "] Import Error Code:(" 부분 문자열로 모두 매칭됨
-            "] Import Error Code:(",
+            // Unity AssetImporter 내부 워커/메인 에러 — SDK 외부 출처 (Unity 자체 에셋 임포트 경고).
+            // 워커 prefix가 있는 변형: "[Worker2] Import Error Code:(4)" (SDK-RC/RD/RE)
+            // prefix 없이 UnityWarning으로 래핑된 변형: "UnityWarning: Import Error Code:(4)" (SDK-V7)
+            // prefix 유무·워커 번호·코드 숫자가 모두 가변이므로 공통 핵심 문구 "Import Error Code:(" 로 일반화.
+            // SDK는 이 문자열을 출력하지 않으므로(AitKeywords에 없음) 보호 가드와 충돌 없음.
+            "Import Error Code:(",
 
             // 서브프로세스 실행 브레드크럼 — SDK가 아닌 외부(Unity Collab/CCD/사용자 도구)가 출력
             // 예: "Exec> git show -s --pretty=%D HEAD", "Exec> git log -1 --pretty=format:%h"

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -823,11 +823,15 @@ public class IsKnownNonSdkMessageTests
     [TestCase(
         "[Worker4] Import Error Code:(4)",
         TestName = "WorkerImportError_Worker4_ReturnsTrue")]
+    // Sentry APPS-IN-TOSS-UNITY-SDK-V7 — 워커 prefix 없이 UnityWarning으로 래핑된 변형
+    [TestCase(
+        "UnityWarning: Import Error Code:(4)",
+        TestName = "WorkerImportError_UnityWarningWrapped_ReturnsTrue")]
     public void WorkerImportError_RealisticVariants_ReturnsTrue(string message)
     {
-        // Sentry APPS-IN-TOSS-UNITY-SDK-RC/RD/RE — Unity AssetImporter 내부 워커 에러.
-        // 워커 번호(2/3/4)가 가변이지만 "] Import Error Code:(" 부분 문자열로 모두 매칭.
-        // SDK 코드에는 "Worker"/"Import Error Code" 문자열이 존재하지 않음 (grep으로 확인).
+        // Sentry APPS-IN-TOSS-UNITY-SDK-RC/RD/RE/V7 — Unity AssetImporter 내부/메인 에셋 임포트 에러.
+        // 워커 prefix 유무·워커 번호·코드 숫자가 가변이지만 "Import Error Code:(" 부분 문자열로 모두 매칭.
+        // SDK 코드에는 "Import Error Code" 문자열이 존재하지 않음 (grep으로 확인).
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(message));
     }
 
@@ -837,6 +841,9 @@ public class IsKnownNonSdkMessageTests
         // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙으면 SDK 자체 로그로 간주되어 필터링되지 않아야 함
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "[AIT] [Worker2] Import Error Code:(4)"));
+        // UnityWarning 래핑 변형에 대한 가드 회귀 방지
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Import Error Code:(4)"));
     }
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-V7

## 묶음 항목 (unity-import-warning, N=1)

| source | id | title |
|--------|----|----|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-V7 | UnityWarning: Import Error Code:(4) |

## 변경 내용

Unity AssetImporter가 출력하는 `Import Error Code:(N)` 노이즈는 워커 prefix가 붙는 변형(`[Worker2] Import Error Code:(4)` — SDK-RC/RD/RE)과 prefix 없이 `UnityWarning`으로 래핑된 변형(`UnityWarning: Import Error Code:(4)` — SDK-V7)이 공존한다. 기존 `NonSdkMessagePatterns`의 `"] Import Error Code:("` 패턴은 워커 prefix가 없는 SDK-V7 변형을 매칭하지 못한다.

### 추출 패턴

워커 prefix 유무·워커 번호·코드 숫자가 모두 가변이므로, 두 변형을 모두 커버하는 공통 핵심 문구로 일반화:

- `"] Import Error Code:("` → `"Import Error Code:("`

`NonSdkMessagePatterns`는 `IndexOf` 기반 부분 문자열 매칭이므로 리터럴로 추가했다. `AitKeywords`에 `Import Error Code` 문자열이 없어 SDK 자체 로그 보호 가드와 충돌하지 않는다.

### 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 패턴 일반화
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — SDK-V7 evidence(`UnityWarning: Import Error Code:(4)`) positive 케이스 + `[AIT]` prefix 보호 negative 케이스 추가

## 검증

`./run-local-tests.sh --validate` 통과 (3/3 passed — 파일 구조 검증, Playwright 설정, SDK 유닛 테스트 18/18).

---

⚠️ 이 PR은 auto-resolve worker가 자동 생성했습니다. **사람 머지 검토가 필요합니다.**