### PR TITLE
수정: CS1503 가드를 List<> 제네릭 SDK 타입 인자에도 매칭

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -995,11 +995,14 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 사용자 코드의 SDK 타입 인자 오용(CS1503) — Unity 컴파일러가 직접 출력.
             // 예: "Assets\Scripts\Manager\TossManager.cs(192,91): error CS1503: Argument 1: cannot convert from 'AppsInToss.GetUserKeyForGameResult' to 'string'"
-            // Sentry APPS-IN-TOSS-UNITY-SDK-VM/PV/PW/DA.
+            // 예(List 제네릭 변형): "Assets/.../RemoteShopInfo.cs(312,68): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.List<Studio.Common.Trident.Billing.ProductInfo>' to 'System.Collections.Generic.List<AppsInToss.IapProductListItem>'"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-VM/PV/PW/DA/WW/WV.
             // 메시지에 'AppsInToss.*' 타입명이 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
-            // 'AppsInToss.' 점(.)을 포함해 namespace prefix를 정확히 요구하므로 단독 토큰 'AppsInToss'만 있는 SDK 빌드 메시지와 충돌 없음.
+            // namespace prefix는 작은따옴표 직후('AppsInToss.) 또는 List<> 등 제네릭 인자 직후(<AppsInToss.) 두 형태를 모두 허용.
+            // 두 변형 모두 점(.)을 포함해 단독 토큰 'AppsInToss'만 있는 SDK 빌드 메시지와는 충돌 없음.
             if (message.IndexOf("error CS1503", StringComparison.Ordinal) >= 0
-                && message.IndexOf("'AppsInToss.", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("'AppsInToss.", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("<AppsInToss.", StringComparison.Ordinal) >= 0)
                 && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
                     || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1294,6 +1294,22 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void UserCode_Cs1503_ListGenericAppsInTossType_ReturnsTrue()
+    {
+        // Sentry SDK-WW — List<T> 제네릭 인자로 SDK 타입을 잘못 사용. namespace prefix가 '<AppsInToss.' 형태로 등장.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/02.Script/Match3/Event/TravelPass/TravelPassEventModel.cs(203,60): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.List<Studio.Common.Trident.Billing.ProductInfo>' to 'System.Collections.Generic.List<AppsInToss.IapProductListItem>'"));
+    }
+
+    [Test]
+    public void UserCode_Cs1503_ListGenericAppsInTossType_PosixPath_ReturnsTrue()
+    {
+        // Sentry SDK-WV — POSIX 경로 + List<T> 제네릭 변형.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/02.Script/Match3/Data/RemoteShopInfo.cs(312,68): error CS1503: Argument 1: cannot convert from 'System.Collections.Generic.List<Studio.Common.Trident.Billing.ProductInfo>' to 'System.Collections.Generic.List<AppsInToss.IapProductListItem>'"));
+    }
+
+    [Test]
     public void Cs1503_AppsInTossTypeMisuse_WithAitPrefix_StillProtected()
     {
         // SDK 보호 가드: 합성 가드(error CS1503 + 'AppsInToss.' + Assets/ + .cs()를 모두 만족하지 않으면


### PR DESCRIPTION
## 요약

`AITEditorErrorTracker.IsKnownNonSdkMessage`의 CS1503 합성 가드가 List<T> 제네릭 인자 변형(SDK-WW, SDK-WV)을 흡수하지 못해 두 이슈가 매시간 escalating 중. namespace prefix 탐색을 `'AppsInToss.` 외에 `<AppsInToss.`도 허용하도록 확장.

## 원인

기존 가드:
```csharp
&& message.IndexOf("'AppsInToss.", StringComparison.Ordinal) >= 0
```

- SDK-VM/PV/PW/DA: `cannot convert from 'AppsInToss.GetUserKeyForGameResult' to 'string'` — 작은따옴표 직후 매칭 OK
- SDK-WW/WV: `cannot convert from 'System.Collections.Generic.List<AppsInToss.IapProductListItem>' to ...` — List<>의 꺽쇠 직후 등장, 작은따옴표 직후가 아니므로 매칭 실패

## 수정

가드 조건을 OR로 확장:
```csharp
&& (message.IndexOf("'AppsInToss.", StringComparison.Ordinal) >= 0
    || message.IndexOf("<AppsInToss.", StringComparison.Ordinal) >= 0)
```

두 변형 모두 `AppsInToss` 다음 점(.)이 필수이므로 단독 토큰 `AppsInToss`만 들어있는 SDK 빌드 메시지와 충돌 없음.

## 추가 테스트

`IsKnownNonSdkMessageTests.cs`에 회귀 테스트 2개 추가:
- `UserCode_Cs1503_ListGenericAppsInTossType_ReturnsTrue` — SDK-WW (Windows 경로 + List<>)
- `UserCode_Cs1503_ListGenericAppsInTossType_PosixPath_ReturnsTrue` — SDK-WV (POSIX 경로 + List<>)

기존 negative 케이스(`Cs1503_WithoutAppsInTossNamespace_NotFiltered`, `Cs1503_AppsInTossTypeMisuse_WithAitPrefix_StillProtected`) 그대로 유지.

## 영향 받는 Sentry 이슈

- WW (12 events, 2.4.7) - TravelPassEventModel.cs List<ProductInfo> → List<IapProductListItem>
- WV (12 events, 2.4.7) - RemoteShopInfo.cs List<ProductInfo> → List<IapProductListItem>

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI E2E EditMode (3 기존 positive + 2 신규 positive + 2 negative)

Fixes APPS-IN-TOSS-UNITY-SDK-WW
Fixes APPS-IN-TOSS-UNITY-SDK-WV