### PR TITLE
수정: npm/pnpm 타임아웃 분기 Sentry 캡처 차단

### DIFF
--- a/Editor/AITNpmRunner.cs
+++ b/Editor/AITNpmRunner.cs
@@ -273,11 +273,15 @@ namespace AppsInToss.Editor
                             EditorUtility.ClearProgressBar();
                             string timeoutOutput = outputBuilder.ToString();
                             string timeoutError = errorBuilder.ToString();
-                            Debug.LogError($"[{pmName}] 명령 시간 초과 ({maxWaitMs / 1000}초): {pmName} {arguments}");
+                            // npm/pnpm 타임아웃 — lockfile drift, 네트워크 지연, AV scan, registry
+                            // 정책 등 사용자 환경 원인. 호출자가 FAIL_NPM_BUILD로 결과 인지 후
+                            // 상위에서 컨텍스트 있는 메시지로 보고하므로 Console 진단만 남기고
+                            // Sentry는 차단 (exit != 0 동기 실패 분기와 동일 정책 — SDK-HA/R6/VF/VA cascade 흡수).
+                            AITLog.Error($"[{pmName}] 명령 시간 초과 ({maxWaitMs / 1000}초): {pmName} {arguments}", sentryCapture: false);
                             if (!string.IsNullOrEmpty(timeoutOutput))
-                                Debug.LogError($"[{pmName}] 출력:\n{timeoutOutput.Trim()}");
+                                AITLog.Error($"[{pmName}] 출력:\n{timeoutOutput.Trim()}", sentryCapture: false);
                             if (!string.IsNullOrEmpty(timeoutError))
-                                Debug.LogError($"[{pmName}] 오류:\n{timeoutError.Trim()}");
+                                AITLog.Error($"[{pmName}] 오류:\n{timeoutError.Trim()}", sentryCapture: false);
                             return AITConvertCore.AITExportError.FAIL_NPM_BUILD;
                         }
 


### PR DESCRIPTION
## 배경

`[auto-resolve]` PR #633 (`external-tool-noise`)을 검토하던 중, `[pnpm] 오류:` 라인의 출처를 코드 레벨로 추적한 결과 **트리아지 라벨이 부정확**함을 발견했습니다.

- 라벨: "Unity가 외부 pnpm 프로세스를 래핑한 노이즈"
- 실제: `[pnpm] 오류:`는 **SDK 코드(`AITNpmRunner.cs`)가 직접 출력하는 진단 로그** (`[{pmName}] 오류:`, `pmName == "pnpm"`)

## 근본 원인

`AITNpmRunner.RunNpmCommandWithCache`(동기)의 **타임아웃 분기**가 `Debug.LogError`로 로그를 출력하면서 `sentryCapture` 인자가 누락:

| 분기 | 위치 | 기존 상태 |
|------|------|-----------|
| exit != 0 동기 실패 | L331~338 | ✅ `AITLog.Error(sentryCapture: false)` |
| 비동기 실패 | L410~413 | ✅ `AITLog.Warning(sentryCapture: false)` |
| **타임아웃** | **L276~280** | ❌ **`Debug.LogError` — source 차단 누락** |

`[pnpm]`은 `AitKeywords`에 없어 `IsKnownNonSdkMessage`의 SDK 보호 가드가 동작하지 않고, source 차단도 없으므로 이 경로의 로그는 Sentry로 전송됩니다.

## 변경

타임아웃 분기 3개 `Debug.LogError` → `AITLog.Error(..., sentryCapture: false)`. 동기 실패 분기와 동일 정책.

npm/pnpm 타임아웃은 lockfile drift·네트워크 지연·AV scan·registry 정책 등 **사용자 환경 원인**으로 SDK 코드 분기로 해결 불가하며(`AITNpmRunner.cs:327` 기존 주석과 일치), 호출자가 `FAIL_NPM_BUILD`로 결과를 인지해 상위에서 컨텍스트 있는 메시지로 보고합니다.

`AITLog.Error`는 내부에서 `Debug.LogError`를 그대로 호출 → **Console 진단 가시성 유지**, Sentry 전송만 억제.

## #633과의 관계

이 PR은 **source-단 수정**, #633은 **content-단 backstop** — 기존 D10a/D10b가 적용한 "source 차단 + content backstop" 이중 안전망 패턴과 동일. backstop은 구버전 SDK가 보내는 cascade를 흡수하므로 #633도 독립적으로 유효합니다.

> Sentry auto-resolve(`Fixes ...` 키워드)는 #633이 담당하므로 이 PR 본문에는 넣지 않습니다 — 중복 시 이슈 종료 타이밍이 어긋납니다. 관련 이슈: APPS-IN-TOSS-UNITY-SDK-VF, APPS-IN-TOSS-UNITY-SDK-VA.

## 검증

`./run-local-tests.sh --validate` — ✅ 통과 (3 passed, 0 failed)