### PR TITLE
리팩토링: inline enum 중복을 named enum으로 흡수

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -626,7 +626,7 @@ jobs:
     name: Sentry 릴리즈 등록
     runs-on: ubuntu-latest
     needs: [create-release-tag]
-    if: needs.create-release-tag.result == 'success'
+    if: always() && needs.create-release-tag.result == 'success' && needs.create-release-tag.outputs.version != ''
     steps:
       - name: Checkout (main 커밋 히스토리)
         uses: actions/checkout@v6

--- a/sdk-runtime-generator~/src/generators/csharp/CSharpTypeGenerator.ts
+++ b/sdk-runtime-generator~/src/generators/csharp/CSharpTypeGenerator.ts
@@ -14,6 +14,7 @@ import {
   collectFunctionParamTypes,
   collectNestedTypesForTypeDefinition,
 } from './type-collector.js';
+import { computeEnumAliases, applyEnumAliases } from './enum-dedup.js';
 
 /**
  * C# 타입 정의 생성기
@@ -161,14 +162,16 @@ export class CSharpTypeGenerator {
    * 타입 정의들을 C# 코드로 생성 (헤더 없이, 본문만)
    * @param typeDefinitions 파싱된 타입 정의 목록
    * @param excludeTypeNames 제외할 타입 이름 Set (API에서 이미 생성된 타입)
-   * @returns 객체 { code: 생성된 C# 코드, generatedTypeNames: 생성된 타입 이름 Set }
+   * @returns 객체 { code: 생성된 C# 코드, generatedTypeNames: 생성된 타입 이름 Set,
+   *                stringEnumValues: 문자열 enum 이름→값 셋(원본 camelCase) Map (inline enum dedup용) }
    */
   async generateTypeDefinitions(
     typeDefinitions: ParsedTypeDefinition[],
     excludeTypeNames?: Set<string>
-  ): Promise<{ code: string; generatedTypeNames: Set<string> }> {
+  ): Promise<{ code: string; generatedTypeNames: Set<string>; stringEnumValues: Map<string, string[]> }> {
     const generatedTypes: string[] = [];
     const generatedTypeNames = new Set<string>();
+    const stringEnumValues = new Map<string, string[]>();
     const exclude = excludeTypeNames || new Set<string>();
 
     for (const typeDef of typeDefinitions) {
@@ -177,6 +180,15 @@ export class CSharpTypeGenerator {
         if (enumCode) {
           generatedTypes.push(enumCode);
           generatedTypeNames.add(typeDef.name);
+          // inline enum dedup용 — 문자열 enum의 원본 값만 수집 (숫자 enum은 dedup 대상 아님)
+          if (typeDef.enumValues && typeDef.enumValues.length > 0) {
+            const isNumeric = typeDef.enumValues.some(
+              v => typeof v === 'object' && v !== null && 'value' in v
+            );
+            if (!isNumeric) {
+              stringEnumValues.set(typeDef.name, typeDef.enumValues as string[]);
+            }
+          }
         }
       } else if (typeDef.kind === 'interface') {
         const classCode = this.generateInterfaceAsClass(typeDef);
@@ -200,11 +212,11 @@ export class CSharpTypeGenerator {
     }
 
     if (generatedTypes.length === 0) {
-      return { code: '', generatedTypeNames };
+      return { code: '', generatedTypeNames, stringEnumValues };
     }
 
     // 헤더/푸터 없이 본문만 반환 (호출자가 합침)
-    return { code: generatedTypes.join('\n\n'), generatedTypeNames };
+    return { code: generatedTypes.join('\n\n'), generatedTypeNames, stringEnumValues };
   }
 
   /**
@@ -304,12 +316,16 @@ ${JSON_EXTENSION_DATA_FIELD}
 
   /**
    * API에서 사용되는 모든 타입 정의 생성
+   *
+   * @param parsedStringEnumValues 문자열 named enum 이름→값 셋. inline enum과 값 셋이
+   *   완전 일치하면 inline enum 생성을 생략하고 named enum 이름으로 alias한다.
    */
   async generateTypes(
     apis: ParsedAPI[],
     excludeTypeNames?: Set<string>,
     typeDefinitions?: ParsedTypeDefinition[],
-    parser?: { parseNativeModulesType: (typeName: string) => ParsedTypeDefinition | null }
+    parser?: { parseNativeModulesType: (typeName: string) => ParsedTypeDefinition | null },
+    parsedStringEnumValues?: Map<string, string[]>
   ): Promise<string> {
     const typeMap = new Map<string, string>(); // typeName -> classDefinition
     const unionResultMap = new Map<string, string>(); // API name -> Union Result class
@@ -520,18 +536,16 @@ ${JSON_EXTENSION_DATA_FIELD}
       }
     }
 
-    // Inline string literal union에서 생성된 enum 코드
+    // Inline string-literal-union enum을 named enum/이전 inline enum과 dedup (값 셋이 같으면 alias)
+    const { emit: inlineEmit, aliases: enumAliases } = computeEnumAliases(
+      this.tracker.inlineEnums,
+      parsedStringEnumValues,
+    );
+
     const inlineEnumTypes: string[] = [];
-    for (const [enumName, enumValues] of this.tracker.inlineEnums) {
-      const enumCode = this.generateEnum({
-        name: enumName,
-        kind: 'enum',
-        file: '',
-        enumValues: enumValues,
-      });
-      if (enumCode) {
-        inlineEnumTypes.push(enumCode);
-      }
+    for (const { name, values } of inlineEmit) {
+      const enumCode = this.generateEnum({ name, kind: 'enum', file: '', enumValues: values });
+      if (enumCode) inlineEnumTypes.push(enumCode);
     }
 
     // Union Result 클래스와 일반 타입 클래스 합치기
@@ -541,7 +555,7 @@ ${JSON_EXTENSION_DATA_FIELD}
       ...Array.from(typeMap.values())
     ];
 
-    // 헤더/푸터 없이 본문만 반환 (호출자가 합침)
-    return allTypes.join('\n\n');
+    // alias된 enum 식별자를 모든 emit 코드에서 rewrite (헤더/푸터 없이 본문만 반환 — 호출자가 합침)
+    return applyEnumAliases(allTypes.join('\n\n'), enumAliases);
   }
 }

