### PR TITLE
수정: 사용자 환경/빌드 외부 노이즈 Sentry 차단

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -232,32 +232,6 @@ namespace AppsInToss.Editor.ErrorTracker
             // 기존 LogType.Warning 가드는 별도로 유지되며(line 432-436), 이 패턴은 Error/Exception LogType 변형도 흡수.
             // SDK 자체 코드는 이 메시지를 출력하지 않으며(주석으로만 참조) Unity 엔진이 직접 출력.
             "immutable packages were unexpectedly altered",
-
-            // Unity Package Manager가 사용자 환경(네트워크/Git 인증/SSL 등) 문제로 Git 패키지 추가/제거 실패 시 직접 출력.
-            // 예: "[Package Manager Window] Error adding/removing packages: https://github.com/toss/apps-in-toss-unity-sdk.git #release/v2.4.3."
-            // Sentry APPS-IN-TOSS-UNITY-SDK-QQ, APPS-IN-TOSS-UNITY-SDK-7Y.
-            // SDK는 "[Package Manager Window]" prefix를 출력하지 않으므로(grep 확인) 안전.
-            "[Package Manager Window] Error adding/removing packages",
-
-            // Unity Package Manager가 의존성 해석 실패 시 직접 출력 — 사용자 환경 manifest.json 충돌 또는 네트워크 장애.
-            // 예: "An error occurred while resolving packages:\n  Project has invalid dependencies: ..."
-            // Sentry APPS-IN-TOSS-UNITY-SDK-V1.
-            // SDK는 이 문자열을 출력하지 않으므로(grep 확인) 안전.
-            "An error occurred while resolving packages",
-
-            // AppsInTossMenu deploy 경로의 pnpm/ait CLI가 잘못된 인자로 호출됐을 때 출력하는 syntax error.
-            // 예: "AIT: [stdout] Unknown Syntax Error: Not enough arguments to option --api-key."
-            // 사용자가 deployment key를 입력하지 않은 사용자 환경 문제. SDK 분기로 해결 불가.
-            // "AIT: [stdout]"/"AIT: [stderr]" prefix는 SDK 키워드 가드에 막히지만, "AIT:" + "Unknown Syntax Error" 합성 가드는
-            // 별도 가드(IsKnownNonSdkMessage)로 처리. 여기 패턴은 단독 substring으로 좁혀도 SDK 출력과 충돌 없음.
-            // Sentry APPS-IN-TOSS-UNITY-SDK-TS.
-            "Unknown Syntax Error: Not enough arguments",
-
-            // Windows shell이 인식 못하는 명령어 호출 시 직접 출력 — 사용자 환경 PATH 누락 또는 인코딩 깨짐.
-            // 예: "AIT: [stderr] '��e' is not recognized as an internal or external command,"
-            // Sentry APPS-IN-TOSS-UNITY-SDK-RG.
-            // SDK는 이 문자열을 출력하지 않으므로(grep 확인) 안전. Windows cmd 표준 에러 메시지.
-            "is not recognized as an internal or external command",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.
@@ -1071,6 +1045,43 @@ namespace AppsInToss.Editor.ErrorTracker
             // Sentry APPS-IN-TOSS-UNITY-SDK-TX.
             if (message.IndexOf("[AIT", StringComparison.Ordinal) >= 0
                 && message.IndexOf("빌드가 취소되었습니다", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // Unity Package Manager가 사용자 환경(네트워크/Git 인증/SSL 등) 문제로 Git 패키지 추가/제거 실패 시 직접 출력.
+            // 예: "[Package Manager Window] Error adding/removing packages: https://github.com/toss/apps-in-toss-unity-sdk.git #release/v2.4.3."
+            // URL에 'apps-in-toss' 토큰이 단어 경계로 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
+            // "[Package Manager Window]" + "Error adding/removing packages" 합성으로 일반 PM 메시지와 충돌 방지.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-QQ, APPS-IN-TOSS-UNITY-SDK-7Y.
+            if (message.IndexOf("[Package Manager Window]", StringComparison.Ordinal) >= 0
+                && message.IndexOf("Error adding/removing packages", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // Unity Package Manager가 의존성 해석 실패 시 직접 출력 — 사용자 환경 manifest.json 충돌 또는 네트워크 장애.
+            // 예: "An error occurred while resolving packages:\n  Project has invalid dependencies: com.example.foo"
+            // 본문에 SDK 패키지 경로(예: com.toss.apps-in-toss)가 들어가면 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
+            // "An error occurred while resolving packages" + "Project has invalid dependencies" 합성으로 좁힌다.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-V1.
+            if (message.IndexOf("An error occurred while resolving packages", StringComparison.Ordinal) >= 0
+                && message.IndexOf("Project has invalid dependencies", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // AppsInTossMenu deploy 경로의 pnpm/ait CLI가 잘못된 인자로 호출됐을 때 redirect한 syntax error.
+            // 예: "AIT: [stdout] Unknown Syntax Error: Not enough arguments to option --api-key."
+            // "AIT: [stdout]" prefix가 SDK 키워드 가드("AIT:")에 막히므로 가드보다 먼저 매칭한다.
+            // "AIT: [std" + "Unknown Syntax Error: Not enough arguments" 합성으로 일반 stdout과 충돌 방지.
+            // 사용자가 deployment key를 입력하지 않은 환경 문제 — SDK 분기로 해결 불가.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-TS.
+            if (message.IndexOf("AIT: [std", StringComparison.Ordinal) >= 0
+                && message.IndexOf("Unknown Syntax Error: Not enough arguments", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // Windows shell이 인식 못하는 명령어 호출 시 redirect한 stderr — 사용자 환경 PATH 누락 또는 인코딩 깨짐.
+            // 예: "AIT: [stderr] '<corrupted-bytes>' is not recognized as an internal or external command,"
+            // "AIT: [stderr]" prefix가 SDK 키워드 가드("AIT:")에 막히므로 가드보다 먼저 매칭한다.
+            // "AIT: [std" + "is not recognized as an internal or external command" 합성으로 좁힌다.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-RG.
+            if (message.IndexOf("AIT: [std", StringComparison.Ordinal) >= 0
+                && message.IndexOf("is not recognized as an internal or external command", StringComparison.Ordinal) >= 0)
                 return true;
 
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -232,6 +232,32 @@ namespace AppsInToss.Editor.ErrorTracker
             // 기존 LogType.Warning 가드는 별도로 유지되며(line 432-436), 이 패턴은 Error/Exception LogType 변형도 흡수.
             // SDK 자체 코드는 이 메시지를 출력하지 않으며(주석으로만 참조) Unity 엔진이 직접 출력.
             "immutable packages were unexpectedly altered",
+
+            // Unity Package Manager가 사용자 환경(네트워크/Git 인증/SSL 등) 문제로 Git 패키지 추가/제거 실패 시 직접 출력.
+            // 예: "[Package Manager Window] Error adding/removing packages: https://github.com/toss/apps-in-toss-unity-sdk.git #release/v2.4.3."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-QQ, APPS-IN-TOSS-UNITY-SDK-7Y.
+            // SDK는 "[Package Manager Window]" prefix를 출력하지 않으므로(grep 확인) 안전.
+            "[Package Manager Window] Error adding/removing packages",
+
+            // Unity Package Manager가 의존성 해석 실패 시 직접 출력 — 사용자 환경 manifest.json 충돌 또는 네트워크 장애.
+            // 예: "An error occurred while resolving packages:\n  Project has invalid dependencies: ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-V1.
+            // SDK는 이 문자열을 출력하지 않으므로(grep 확인) 안전.
+            "An error occurred while resolving packages",
+
+            // AppsInTossMenu deploy 경로의 pnpm/ait CLI가 잘못된 인자로 호출됐을 때 출력하는 syntax error.
+            // 예: "AIT: [stdout] Unknown Syntax Error: Not enough arguments to option --api-key."
+            // 사용자가 deployment key를 입력하지 않은 사용자 환경 문제. SDK 분기로 해결 불가.
+            // "AIT: [stdout]"/"AIT: [stderr]" prefix는 SDK 키워드 가드에 막히지만, "AIT:" + "Unknown Syntax Error" 합성 가드는
+            // 별도 가드(IsKnownNonSdkMessage)로 처리. 여기 패턴은 단독 substring으로 좁혀도 SDK 출력과 충돌 없음.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-TS.
+            "Unknown Syntax Error: Not enough arguments",
+
+            // Windows shell이 인식 못하는 명령어 호출 시 직접 출력 — 사용자 환경 PATH 누락 또는 인코딩 깨짐.
+            // 예: "AIT: [stderr] '��e' is not recognized as an internal or external command,"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-RG.
+            // SDK는 이 문자열을 출력하지 않으므로(grep 확인) 안전. Windows cmd 표준 에러 메시지.
+            "is not recognized as an internal or external command",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1472,6 +1472,69 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 사용자 환경 / 빌드 외부 노이즈 (SDK-QQ, SDK-7Y, SDK-V1, SDK-TS, SDK-RG)
+
+    [Test]
+    public void PackageManager_ErrorAddingPackages_ReturnsTrue()
+    {
+        // Sentry SDK-QQ — 사용자 환경 git/네트워크 문제로 Package Manager가 직접 출력.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[Package Manager Window] Error adding/removing packages: " +
+            "https://github.com/toss/apps-in-toss-unity-sdk.git #release/v2.4.3."));
+    }
+
+    [Test]
+    public void PackageManager_ErrorRemovingPackages_AltVersion_ReturnsTrue()
+    {
+        // Sentry SDK-7Y — 동일 패턴 다른 버전 변형.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[Package Manager Window] Error adding/removing packages: " +
+            "https://github.com/toss/apps-in-toss-unity-sdk.git#release/v2.4.5."));
+    }
+
+    [Test]
+    public void PackageManager_ResolvingPackagesError_ReturnsTrue()
+    {
+        // Sentry SDK-V1 — 사용자 manifest.json 충돌.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "An error occurred while resolving packages:\n" +
+            "  Project has invalid dependencies: com.example.foo"));
+    }
+
+    [Test]
+    public void Pnpm_UnknownSyntaxError_ApiKey_ReturnsTrue()
+    {
+        // Sentry SDK-TS — 사용자가 deployment key 미입력 상태로 deploy 실행.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: [stdout] Unknown Syntax Error: Not enough arguments to option --api-key."));
+    }
+
+    [Test]
+    public void WindowsShell_NotRecognized_ReturnsTrue()
+    {
+        // Sentry SDK-RG — Windows cmd 인코딩/PATH 문제.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: [stderr] '��e' is not recognized as an internal or external command,"));
+    }
+
+    [Test]
+    public void PackageManager_GenericPmMessage_NotFiltered()
+    {
+        // 다른 "[Package Manager Window]" 메시지는 통과 — "Error adding/removing" 토큰 미포함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[Package Manager Window] Successfully installed package"));
+    }
+
+    [Test]
+    public void Pnpm_OtherSyntaxError_NotFiltered()
+    {
+        // "Not enough arguments" 부분이 없으면 통과 — 다른 Unknown Syntax 메시지 보호.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: [stdout] Unknown Syntax Error: Invalid flag --foo."));
+    }
+
+    #endregion
+
     #region IL2CPP/Bee 빌드 단위별 실패 (SDK-SA~SV, T7, TV)
 
     [Test]


### PR DESCRIPTION
## 요약

`AITEditorErrorTracker.NonSdkMessagePatterns`에 사용자 환경/빌드 외부에서 발생하는 노이즈 4개 패턴(5개 Sentry 이슈)을 추가. 모두 Unity Package Manager / Windows cmd / pnpm CLI가 직접 출력하며 SDK 코드 분기로 해결 불가.

## 추가 패턴

| 패턴 | Sentry 이슈 | 원본 메시지 |
|------|-------------|-------------|
| `[Package Manager Window] Error adding/removing packages` | QQ, 7Y | `[Package Manager Window] Error adding/removing packages: https://github.com/toss/apps-in-toss-unity-sdk.git #release/v2.4.3.` |
| `An error occurred while resolving packages` | V1 | `An error occurred while resolving packages:\n  Project has invalid dependencies: ...` |
| `Unknown Syntax Error: Not enough arguments` | TS | `AIT: [stdout] Unknown Syntax Error: Not enough arguments to option --api-key.` |
| `is not recognized as an internal or external command` | RG | `AIT: [stderr] '��e' is not recognized as an internal or external command,` |

## 안전성 확인

SDK 자체 코드(`Editor/`, `Runtime/`, `Tests~/`)에 위 4개 패턴 출력 없음 — grep 확인 완료. TS의 `--api-key`는 SDK가 명령 인자로 전달하지만, `Unknown Syntax Error` 본문은 pnpm/ait CLI 출력이므로 충돌 없음.

## Negative 보호

| 테스트 | 메시지 | 보호 메커니즘 |
|--------|--------|--------------|
| `PackageManager_GenericPmMessage_NotFiltered` | `[Package Manager Window] Successfully installed package` | `Error adding/removing` 토큰 미포함 |
| `Pnpm_OtherSyntaxError_NotFiltered` | `Unknown Syntax Error: Invalid flag --foo.` | `Not enough arguments` 부분 미포함 |

## 영향 받는 Sentry 이슈

- QQ (2 events) - Package Manager Git failure v2.4.3
- 7Y (2 events) - Package Manager Git failure v2.4.5
- V1 (1 event) - resolving packages
- TS (1 event) - Unknown Syntax Error --api-key
- RG (1 event) - Windows shell not recognized

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E EditMode (5 positive + 2 negative)