### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — meta-asset-cs1998-iap (x4)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -111,6 +111,16 @@ namespace AppsInToss.Editor.ErrorTracker
             // 외부 패키지 (Unity 버전별 괄호 유무에 관계없이 매칭되도록 핵심 문구만 추출)
             "exists but its folder",
 
+            // 위 "exists but its folder"의 에셋 변형 — 사용자가 Unity 외부에서 자산을 이동/삭제해
+            // .meta만 고아로 남은 경우 Unity 에디터가 직접 출력하는 표준 경고.
+            // 예: "A meta data file (.meta) exists but its asset 'Assets/.../Foo.cs' can't be found.
+            //      When moving or deleting files outside of Unity, please ensure that the corresponding
+            //      .meta file is moved or deleted along with it."
+            // 자산 경로(Assets/ 또는 Packages/...)가 가변이라 불변 핵심 문구만 추출.
+            // SDK는 이 문구를 출력하지 않으므로(grep 확인) AitKeywords 보호 가드와 충돌 없음.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-ZS, APPS-IN-TOSS-UNITY-SDK-ZQ.
+            "exists but its asset",
+
             // 외부 UPM 패키지(immutable 폴더)의 에셋에 .meta 파일이 없을 때 Unity 에디터가 직접 출력하는 표준 경고.
             // 외부 서드파티 패키지(예: com.lupidan.apple-signin-unity)가 .meta를 누락한 채 배포되어 발생.
             // 예: "Asset 'Packages/com.lupidan.apple-signin-unity/AppleAuthSampleProject/ProjectSettings/...'
@@ -281,6 +291,10 @@ namespace AppsInToss.Editor.ErrorTracker
             "Assets\\FTR_AppsInToss\\",
             "Assets/FTR_AppsInToss/",
             "AITPromotion</color>",
+            // SDK-ZV: [AppsInTossIAPManager] IAPGetPendingOrders: null (앱 버전 미지원 등) — 사용자/샘플 IAP wrapper 클래스 로그.
+            // SDK는 IAPGetPendingOrders API는 제공하지만 "[AppsInTossIAPManager]" prefix는 출력하지 않으며(grep 확인),
+            // "AppsInToss"가 "IAPManager"와 붙어 단어 경계가 깨져 AitKeywords 가드에도 안 걸리므로 ExternalAitPrefixes로 분류.
+            "[AppsInTossIAPManager]",
         };
 
         #endregion
