### PR TITLE
빌드: String Check 워크플로 — bot PR scan skip

### DIFF
--- a/.github/workflows/string-check.yml
+++ b/.github/workflows/string-check.yml
@@ -14,12 +14,22 @@ jobs:
     timeout-minutes: 5
     env:
       PATTERN: ${{ secrets.STRING_CHECK_PATTERN }}
+      # dependabot/github-actions[bot] PR은 GitHub 정책상 repository secret 접근 불가 →
+      # PATTERN이 빈 값이라 Guard가 무조건 fail. 작성자가 bot이면 scan을 skip해
+      # required check가 영원히 blocked되는 것을 방지.
+      IS_BOT_PR: ${{ github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'github-actions[bot]') }}
 
     steps:
       - name: Checkout
+        if: env.IS_BOT_PR != 'true'
         uses: actions/checkout@v6
 
+      - name: Skip scan for bot PR
+        if: env.IS_BOT_PR == 'true'
+        run: echo "Bot PR (${{ github.event.pull_request.user.login }}) — scan skipped (secret 접근 불가)"
+
       - name: Guard
+        if: env.IS_BOT_PR != 'true'
         run: |
           if [ -z "$PATTERN" ]; then
             echo "::error::STRING_CHECK_PATTERN repository secret이 설정되지 않았습니다."
@@ -28,6 +38,7 @@ jobs:
           echo "::add-mask::$PATTERN"
 
       - name: Scan tree
+        if: env.IS_BOT_PR != 'true'
         run: |
           set +e
           FOUND=$(grep -rIn \
@@ -46,6 +57,7 @@ jobs:
           echo "scan OK"
 
       - name: Scan lockfiles
+        if: env.IS_BOT_PR != 'true'
         run: |
           set -e
           BAD=0


### PR DESCRIPTION
## 요약

dependabot / github-actions[bot]이 만든 PR은 GitHub 정책상 repository secret에 접근할 수 없음. `STRING_CHECK_PATTERN`이 빈 값으로 노출되어 `scan` job의 `Guard` step에서 무조건 fail → required check가 영원히 fail해 PR이 `blocked` 상태로 멈춤.

**영향 받던 PR**: #671 (github-actions, API Changelog 자동 갱신), #672/#673/#674/#675 (dependabot, npm dep bumps). 모두 E2E는 통과했지만 scan이 fail해 머지 불가.

## 변경

`.github/workflows/string-check.yml`:
- `IS_BOT_PR` env: pull_request 이벤트 + 작성자가 `dependabot[bot]` 또는 `github-actions[bot]`이면 true
- bot PR이면 모든 scan step(Checkout/Guard/Scan tree/Scan lockfiles)을 skip하고 "scan skipped" 안내 step만 실행 → job 자체는 success로 보고되어 머지 가능
- `push: main` 이벤트는 `pull_request` 컨텍스트가 아니므로 IS_BOT_PR=false → 기존 동작 유지

## 보안

- bot PR 시점의 scan만 skip되고, 머지 후 main push에서는 scan이 정상 실행됨 → lockfile에 금지 패턴이 들어가면 결국 잡힘
- bot 작성자 판별은 push 시점이 아닌 PR head의 `github.event.pull_request.user.login`을 사용 → bot 사칭 가능성은 GitHub 인증 영역
- skip은 "step level conditional"이라 별도 fork job/secret 노출 위험 없음

## Test plan

- [x] 워크플로 YAML 구문 유효성 (git push 시 사전 검증)
- [ ] 머지 후 #671/#672/#673/#674/#675 scan job이 success로 보고되는지 확인
- [ ] 일반 PR(human author)에서 scan이 그대로 동작하는지 확인 (본 PR 자체가 그 케이스)