### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — user-code-compile-error (x5)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1035,6 +1035,36 @@ namespace AppsInToss.Editor.ErrorTracker
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // 사용자 코드의 컴파일 에러가 SDK 식별자(AppsInToss...)를 참조하는 경우 — Unity C# 컴파일러가 직접 출력.
+            // 위 CS0103/CS0246/CS1503 가드는 "Assets/" 경로 + ".cs(" 마커가 포함된 풀 라인을 요구하지만,
+            // Sentry로는 파일 경로 prefix 없이 컴파일러 진단 본문만 도달하는 변형이 있어(아래 이슈) 별도로 흡수한다.
+            // 진단 문구("does not exist in the current context" / "type or namespace name ... could not be found" /
+            // "cannot convert from")는 C# 컴파일러만 출력하며 SDK 런타임/빌드 코드는 이 문구를 직접 출력하지 않는다.
+            // SDK 자체 로그("[AIT" prefix)와 SDK 패키지 경로("com.toss.apps-in-toss")의 컴파일 에러는 방어적으로 제외해
+            // 실제 SDK 버그가 묻히지 않도록 한다. 'AppsInToss' 토큰을 동반할 때만 매칭해 SDK와 무관한 컴파일 에러는 통과시킨다.
+
+            // CS0103 변형 — "The name 'AppsInToss...' does not exist in the current context" (SDK-ZR: DreamPassDefinition.cs)
+            if (message.IndexOf("does not exist in the current context", StringComparison.Ordinal) >= 0
+                && message.IndexOf("AppsInToss", StringComparison.Ordinal) >= 0
+                && !message.StartsWith("[AIT", StringComparison.Ordinal)
+                && message.IndexOf("com.toss.apps-in-toss", StringComparison.Ordinal) < 0)
+                return true;
+
+            // CS0246 변형 — "The type or namespace name 'AppsInToss' could not be found" (SDK-103/104/105: SDK 패키지 미설치)
+            if (message.IndexOf("type or namespace name", StringComparison.Ordinal) >= 0
+                && message.IndexOf("could not be found", StringComparison.Ordinal) >= 0
+                && message.IndexOf("AppsInToss", StringComparison.Ordinal) >= 0
+                && !message.StartsWith("[AIT", StringComparison.Ordinal)
+                && message.IndexOf("com.toss.apps-in-toss", StringComparison.Ordinal) < 0)
+                return true;
+
+            // CS1503 변형 — "cannot convert from 'AppsInToss.AITException' to 'string'" (SDK-102: TossAdManager.cs)
+            if (message.IndexOf("cannot convert from", StringComparison.Ordinal) >= 0
+                && message.IndexOf("AppsInToss", StringComparison.Ordinal) >= 0
+                && !message.StartsWith("[AIT", StringComparison.Ordinal)
+                && message.IndexOf("com.toss.apps-in-toss", StringComparison.Ordinal) < 0)
+                return true;
+
             // Unity AssetDatabase가 Library/ 경로의 SDK 외부 캐시 로딩 실패 시 직접 출력.
             // 예: "Unknown error occurred while loading 'Library/AppsInToss/AITBuildSession.asset'."
             // 메시지에 'AppsInToss'/'AIT' 토큰이 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1396,6 +1396,101 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 사용자 코드 컴파일 에러 — 파일 경로 prefix 없는 진단 본문 변형 (SDK-ZR, SDK-102~105)
