### PR TITLE
빌드: Sentry release commit tracking 활성화

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -615,6 +615,36 @@ jobs:
       tag_name: ${{ needs.release.outputs.tag_name }}
 
   # =====================================================
+  # Sentry 릴리즈 등록 + 커밋 연동
+  # =====================================================
+  # 런타임 envelope 의 release 식별자(`apps-in-toss.unity@<version>`)와 동일한
+  # 이름으로 Sentry 에 릴리즈를 등록하고 commit range 를 연결한다.
+  # 이렇게 해야 PR 머지 메시지의 `Fixes APPS-IN-TOSS-UNITY-SDK-XX` trailer 가
+  # Sentry GitHub Integration 을 통해 해당 이슈를 자동으로 resolve in next release
+  # 로 표기하고, 다음 릴리즈가 배포되면 자동 closed 처리된다.
+  sentry-release:
+    name: Sentry 릴리즈 등록
+    runs-on: ubuntu-latest
+    needs: [create-release-tag]
+    if: needs.create-release-tag.result == 'success'
+    steps:
+      - name: Checkout (main 커밋 히스토리)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Sentry Release 생성 + 커밋 연동
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: toss
+          SENTRY_PROJECT: apps-in-toss-unity-sdk
+        with:
+          version: apps-in-toss.unity@${{ needs.create-release-tag.outputs.version }}
+          set_commits: auto
+          finalize: true
+
+  # =====================================================
   # AIT 패키지 배포
   # =====================================================
   deploy-ait:


### PR DESCRIPTION
## 요약

릴리즈 워크플로에 `sentry-release` job 추가. 런타임 envelope 의 release 식별자 (`apps-in-toss.unity@<version>`) 와 동일한 이름으로 Sentry 에 릴리즈를 등록하고 commit range 를 자동 연결한다.

## 배경 / 원인

- `Editor/ErrorTracker/AITSentryEnvelope.cs` 는 런타임에 `"release": "apps-in-toss.unity@<AITVersion.Version>"` 를 envelope 에 박아 이벤트를 전송한다.
- 그러나 `.github/workflows/release.yml` 은 **Sentry 릴리즈 객체 자체를 만들지 않으며**, commit 정보도 업로드하지 않는다.
- 결과: Sentry GitHub Integration 이 commit-to-release 매핑을 못 잡아, PR 머지 커밋 메시지의 `Fixes APPS-IN-TOSS-UNITY-SDK-XX` trailer 가 무시된다. (예: PR #633 머지 후 SDK-VF 이 auto-resolve 되지 않음)

## 수정

`create-release-tag` 성공 후 새 job `sentry-release` 실행:

- `actions/checkout@v6` 를 `fetch-depth: 0` 으로 호출 → main 커밋 히스토리 전체 확보
- `getsentry/action-release@v3` 호출:
  - `version: apps-in-toss.unity@${{ needs.create-release-tag.outputs.version }}` (런타임 envelope 형식과 1:1 일치)
  - `set_commits: auto` (직전 릴리즈 이후 commit range 자동 산정)
  - `finalize: true`
- env: `SENTRY_AUTH_TOKEN` (시크릿), `SENTRY_ORG=toss`, `SENTRY_PROJECT=apps-in-toss-unity-sdk` (plaintext — 공개 정보)

## 사전 작업

- [x] `SENTRY_AUTH_TOKEN` repo secret 등록 (Personal user auth token, scopes: `project:releases` 등)

## 영향

- 이 PR 머지 자체는 동작 없음 (워크플로 정의 변경만).
- 다음 릴리즈 워크플로 실행 시점부터 Sentry 에 release 객체가 만들어지고 commit 이 연결됨.
- 그 이후 PR 머지 메시지에 `Fixes APPS-IN-TOSS-UNITY-SDK-XX` trailer 가 포함되면 Sentry GitHub Integration 이 이슈를 `resolve in next release` 로 표시, 다음 릴리즈에서 자동 closed.

## actionlint 노이즈

actionlint 가 `secrets.SENTRY_AUTH_TOKEN` 을 "property not defined" 로 경고하지만, 이는 actionlint 가 정적 type list (`.github/actionlint.yaml` 등) 만 보기 때문의 false positive 다. 실제 secret 은 등록되어 있음 (`gh api .../actions/secrets` 확인).

## Test plan

- [x] YAML 구조 actionlint 통과 (false positive 외 신규 오류 없음)
- [ ] 다음 릴리즈 워크플로 실행 시 `sentry-release` job 이 success 인지 확인
- [ ] Sentry UI 에서 새 릴리즈에 commits 가 연결되었는지 확인 (`toss.sentry.io/releases/apps-in-toss.unity@<version>/commits`)
