### PR TITLE
수정: Sentry 릴리즈 job if 조건 보정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -626,7 +626,7 @@ jobs:
     name: Sentry 릴리즈 등록
     runs-on: ubuntu-latest
     needs: [create-release-tag]
-    if: needs.create-release-tag.result == 'success'
+    if: always() && needs.create-release-tag.result == 'success' && needs.create-release-tag.outputs.version != ''
     steps:
       - name: Checkout (main 커밋 히스토리)
         uses: actions/checkout@v6


### PR DESCRIPTION
## 요약

v2.6.0 release run에서 `Sentry 릴리즈 등록` job이 항상 skipped됨. release 자체는 성공(UPM 태그/패키지 모두 정상)하지만 Sentry 측 release 레지스트레이션이 누락돼 `Fixes APPS-IN-TOSS-UNITY-SDK-XX` trailer 기반 auto-close가 동작하지 않음.

## 원인

기존 조건:
```yaml
if: needs.create-release-tag.result == 'success'
```

GitHub Actions의 if 평가는 명시적 `result == 'success'` 외에도 implicit `success()` 가드를 적용. `success()`는 **needs 체인 전체**에 대해 평가되는데, `create-release-tag`의 needs(`[release, regenerate-sdk, build-ait-macos, build-ait-windows]`) 중 `build-ait-windows`가 항상 skipped라서 implicit gate가 false → sentry-release job 자체가 skipped됨.

v2.6.0 release 26170510866 jobs:
- 릴리즈 태그 생성: success
- Sentry 릴리즈 등록: **skipped** (실행 시도 자체 안 됨, steps 빈 배열)

## 수정

```yaml
if: always() && needs.create-release-tag.result == 'success' && needs.create-release-tag.outputs.version != ''
```

- `always()`: implicit `success()` 가드 우회 — transitive skipped를 무시
- `result == 'success'`: create-release-tag의 직접 성공만 직접 평가
- `version != ''`: outputs 누락 시 방어

## v2.6.0 수동 보완

이 PR과 별개로 v2.6.0 Sentry release는 별도로 수동 등록할 예정 (sentry-cli `releases new` + `set-commits` + `finalize`). 다음 릴리스(v2.6.1/v2.7.0 등)부터는 이 PR 덕에 자동 등록됨.

## Test plan

- [x] `./run-local-tests.sh --validate` 통과
- [ ] 다음 release 워크플로우 실행 시 Sentry 릴리즈 등록 job이 success로 마무리되는지 확인