--- a/sdk-runtime-generator~/src/generators/csharp/enum-dedup.ts
+++ b/sdk-runtime-generator~/src/generators/csharp/enum-dedup.ts
@@ -1,0 +1,88 @@
+/**
+ * Inline string-literal-union enum의 중복을 named enum으로 흡수 (또는 같은 값 셋의 다른 inline enum끼리 합치기).
+ *
+ * 배경: TS API 시그니처가 inline string union을 쓰면 함수마다 별도 enum이 생성된다
+ *   (예: GetPermissionPermissionName, OpenPermissionDialogPermissionName, RequestPermissionPermissionName).
+ *   이들은 값 셋이 모두 같지만 generator는 그 사실을 알 수 없어 중복을 emit.
+ *   원본 SDK에 named `PermissionName` enum이 따로 있으면 그쪽으로 alias해 중복 제거.
+ *
+ * 알고리즘:
+ *   1) 각 inline enum의 값 셋(set semantics)을 key로 정렬+조인.
+ *   2) 같은 key의 named enum이 있으면 그 이름으로 alias.
+ *   3) 그 외에는 같은 key가 이미 등장한 inline enum 이름으로 alias.
+ *   4) alias 결과를 string rewrite로 모든 사용처에 반영 (word-boundary).
+ */
+
+/** 값 셋을 정렬 후 공백 조인 — 순서 무시 비교용 */
+function valueSetKey(values: string[]): string {
+  return [...values].sort().join(' ');
+}
+
+export interface EnumAliasResult {
+  /** 결과적으로 emit해야 할 inline enum 이름과 값들 (alias된 enum은 빠짐, 등장 순서 보존) */
+  emit: Array<{ name: string; values: string[] }>;
+  /** aliasFrom → aliasTo (rewrite용) */
+  aliases: Map<string, string>;
+}
+
+/**
+ * Inline enum 목록을 named enum 값셋과 비교하여 alias 계획을 만든다.
+ * @param inlineEnums 등장 순서가 보존된 inline enum의 Map (이름 → 값 배열).
+ * @param parsedStringEnumValues 문자열 named enum의 Map. 값 셋이 일치하면 이쪽 이름으로 alias.
+ */
+export function computeEnumAliases(
+  inlineEnums: Map<string, string[]>,
+  parsedStringEnumValues?: Map<string, string[]>
+): EnumAliasResult {
+  const aliases = new Map<string, string>();
+  const emit: Array<{ name: string; values: string[] }> = [];
+
+  const namedByKey = new Map<string, string>();
+  if (parsedStringEnumValues) {
+    for (const [name, values] of parsedStringEnumValues) {
+      if (values.length === 0) continue;
+      const key = valueSetKey(values);
+      // 첫 등장만 사용 (named 끼리 중복이 있어도 안정적)
+      if (!namedByKey.has(key)) {
+        namedByKey.set(key, name);
+      }
+    }
+  }
+
+  const seenInlineByKey = new Map<string, string>();
+  for (const [name, values] of inlineEnums) {
+    if (values.length === 0) continue;
+    const key = valueSetKey(values);
+
+    const namedMatch = namedByKey.get(key);
+    if (namedMatch && namedMatch !== name) {
+      aliases.set(name, namedMatch);
+      continue;
+    }
+
+    const inlineMatch = seenInlineByKey.get(key);
+    if (inlineMatch && inlineMatch !== name) {
+      aliases.set(name, inlineMatch);
+      continue;
+    }
+    seenInlineByKey.set(key, name);
+    emit.push({ name, values });
+  }
+
+  return { emit, aliases };
+}
+
+/**
+ * Alias map대로 본문 코드의 식별자를 word-boundary 치환.
+ * 더 긴 이름부터 치환해 substring 충돌(예: PermissionName ⊂ GetPermissionPermissionName) 방지.
+ */
+export function applyEnumAliases(body: string, aliases: Map<string, string>): string {
+  if (aliases.size === 0) return body;
+  const ordered = Array.from(aliases.entries()).sort((a, b) => b[0].length - a[0].length);
+  let out = body;
+  for (const [from, to] of ordered) {
+    const escaped = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    out = out.replace(new RegExp(`\\b${escaped}\\b`, 'g'), to);
+  }
+  return out;
+}

