### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-package-meta-warning (x2)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -111,6 +111,14 @@ namespace AppsInToss.Editor.ErrorTracker
             // 외부 패키지 (Unity 버전별 괄호 유무에 관계없이 매칭되도록 핵심 문구만 추출)
             "exists but its folder",
 
+            // 외부 UPM 패키지(immutable 폴더)의 에셋에 .meta 파일이 없을 때 Unity 에디터가 직접 출력하는 표준 경고.
+            // 예: "Asset 'Packages/com.lupidan.apple-signin-unity/AppleAuthSampleProject/ProjectSettings/...'
+            //      has no meta file, but it's in an immutable folder. The asset will be ignored."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-10E, APPS-IN-TOSS-UNITY-SDK-10D.
+            // immutable 폴더(외부 패키지)의 누락 .meta는 사용자가 조치 불가한 Unity 자체 노이즈이며,
+            // SDK는 이 문구를 출력하지 않으므로(AitKeywords 미포함) 보호 가드와 충돌 없음.
+            "has no meta file, but it's in an immutable folder",
+
             // Unity URP 내부
             "exceeds previous array size",
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -688,6 +688,32 @@ public class IsKnownNonSdkMessageTests
             "Foo.meta exists but its folder doesn't"));
     }
 
+    [Test]
+    public void MetaMissingInImmutableFolder_AppleSignin_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-10E — 외부 UPM 패키지(apple-signin-unity)의 immutable 폴더에
+        // .meta 파일이 없을 때 Unity 에디터가 직접 출력하는 표준 경고. 사용자가 조치 불가한 Unity 자체 노이즈.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Asset 'Packages/com.lupidan.apple-signin-unity/AppleAuthSampleProject/ProjectSettings/ProjectSettings.asset' has no meta file, but it's in an immutable folder. The asset will be ignored."));
+    }
+
+    [Test]
+    public void MetaMissingInImmutableFolder_AppleSigninAltPath_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-10D — 동일 패키지의 또 다른 immutable 경로 변형도
+        // 단일 "has no meta file, but it's in an immutable folder" 부분 문자열로 모두 매칭됨을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Asset 'Packages/com.lupidan.apple-signin-unity/AppleAuthSampleProject/.editorconfig' has no meta file, but it's in an immutable folder. The asset will be ignored."));
+    }
+
+    [Test]
+    public void MetaMissingInImmutableFolder_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 동일 본문은 SDK 자체 로그로 간주되어 필터링되지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Asset 'Packages/foo' has no meta file, but it's in an immutable folder."));
+    }
+
     #endregion
 
     #region Unity URP 내부


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-10E
Fixes APPS-IN-TOSS-UNITY-SDK-10D

## ⚠️ 머지 검토 우선 안내 — PR #695와 코드 중복
같은 category(`unity-package-meta-warning`)를 다른 worker가 처리한 **PR #695**(items 10K/10J/10H/10G/10F)가 **이 PR과 동일한 패턴** `"has no meta file, but it's in an immutable folder"` 를 `NonSdkMessagePatterns`에 이미 추가합니다. 두 PR이 같은 배열 위치에 같은 라인을 추가하므로 **나중에 머지되는 쪽은 충돌**합니다.

권장 처리(택1):
1. **#695를 먼저 머지** → 이 PR(#699)은 코드가 중복되므로 닫고, #695 squash 커밋 메시지에 `Fixes APPS-IN-TOSS-UNITY-SDK-10E` / `Fixes APPS-IN-TOSS-UNITY-SDK-10D` 두 줄을 추가해 10E/10D도 함께 자동 resolve.
2. 또는 이 PR(#699)만 머지하고 #695는 동일 패턴 충돌만 해소(라인 1개) 후 머지.

어느 경로든 **패턴 라인은 1개만** 남아야 합니다. (이 PR 고유 가치 = 10E/10D의 `Fixes` 키워드)

## 개요
외부 UPM 패키지(`com.lupidan.apple-signin-unity`)의 immutable 폴더 내 에셋에 `.meta` 파일이 없을 때 **Unity 에디터가 직접 출력하는 표준 경고**로, 사용자가 조치할 수 없는 Unity 자체 노이즈입니다. SDK 코드가 출력하는 메시지가 아니므로 Sentry 캡처에서 제외합니다.

## 묶음 항목 (batch2, 2건)

| source | id | title |
|--------|----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-10E | Asset Packages/com.lupidan.apple-signin-unity/AppleAuthSampleProject/ProjectSett… |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-10D | Asset Packages/com.lupidan.apple-signin-unity/AppleAuthSampleProject/ProjectSett… |

두 항목 모두 동일한 Unity 메시지(`Asset '…' has no meta file, but it's in an immutable folder. The asset will be ignored.`)이므로 **공통 패턴 1개**로 일반화했습니다.

## 추출 패턴
`NonSdkMessagePatterns`는 `string.IndexOf(..., StringComparison.Ordinal)` 기반 **부분 문자열** 매칭(정규식 아님)이므로 메시지의 불변 핵심 문구를 리터럴로 추가:

- `"has no meta file, but it's in an immutable folder"`

경로/파일명 가변 부분을 제외한 Unity 표준 문구만 사용해 버전·환경 차이에 무관하게 매칭됩니다. SDK는 이 문구를 출력하지 않고(AitKeywords 미포함), `[AIT]` prefix 로그는 `MessageContainsSdkKeyword` 가드로 보호되므로 SDK 자체 로그와 충돌 없습니다.

## 추가 위치
- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열에 패턴 1개 추가
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 2개(10E/10D 각 evidence) + AIT prefix 보호 negative 1개

## 검증
`./run-local-tests.sh --validate` — ✅ 통과 (파일 구조 + SDK 유닛 테스트/vitest invariants 18 passed)

## 머지
사람 머지 검토 필요. squash merge만 허용되며, 머지 후 PR body의 `Fixes …` 키워드로 Sentry 이슈가 자동 resolve됩니다.