+
+    [Test]
+    public void BareDiagnostic_Cs0103_AppsInTossIdentifier_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-ZR — DreamPassDefinition.cs에서 'AppsInTossProductSkus' 식별자 미존재(CS0103).
+        // "Assets/.../...cs(L,C): error CS0103:" 경로 prefix 없이 진단 본문만 Sentry에 도달한 변형.
+        // 위 Assets/ 기반 CS0103 가드가 잡지 못하므로 진단 문구 + AppsInToss 토큰 합성 가드로 흡수.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "The name 'AppsInTossProductSkus' does not exist in the current context"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs0246_AppsInTossNamespace_InGameUI_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-105 — InGameUI.cs에서 AppsInToss 네임스페이스 미발견(CS0246).
+        // SDK 패키지 미설치/asmdef 참조 누락이라는 사용자측 환경 문제. 경로 prefix 없는 본문 변형.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "The type or namespace name 'AppsInToss' could not be found (are you missing a using directive or an assembly reference?)"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs0246_AppsInTossNamespace_IngameTower_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-104 — IngameTower.cs 변형. 동일 패턴이 항목별 evidence를 모두 커버하는지 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "The type or namespace name 'AppsInToss' could not be found"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs0246_AppsInTossNamespace_VersionCheckManager_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-103 — VersionCheckManager.cs 변형.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "VersionCheckManager.cs: The type or namespace name 'AppsInToss' could not be found"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs1503_AitException_TossAdManager_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-102 — TossAdManager.cs에서 AITException을 string 자리에 전달(CS1503).
+        // 경로 prefix 없이 본문만 도달한 변형이라 위 'AppsInToss.'/Assets/ 합성 가드가 잡지 못해 별도 흡수.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Argument 1: cannot convert from 'AppsInToss.AITException' to 'string'"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs0103_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 보호 가드: [AIT] prefix가 붙은 동일 본문은 SDK 자체 로그로 간주되어 필터링되지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] The name 'AppsInTossProductSkus' does not exist in the current context"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs0246_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] The type or namespace name 'AppsInToss' could not be found"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs1503_WithAitPrefix_NeverFiltered()
+    {
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Argument 1: cannot convert from 'AppsInToss.AITException' to 'string'"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs0246_SdkPackagePath_NotFiltered()
+    {
+        // SDK 자체 .cs의 실제 컴파일 에러는 'com.toss.apps-in-toss' 패키지 경로로 출력되므로
+        // 진단 본문 가드가 이를 흡수해 실 SDK 버그를 묻으면 안 된다 (패키지 경로 제외 가드 검증).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/com.toss.apps-in-toss/Runtime/Foo.cs(10,5): error CS0246: The type or namespace name 'AppsInToss' could not be found"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs1503_WithoutAppsInTossToken_NotFiltered()
+    {
+        // 'AppsInToss' 토큰이 없으면 SDK와 무관한 일반 컴파일 에러이므로 진단 본문 가드가 매칭되지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Argument 1: cannot convert from 'System.Int32' to 'string'"));
+    }
+
+    [Test]
+    public void BareDiagnostic_Cs0103_WithoutAppsInTossToken_NotFiltered()
+    {
+        // 동일 — AppsInToss 토큰 없는 일반 CS0103 진단 본문은 통과(노이즈로 단정하지 않음).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "The name 'someLocalVariable' does not exist in the current context"));
+    }
+
+    #endregion
+
     #region 'ait deploy' stdout/stderr ANSI escape 노이즈 (SDK-VK, SDK-BD, SDK-T5)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-ZR
Fixes APPS-IN-TOSS-UNITY-SDK-105
Fixes APPS-IN-TOSS-UNITY-SDK-104
Fixes APPS-IN-TOSS-UNITY-SDK-103
Fixes APPS-IN-TOSS-UNITY-SDK-102

## 요약

`auto-resolve`가 `user-code-compile-error` 카테고리로 묶은 5개 Sentry 노이즈 항목을 한 번에 처리합니다. 모두 **사용자 프로젝트 코드가 SDK 식별자(AppsInToss 네임스페이스/타입)를 잘못 참조하거나 SDK 미설치 상태에서 발생한 C# 컴파일 에러**로, SDK 코드 분기로 해결 불가능한 사용자측 노이즈입니다.

## 묶음 항목

| source | id | title |
|--------|----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-ZR | The name 'AppsInTossProductSkus' does not exist in the current context (CS0103, DreamPassDefinition.cs) |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-105 | The type or namespace name 'AppsInToss' could not be found (CS0246, InGameUI.cs) |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-104 | The type or namespace name 'AppsInToss' could not be found (CS0246, IngameTower.cs) |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-103 | The type or namespace name 'AppsInToss' could not be found (CS0246, VersionCheckManager.cs) |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-102 | Argument 1: cannot convert from 'AppsInToss.AITException' to 'string' (CS1503, TossAdManager.cs) |

## 배경 — 왜 기존 가드로 안 잡혔나

`IsKnownNonSdkMessage`에는 이미 사용자 코드 컴파일 에러용 CS0103/CS0246/CS1503 합성 가드가 있지만, 모두 `Assets/` 경로 + `.cs(L,C)` 마커가 포함된 **풀 라인**을 요구합니다. 위 5개 이슈는 파일 경로 prefix 없이 **컴파일러 진단 본문만** Sentry로 도달한 변형이라 기존 가드를 통과했습니다.

## 추출 패턴 (일반화 3개)

5개 항목의 action_hint를 종합해 진단 문구별로 일반화한 합성 AND 조건 3개를 `IsKnownNonSdkMessage`에 추가:

1. **CS0103 변형** — `"does not exist in the current context"` + `AppsInToss` 토큰 → SDK-ZR
2. **CS0246 변형** — `"type or namespace name"` + `"could not be found"` + `AppsInToss` 토큰 → SDK-103/104/105
3. **CS1503 변형** — `"cannot convert from"` + `AppsInToss` 토큰 → SDK-102

세 조건 모두 SDK 자체 로그 보호를 위해 `[AIT` prefix 제외 + `com.toss.apps-in-toss` 패키지 경로 제외 가드를 포함합니다(실 SDK 컴파일 버그가 묻히지 않도록). `AppsInToss` 토큰을 동반할 때만 매칭하므로 SDK와 무관한 일반 컴파일 에러는 통과합니다.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `IsKnownNonSdkMessage` 내 CS1503 합성 가드 직후에 3개 조건 추가 (SDK 키워드 보호 가드보다 먼저 매칭)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — 항목별 evidence positive 5건 + AIT prefix 보호 negative 3건 + 패키지 경로/토큰 부재 negative 3건

## 검증

`./run-local-tests.sh --validate` 통과 (파일 구조 + Playwright + SDK 유닛 테스트 18 passed). C# EditMode 테스트는 Unity 환경(CI)에서 실행됩니다.

## 참고 — TODO.md P2 관련 (사람 머지 검토 시 확인)

`TODO.md`의 P2 "사용자 SDK API 변경으로 인한 컴파일 에러 모니터링" 항목은 이런 컴파일 에러를 삭제/무시하지 말고 `sdk_breaking_change`로 **분류**하는 방안을 *검토*하자는 미구현 제안입니다. 본 PR은 그 대안(분류) 대신 기존 프로젝트 동작(CS0246 `'AppsInToss'` not-found를 노이즈로 드롭하는 SDK-C3/M7 가드)을 **확장**합니다. 정책 충돌은 아니지만, 분류 방식을 선호한다면 머지 전 재검토가 필요합니다. TODO P2는 본 PR로 완료되지 않으므로 제거하지 않았습니다.

---

⚠️ **사람 머지 검토 필요** — auto-resolve worker가 생성한 PR입니다. squash merge만 허용되며, 머지 시 위 `Fixes` 키워드로 해당 Sentry 이슈들이 자동 resolve됩니다.