### PR TITLE
수정: 빌드 누락 진단 다단 로그 Sentry fingerprint 통합

### DIFF
--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -351,23 +351,26 @@ namespace AppsInToss.Editor
 
             if (isRequired)
             {
-                Debug.LogError($"[AIT] ✗ 필수 파일을 찾을 수 없습니다: {pattern}");
-                Debug.LogError($"[AIT]   검색 경로: {buildPath}");
-                Debug.LogError($"[AIT]   이 파일이 없으면 런타임에서 'createUnityInstance is not defined' 에러가 발생합니다.");
+                // 사용자 환경의 빌드 산출물 누락 진단 로그 — Sentry로는 한 줄로 요약 전송하고
+                // 상세 다단 로그는 sentryCapture:false로 콘솔에만 남긴다.
+                // 첫 줄만 Sentry로 전송하면 fingerprint가 pattern 별로 안정적으로 묶임(SDK-KX 계열).
+                // 후속 진단 줄들은 hash/path가 빌드마다 달라 fingerprint가 분산되므로(SDK-KY~M6 계열) Sentry 억제.
+                AITLog.Error($"[AIT] ✗ 필수 파일을 찾을 수 없습니다: {pattern}");
+                AITLog.Error($"[AIT]   검색 경로: {buildPath}", sentryCapture: false);
+                AITLog.Error($"[AIT]   이 파일이 없으면 런타임에서 'createUnityInstance is not defined' 에러가 발생합니다.", sentryCapture: false);
 
-                // 실제로 어떤 파일들이 있는지 출력
                 var existingFiles = Directory.GetFiles(buildPath);
                 if (existingFiles.Length > 0)
                 {
-                    Debug.LogError($"[AIT]   Build 폴더의 실제 파일들:");
+                    AITLog.Error($"[AIT]   Build 폴더의 실제 파일들:", sentryCapture: false);
                     foreach (var file in existingFiles)
                     {
-                        Debug.LogError($"[AIT]     - {Path.GetFileName(file)}");
+                        AITLog.Error($"[AIT]     - {Path.GetFileName(file)}", sentryCapture: false);
                     }
                 }
                 else
                 {
-                    Debug.LogError($"[AIT]   Build 폴더가 비어 있습니다!");
+                    AITLog.Error($"[AIT]   Build 폴더가 비어 있습니다!", sentryCapture: false);
                 }
             }
 

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -104,16 +104,18 @@ namespace AppsInToss.Editor.Package
 
             if (missingFiles.Count > 0)
             {
-                Debug.LogError(
-                    $"[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락!\n"
-                    + $"누락된 필수 파일: {string.Join(", ", missingFiles)}\n"
-                    + "가능한 원인:\n"
+                // Sentry로는 단일 fingerprint(누락 파일 요약)만 보내고, 상세 가이드/원인은 콘솔에만 남긴다.
+                // Unity Log Listener가 \n으로 분할된 라인을 각각 다른 이슈로 묶는 경우를 회피.
+                AITLog.Error($"[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: {string.Join(", ", missingFiles)}");
+                AITLog.Error(
+                    "[AIT]   가능한 원인:\n"
                     + "  1. Unity WebGL 빌드가 완료되지 않았습니다.\n"
                     + "  2. WebGL 빌드가 실패했지만 부분 결과물만 남아있습니다.\n"
                     + "  3. 빌드 설정(압축 방식 등)이 예상과 다릅니다.\n"
                     + "해결 방법:\n"
                     + "  1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n"
-                    + "  2. Unity Console에서 빌드 에러를 확인하세요."
+                    + "  2. Unity Console에서 빌드 에러를 확인하세요.",
+                    sentryCapture: false
                 );
                 return AITConvertCore.AITExportError.REQUIRED_FILE_MISSING;
             }


### PR DESCRIPTION
## 요약

WebGL 빌드 필수 파일 누락 시 출력되는 다단 진단 로그가 Sentry에서 줄별로 11개 fingerprint(SDK-M0~M6/KX~KZ)로 분산되던 문제를 정리. 리드 한 줄만 Sentry로 캡처하고 상세 안내 줄은 콘솔에만 남긴다.

## 원인

두 곳에서 다단 LogError 출력:

1. `Editor/AITBuildValidator.cs:354-371` — `Debug.LogError($"[AIT] ✗ 필수 파일을 찾을 수 없습니다: {pattern}")` 외에 검색 경로/원인 안내/실제 파일 목록을 줄별로 LogError. 각 줄에 hash가 다른 파일명(`*.data.unityweb` 등)이 포함돼 빌드마다 fingerprint가 갈라짐.
2. `Editor/Package/WebGLBuildCopier.cs:107-117` — `[AIT] ✗ 치명적: ...` 한 LogError 호출이지만 `\n` 분할 시 Unity Log Listener가 줄을 끊을 수 있고, 동일 카테고리(SDK-M6)로 묶임.

## 수정

- `AITBuildValidator.cs`: 첫 줄(`✗ 필수 파일을 찾을 수 없습니다: {pattern}`)만 `AITLog.Error(...)`(=Sentry 캡처). 검색 경로/원인 안내/파일 목록은 `AITLog.Error(..., sentryCapture: false)`로 콘솔만.
- `WebGLBuildCopier.cs`: 누락 요약 한 줄을 Sentry로 보내고, 가이드 본문은 별도 `AITLog.Error(..., sentryCapture: false)`로 분리.

빌드 실패 신호는 보존(콘솔 LogError 가시성 유지 + Sentry 단일 fingerprint).

## 영향 받는 Sentry 이슈

SDK-M0~M6, KX~KZ — 모두 24일 전 한 사용자의 1회 빌드에서 11개 별도 이슈로 분산된 케이스. 이후 같은 컨텍스트가 재발해도 단일 fingerprint(`[AIT] ✗ 필수 파일을 찾을 수 없습니다: {pattern}` / `[AIT] ✗ 치명적: ... 누락된 필수 파일: ...`)로만 보고됨.

## Test plan

- [x] `./run-local-tests.sh --validate` 통과 (파일 구조 + SDK 유닛)
- [ ] CI E2E EditMode (C# 컴파일 + 기존 테스트 회귀 검증) — `AITLog` 호출은 같은 namespace 부모 접근으로 컴파일됨