### PR TITLE
기능: web-framework 3.0.0 베타 채널 + stable-only 자동 업데이트 하드닝

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,327 @@
+name: Beta Release
+run-name: "Beta Release - v${{ inputs.version }} → #${{ inputs.channel_ref }}"
+
+# =====================================================
+# 베타 채널 릴리즈
+# 선택된 제휴사만 옵트인으로 파일럿 테스트할 수 있는 prerelease 채널을 만든다.
+# stable release.yml과 달리 다음 부작용을 전부 생략한다:
+#   - main 브랜치 / package.json 변경 (main은 절대 건드리지 않음)
+#   - Latest 릴리즈 표시 (항상 --prerelease --latest=false)
+#   - AIT 배포(deploy-ait) / Slack·Sentry 알림 / GettingStarted.md 갱신
+# 산출물: 정리된 orphan commit을 channel_ref 브랜치(기본 beta)로 force-push.
+#         제휴사는 manifest에서 `...git#beta`로 핀한다.
+# 자동 업데이터(AITAutoUpdater)는 prerelease 채널에 자동 프롬프트를 띄우지 않으므로,
+# 새 베타 배포는 out-of-band(슬랙/이슈)로 알리고 제휴사가 수동으로 갱신한다.
+# =====================================================
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '파일럿 web-framework 버전 (예: 3.0.0 또는 3.0.0-beta.9d42c0b)'
+        required: true
+        type: string
+      channel_ref:
+        description: '베타 채널 브랜치 이름 (제휴사가 #<ref>로 핀)'
+        required: false
+        type: string
+        default: beta
+
+permissions:
+  contents: write
+
+jobs:
+  beta-release:
+    name: 베타 채널 빌드 및 게시
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 입력 검증
+        id: validate
+        run: |
+          VERSION="${{ inputs.version }}"
+          CHANNEL_REF="${{ inputs.channel_ref }}"
+
+          # 버전 형식 검증 (stable 또는 prerelease 접미사 허용)
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::올바른 버전 형식이 아닙니다: ${VERSION}"
+            exit 1
+          fi
+
+          # 채널 ref는 stable 브랜치(main/master)일 수 없음 (베타 전용 안전 가드)
+          if [ "$CHANNEL_REF" = "main" ] || [ "$CHANNEL_REF" = "master" ]; then
+            echo "::error::channel_ref는 main/master일 수 없습니다 (베타 채널 전용): ${CHANNEL_REF}"
+            exit 1
+          fi
+          if [ -z "$CHANNEL_REF" ]; then
+            echo "::error::channel_ref가 비어 있습니다."
+            exit 1
+          fi
+
+          # 베타 스냅샷 태그 이름 derivation
+          # - 이미 prerelease 접미사가 있으면 그대로 (release/v3.0.0-beta.9d42c0b)
+          # - bare 버전이면 -beta 부여 (release/v3.0.0-beta)
+          # 두 경우 모두 IsPrereleaseChannel의 semver-prerelease 패턴(release/vX.Y.Z-)에 매칭됨.
+          if echo "$VERSION" | grep -q '-'; then
+            BETA_TAG="release/v${VERSION}"
+          else
+            BETA_TAG="release/v${VERSION}-beta"
+          fi
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "channel_ref=${CHANNEL_REF}" >> $GITHUB_OUTPUT
+          echo "beta_tag=${BETA_TAG}" >> $GITHUB_OUTPUT
+
+          echo "버전: ${VERSION}"
+          echo "채널 브랜치: ${CHANNEL_REF}"
+          echo "스냅샷 태그: ${BETA_TAG}"
+
+      - name: Checkout (main)
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Git 설정
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: web-framework 버전 업데이트 및 SDK 재생성
+        working-directory: sdk-runtime-generator~
+        run: |
+          VERSION="${{ steps.validate.outputs.version }}"
+
+          echo "=== web-framework v${VERSION} 업데이트 (베타) ==="
+
+          # 캐시 정리 후 강제 업데이트 (캐시로 인한 오래된 버전 문제 방지)
+          pnpm store prune
+
+          # web-analytics에 동일 버전이 존재하면 함께 업데이트 (major 베타에서 둘이 갈라질 수 있으므로 조건부)
+          if npm view "@apps-in-toss/web-analytics@${VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "web-analytics@${VERSION} 존재 — 함께 업데이트"
+            pnpm update "@apps-in-toss/web-framework@${VERSION}" "@apps-in-toss/web-analytics@${VERSION}" --force --registry https://registry.npmjs.org
+          else
+            echo "::warning::web-analytics@${VERSION} 없음 — web-framework만 업데이트"
+            pnpm update "@apps-in-toss/web-framework@${VERSION}" --force --registry https://registry.npmjs.org
+          fi
+
+          # 설치된 버전 검증
+          INSTALLED_VERSION=$(pnpm list @apps-in-toss/web-framework --json | jq -r '.[0].dependencies["@apps-in-toss/web-framework"].version')
+          echo "요청 버전: ${VERSION}"
+          echo "설치된 버전: ${INSTALLED_VERSION}"
+          if [ "$INSTALLED_VERSION" != "$VERSION" ]; then
+            echo "::error::버전 불일치! 요청: ${VERSION}, 설치됨: ${INSTALLED_VERSION}"
+            exit 1
+          fi
+          echo "✅ 버전 검증 완료: ${INSTALLED_VERSION}"
+
+          echo "SDK 코드 생성 중..."
+          pnpm generate
+          echo "SDK 코드 생성 완료"
+
+      - name: 루트 package.json 버전 업데이트
+        run: |
+          VERSION="${{ steps.validate.outputs.version }}"
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json
+          mv tmp.json package.json
+          echo "package.json 버전: ${VERSION}"
+
+      - name: BuildConfig package.json 버전 동기화
+        run: |
+          VERSION="${{ steps.validate.outputs.version }}"
+          BUILDCONFIG_PKG="WebGLTemplates/AITTemplate/BuildConfig~/package.json"
+
+          # 베타 빌드가 3.0.0 기준 생성 브릿지와 동일한 web-framework로 빌드되도록 동기화.
+          # web-analytics는 동일 버전이 존재할 때만 맞춘다.
+          if npm view "@apps-in-toss/web-analytics@${VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            jq --arg v "$VERSION" '
+              .dependencies["@apps-in-toss/web-framework"] = $v |
+              .dependencies["@apps-in-toss/web-analytics"] = $v
+            ' "$BUILDCONFIG_PKG" > tmp.json
+          else
+            jq --arg v "$VERSION" '
+              .dependencies["@apps-in-toss/web-framework"] = $v
+            ' "$BUILDCONFIG_PKG" > tmp.json
+          fi
+          mv tmp.json "$BUILDCONFIG_PKG"
+          echo "BuildConfig dependencies:"
+          jq '.dependencies' "$BUILDCONFIG_PKG"
+
+      - name: BuildConfig pnpm-lock.yaml 업데이트
+        run: |
+          cd WebGLTemplates/AITTemplate/BuildConfig~
+          pnpm install --no-frozen-lockfile
+          echo "BuildConfig pnpm-lock.yaml 업데이트 완료"
+
+      - name: 릴리즈용 테스트 코드 제외
+        run: |
+          echo "=== 릴리즈 빌드용 테스트 코드 제외 ==="
+
+          SHARED_RUNTIME="Tests~/E2E/SharedScripts/Runtime"
+
+          if [ -d "$SHARED_RUNTIME" ]; then
+            echo "SharedScripts/Runtime .cs 파일 삭제 중..."
+            find "$SHARED_RUNTIME" -name "*.cs" -type f -delete
+
+            # E2EBuildRunner.cs가 의존하는 최소 스텁 파일 생성
+            cat > "${SHARED_RUNTIME}/E2EBootstrapperHelper.cs" << 'STUB_EOF'
+          using UnityEngine;
+          // 릴리즈 빌드용 스텁 - 실제 기능 없음
+          public class E2EBootstrapperHelper : MonoBehaviour
+          {
+              void Start() { }
+          }
+          STUB_EOF
+
+            cat > "${SHARED_RUNTIME}/E2EBootstrapper.cs" << 'STUB_EOF'
+          using UnityEngine;
+          // 릴리즈 빌드용 스텁 - 실제 기능 없음
+          public static class E2EBootstrapper
+          {
+              public static void Initialize() { }
+          }
+          STUB_EOF
+          fi
+
+          SHARED_PLUGINS="Tests~/E2E/SharedScripts/Plugins"
+          if [ -d "$SHARED_PLUGINS" ]; then
+            find "$SHARED_PLUGINS" -name "*.cs" -type f -delete
+          fi
+
+      - name: UPM 패키지 정리
+        run: |
+          echo "=== UPM 패키지 정리 ==="
+
+          # 불필요한 디렉토리 제거 (~ 접미사 디렉토리는 Unity가 무시하므로 .meta 없음)
+          rm -rf .github/
+          rm -rf Tests~/
+          rm -rf Tools~/
+          rm -rf sdk-runtime-generator~/
+          rm -rf scripts~/
+
+          # 불필요한 파일 제거
+          rm -f .gitignore
+          rm -f CLAUDE.md
+          rm -f run-local-tests.sh
+
+          # 해당 .meta 파일도 제거
+          rm -f .gitignore.meta
+          rm -f CLAUDE.md.meta
+          rm -f run-local-tests.sh.meta
+
+          echo "정리된 파일 목록:"
+          ls -la
+
+      - name: Orphan Commit 생성 및 채널 ref / 스냅샷 태그 푸시
+        id: publish
+        run: |
+          VERSION="${{ steps.validate.outputs.version }}"
+          CHANNEL_REF="${{ steps.validate.outputs.channel_ref }}"
+          BETA_TAG="${{ steps.validate.outputs.beta_tag }}"
+
+          echo "=== Orphan Commit 생성 ==="
+          git add -A
+          TREE=$(git write-tree)
+          COMMIT=$(git commit-tree "$TREE" -m "베타: SDK v${VERSION} (prerelease 채널)
+
+          - @apps-in-toss/web-framework v${VERSION} 기반 SDK 코드 재생성
+          - UPM 패키지용 정리된 베타 빌드 (개발/테스트 파일 제외)
+          - 채널: ${CHANNEL_REF}
+
+          Generated at: $(date -u +%Y-%m-%dT%H:%M:%SZ)")
+          echo "Orphan commit SHA: ${COMMIT}"
+
+          # 채널 브랜치로 force-push (이동 ref — 항상 최신 베타 HEAD)
+          git push -f origin "${COMMIT}:refs/heads/${CHANNEL_REF}"
+          echo "채널 브랜치 푸시 완료: refs/heads/${CHANNEL_REF}"
+
+          # 스냅샷 태그 upsert (immutable 스냅샷 + GitHub Release 앵커)
+          git push origin --delete "${BETA_TAG}" 2>/dev/null || true
+          git tag -f "${BETA_TAG}" "${COMMIT}" -m "베타 릴리즈: v${VERSION}"
+          git push -f origin "refs/tags/${BETA_TAG}:refs/tags/${BETA_TAG}"
+          echo "스냅샷 태그 푸시 완료: ${BETA_TAG}"
+
+          echo "sha=${COMMIT}" >> $GITHUB_OUTPUT
+
+      - name: GitHub Release 생성 (prerelease, Latest 아님)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.validate.outputs.version }}"
+          CHANNEL_REF="${{ steps.validate.outputs.channel_ref }}"
+          BETA_TAG="${{ steps.validate.outputs.beta_tag }}"
+
+          RELEASE_BODY=$(cat <<EOF
+          ## Apps in Toss Unity SDK — 베타 (v${VERSION})
+
+          ⚠️ **prerelease 채널입니다.** 선택된 제휴사 파일럿 테스트 전용이며, 안정 버전이 아닙니다.
+
+          \`@apps-in-toss/web-framework\` v${VERSION} 기반으로 생성된 베타 SDK입니다.
+
+          ### 설치 (파일럿 제휴사 전용)
+
+          \`Packages/manifest.json\`:
+
+          \`\`\`json
+          {
+            "dependencies": {
+              "im.toss.apps-in-toss-unity-sdk": "https://github.com/${{ github.repository }}.git#${CHANNEL_REF}"
+            }
+          }
+          \`\`\`
+
+          - \`#${CHANNEL_REF}\` 은 항상 최신 베타를 가리키는 이동 채널입니다.
+          - 베타 채널은 **자동 업데이트 대상이 아닙니다.** 새 베타는 별도 안내 후 Package Manager에서 수동 갱신하세요.
+          - 파일럿 종료 시 안정 태그(예: \`#release/vX.Y.Z\`)로 다시 핀하세요.
+
+          이 스냅샷 태그: \`${BETA_TAG}\`
+          EOF
+          )
+
+          # 기존 릴리즈가 있으면 삭제 후 재생성 (태그는 이미 푸시됨)
+          gh release delete "${BETA_TAG}" --yes 2>/dev/null || true
+
+          echo "태그 전파 대기 중 (5초)..."
+          sleep 5
+
+          # prerelease로 생성 — 절대 Latest로 표시되지 않음
+          gh release create "${BETA_TAG}" \
+            --title "v${VERSION} (beta)" \
+            --notes "$RELEASE_BODY" \
+            --verify-tag \
+            --prerelease \
+            --latest=false
+
+          echo "GitHub Release(prerelease) 생성 완료: ${BETA_TAG}"
+
+      - name: 베타 릴리즈 요약
+        run: |
+          VERSION="${{ steps.validate.outputs.version }}"
+          CHANNEL_REF="${{ steps.validate.outputs.channel_ref }}"
+          BETA_TAG="${{ steps.validate.outputs.beta_tag }}"
+
+          echo "## 베타 채널 릴리즈 완료" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| 항목 | 값 |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-----|" >> $GITHUB_STEP_SUMMARY
+          echo "| web-framework 버전 | v${VERSION} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 채널 브랜치 | \`${CHANNEL_REF}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| 스냅샷 태그 | \`${BETA_TAG}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Latest 표시 | ❌ (prerelease) |" >> $GITHUB_STEP_SUMMARY
+          echo "| main 변경 | 없음 |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 파일럿 제휴사 UPM 설치" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "https://github.com/${{ github.repository }}.git#${CHANNEL_REF}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> 베타 채널은 자동 업데이트 대상이 아닙니다. 새 베타 배포 시 제휴사에게 별도 안내 후 수동 갱신 요청." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,11 +583,21 @@ jobs:
           echo "태그 전파 대기 중 (5초)..."
           sleep 5
 
+          # prerelease 버전(예: 3.0.0-beta)이면 Latest로 표시되지 않도록 방어
+          # stable 자동 승격은 update.yml의 메이저 ceiling 가드가 1차 차단하지만,
+          # release.yml을 prerelease 버전으로 직접 디스패치하는 경우의 안전망.
+          PRERELEASE_FLAGS=""
+          if echo "$VERSION" | grep -q '-'; then
+            PRERELEASE_FLAGS="--prerelease --latest=false"
+            echo "prerelease 버전 감지: ${VERSION} → Latest 표시 안 함"
+          fi
+
           # 태그 기반으로 릴리즈 생성 (--verify-tag로 태그 확인)
           gh release create "${TAG_NAME}" \
             --title "v${VERSION}" \
             --notes "$RELEASE_BODY" \
-            --verify-tag
+            --verify-tag \
+            $PRERELEASE_FLAGS
 
           echo "GitHub Release 생성 완료"
           echo "URL: https://github.com/${{ github.repository }}/releases/tag/${TAG_NAME}"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -68,8 +68,9 @@ jobs:
 
           # 현재 SDK 버전 확인
           CURRENT_VERSION=$(jq -r '.version' package.json)
+          CURRENT_MAJOR="${CURRENT_VERSION%%.*}"
           echo ""
-          echo "현재 SDK 버전: ${CURRENT_VERSION}"
+          echo "현재 SDK 버전: ${CURRENT_VERSION} (메이저: ${CURRENT_MAJOR})"
 
           # 기존 릴리즈 태그 목록
           echo ""
@@ -91,6 +92,15 @@ jobs:
           MISSING_VERSIONS=""
 
           for VERSION in $ALL_NPM_VERSIONS; do
+            # 메이저 버전 ceiling 가드: 현재 메이저보다 높은 메이저는 자동 승격 차단
+            # (예: 현재 2.x → 3.0.0 자동 PR 생성 금지). 메이저는 API 표면이 바뀌므로
+            # 의도적 검증을 거쳐 workflow_dispatch의 version 입력으로만 승격한다.
+            CANDIDATE_MAJOR="${VERSION%%.*}"
+            if [ "$CANDIDATE_MAJOR" -gt "$CURRENT_MAJOR" ]; then
+              echo "  ${VERSION}: 메이저 상향(${CURRENT_MAJOR} → ${CANDIDATE_MAJOR}) 자동 승격 차단 (스킵)"
+              continue
+            fi
+
             # 2.0.0 미만 버전은 스킵 (SDK 1.x 지원 종료)
             if [ "$(printf '%s\n' "2.0.0" "$VERSION" | sort -V | head -n1)" = "$VERSION" ] && [ "$VERSION" != "2.0.0" ]; then
               echo "  ${VERSION}: SDK 1.x 지원 종료 (스킵)"

--- a/Editor/AITAutoUpdater.cs
+++ b/Editor/AITAutoUpdater.cs
@@ -141,6 +141,31 @@ namespace AppsInToss.Editor
                 return;
             }
 
+            // prerelease 채널(베타/RC/canary 등)은 stable-only 정책에 따라 자동 업데이트 대상이 아님.
+            // 자동 체크는 조용히 스킵하고, 수동 메뉴 실행 시에는 안내 다이얼로그를 표시한다.
+            // (private repo라 원격 버전을 무인증으로 못 읽으므로 ref 이름 패턴으로만 분류)
+            if (IsPrereleaseChannel(fragment))
+            {
+                if (isManualCheck)
+                {
+                    EditorUtility.DisplayDialog(
+                        "Apps in Toss SDK",
+                        $"현재 베타/프리릴리즈 채널('{fragment}')을 사용 중입니다.\n\n" +
+                        "베타 채널은 자동 업데이트 대상이 아니며, 수동으로 관리해야 합니다.\n\n" +
+                        "• 최신 베타로 갱신: Package Manager에서 패키지를 다시 추가\n" +
+                        "• 안정 버전으로 전환: manifest의 ref를 stable 태그(예: #release/vX.Y.Z)로 변경",
+                        "확인"
+                    );
+                }
+                else
+                {
+                    Debug.Log(
+                        $"[AIT] 베타/프리릴리즈 채널('{fragment}')은 자동 업데이트 대상이 아닙니다. 수동으로 관리하세요."
+                    );
+                }
+                return;
+            }
+
             // 2. 설치된 커밋 해시 가져오기
             string installedHash = GetInstalledCommitHash(packageInfo);
             if (string.IsNullOrEmpty(installedHash))
@@ -254,6 +279,43 @@ namespace AppsInToss.Editor
             }
 
             return !string.IsNullOrEmpty(gitUrl);
+        }
+
+        // prerelease 마커(베타/RC/canary 등)가 ref 이름의 토큰 경계에 등장하는지 판정.
+        // 경계 = 문자열 시작/끝 또는 구분자([/_.\-]). 트레일링 경계로 토큰을 한정해
+        // "development"(=dev 뒤 'e') 같은 단어는 stable로 취급한다.
+        // 매칭 예: beta, rc1, x_canary, dev.2, foo/preview-1 / 비매칭 예: main, development, release/v2.6.1
+        private static readonly Regex PrereleaseMarkerRegex = new Regex(
+            @"(^|[/_.\-])(alpha|beta|rc|canary|nightly|preview|dev|next|pre)([0-9._\-]|$)",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant
+        );
+
+        // semver prerelease 접미사를 가진 release 태그(예: release/v3.0.0-beta, release/v3.0.0-rc.1).
+        // stable release 태그(release/v3.0.0)는 '-'가 없어 매칭되지 않는다.
+        private static readonly Regex SemverPrereleaseTagRegex = new Regex(
+            @"^release/v\d+\.\d+\.\d+-",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant
+        );
+
+        /// <summary>
+        /// fragment(git ref 이름)가 prerelease 채널(베타/RC/canary 등)인지 판정합니다.
+        /// 자동 업데이터는 stable 채널로만 업데이트하므로, prerelease 채널은 자동 프롬프트에서 제외됩니다.
+        /// </summary>
+        /// <remarks>
+        /// 비공개 저장소에서는 원격 파일/버전을 무인증으로 읽을 수 없어 ref 이름 패턴으로만 분류합니다
+        /// (AITDeprecationChecker는 System.Version을 사용하므로 prerelease 접미사를 파싱하지 못함).
+        /// 누군가 stable ref(main 등)에 prerelease SDK를 잘못 머지하는 moving-ref 오염은
+        /// 이름만으로 막을 수 없으므로, 서버측 update.yml 메이저 ceiling 가드가 1차 방어를 담당합니다.
+        /// </remarks>
+        internal static bool IsPrereleaseChannel(string fragment)
+        {
+            if (string.IsNullOrEmpty(fragment))
+            {
+                return false;
+            }
+
+            return PrereleaseMarkerRegex.IsMatch(fragment)
+                || SemverPrereleaseTagRegex.IsMatch(fragment);
         }
 
         /// <summary>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AutoUpdaterChannelTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AutoUpdaterChannelTests.cs
@@ -1,0 +1,101 @@
+// -----------------------------------------------------------------------
+// AutoUpdaterChannelTests.cs - EditMode AITAutoUpdater 채널 분류 테스트
+// Level 0: stable-only 자동 업데이트 정책을 위한 fragment(ref) prerelease 판정 검증
+// -----------------------------------------------------------------------
+
+using System.Reflection;
+using NUnit.Framework;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AutoUpdaterChannelTests
+{
+    // =====================================================
+    // IsPrereleaseChannel: 메서드 존재 확인
+    // =====================================================
+
+    [Test]
+    public void IsPrereleaseChannel_MethodExists()
+    {
+        var method = typeof(AITAutoUpdater).GetMethod("IsPrereleaseChannel",
+            BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public);
+        Assert.IsNotNull(method, "IsPrereleaseChannel() should exist as a static method");
+        Assert.AreEqual(typeof(bool), method.ReturnType);
+    }
+
+    // =====================================================
+    // STABLE 채널 (false 기대) — 자동 업데이트 대상
+    // =====================================================
+
+    [TestCase("main")]
+    [TestCase("master")]
+    [TestCase("release/v2.6.1")]
+    [TestCase("release/v3.0.0")]   // stable major 릴리즈 태그: '-' 없음
+    [TestCase("release/v10.20.30")]
+    [TestCase("2.6.1")]            // bare stable 버전
+    [TestCase("develop")]
+    [TestCase("development")]      // 'dev' 뒤에 'e' → 토큰 경계 불충족 → stable
+    [TestCase("feature/login")]
+    [TestCase("hotfix-123")]
+    public void IsPrereleaseChannel_StableRefs_ReturnsFalse(string fragment)
+    {
+        Assert.IsFalse(AITAutoUpdater.IsPrereleaseChannel(fragment),
+            $"'{fragment}' should be classified as STABLE (auto-update eligible)");
+    }
+
+    // =====================================================
+    // PRERELEASE 채널 (true 기대) — 자동 업데이트 제외
+    // =====================================================
+
+    [TestCase("beta")]
+    [TestCase("alpha")]
+    [TestCase("rc")]
+    [TestCase("rc1")]
+    [TestCase("canary")]
+    [TestCase("nightly")]
+    [TestCase("next")]
+    [TestCase("preview")]
+    [TestCase("3.0.0-beta.9d42c0b")]
+    [TestCase("release/v3.0.0-beta")]
+    [TestCase("release/v3.0.0-rc.1")]
+    [TestCase("release/v3.0.0-beta.9d42c0b")]
+    [TestCase("feature/preview-x")]
+    [TestCase("dev.2")]
+    [TestCase("x_canary")]
+    public void IsPrereleaseChannel_PrereleaseRefs_ReturnsTrue(string fragment)
+    {
+        Assert.IsTrue(AITAutoUpdater.IsPrereleaseChannel(fragment),
+            $"'{fragment}' should be classified as PRERELEASE (auto-update excluded)");
+    }
+
+    // =====================================================
+    // 경계 조건: null / 빈 문자열
+    // =====================================================
+
+    [Test]
+    public void IsPrereleaseChannel_Null_ReturnsFalse()
+    {
+        Assert.IsFalse(AITAutoUpdater.IsPrereleaseChannel(null),
+            "null fragment should be treated as non-prerelease (stable path handles empty separately)");
+    }
+
+    [Test]
+    public void IsPrereleaseChannel_Empty_ReturnsFalse()
+    {
+        Assert.IsFalse(AITAutoUpdater.IsPrereleaseChannel(string.Empty),
+            "empty fragment should be treated as non-prerelease");
+    }
+
+    // =====================================================
+    // 대소문자 무시 확인
+    // =====================================================
+
+    [TestCase("BETA")]
+    [TestCase("Beta")]
+    [TestCase("RELEASE/v3.0.0-BETA")]
+    public void IsPrereleaseChannel_CaseInsensitive_ReturnsTrue(string fragment)
+    {
+        Assert.IsTrue(AITAutoUpdater.IsPrereleaseChannel(fragment),
+            $"'{fragment}' should match prerelease markers case-insensitively");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AutoUpdaterChannelTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AutoUpdaterChannelTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae038084967541359321a5410ac67033
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 개요

`@apps-in-toss/web-framework` 3.0.0이 npm에 publish 되었으나 아직 production-ready가 아닙니다. 현재 자동화는 3.0.0을 stable 채널로 흘려보내 **기존 유저 전체를 자동 업데이트 프롬프트로 3.0.0으로 끌고 갈 위험**이 있습니다. 이 PR은:

1. 3.0.0의 stable 자동 승격을 **서버측에서 즉시·보편 차단**
2. **선택된 제휴사만** 옵트인으로 3.0.0을 파일럿하는 **베타 채널** 제공
3. 자동 업데이터를 **stable-only**로 하드닝 (클라이언트측, 지속)
4. 기존 stable 유저는 전혀 건드리지 않음

> 현재 상태(검증): main = 2.6.1, `release/v3*` 태그 없음, `update/3*` 열린 PR 없음. 위협은 잠재 상태이며, 본 PR의 `update.yml` 가드가 main에 도달하면 다음 평일 cron의 3.0.0 자동 PR을 막습니다.

## 변경 사항

### A. `update.yml` — 메이저 버전 ceiling 가드 (서버측, 시급)
감지 루프에 `현재 메이저 < 후보 메이저`면 스킵하는 가드 추가. 3.x·미래 4.x 등 모든 메이저 업그레이드를 자동 감지에서 제외 → cron이 3.0.0 PR을 만들지 않음 → **이미 배포된 SDK 포함 전체 보호**. 의도적 메이저 승격은 `workflow_dispatch`의 `version` 입력으로만 수행.

### B. `beta-release.yml` — 신규 베타 채널 워크플로
`release.yml`의 검증된 단계를 재사용하되 stable 부작용(Latest 태그·deploy-ait·Slack/Sentry 알림·GettingStarted.md 갱신·main package.json bump)을 전부 생략:
- 입력: `version`(파일럿 web-framework 버전), `channel_ref`(기본 `beta`)
- 3.0.0 기준 SDK 재생성 + BuildConfig 동기화 → 정리된 orphan commit을 `refs/heads/<channel_ref>`로 force-push
- 스냅샷 태그(`release/vX.Y.Z-beta`) + **prerelease GitHub Release** (`--prerelease --latest=false`)
- **main은 절대 건드리지 않음**

### C. `release.yml` — prerelease 방어 가드
버전에 `-`가 있으면 `gh release create`에 `--prerelease --latest=false` 부여. release.yml을 prerelease 버전으로 직접 디스패치해도 Latest 오염 방지.

### D. `AITAutoUpdater` — 완전 stable-only 하드닝
`IsPrereleaseChannel(fragment)` 추가 (비공개 저장소라 원격 버전 fetch 불가 → ref 이름 패턴으로 분류):
- **STABLE 채널** (`main`, `release/vX.Y.Z` 등) → 기존 동작 유지(원격 변경 시 프롬프트)
- **PRERELEASE 채널** (`#beta`, `release/vX.Y.Z-beta`, `3.0.0-beta.*` 등) → 자동 체크 스킵. 수동 메뉴 실행 시에는 안내 다이얼로그 표시(침묵하지 않음)
- moving-ref 오염(예: stable ref에 prerelease 잘못 머지)은 이름만으론 못 막으므로 **A의 서버측 가드가 1차 방어** (합집합 커버)
- 소급 적용 안 됨 — 이미 배포된 SDK는 이 가드 포함 버전으로 1회 업데이트 후 적용. 즉시·보편 보호는 A가 담당
- `AutoUpdaterChannelTests` EditMode 테스트 추가 (stable/prerelease/대소문자/경계 30+ 케이스)

## 제휴사 안내 (코드 변경 없음 — Section E)
파일럿 제휴사 `Packages/manifest.json`:
```json
"im.toss.apps-in-toss-unity-sdk": "https://github.com/toss/apps-in-toss-unity-sdk.git#beta"
```
- 자동 업데이터가 prerelease 채널엔 프롬프트를 안 띄우므로, **새 beta 배포 시 슬랙/이슈로 별도 안내** → 제휴사는 Package Manager에서 수동 갱신
- 파일럿 종료 시 stable 태그(`#release/vX.Y.Z`)로 repin → 이후 자동 업데이터가 정상 추적

## 검증
- `./run-local-tests.sh --validate` 통과 (파일구조 + Playwright + vitest invariants 18개)
- `update.yml` 가드 bash 로직 격리 검증 (3.x/4.x 차단, 2.x minor/patch 통과)
- `IsPrereleaseChannel` regex 30/30 케이스 통과 (동등 검증)
- `beta-release.yml` actionlint error/warning 0건
- C# EditMode 테스트는 CI에서 실행 (로컬 Unity 미설치)

## 후속 (이 PR 범위 밖)
- 파일럿 대상 버전 확정 후 `beta-release.yml` 실제 디스패치 (별도 명시적 실행)
- (선택) beta 런타임 에러 Sentry environment 분리
- (선택) `docs/claude/github-actions.md`에 beta-release 워크플로 ID/트리거 추가 — *.md 정책상 별도 허락 후