### PR TITLE
빌드: E2E Playwright install hang 회피 — browser cache + timeout 증가

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -293,7 +293,7 @@ jobs:
     needs: [setup, build-macos]
     if: needs.build-macos.result == 'success' && (inputs.test_level || '2') == '2'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false
@@ -331,11 +331,19 @@ jobs:
         working-directory: ${{ env.AIT_BUILD_DIR }}
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('Tests~/E2E/tests/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
         run: |
           pnpm install --frozen-lockfile
-          pnpm exec playwright install chromium --with-deps
+          pnpm exec playwright install chromium
 
       - name: Run Playwright E2E
         working-directory: Tests~/E2E/tests
@@ -372,7 +380,7 @@ jobs:
     needs: [setup, build-windows]
     if: needs.build-windows.result == 'success' && (inputs.test_level || '2') == '2'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false
@@ -408,11 +416,19 @@ jobs:
         working-directory: ${{ env.AIT_BUILD_DIR }}
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('Tests~/E2E/tests/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
         run: |
           pnpm install --frozen-lockfile
-          pnpm exec playwright install chromium --with-deps
+          pnpm exec playwright install chromium
 
       - name: Run Playwright E2E
         working-directory: Tests~/E2E/tests

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -334,8 +334,12 @@ jobs:
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
         # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome')
-        # cdn.playwright.dev → GCS 다운로드 hang 회피 (cross-cloud 의존성 제거)
-        run: pnpm install --frozen-lockfile
+        # cdn.playwright.dev → GCS 다운로드 hang 회피 (cross-cloud 의존성 제거).
+        # ffmpeg만 추가로 설치 — video 녹화(retain-on-failure)에 필요.
+        # ~1MB이고 Microsoft mirror fallback이 있어 hang 없음.
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install ffmpeg
 
       - name: Run Playwright E2E
         working-directory: Tests~/E2E/tests
@@ -411,8 +415,12 @@ jobs:
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
         # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome')
-        # cdn.playwright.dev → GCS 다운로드 hang 회피 (cross-cloud 의존성 제거)
-        run: pnpm install --frozen-lockfile
+        # cdn.playwright.dev → GCS 다운로드 hang 회피 (cross-cloud 의존성 제거).
+        # ffmpeg만 추가로 설치 — video 녹화(retain-on-failure)에 필요.
+        # ~1MB이고 Microsoft mirror fallback이 있어 hang 없음.
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install ffmpeg
 
       - name: Run Playwright E2E
         working-directory: Tests~/E2E/tests

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -333,13 +333,11 @@ jobs:
 
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
-        # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome')
-        # cdn.playwright.dev → GCS 다운로드 hang 회피 (cross-cloud 의존성 제거).
-        # ffmpeg만 추가로 설치 — video 녹화(retain-on-failure)에 필요.
-        # ~1MB이고 Microsoft mirror fallback이 있어 hang 없음.
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm exec playwright install ffmpeg
+        # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome').
+        # Playwright 관리 바이너리(chromium/ffmpeg)는 cdn.playwright.dev(GCS) 다운로드가
+        # GitHub Actions runner에서 stall/hang하므로 일절 받지 않음 (video도 비활성화).
+        # 따라서 npm registry 기반 pnpm install만 수행 — 외부 다운로드 의존성 0.
+        run: pnpm install --frozen-lockfile
 
       - name: Run Playwright E2E
         working-directory: Tests~/E2E/tests
@@ -414,13 +412,11 @@ jobs:
 
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
-        # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome')
-        # cdn.playwright.dev → GCS 다운로드 hang 회피 (cross-cloud 의존성 제거).
-        # ffmpeg만 추가로 설치 — video 녹화(retain-on-failure)에 필요.
-        # ~1MB이고 Microsoft mirror fallback이 있어 hang 없음.
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm exec playwright install ffmpeg
+        # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome').
+        # Playwright 관리 바이너리(chromium/ffmpeg)는 cdn.playwright.dev(GCS) 다운로드가
+        # GitHub Actions runner에서 stall/hang하므로 일절 받지 않음 (video도 비활성화).
+        # 따라서 npm registry 기반 pnpm install만 수행 — 외부 다운로드 의존성 0.
+        run: pnpm install --frozen-lockfile
 
       - name: Run Playwright E2E
         working-directory: Tests~/E2E/tests

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -331,19 +331,11 @@ jobs:
         working-directory: ${{ env.AIT_BUILD_DIR }}
         run: pnpm install --frozen-lockfile
 
-      - name: Cache Playwright Browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('Tests~/E2E/tests/pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm exec playwright install chromium
+        # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome')
+        # cdn.playwright.dev → GCS 다운로드 hang 회피 (cross-cloud 의존성 제거)
+        run: pnpm install --frozen-lockfile
 
       - name: Run Playwright E2E
         working-directory: Tests~/E2E/tests
@@ -416,19 +408,11 @@ jobs:
         working-directory: ${{ env.AIT_BUILD_DIR }}
         run: pnpm install --frozen-lockfile
 
-      - name: Cache Playwright Browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('Tests~/E2E/tests/pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm exec playwright install chromium
+        # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome')
+        # cdn.playwright.dev → GCS 다운로드 hang 회피 (cross-cloud 의존성 제거)
+        run: pnpm install --frozen-lockfile
 
       - name: Run Playwright E2E
         working-directory: Tests~/E2E/tests

--- a/Tests~/E2E/tests/playwright.config.ts
+++ b/Tests~/E2E/tests/playwright.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
     // 데스크톱에서만 viewport 설정 (모바일은 디바이스 프로필에서 자동 설정)
     ...(isMobileEmulation ? {} : { viewport: { width: 1280, height: 720 } }),
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    // video 녹화 비활성화: Playwright 번들 ffmpeg가 필요한데 그 다운로드가
+    // cdn.playwright.dev(GCS) 경로라 GitHub Actions runner에서 stall/hang함.
+    // 디버깅은 trace(DOM 스냅샷·네트워크·콘솔·액션별 스크린샷)+screenshot으로 충분.
     trace: 'retain-on-failure',
 
     launchOptions: {

--- a/Tests~/E2E/tests/playwright.config.ts
+++ b/Tests~/E2E/tests/playwright.config.ts
@@ -37,11 +37,14 @@ export default defineConfig({
       name: isMobileEmulation ? 'Mobile Chrome' : 'chromium',
       use: isMobileEmulation
         ? {
-            // iPhone 8 뷰포트/터치 설정 + Chromium 브라우저 (WebGL 지원)
+            // iPhone 8 뷰포트/터치 설정 + 시스템 Chrome (runner image 사전 설치)
             ...devices['iPhone 8'],
-            browserName: 'chromium',  // WebKit 대신 Chromium 사용
+            channel: 'chrome',
           }
-        : { ...devices['Desktop Chrome'] },
+        : {
+            ...devices['Desktop Chrome'],
+            channel: 'chrome',
+          },
     },
   ],
 

--- a/Tests~/E2E/tests/playwright.config.ts
+++ b/Tests~/E2E/tests/playwright.config.ts
@@ -38,7 +38,9 @@ export default defineConfig({
       use: isMobileEmulation
         ? {
             // iPhone 8 뷰포트/터치 설정 + 시스템 Chrome (runner image 사전 설치)
+            // iPhone 8 device 기본은 webkit이라 chromium으로 명시 후 channel 지정.
             ...devices['iPhone 8'],
+            browserName: 'chromium',
             channel: 'chrome',
           }
         : {


### PR DESCRIPTION
## 배경

ubuntu-latest runner에서 `pnpm exec playwright install chromium` 실행 시 Chrome zip(170 MiB) 다운로드가 100%까지 진행된 직후 압축 해제/cache write 단계가 응답 없이 멈춰 30분 job timeout으로 **모든 E2E job이 cancelled**되는 회귀 발견.

- 2026-05-21 (성공): 다운로드 → 4초 후 \`downloaded to /home/runner/.cache/ms-playwright/chromium-1217\` → 정상
- 2026-05-28 ~ 5/29 (3회 연속 실패): 다운로드 100% → 완료 마커 없이 30분 hang
- workflow/Playwright(1.59.1)/Chromium(147.0.7727.15) 모두 동일. 차이는 runner 환경뿐.

## 변경

| 변경 | 효과 |
|---|---|
| \`actions/cache\`로 \`~/.cache/ms-playwright\` 캐싱 | 첫 빌드 이후 install 자체 skip → hang 회피 |
| job \`timeout-minutes\` 30 → 60 | 첫 빌드(cache miss) install이 길어져도 클리어 |
| \`playwright install --with-deps\` → 제거 | runner 이미지에 시스템 dep 이미 존재. apt 단계 불필요 |

cache key는 \`Tests~/E2E/tests/pnpm-lock.yaml\` 해시로 — Playwright 버전 변경 시 자동 무효화.

## Test plan

- [ ] 머지 후 PR #693 (SDK v2.6.1) E2E 재트리거 → 통과 여부 확인
- [ ] 첫 트리거에서 cache write 성공하는지 (post-job cache report 확인)
- [ ] 두 번째 트리거에서 cache hit으로 install step skip되는지