--- a/sdk-runtime-generator~/src/index.ts
+++ b/sdk-runtime-generator~/src/index.ts
@@ -556,7 +556,14 @@ async function generate(options: {
 
     // C# 타입 정의 생성 (API에서 추출된 타입) - 본문만 (중복 제외)
     // typeDefinitions와 parser도 전달하여 pending external types 해결에 사용
-    const apiTypesBody = await typeGenerator.generateTypes(apis, parsedTypeNames, typeDefinitions, parser);
+    // parsedTypesResult.stringEnumValues는 inline enum dedup용 (named enum과 값 셋 일치 시 alias)
+    const apiTypesBody = await typeGenerator.generateTypes(
+      apis,
+      parsedTypeNames,
+      typeDefinitions,
+      parser,
+      parsedTypesResult.stringEnumValues,
+    );
 
     // 헤더 + 본문들을 합침
     const typeFileHeader = `// -----------------------------------------------------------------------

--- a/sdk-runtime-generator~/tests/unit/enum-dedup.test.ts
+++ b/sdk-runtime-generator~/tests/unit/enum-dedup.test.ts
@@ -1,0 +1,281 @@
+/**
+ * computeEnumAliases / applyEnumAliases 단위 테스트
+ *
+ * Inline string-literal-union enum 중복 제거 로직 검증.
+ * 실제 Permission* 시나리오를 fixture로 사용해 회귀 방지.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  computeEnumAliases,
+  applyEnumAliases,
+} from '../../src/generators/csharp/enum-dedup.js';
+
+describe('computeEnumAliases', () => {
+  test('빈 입력은 빈 결과를 반환한다', () => {
+    const result = computeEnumAliases(new Map());
+    expect(result.emit).toEqual([]);
+    expect(result.aliases.size).toBe(0);
+  });
+
+  test('값이 빈 inline enum은 무시한다', () => {
+    const inline = new Map<string, string[]>([['Empty', []]]);
+    const result = computeEnumAliases(inline);
+    expect(result.emit).toEqual([]);
+    expect(result.aliases.size).toBe(0);
+  });
+
+  test('named enum과 값 셋이 같은 inline enum은 named로 alias된다', () => {
+    const inline = new Map<string, string[]>([
+      [
+        'GetPermissionPermissionName',
+        ['clipboard', 'contacts', 'photos', 'geolocation', 'camera', 'microphone'],
+      ],
+    ]);
+    const named = new Map<string, string[]>([
+      [
+        'PermissionName',
+        ['clipboard', 'contacts', 'photos', 'geolocation', 'camera', 'microphone'],
+      ],
+    ]);
+
+    const result = computeEnumAliases(inline, named);
+
+    expect(result.emit).toEqual([]);
+    expect(result.aliases.get('GetPermissionPermissionName')).toBe('PermissionName');
+  });
+
+  test('Permission 3중 중복 시나리오: 모든 inline이 named로 합쳐진다', () => {
+    const permissionValues = [
+      'clipboard',
+      'contacts',
+      'photos',
+      'geolocation',
+      'camera',
+      'microphone',
+    ];
+    const inline = new Map<string, string[]>([
+      ['GetPermissionPermissionName', permissionValues],
+      ['OpenPermissionDialogPermissionName', permissionValues],
+      ['RequestPermissionPermissionName', permissionValues],
+    ]);
+    const named = new Map<string, string[]>([
+      ['PermissionName', permissionValues],
+    ]);
+
+    const result = computeEnumAliases(inline, named);
+
+    expect(result.emit).toEqual([]);
+    expect(result.aliases.size).toBe(3);
+    expect(result.aliases.get('GetPermissionPermissionName')).toBe('PermissionName');
+    expect(result.aliases.get('OpenPermissionDialogPermissionName')).toBe('PermissionName');
+    expect(result.aliases.get('RequestPermissionPermissionName')).toBe('PermissionName');
+  });
+
+  test('값 순서가 달라도 같은 set이면 alias된다', () => {
+    const inline = new Map<string, string[]>([
+      ['InlineA', ['a', 'b', 'c']],
+    ]);
+    const named = new Map<string, string[]>([
+      ['NamedA', ['c', 'a', 'b']],
+    ]);
+
+    const result = computeEnumAliases(inline, named);
+
+    expect(result.aliases.get('InlineA')).toBe('NamedA');
+    expect(result.emit).toEqual([]);
+  });
+
+  test('named가 없으면 첫 inline에 나머지 inline이 alias된다', () => {
+    const inline = new Map<string, string[]>([
+      ['FirstFoo', ['x', 'y']],
+      ['SecondFoo', ['x', 'y']],
+      ['ThirdFoo', ['x', 'y']],
+    ]);
+
+    const result = computeEnumAliases(inline);
+
+    expect(result.emit).toEqual([{ name: 'FirstFoo', values: ['x', 'y'] }]);
+    expect(result.aliases.get('SecondFoo')).toBe('FirstFoo');
+    expect(result.aliases.get('ThirdFoo')).toBe('FirstFoo');
+  });
+
+  test('값 셋이 다른 inline enum은 alias되지 않는다', () => {
+    const inline = new Map<string, string[]>([
+      ['EnumA', ['a', 'b']],
+      ['EnumB', ['a', 'c']],
+    ]);
+
+    const result = computeEnumAliases(inline);
+
+    expect(result.emit).toEqual([
+      { name: 'EnumA', values: ['a', 'b'] },
+      { name: 'EnumB', values: ['a', 'c'] },
+    ]);
+    expect(result.aliases.size).toBe(0);
+  });
+
+  test('자기 자신은 alias하지 않는다 (named에 같은 이름이 있어도)', () => {
+    const inline = new Map<string, string[]>([['PermissionName', ['a', 'b']]]);
+    const named = new Map<string, string[]>([['PermissionName', ['a', 'b']]]);
+
+    const result = computeEnumAliases(inline, named);
+
+    expect(result.emit).toEqual([{ name: 'PermissionName', values: ['a', 'b'] }]);
+    expect(result.aliases.size).toBe(0);
+  });
+
+  test('emit은 등장 순서를 보존한다', () => {
+    const inline = new Map<string, string[]>([
+      ['Z', ['1']],
+      ['A', ['2']],
+      ['M', ['3']],
+    ]);
+
+    const result = computeEnumAliases(inline);
+
+    expect(result.emit.map((e) => e.name)).toEqual(['Z', 'A', 'M']);
+  });
+
+  test('PermissionAccess 시나리오 (read/write/access)', () => {
+    const accessValues = ['read', 'write', 'access'];
+    const inline = new Map<string, string[]>([
+      ['GetPermissionPermissionAccess', accessValues],
+      ['OpenPermissionDialogPermissionAccess', accessValues],
+      ['RequestPermissionPermissionAccess', accessValues],
+    ]);
+    const named = new Map<string, string[]>([
+      ['PermissionAccess', accessValues],
+    ]);
+
+    const result = computeEnumAliases(inline, named);
+
+    expect(result.emit).toEqual([]);
+    expect(result.aliases.size).toBe(3);
+    for (const from of [
+      'GetPermissionPermissionAccess',
+      'OpenPermissionDialogPermissionAccess',
+      'RequestPermissionPermissionAccess',
+    ]) {
+      expect(result.aliases.get(from)).toBe('PermissionAccess');
+    }
+  });
+});
+
+describe('applyEnumAliases', () => {
+  test('alias가 비어있으면 원문을 그대로 반환한다', () => {
+    const body = 'public class Foo { GetPermissionPermissionName Name; }';
+    expect(applyEnumAliases(body, new Map())).toBe(body);
+  });
+
+  test('단순 치환', () => {
+    const aliases = new Map([['GetPermissionPermissionName', 'PermissionName']]);
+    const body = 'GetPermissionPermissionName name;';
+    expect(applyEnumAliases(body, aliases)).toBe('PermissionName name;');
+  });
+
+  test('substring 충돌을 피한다 (긴 이름이 먼저 치환됨)', () => {
+    // PermissionName ⊂ GetPermissionPermissionName 충돌 방지 시나리오
+    const aliases = new Map([
+      ['GetPermissionPermissionName', 'PermissionName'],
+      ['ShortName', 'NewShortName'],
+    ]);
+    const body = 'GetPermissionPermissionName foo; PermissionName bar; ShortName baz;';
+    const result = applyEnumAliases(body, aliases);
+
+    // GetPermissionPermissionName가 먼저 치환되어야 PermissionName이 두 번 치환되지 않음
+    expect(result).toBe('PermissionName foo; PermissionName bar; NewShortName baz;');
+  });
+
+  test('word boundary로 식별자 일부 매칭 방지', () => {
+    const aliases = new Map([['Foo', 'Bar']]);
+    const body = 'Foo x; FooBar y; xFoo z; Foo.method();';
+    const result = applyEnumAliases(body, aliases);
+
+    // FooBar, xFoo는 식별자 일부라서 치환되면 안 됨
+    expect(result).toBe('Bar x; FooBar y; xFoo z; Bar.method();');
+  });
+
+  test('다중 등장 모두 치환', () => {
+    const aliases = new Map([['A', 'X']]);
+    const body = 'A first; A second; A third;';
+    expect(applyEnumAliases(body, aliases)).toBe('X first; X second; X third;');
+  });
+
+  test('Permission 3중 alias가 본문에 모두 반영된다', () => {
+    const aliases = new Map([
+      ['GetPermissionPermissionName', 'PermissionName'],
+      ['OpenPermissionDialogPermissionName', 'PermissionName'],
+      ['RequestPermissionPermissionName', 'PermissionName'],
+    ]);
+    const body = [
+      'GetPermissionPermissionName Get(GetPermissionPermissionName name);',
+      'OpenPermissionDialogPermissionName Open();',
+      'RequestPermissionPermissionName Request();',
+      'PermissionName Existing();', // 원본 named enum은 유지
+    ].join('\n');
+
+    const result = applyEnumAliases(body, aliases);
+
+    expect(result).toBe(
+      [
+        'PermissionName Get(PermissionName name);',
+        'PermissionName Open();',
+        'PermissionName Request();',
+        'PermissionName Existing();',
+      ].join('\n'),
+    );
+  });
+
+  test('정규식 특수문자가 포함된 식별자도 안전하게 escape된다', () => {
+    // 실제로는 C# 식별자에 특수문자가 없지만, 방어적 escape 검증
+    const aliases = new Map([['Foo.Bar', 'Baz']]);
+    const body = 'Foo.Bar x; Foo_Bar y;';
+    // Foo.Bar는 . 때문에 word boundary 매칭이 안 되지만, regex 안전성은 확보됨
+    // (실패하지 않고 정상 동작하는지만 검증)
+    expect(() => applyEnumAliases(body, aliases)).not.toThrow();
+  });
+});
+
+describe('end-to-end: computeEnumAliases + applyEnumAliases', () => {
+  test('Permission 시나리오 통합', () => {
+    const permissionValues = [
+      'clipboard',
+      'contacts',
+      'photos',
+      'geolocation',
+      'camera',
+      'microphone',
+    ];
+    const inline = new Map<string, string[]>([
+      ['GetPermissionPermissionName', permissionValues],
+      ['OpenPermissionDialogPermissionName', permissionValues],
+      ['RequestPermissionPermissionName', permissionValues],
+    ]);
+    const named = new Map<string, string[]>([
+      ['PermissionName', permissionValues],
+    ]);
+
+    const { emit, aliases } = computeEnumAliases(inline, named);
+
+    // emit해야 할 inline enum 없음 (모두 named로 흡수)
+    expect(emit).toEqual([]);
+
+    // 가상의 SDK 본문 코드
+    const body = [
+      'public partial class AIT {',
+      '  public static GetPermissionPermissionName GetPermission(GetPermissionPermissionName name) {}',
+      '  public static OpenPermissionDialogPermissionName OpenPermissionDialog() {}',
+      '  public static RequestPermissionPermissionName RequestPermission() {}',
+      '}',
+    ].join('\n');
+
+    const rewritten = applyEnumAliases(body, aliases);
+
+    // 모든 inline 참조가 PermissionName으로 치환되어야 함
+    expect(rewritten).not.toContain('GetPermissionPermissionName');
+    expect(rewritten).not.toContain('OpenPermissionDialogPermissionName');
+    expect(rewritten).not.toContain('RequestPermissionPermissionName');
+    expect(rewritten.split('PermissionName').length - 1).toBe(4); // 4번 등장 (1 param type + 3 return type)
+  });
+});


### PR DESCRIPTION
## 요약

같은 값 셋을 가진 inline string-literal-union enum이 함수마다 별도로 emit되던 문제를 해결. 동일 값 셋의 named enum이 이미 존재하면 그쪽으로 alias.

대표 사례 — 현재 `Runtime/SDK/AIT.Types.cs`에 동일 값 셋(`clipboard/contacts/photos/geolocation/camera/microphone`)의 enum이 4개 존재:
- `PermissionName` (named, line 1931) ← canonical
- `GetPermissionPermissionName` (line 33)
- `OpenPermissionDialogPermissionName` (line 67)
- `RequestPermissionPermissionName` (line 93)

PermissionAccess(`read/write/access`)도 같은 4중 패턴 (1921, 49, 83, 109).

## 변경

- `sdk-runtime-generator~/src/generators/csharp/enum-dedup.ts` (신규)
  - `computeEnumAliases(inlineEnums, parsedStringEnumValues?)`: 값 셋 일치 시 named로 alias, 없으면 같은 값 셋 첫 inline에 흡수
  - `applyEnumAliases(body, aliases)`: word-boundary 치환 (긴 이름부터 처리해 substring 충돌 방지 — `PermissionName ⊂ GetPermissionPermissionName`)
- `CSharpTypeGenerator.generateTypeDefinitions`: 문자열 named enum의 값 셋을 수집해 반환 (숫자 enum 제외)
- `CSharpTypeGenerator.generateTypes`: 수집된 값 셋을 5번째 인자로 받아 dedup 후 본문 rewrite
- 단위 테스트 18개 (`tests/unit/enum-dedup.test.ts`) — Permission/PermissionAccess 시나리오 + edge case

## 효과 확인 시점

이 PR은 generator 로직만 변경. 실제 `Runtime/SDK/AIT.Types.cs`에서 inline Permission 중복이 사라지는 효과는 **다음 SDK 업데이트** 시 `pnpm generate`가 새 `@apps-in-toss/web-framework`를 받을 수 있을 때 자동으로 반영됨.

(현재 npm에 web-framework@2.6.0이 아직 publish되지 않아 로컬에서 `pnpm generate`로 즉시 검증 불가. 다음 정기 SDK update PR에서 diff로 확인 예정.)

## Test plan

- [x] `pnpm test`: 444개 테스트 중 새 enum-dedup 18개 포함 442개 pass (기존 differential.test.ts 2개 실패는 사전 존재, golden file stale 문제로 본 PR과 무관)
- [x] `./run-local-tests.sh --validate`: 통과
- [x] `pnpm exec tsc --noEmit`: 통과
- [ ] 다음 SDK update PR에서 `Runtime/SDK/AIT.Types.cs` diff로 Permission/PermissionAccess inline 중복 제거 확인