@@ -993,6 +1007,18 @@ namespace AppsInToss.Editor.ErrorTracker
             // Sentry APPS-IN-TOSS-UNITY-SDK-80.
             // SDK 타입명을 잘못 참조한 경우라도 사용자 코드가 잘못 사용한 것이며 SDK 분기로 해결 불가.
             if (message.IndexOf("error CS0117", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 코드의 async/await 미사용 경고 (CS1998) — Unity 컴파일러가 직접 출력.
+            // 예: "Assets\Scripts\1. System\AppsInToss\TossManager.cs(260,43): warning CS1998:
+            //       This async method lacks 'await' operators and will run synchronously. ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-Z6.
+            // 사용자 폴더명에 'AppsInToss'가 포함돼 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다(Assets/ 경로 + .cs(L,C)).
+            // SDK 자체 코드는 Packages/ 또는 Library/PackageCache/ 경로로 출력되어 Assets/ 가드와 충돌 없음.
+            if (message.IndexOf("warning CS1998", StringComparison.Ordinal) >= 0
                 && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
                     || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1903,6 +1903,66 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 고아 .meta 에셋 / CS1998 / 외부 IAP wrapper (SDK-ZS, ZQ, Z6, ZV)
+
+    [Test]
+    public void OrphanMetaAsset_AssetsPath_ReturnsTrue()
+    {
+        // Sentry SDK-ZS — 사용자가 Unity 외부에서 .cs를 삭제해 .meta만 고아로 남음.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "A meta data file (.meta) exists but its asset 'Assets/02_Scripts/00_Common/AppsInTossProductSkus.cs' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it."));
+    }
+
+    [Test]
+    public void OrphanMetaAsset_PackagesPath_ReturnsTrue()
+    {
+        // Sentry SDK-ZQ — 외부 패키지(com.wooshii.foldericons)의 고아 .meta.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "A meta data file (.meta) exists but its asset 'Packages/com.wooshii.foldericons/package-lock.json' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it."));
+    }
+
+    [Test]
+    public void OrphanMetaAsset_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 자체 로그는 보호 — "[AIT]" prefix가 붙으면 SDK 키워드 가드로 통과시킨다(array 도달 전 차단).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 에셋 검증 중: exists but its asset placeholder"));
+    }
+
+    [Test]
+    public void UserCodeCs1998_AppsInTossFolder_ReturnsTrue()
+    {
+        // Sentry SDK-Z6 — 사용자 폴더명에 AppsInToss가 포함된 .cs의 async/await 경고.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\Scripts\\1. System\\AppsInToss\\TossManager.cs(260,43): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread."));
+    }
+
+    [Test]
+    public void Cs1998_SdkPackagesPath_NeverFiltered()
+    {
+        // SDK 자체 코드(Packages/ 경로)의 CS1998은 Assets/ 가드 미충족 + SDK 키워드 가드로 보호되어 필터링 안 됨.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/im.toss.apps-in-toss-unity-sdk/Runtime/Foo.cs(10,5): warning CS1998: This async method lacks 'await' operators and will run synchronously."));
+    }
+
+    [Test]
+    public void ExternalIapManagerPrefix_ReturnsTrue()
+    {
+        // Sentry SDK-ZV — 사용자/샘플 IAP wrapper 클래스 로그. SDK는 "[AppsInTossIAPManager]" prefix를 출력하지 않음.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AppsInTossIAPManager] IAPGetPendingOrders: null (앱 버전 미지원 등)"));
+    }
+
+    [Test]
+    public void SdkIapLog_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 자체 IAP 로그("[AIT]" prefix)는 보호 — 새 ExternalAitPrefix가 너무 넓지 않음을 검증.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] IAPGetPendingOrders 호출: 보류 주문 0건"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-ZS
Fixes APPS-IN-TOSS-UNITY-SDK-ZQ
Fixes APPS-IN-TOSS-UNITY-SDK-Z6
Fixes APPS-IN-TOSS-UNITY-SDK-ZV

## 묶음 항목 (4)
| source | id | title |
|---|---|---|
| sentry-issue | ZS | `.meta exists but its asset 'Assets/.../AppsInTossProductSkus.cs' can't be found` |
| sentry-issue | ZQ | `.meta exists but its asset 'Packages/com.wooshii.foldericons/package-lock.json' can't be found` |
| sentry-issue | Z6 | `Assets\Scripts\...\AppsInToss\TossManager.cs(260,43): warning CS1998` |
| sentry-issue | ZV | `[AppsInTossIAPManager] IAPGetPendingOrders: null (앱 버전 미지원 등)` |

## 추출 패턴 (3)
- **`NonSdkMessagePatterns += "exists but its asset"`** — 사용자가 Unity 외부에서 자산 이동/삭제 시 남는 고아 `.meta` 경고(ZS, ZQ). 기존 `"exists but its folder"`의 에셋 변형.
- **신규 composite 가드** `warning CS1998` + (`Assets/`|`Assets\`) + `.cs(` — 사용자 폴더명에 `AppsInToss`가 포함돼 SDK 키워드 가드가 발동하는 케이스(Z6)를 가드보다 먼저 매칭. 기존 CS0103/CS0117/CS0246 가드와 동일 구조.
- **`ExternalAitPrefixes += "[AppsInTossIAPManager]"`** — 사용자/샘플 IAP wrapper 클래스 로그(ZV). SDK는 `IAPGetPendingOrders` API는 제공하지만 이 prefix는 출력하지 않음(grep 확인). `AppsInToss`+`IAPManager`로 단어 경계가 깨져 AitKeywords 가드에도 안 걸림.

## 추가 위치
- `Editor/ErrorTracker/AITEditorErrorTracker.cs`
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` (positive 4건 + 보호 negative 3건)

## 검증
- 로컬 `./run-local-tests.sh --validate`는 **동시 빌드 3건 경합**으로 self-guard에 따라 **skip — 사람 확인 필요**.
- 참고: `--validate`는 파일구조+JS(vitest) 게이트라 C# 변경을 직접 실행하지 않음. 본 변경의 **C# EditMode 테스트(7건 신규) + lint(.meta)는 CI가 검증**.
- C# brace balance 확인, 기존 가드와 동일 패턴.

## 안전성
- 세 문자열 모두 SDK 코드가 출력하지 않음(grep 확인) → `[AIT]`/AitKeywords 보호 가드와 충돌 없음.
- `CS1998`·`exists but its asset`는 `Assets/` 경로 + SDK 키워드 가드로 SDK 자체 코드(Packages/) 보호.

**사람 머지 검토 필요** (squash merge, 커밋 서명 필수).
