### PR TITLE
문서: auto-resolve 절차에 머지 후 Sentry 수동 resolve 단계 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,11 @@
   - **Windows artifact upload finalize transient** — `actions/upload-artifact@v7`가 `successfully finalized` 메시지 없이 종료 (~1.3% 빈도). 진단 step + `continue-on-error`가 적용되어 있고 재실행으로 해결됨
   - **Unity WebGL Brotli/Gzip 크래시** — `[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`. self-hosted runner 동시 빌드 시 리소스 경합. **현재 E2E CI는 압축 비활성화(`AIT_COMPRESSION_FORMAT="0"`)** 로 압축 단계 자체를 건너뛰므로 신규 발생 없음 (E2E는 vite preview에서만 로드되며 배포되지 않아 압축 불필요). 로컬 재현은 아래 "로컬 CI 재현" 가이드 참조
 - **Sentry 노이즈 패턴 추가**는 자동화(`auto-resolve`)가 처리하므로 수동 PR 불필요 — `Editor/ErrorTracker/AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 자동 흡수됨
+- **⚠️ 머지 후 Sentry 이슈 수동 resolve 단계 필수** — auto-resolve PR body의 `Fixes APPS-IN-TOSS-UNITY-SDK-XX` 키워드는 squash 머지 커밋에 그대로 들어가지만, **이 repo의 Sentry GitHub 연동은 "커밋 push 즉시 resolve"가 아니라 release 연결 기반**이라 머지만으로는 대상 이슈가 `unresolved`로 남는다 (2026-06 PR #703에서 확인). 따라서 auto-resolve PR을 머지한 뒤 다음을 수행:
+  1. 대상 short ID들의 상태 확인 — Sentry MCP `get_sentry_resource(resourceType='issue', organizationSlug='toss', resourceId='APPS-IN-TOSS-UNITY-SDK-XX')` 또는 `search_issues`
+  2. 여전히 `unresolved`이면 직접 resolve — Sentry MCP `update_issue(organizationSlug='toss', issueId='APPS-IN-TOSS-UNITY-SDK-XX', status='resolved', reason='노이즈 패턴 PR #N 머지로 현행 SDK가 드롭 — Fixes 자동 resolve 미발동분 수동 resolve')`
+  3. 노이즈가 **이미 현행 main에 커버된 잔여 이벤트**(구버전 SDK에서 유입)인 경우에도 동일하게 수동 resolve (코드 변경/PR 없이 Sentry만 정리)
+  4. (근본 대응, 선택) Sentry GitHub integration을 commit 기반 resolve(기본 브랜치 push 시)로 전환하면 이 수동 단계를 제거 가능 — 연동 설정 검토 필요
 
 ### 테스트 관련
 - E2E 테스트 전 빌드 필요: `./run-local-tests.sh --all` (빌드+테스트) vs `--e2e` (테스트만)


### PR DESCRIPTION
## 배경
PR #703 머지 후 `Fixes APPS-IN-TOSS-UNITY-SDK-ZS/ZQ/Z6/ZV` 키워드가 머지 커밋에 포함됐음에도 4개 이슈가 `unresolved`로 남았다. 이 repo의 Sentry GitHub 연동이 **커밋 push 즉시 resolve가 아니라 release 연결 기반**으로 동작하기 때문으로 추정된다.

## 변경
`CLAUDE.md` → `### E2E 테스트 실패 대응`의 auto-resolve 항목에 **머지 후 Sentry 수동 resolve 단계**를 추가:
- 머지 후 대상 short ID 상태 확인 (Sentry MCP `get_sentry_resource`/`search_issues`)
- `unresolved`이면 `update_issue(..., status='resolved', reason=...)`로 직접 resolve
- 현행 main에 이미 커버된 잔여 이벤트도 동일하게 Sentry만 정리
- (근본 대응) 연동을 commit 기반 resolve로 전환 검토

## 범위
- 문서 1파일(CLAUDE.md), +5줄. 코드 변경 없음.

**사람 머지 검토 필요** (squash merge, 서명 필수).
