### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-asset-database-warning

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -232,6 +232,14 @@ namespace AppsInToss.Editor.ErrorTracker
             // 기존 LogType.Warning 가드는 별도로 유지되며(line 432-436), 이 패턴은 Error/Exception LogType 변형도 흡수.
             // SDK 자체 코드는 이 메시지를 출력하지 않으며(주석으로만 참조) Unity 엔진이 직접 출력.
             "immutable packages were unexpectedly altered",
+
+            // Unity AssetDatabase가 존재하지 않는 검색 폴더로 FindAssets 호출 시 직접 출력하는 엔진 경고.
+            // 예: "AssetDatabase.FindAssets: Folder not found: 'Assets/Foo'"
+            // SDK 자체 로그 접두사([AIT 등)가 없는 Unity 패키지 탐색 노이즈이며 사용자 프로젝트의
+            // 폴더 구성/검색 경로 문제에 해당. SDK는 FindAssets를 호출하긴 하지만(AITBuildOptimizationScanner)
+            // 이 경고 문자열을 직접 출력하지 않고 Unity 엔진이 출력하므로 AitKeywords 보호 가드와 충돌 없음.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-ZZ.
+            "AssetDatabase.FindAssets: Folder not found",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -690,6 +690,35 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region Unity AssetDatabase.FindAssets 폴더 미발견 경고 (SDK-ZZ)
+
+    [Test]
+    public void AssetDatabaseFindAssetsFolderNotFound_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-ZZ — Unity AssetDatabase가 존재하지 않는 검색 폴더로
+        // FindAssets 호출 시 직접 출력하는 엔진 경고. SDK 로그 접두사 없는 Unity 패키지 탐색 노이즈.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AssetDatabase.FindAssets: Folder not found: 'Assets/NonExistentFolder'"));
+    }
+
+    [Test]
+    public void AssetDatabaseFindAssetsFolderNotFound_BareMessage_ReturnsTrue()
+    {
+        // 경로 suffix 없이 핵심 문구만 도착하는 변형도 동일하게 드롭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AssetDatabase.FindAssets: Folder not found"));
+    }
+
+    [Test]
+    public void AssetDatabaseFindAssetsFolderNotFound_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] AssetDatabase.FindAssets: Folder not found: 'Assets/Foo'"));
+    }
+
+    #endregion
+
     #region Unity URP 내부
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-ZZ

## 개요
auto-resolve 자동 PR — `auto` box / `unity-asset-database-warning` 카테고리 묶음(1건) 처리.

Unity AssetDatabase가 존재하지 않는 검색 폴더로 `FindAssets`를 호출할 때 엔진이 직접 출력하는 경고를 Sentry 노이즈로 분류한다. SDK 로그 접두사(`[AIT` 등)가 없는 Unity 패키지 탐색 노이즈이며, 사용자 프로젝트의 폴더 구성/검색 경로 문제에 해당한다.

## 묶음 항목
| source | id | title |
|--------|----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-ZZ | AssetDatabase.FindAssets: Folder not found |

## 추출 패턴
`NonSdkMessagePatterns`에 부분 문자열 패턴 1개 추가:

- `AssetDatabase.FindAssets: Folder not found`

예: `AssetDatabase.FindAssets: Folder not found: 'Assets/Foo'` — 경로 suffix가 가변이므로 핵심 불변 문구만 매칭.

## 추가 위치
- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열에 패턴 추가
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 2건(경로 포함/핵심 문구만) + AIT prefix 보호 negative 1건 추가

## 안전성
- SDK는 `FindAssets`를 호출하긴 하지만(`AITBuildOptimizationScanner.cs`) 이 경고 문자열을 직접 출력하지 않고 Unity 엔진이 출력하므로 `AitKeywords` 보호 가드와 충돌 없음 (grep 확인).
- `[AIT]` prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어 필터링되지 않음 (negative 테스트로 검증).

## 검증
- `./run-local-tests.sh --validate` ✅ 통과 (E2E 파일 검증 + Playwright 설정 + SDK 유닛 테스트 18 passed)
- C# EditMode 테스트는 Unity 환경 필요로 `--validate` 범위 밖이나, 변경이 단순 부분 문자열 추가라 위험 낮음.

⚠️ **사람 머지 검토 필요** — auto-resolve가 생성한 자동 PR입니다.