### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-package-meta-warning (x5)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -232,6 +232,14 @@ namespace AppsInToss.Editor.ErrorTracker
             // 기존 LogType.Warning 가드는 별도로 유지되며(line 432-436), 이 패턴은 Error/Exception LogType 변형도 흡수.
             // SDK 자체 코드는 이 메시지를 출력하지 않으며(주석으로만 참조) Unity 엔진이 직접 출력.
             "immutable packages were unexpectedly altered",
+
+            // Unity PackageManager가 immutable(읽기 전용) 폴더 내 에셋에 .meta 파일이 없을 때 직접 출력하는 경고.
+            // 외부 서드파티 패키지(예: com.lupidan.apple-signin-unity)가 .meta를 누락한 채 배포되어 발생하는
+            // Unity 자체 에셋 관리 노이즈이며 SDK 영역 아님.
+            // 예: "Asset Packages/com.lupidan.apple-signin-unity/Img has no meta file, but it's in an immutable folder. The asset will be ignored."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-10K, 10J, 10H, 10G, 10F.
+            // 에셋 경로/패키지명이 가변이므로 불변 핵심 문구만 추출. SDK는 이 문자열을 출력하지 않으므로(grep 확인) 안전.
+            "has no meta file, but it's in an immutable folder",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1812,6 +1812,42 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region immutable 폴더 meta 파일 누락 경고 (SDK-10K, 10J, 10H, 10G, 10F)
+
+    [Test]
+    public void ImmutableFolder_MissingMeta_Img_ReturnsTrue()
+    {
+        // Sentry SDK-10K — apple-signin-unity의 Img 폴더 meta 누락.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Asset Packages/com.lupidan.apple-signin-unity/Img has no meta file, but it's in an immutable folder. The asset will be ignored."));
+    }
+
+    [Test]
+    public void ImmutableFolder_MissingMeta_ProjectSettings_ReturnsTrue()
+    {
+        // Sentry SDK-10J, 10H, 10G, 10F — AppleAuthSampleProject/ProjectSettings 경로 변형.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Asset Packages/com.lupidan.apple-signin-unity/AppleAuthSampleProject/ProjectSettings has no meta file, but it's in an immutable folder. The asset will be ignored."));
+    }
+
+    [Test]
+    public void ImmutableFolder_MissingMeta_UnityWarningPrefix_ReturnsTrue()
+    {
+        // "UnityWarning: " prefix가 덧붙은 변형도 부분 문자열 매칭으로 동일하게 드롭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: Asset Packages/com.foo.bar/Baz has no meta file, but it's in an immutable folder."));
+    }
+
+    [Test]
+    public void ImmutableFolder_MissingMeta_AitPrefix_NotFiltered()
+    {
+        // AIT prefix가 붙은 SDK 자체 로그는 보호 — immutable 폴더 문구가 없는 SDK 메시지는 매칭 안 됨.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 패키지 meta 파일을 검증합니다."));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-10K
Fixes APPS-IN-TOSS-UNITY-SDK-10J
Fixes APPS-IN-TOSS-UNITY-SDK-10H
Fixes APPS-IN-TOSS-UNITY-SDK-10G
Fixes APPS-IN-TOSS-UNITY-SDK-10F

## 개요

Unity PackageManager가 immutable(읽기 전용) 폴더 내 에셋의 `.meta` 파일 누락을 경고하는 Unity 자체 출력 노이즈입니다. 외부 서드파티 패키지(`com.lupidan.apple-signin-unity`)가 `.meta`를 누락한 채 배포되어 발생하며 SDK 영역이 아닙니다. 5개 항목 모두 동일한 Unity 경고 포맷이라 **공통 패턴 1개**로 일반화했습니다.

## 묶음 항목 (5건)

| source | id | title |
|--------|-----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-10K | Asset Packages/com.lupidan.apple-signin-unity/Img has no meta file, but it's in … |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-10J | …/AppleAuthSampleProject/ProjectSett… has no meta file |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-10H | …/AppleAuthSampleProject/ProjectSett… has no meta file |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-10G | …/AppleAuthSampleProject/ProjectSett… has no meta file |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-10F | …/AppleAuthSampleProject/ProjectSett… has no meta file |

## 추출 패턴

`NonSdkMessagePatterns` (메시지 본문 부분 문자열):

- `has no meta file, but it's in an immutable folder`

에셋 경로/패키지명은 가변이므로 불변 핵심 문구만 추출했습니다. SDK는 이 문자열을 출력하지 않으므로(grep 확인) AitKeywords 보호 가드와 충돌하지 않습니다.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열에 패턴 1개
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 3개(Img / ProjectSettings / UnityWarning prefix 변형) + AIT prefix 보호 negative 1개

## 검증

`./run-local-tests.sh --validate` 통과 (Passed: 3 / Failed: 0)

---

⚠️ **사람 머지 검토 필요** — auto-resolve가 생성한 PR입니다.