### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-meta-warning (x2)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -110,6 +110,13 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // 외부 패키지 (Unity 버전별 괄호 유무에 관계없이 매칭되도록 핵심 문구만 추출)
             "exists but its folder",
+            // .meta 파일은 있으나 대응 에셋을 못 찾을 때 Unity가 출력하는 표준 경고 — SDK 외부 패키지 노이즈.
+            // 예: "A meta data file (.meta) exists but its asset 'Packages/com.wooshii.foldericons/...' can't be found ..."
+            //     "A meta data file (.meta) exists but its asset can't be found. ..."
+            // 위 "exists but its folder"와 동일한 Unity 메시지 계열로, asset 경로 유무·버전 차이와 무관하게
+            // 핵심 문구 "exists but its asset" 만으로 두 변형을 모두 매칭. SDK는 이 문자열을 출력하지 않음.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-ZQ, APPS-IN-TOSS-UNITY-SDK-ZS
+            "exists but its asset",
 
             // 외부 UPM 패키지(immutable 폴더)의 에셋에 .meta 파일이 없을 때 Unity 에디터가 직접 출력하는 표준 경고.
             // 외부 서드파티 패키지(예: com.lupidan.apple-signin-unity)가 .meta를 누락한 채 배포되어 발생.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -714,6 +714,32 @@ public class IsKnownNonSdkMessageTests
             "[AIT] Asset 'Packages/foo' has no meta file, but it's in an immutable folder."));
     }
 
+    [Test]
+    public void MetaButAssetMissing_ExternalPackagePath_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-ZQ — .meta는 있으나 외부 패키지(com.wooshii.foldericons)의
+        // 대응 에셋을 못 찾을 때 Unity가 출력하는 표준 경고. asset 경로가 포함된 변형.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "A meta data file (.meta) exists but its asset 'Packages/com.wooshii.foldericons/Editor/Icons/folder.png' can't be found. When the asset is reimported, its data will be lost."));
+    }
+
+    [Test]
+    public void MetaButAssetMissing_GenericForm_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-ZS — asset 경로 없이 핵심 문구만 출력되는 변형.
+        // 동일한 "exists but its asset" 패턴이 두 변형을 모두 매칭함을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "A meta data file (.meta) exists but its asset can't be found. When the asset is reimported, its data will be lost."));
+    }
+
+    [Test]
+    public void MetaButAssetMissing_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 보호 가드 회귀 방지: [AIT] prefix가 붙은 동일 본문은 SDK 자체 로그로 간주되어 필터링되지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] A meta data file (.meta) exists but its asset can't be found."));
+    }
+
     #endregion
 
     #region Unity AssetDatabase.FindAssets 폴더 미발견 경고 (SDK-ZZ)


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-ZQ
Fixes APPS-IN-TOSS-UNITY-SDK-ZS

## 묶음 항목 (unity-meta-warning, x2)

| source | id | title |
|--------|----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-ZQ | A meta data file (.meta) exists but its asset 'Packages/com.wooshii.foldericons/...' |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-ZS | A meta data file (.meta) exists but its asset can't be found |

## 원인

Unity 에디터가 `.meta` 파일은 존재하지만 대응 에셋을 찾지 못할 때 출력하는 표준 경고로, SDK 코드와 무관한 Unity 자체 노이즈입니다. ZQ는 외부 패키지(`com.wooshii.foldericons`) 에셋 경로가 포함된 변형, ZS는 경로 없이 핵심 문구만 출력되는 변형입니다.

## 추출 패턴

두 변형의 공통 핵심 문구를 일반화하여 패턴 **1개**만 추가했습니다. (기존 `"exists but its folder"` 패턴과 동일한 Unity 메시지 계열)

- `"exists but its asset"` — asset 경로 유무·Unity 버전 차이와 무관하게 두 변형을 모두 매칭

`grep` 확인 결과 SDK 코드는 이 문자열을 출력하지 않으며(`AitKeywords` 미포함), `[AIT]` prefix가 붙은 SDK 자체 로그는 `MessageContainsSdkKeyword` 보호 가드로 드롭되지 않습니다.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열에 패턴 1개 추가
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — 항목별 positive 테스트 2개(ZQ/ZS) + AIT prefix 보호 negative 테스트 1개

## 검증

`./run-local-tests.sh --validate` 통과 (3 passed / 0 failed, vitest invariants 18 passed).

> ⚠️ EditMode C# 테스트는 Unity 환경에서 실행되며 `--validate` 범위에 포함되지 않습니다. 패턴/테스트는 기존 `exists but its folder` 케이스와 동일 구조로 작성되었습니다.

---

🔍 **사람 머지 검토 필요** — auto-resolve가 자동 생성한 PR입니다.