### PR TITLE
수정: SDK-TX 테스트 메서드 중복 정의 제거

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1765,25 +1765,6 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
-    public void UserCancelledWebGLBuild_ReturnsTrue()
-    {
-        // Sentry SDK-TX — 사용자가 직접 WebGL 빌드를 취소한 정보성 경고.
-        // #591에서 origin(AITLog sentryCapture:false)으로 차단되지만, 이전 SDK 버전
-        // 사용자 빌드에서 도달하는 케이스를 message-filter로도 흡수.
-        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다."));
-    }
-
-    [Test]
-    public void GenericAitBuildFailed_NotFiltered()
-    {
-        // negative — 일반 [AIT] WebGL 빌드 실패 메시지는 SDK 보호 가드로 통과해야 한다.
-        // "사용자에 의해 ... 취소" 부분 문자열이 없으면 영향 없음.
-        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
-            "[AIT] WebGL 빌드가 실패했습니다."));
-    }
-
-    [Test]
     public void SdkPolicyFetch_NotMatching_GenericMessage_NotFiltered()
     {
         // negative — 단순 'sdk-policy' 문자열만 포함된 다른 메시지는 영향받지 않아야 함.


### PR DESCRIPTION
## 요약

`IsKnownNonSdkMessageTests.cs`에 `UserCancelledWebGLBuild_ReturnsTrue` 메서드가 두 번 정의되어 있어 CS0111 컴파일 에러로 #655/#648/#656 SDK Update PR의 build job 10개(macOS/Windows × 5 Unity 버전) 전부 실패.

## 원인

#591(첫 번째 region — `사용자 WebGL 빌드 취소 (SDK-TX)`)과 별도 PR(두 번째 region — 동명 region)이 main에 합쳐지면서 같은 테스트 메서드를 각자 정의. 두 번째 region이 short variant 케이스와 추가 negative(BuildFailure/WithoutAitPrefix)까지 갖춰 더 완전.

## 수정

첫 번째 region의 중복 블록 2개 제거:
- `UserCancelledWebGLBuild_ReturnsTrue` (1768) — 두 번째 region 1799와 본문 동일
- `GenericAitBuildFailed_NotFiltered` (1778) — 두 번째 region의 `BuildFailure_NotCancellation_NotFiltered`(1816)와 본문 동일

`SdkPolicyFetch_NotMatching_GenericMessage_NotFiltered`(유일한 negative)는 보존.

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] CI Validate + 첫 E2E build job에서 CS0111 해소 확인