### PR TITLE
문서: TODO.md에서 완료된 Permission enum 항목 제거

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,8 @@
 
 ### P1 — AIT.Types.cs (2,086행): 자동 생성 타입 파일 분할
 - **파일**: `Runtime/SDK/AIT.Types.cs`
-- **현상**: 100+ enum/class 정의가 단일 파일에 집중. Permission 관련 enum 3개 중복 (`GetPermissionPermissionName`, `OpenPermissionDialogPermissionName`, `RequestPermissionPermissionName` — 동일 값)
-- **조치**: sdk-runtime-generator에서 카테고리별 타입 파일 분할 생성 검토, Permission enum 통합
+- **현상**: 100+ enum/class 정의가 단일 파일에 집중
+- **조치**: sdk-runtime-generator에서 카테고리별 타입 파일 분할 생성 검토
 
 ### P1 — AppsInTossMenu.cs (1,915행): 모놀리식 메뉴 컨트롤러
 - **파일**: `Editor/AppsInTossMenu.cs`
@@ -70,11 +70,6 @@
 - **파일**: `AITGitGuard.cs`, `AITPlatformHelper.cs`, `AITAsyncCommandRunner.cs`
 - **현상**: "프로세스 생성 → 타임아웃 대기 → 출력 캡처" 패턴이 3곳 이상에서 반복
 - **조치**: `ProcessExecutor` 유틸리티 클래스 추출
-
-### P1 — Permission enum 3중 중복
-- **파일**: `Runtime/SDK/AIT.Types.cs` (33, 67, 93행)
-- **현상**: `GetPermissionPermissionName`, `OpenPermissionDialogPermissionName`, `RequestPermissionPermissionName` — 동일한 enum 값이 3번 정의
-- **조치**: sdk-runtime-generator에서 공유 `PermissionName` enum 하나로 통합 생성
 
 ---
 


### PR DESCRIPTION
## 요약

#670에서 sdk-runtime-generator에 inline enum dedup 로직이 추가되어, 다음 SDK update 시 `Runtime/SDK/AIT.Types.cs`의 inline Permission/PermissionAccess 3중 중복이 자동으로 named `PermissionName`/`PermissionAccess` enum으로 흡수됨.

## 변경

- `TODO.md` "코드 중복 제거 > P1 — Permission enum 3중 중복" 항목 제거
- `TODO.md` "P1 — AIT.Types.cs ... 자동 생성 타입 파일 분할" 항목에서 Permission enum 통합 부분 제거 (파일 분할 본질만 유지)

## 비고

실제 효과는 다음 정기 SDK update PR의 generated diff로 확인 예정 (web-framework@2.6.0 npm publish 후).