### PR TITLE
수정: web-framework 3.0.0 SDK 생성 — web-bridge 폴백 최신 선택 + 제거된 API 필터

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,5 +1,5 @@
 name: Beta Release
-run-name: "Beta Release - v${{ inputs.version }} → #${{ inputs.channel_ref }}"
+run-name: "Beta Release - v${{ inputs.version }} → #${{ inputs.channel_ref }} (from ${{ inputs.source_ref }})"
 
 # =====================================================
 # 베타 채널 릴리즈
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: beta
+      source_ref:
+        description: '빌드 베이스 ref (생성기·소스를 가져올 브랜치/태그). 기본 main. 머지 전 브랜치 검증에 사용.'
+        required: false
+        type: string
+        default: main
 
 permissions:
   contents: write
@@ -75,11 +80,14 @@ jobs:
           echo "버전: ${VERSION}"
           echo "채널 브랜치: ${CHANNEL_REF}"
           echo "스냅샷 태그: ${BETA_TAG}"
+          echo "빌드 베이스(source_ref): ${{ inputs.source_ref }}"
 
-      - name: Checkout (main)
+      # 기본 main에서 빌드(생성기·소스). source_ref로 머지 전 브랜치를 지정해 베타를 검증할 수 있다.
+      # 어떤 경우에도 이 워크플로는 source_ref에 push하지 않는다(읽기 전용) — main은 절대 변경되지 않음.
+      - name: Checkout (source_ref)
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ inputs.source_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js

--- a/sdk-runtime-generator~/src/generators/jslib-compiler.ts
+++ b/sdk-runtime-generator~/src/generators/jslib-compiler.ts
@@ -17,8 +17,11 @@ const __dirname = path.dirname(__filename);
 /**
  * pnpm의 flat node_modules 구조에서 패키지 경로를 해석합니다.
  * 직접 node_modules에 없으면 .pnpm 스토어에서 최신 버전을 찾습니다.
+ *
+ * jslib 타입 검사와 동일한 해석 경로를 다른 모듈(예: 공개 export 목록 계산)에서도
+ * 재사용할 수 있도록 export 합니다 — 단일 진실 원천(single source of truth) 유지.
  */
