### PR TITLE
빌드: 생성기 export 탐지 probe 임시 파일 .gitignore 추가

### DIFF
--- a/sdk-runtime-generator~/.gitignore
+++ b/sdk-runtime-generator~/.gitignore
@@ -5,3 +5,6 @@ node_modules/
 debug-parse-output.ts
 tests/unit/fixtures/
 reports/
+# export 탐지 probe 임시 파일 (생성 중 임시로 쓰였다 삭제됨 — 커밋 금지)
+__export_probe*.ts
+__ait_wf_export_probe__.ts


### PR DESCRIPTION
## 배경
`sdk-runtime-generator~/__export_probe_tmp.ts` 등 export 탐지용 probe 임시 파일이 working tree에 남았는데 **gitignore에 안 잡혀 있어**(`git check-ignore` → not-ignored) `git add` 시 실수로 커밋될 위험이 있었다.

## 조사 결과
- 이 probe 파일들(`__export_probe_tmp.ts`, `__export_probe_bundler.ts`, `__ait_wf_export_probe__.ts`)은 생성 중 임시로 쓰였다 삭제되는 transient 산출물 (생성/삭제 churn 관찰됨)
- 현행 main의 커밋된 생성기 소스(src+dist)는 이 파일명을 참조하지 않음 → 방어적 ignore로만 처리

## 변경 (`sdk-runtime-generator~/.gitignore`, +3줄)
```
__export_probe*.ts
__ait_wf_export_probe__.ts
```
- 기존 `debug-parse-output.ts` 등 루트 임시 .ts ignore 컨벤션과 동일
- 검증: 3개 probe 파일명 모두 `git check-ignore` 매칭, `src/index.ts` 등 실제 소스는 미매칭(영향 없음)

## 범위
- `.gitignore` 1파일 / +3줄. 코드/생성물 변경 없음.

**사람 머지 검토 필요** (squash merge, 서명 필수).