-function resolvePackagePath(packageName: string): string {
+export function resolvePackagePath(packageName: string): string {
   const nodeModulesDir = path.resolve(__dirname, '../../node_modules');
   const directPath = path.join(nodeModulesDir, packageName);
 
@@ -89,7 +92,12 @@ export async function typeCheckBridgeCode(
   const checkedFiles: string[] = [];
 
   try {
-    // 캐시 디렉토리 생성
+    // 캐시 디렉토리를 매 실행마다 비운다.
+    // include: ['*.ts']가 디렉토리의 모든 .ts를 검사하므로, 이전 실행에서 남은
+    // 브릿지 파일이 그대로 남아 있으면 이번 생성에서 제거된 API(예: web-framework
+    // 메이저 업데이트로 사라진 export)의 stale 브릿지가 계속 검사되어 거짓 TS2305가
+    // 발생한다. 현재 생성 결과만 정확히 검사하도록 시작 시 클린 슬레이트로 만든다.
+    await fs.rm(cacheDir, { recursive: true, force: true });
     await fs.mkdir(cacheDir, { recursive: true });
 
     // TypeScript 파일들 작성

--- a/sdk-runtime-generator~/src/index.ts
+++ b/sdk-runtime-generator~/src/index.ts
@@ -15,6 +15,7 @@ import { generateUnityBridge } from './generators/unity-bridge.js';
 import { generateScreenManualCs, generateScreenManualJslib } from './generators/webgl-manual.js';
 import { formatCommand } from './commands/format.js';
 import { FRAMEWORK_APIS, EXCLUDED_APIS } from './categories.js';
+import { getApiImportSource, type ParsedAPI } from './types.js';
 
 const program = new Command();
 
@@ -27,6 +28,58 @@ const program = new Command();
  */
 function generateUnityGUID(): string {
   return crypto.randomBytes(16).toString('hex');
+}
+
+/**
+ * 타깃 web-framework가 더 이상 공개 export하지 않는 API를 발견 목록에서 제거한다.
+ *
+ * 배경: 발견(discovery)은 web-bridge .d.ts 스캔에 의존하는데, web-framework 메이저
+ * 업데이트로 패키지가 재구성되면(예: web-bridge → webview-bridge 리네임) 발견 경로가
+ * pnpm 스토어의 stale 구버전 .d.ts로 폴백할 수 있다. 그러면 신버전에서 제거된 API가
+ * 계속 발견되고, 그 API의 브릿지가 존재하지 않는 심볼을 import 하여 jslib 타입 검사
+ * (TS2305)에서 실패한다.
+ *
+ * 이 필터는 **@apps-in-toss/web-framework에서 import 될** API에 한해, 그 심볼이 실제
+ * 타깃 web-framework의 public export 집합에 있는지 확인하고 없으면 제거한다.
+ * - @apps-in-toss/framework(isTopLevelExport) / @apps-in-toss/web-analytics 소속 API는
+ *   web-framework export와 무관하므로 게이트 대상이 아니다.
+ * - export 집합 계산 실패 시(빈 집합) 필터를 적용하지 않는다(fail-open) — 정상 동작하는
+ *   기존 버전 생성이 빈 집합 때문에 전부 제거되는 사고를 방지.
+ *
+ * 2.6.1 등 기존 stable 버전에서는 발견 API가 모두 여전히 export되므로 무회귀.
+ */
+function filterToWebFrameworkExports(apis: ParsedAPI[], parser: TypeScriptParser): ParsedAPI[] {
+  const wfExports = parser.getWebFrameworkExportedNames();
+  if (wfExports.size === 0) {
+    // 판별 불가 → 필터 스킵 (경고는 getWebFrameworkExportedNames에서 이미 출력)
+    return apis;
+  }
+
+  const skipped: string[] = [];
+  const kept = apis.filter(api => {
+    // @apps-in-toss/framework 소속(top-level export)은 framework에서 import → 게이트 제외
+    if (api.isTopLevelExport) return true;
+    // web-framework가 아닌 패키지(web-analytics)에서 import → 게이트 제외
+    if (getApiImportSource(api) !== '@apps-in-toss/web-framework') return true;
+
+    // 브릿지가 web-framework에서 import할 심볼: 네임스페이스 API는 네임스페이스 이름,
+    // 그 외는 원본 함수 이름.
+    const requiredSymbol = api.namespace ?? api.originalName;
+    if (wfExports.has(requiredSymbol)) return true;
+
+    skipped.push(`${api.name} (심볼: ${requiredSymbol})`);
+    return false;
+  });
+
+  if (skipped.length > 0) {
+    console.log(
+      picocolors.yellow(
+        `⚠️  web-framework public export 제외: ${skipped.join(', ')} (이 web-framework 버전에서 제거됨 — 브릿지 생성 건너뜀)`,
+      ),
+    );
+  }
+
+  return kept;
 }
 
 /**
@@ -144,18 +197,47 @@ async function ensureMetaFile(
 /**
  * pnpm virtual store에서 web-bridge 패키지 동적 검색
  * v1.8.0+: dist/ 디렉토리, v1.5.0~v1.7.x: built/ 디렉토리
+ *
+ * 스토어에 여러 web-bridge 버전이 공존할 수 있다(여러 web-framework 버전을 testfixture로
+ * 설치하면 각자의 transitive web-bridge가 함께 깔린다). 이 폴백은 web-framework의
+ * 의존성 그래프에서 sibling web-bridge를 못 찾았을 때만 쓰이므로(findTypeDefinitions의
+ * strategy 1 실패 — 예: 3.0.0은 web-bridge가 webview-bridge로 rename됨), 가능한 한
+ * **가장 최신** web-bridge 버전을 선택해 그 시점에 알려진 최대 API 표면을 발견하게 한다.
+ * (과거에는 readdir 순서상 lexicographically-first 항목 — 예: 1.10.0 — 이 선택되어
+ * 오래된 표면으로 폴백하는 버그가 있었다.)
  */
 async function findWebBridgeInPnpmStore(): Promise<string | null> {
   const pnpmDir = path.join(process.cwd(), 'node_modules/.pnpm');
+  const PREFIX = '@apps-in-toss+web-bridge@';
 
   try {
     const entries = await fs.readdir(pnpmDir);
-    // @apps-in-toss+web-bridge@{version}_... 패턴 찾기
-    const webBridgeEntry = entries.find(e =>
-      e.startsWith('@apps-in-toss+web-bridge@') && !e.includes('+web-analytics')
+    // @apps-in-toss+web-bridge@{version}[_<peer>] 패턴 찾기 (web-analytics 제외)
+    const webBridgeEntries = entries.filter(e =>
+      e.startsWith(PREFIX) && !e.includes('+web-analytics')
     );
 
-    if (webBridgeEntry) {
+    // 버전 내림차순 정렬 — 가장 최신 web-bridge를 우선 선택.
+    // 엔트리명: "@apps-in-toss+web-bridge@2.6.1" 또는
+    //           "@apps-in-toss+web-bridge@1.5.0_@apps-in-toss+bridge-core@1.5.0"
+    const parseVersion = (entry: string): number[] => {
+      const raw = entry.slice(PREFIX.length);
+      // peer-dep 접미사(_… 또는 (…) 와 prerelease(-…) 제거 후 숫자 파트만 비교
+      const version = raw.split(/[_(]/)[0].split('-')[0];
+      return version.split('.').map(n => Number(n) || 0);
+    };
+    webBridgeEntries.sort((a, b) => {
+      const va = parseVersion(a);
+      const vb = parseVersion(b);
+      for (let i = 0; i < Math.max(va.length, vb.length); i++) {
+        const diff = (vb[i] || 0) - (va[i] || 0);
+        if (diff !== 0) return diff;
+      }
+      return 0;
+    });
+
+    // 최신 버전부터 순회하며 dist/built가 실재하는 첫 엔트리를 사용
+    for (const webBridgeEntry of webBridgeEntries) {
       const basePath = path.join(
         pnpmDir,
         webBridgeEntry,
@@ -167,6 +249,7 @@ async function findWebBridgeInPnpmStore(): Promise<string | null> {
         const candidatePath = path.join(basePath, subdir);
         try {
           await fs.access(candidatePath);
+          console.log(picocolors.gray(`  pnpm store에서 web-bridge 선택(최신): ${webBridgeEntry}`));
           return candidatePath;
         } catch {
           continue;
@@ -455,7 +538,13 @@ async function generate(options: {
 
     // 제외 목록에 있는 API 필터링
     const excludedSet = new Set(EXCLUDED_APIS);
-    const apis = allParsedApis.filter(api => !excludedSet.has(api.name));
+    const notExcludedApis = allParsedApis.filter(api => !excludedSet.has(api.name));
+
+    // 타깃 web-framework가 더 이상 public export하지 않는 API 제거
+    // (예: 3.0.0에서 제거된 onVisibilityChangedByTransparentServiceWeb).
+    // 발견 경로가 stale .d.ts로 폴백해 제거된 API를 계속 발견하더라도, 실제 타깃
+    // web-framework export에 없으면 브릿지를 생성하지 않아 TS2305 실패를 예방한다.
+    const apis = filterToWebFrameworkExports(notExcludedApis, parser);
 
     if (apis.length === 0) {
       console.error(picocolors.red('\n❌ web-framework에서 API를 발견하지 못했습니다.\n'));

--- a/sdk-runtime-generator~/src/parser/TypeScriptParser.ts
+++ b/sdk-runtime-generator~/src/parser/TypeScriptParser.ts
@@ -1,4 +1,4 @@
-import { Project } from 'ts-morph';
+import { Project, ts } from 'ts-morph';
 import * as path from 'path';
 import * as fs from 'fs';
 import { ParsedAPI, ParsedTypeDefinition } from '../types.js';
@@ -6,6 +6,7 @@ import { parseSourceFile } from './api-parser.js';
 import { parseNamespaceObjects } from './namespace-parser.js';
 import { parseTypeDefinitionsFromFile } from './type-definition-parser.js';
 import { findFrameworkPath, parseFrameworkAPIs, parseFrameworkTypeDefinitions, parseNativeModulesType } from './framework-parser.js';
+import { resolvePackagePath } from '../generators/jslib-compiler.js';
 
 /**
  * TypeScript 소스 파일들을 파싱하여 API 정보 추출
@@ -60,6 +61,66 @@ export class TypeScriptParser {
    */
   addSourceDirectory(dir: string): void {
     this.project.addSourceFilesAtPaths(path.join(dir, '**', '*.d.ts'));
+  }
+
+  /**
+   * @apps-in-toss/web-framework가 공개적으로 export하는 심볼 이름 집합을 계산한다.
+   *
+   * jslib 타입 검사(jslib-compiler.ts)와 **동일한** 방식으로 web-framework 패키지를
+   * 해석(resolvePackagePath + bundler resolution)하므로, 생성된 브릿지가 import하게 될
+   * 심볼이 그 버전에서 실제로 존재하는지를 생성 이전에 판별할 수 있다.
+   *
+   * 용도: web-framework 메이저 업데이트(예: 3.0.0)에서 public export가 제거된 API를
+   * 발견 단계에서 걸러내, 존재하지 않는 심볼을 import하는 브릿지가 생성되어
+   * 타입 검사(TS2305)에서 실패하는 것을 방지한다. (구버전 발견 경로가 stale .d.ts로
+   * 폴백하여 제거된 API를 계속 발견하는 케이스 대응.)
+   *
+   * 해석에 실패하면 **빈 집합**을 반환한다 — 호출부는 이를 "판별 불가"로 보고
+   * 필터를 건너뛰어야 한다(fail-open). 빈 집합으로 필터링하면 모든 web-framework API가
+   * 제거되는 치명적 오작동이 발생하므로, 절대 빈 집합으로 필터를 적용하지 말 것.
+   */
+  getWebFrameworkExportedNames(): Set<string> {
+    const names = new Set<string>();
+    try {
+      const wfPkgDir = resolvePackagePath('@apps-in-toss/web-framework');
+
+      // jslib-compiler.ts의 타입 검사와 동일한 resolution(bundler + paths)으로
+      // 격리된 probe 프로젝트를 구성한다. 파일 위치에 의존하는 node_modules 탐색
+      // 대신 paths 매핑으로 명시 해석하여 stale 패키지로의 폴백을 차단한다.
+      const probeProject = new Project({
+        compilerOptions: {
+          moduleResolution: ts.ModuleResolutionKind.Bundler,
+          module: ts.ModuleKind.ESNext,
+          target: ts.ScriptTarget.ES2020,
+          strict: true,
+          skipLibCheck: true,
+          esModuleInterop: true,
+          allowSyntheticDefaultImports: true,
+          resolveJsonModule: true,
+          baseUrl: '.',
+          paths: {
+            '@apps-in-toss/web-framework': [wfPkgDir],
+          },
+        },
+        skipAddingFilesFromTsConfig: true,
+      });
+
+      const probe = probeProject.createSourceFile(
+        path.join(wfPkgDir, '..', '__ait_wf_export_probe__.ts'),
+        `export * from '@apps-in-toss/web-framework';`,
+        { overwrite: true },
+      );
+
+      for (const [name] of probe.getExportedDeclarations()) {
+        names.add(name);
+      }
+    } catch (err) {
+      // 해석 실패 → 빈 집합 반환(호출부에서 필터 스킵). 경고만 남긴다.
+      console.warn(
+        `⚠️  web-framework 공개 export 목록 계산 실패 — export 필터를 건너뜁니다: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return names;
   }
 
   /**


### PR DESCRIPTION
## 배경
`@apps-in-toss/web-framework` 3.0.0 베타 채널 게시(`beta-release.yml`)가 jslib 타입 검사에서 실패(TS2305).
근본 원인: SDK 생성기의 web-bridge 발견이 pnpm 스토어에서 **lexicographically-first(1.10.0)** 를 골라
구버전 표면을 생성 → 3.0.0에서 제거된 심볼(`onVisibilityChangedByTransparentServiceWeb`)의 브릿지가
존재하지 않는 export를 import → 타입 검사 실패.

## 변경
- **findWebBridgeInPnpmStore**: 버전 내림차순 정렬로 **최신**(2.6.1) web-bridge 선택 (3.0.0 발견이 이 폴백 경로를 탐).
- **filterToWebFrameworkExports**: 타깃 web-framework가 더 이상 public export하지 않는 심볼을 발견 목록에서
  제거 → 존재하지 않는 심볼 import 브릿지 생성 방지. export 집합 계산 실패 시 필터 스킵(fail-open) → 무회귀.
- **typeCheckBridgeCode**: 타입 검사 캐시를 매 실행 클린 → stale 브릿지로 인한 거짓 TS2305 방지.

## 검증 (CI 충실 재현)
- 3.0.0-beta: web-bridge 2.6.1 선택, visibility만 제거된 **81개 API** 생성 + jslib 타입 검사 통과.
- 2.6.1: `Runtime/SDK` **바이트 동일** — 기존 stable 무회귀 (main은 계속 2.6.1).
- 생성기 유닛 테스트 476개 통과, `./run-local-tests.sh --validate` 통과.

## 비고
- `beta-release.yml`은 `ref: main`을 체크아웃하므로 **이 수정이 main에 머지되어야** 베타 게시가 생성기 수정을 사용함.
- 브랜치 rename(`fix/sdk-gen-skip-unexported` → `feat/sdk-3.0.0-beta`)으로 닫힌 #712를 대체.