### PR TITLE
개선: WebGL 빌드 로드타임 최적화 (WebAssembly 2023·OptimizeSize·LTO·decompression-fallback off)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -353,7 +353,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-macos-${{ matrix.unity-version }}
-          path: Tests~/E2E/tests/benchmark-results.json
+          path: |
+            Tests~/E2E/tests/benchmark-results.json
+            Tests~/E2E/tests/load-profile.json
           if-no-files-found: ignore
 
       - name: Upload Playwright Report
@@ -432,7 +434,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-windows-${{ matrix.unity-version }}
-          path: Tests~/E2E/tests/benchmark-results.json
+          path: |
+            Tests~/E2E/tests/benchmark-results.json
+            Tests~/E2E/tests/load-profile.json
           if-no-files-found: ignore
 
       - name: Upload Playwright Report

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1,6 +1,43 @@
 name: Unity Build
 
 on:
+  # 수동 트리거: 단일 (os, unity-version) 빌드를 직접 dispatch한다(전체 매트릭스 회피).
+  # 프로덕션 설정 빌드 산출물을 받아 크기/구성을 분석하는 용도. 기본 production-build=true.
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'Operating system'
+        type: choice
+        options:
+          - macos
+          - windows
+        default: macos
+        required: true
+      unity-version:
+        description: 'Unity version pattern (e.g., 2021.3, 6000.3)'
+        type: string
+        required: true
+        default: '6000.3'
+      production-build:
+        description: '프로덕션 설정으로 빌드 (현 SDK 권장: Brotli + IL2CPP Release + non-dev). 끄면 E2E 빠른 빌드(무압축/Development/Debug)'
+        type: boolean
+        required: false
+        default: true
+      run-build:
+        description: 'Run Unity WebGL build'
+        type: boolean
+        required: false
+        default: true
+      web-framework-version:
+        description: '@apps-in-toss/web-framework version for BuildConfig (빈 값=기본)'
+        type: string
+        required: false
+        default: ''
+      test-level:
+        description: 'Test level: 0=editmode, 1=build+validation, 2=full-e2e'
+        type: string
+        required: false
+        default: '2'
   workflow_call:
     inputs:
       repository:
@@ -66,6 +103,11 @@ on:
         type: string
         required: false
         default: '2'
+      production-build:
+        description: '프로덕션 설정으로 빌드 (현 SDK 권장: Brotli + IL2CPP Release + non-dev). 기본 false=E2E 빠른 빌드 오버라이드 유지'
+        type: boolean
+        required: false
+        default: false
     secrets:
       AIT_AD_INTERSTITIAL_ID:
         description: 'Interstitial ad ID for testing'
@@ -1443,19 +1485,18 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: 압축 비활성화. E2E는 vite dev/preview 서버에서만 로드되며
-          # 배포되지 않으므로 압축이 불필요. Brotli/Gzip 단계 자체를 건너뛰어
-          # wallclock 절감(~120s).
-          AIT_COMPRESSION_FORMAT: "0"
-          # E2E 한정: Development Build 활성화 — Link_WebGL_wasm 단계가 단독 실행
-          # critical path에서 ~163s를 차지(Emscripten 옵티마이저 -O3 풀스피드).
-          # Development Build로 옵티마이저 단축, Build wallclock 대폭 절감 기대.
-          # E2E는 SDK API 동작만 검증하며 런타임 성능을 보지 않으므로 무관.
-          AIT_DEVELOPMENT_BUILD: "true"
-          # E2E 한정: IL2CPP 컴파일러 옵티마이저 레벨도 Debug로 강제. developmentBuild
-          # 플래그는 Player 측 설정이라 IL2CPP 옵티마이저(C_WebGL_wasm/Link_WebGL_wasm)에는
-          # 영향이 없어 별도 변수로 페어링. -O3 → -O0/-Og 수준으로 wasm 컴파일/링크 단축.
-          AIT_IL2CPP_CONFIGURATION: "Debug"
+          # 빌드 설정은 production-build 플래그로 분기한다.
+          #  - production-build=true  → 현 SDK 권장 프로덕션 설정(Brotli + IL2CPP Release + non-dev).
+          #                             env를 SDK 권장값으로 명시 → AITBuildInitializer가 그대로 적용.
+          #  - production-build=false → E2E 빠른 빌드(무압축 / Development Build / IL2CPP Debug).
+          #                             E2E는 vite preview에서만 로드되고 배포되지 않으며 런타임 성능을
+          #                             보지 않으므로, 압축(~120s)·Emscripten/IL2CPP -O3(~163s)를 건너뛰어
+          #                             wallclock을 크게 단축한다. 이게 기본값(=preview/release 외 호출자).
+          # ⚠️ GHA 표현식에서 빈 문자열은 falsy → `x && '' || 'y'`가 항상 'y'로 흐른다.
+          #    그래서 프로덕션 분기는 반드시 비어있지 않은 명시값(2 / false / Release)을 쓴다.
+          AIT_COMPRESSION_FORMAT: ${{ inputs.production-build && '2' || '0' }}       # 2=Brotli / 0=Disabled
+          AIT_DEVELOPMENT_BUILD: ${{ inputs.production-build && 'false' || 'true' }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Release' || 'Debug' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30
@@ -1596,10 +1637,10 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: macOS step의 동일 주석 참조.
-          AIT_COMPRESSION_FORMAT: "0"
-          AIT_DEVELOPMENT_BUILD: "true"
-          AIT_IL2CPP_CONFIGURATION: "Debug"
+          # production-build 게이트: macOS step의 동일 주석 참조.
+          AIT_COMPRESSION_FORMAT: ${{ inputs.production-build && '2' || '0' }}       # 2=Brotli / 0=Disabled
+          AIT_DEVELOPMENT_BUILD: ${{ inputs.production-build && 'false' || 'true' }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Release' || 'Debug' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1486,17 +1486,18 @@ jobs:
         env:
           AIT_DEBUG_CONSOLE: "true"
           # 빌드 설정은 production-build 플래그로 분기한다.
-          #  - production-build=true  → 현 SDK 권장 프로덕션 설정(Brotli + IL2CPP Release + non-dev).
-          #                             env를 SDK 권장값으로 명시 → AITBuildInitializer가 그대로 적용.
+          #  - production-build=true  → 현 SDK 권장 프로덕션 설정(Brotli + IL2CPP Master(LTO) + non-dev).
+          #                             env를 SDK 기본값(GetDefaultIl2CppConfiguration=Master)과 일치시켜
+          #                             명시 → AITBuildInitializer가 그대로 적용(Meta 로드타임 스택 L3 측정).
           #  - production-build=false → E2E 빠른 빌드(무압축 / Development Build / IL2CPP Debug).
           #                             E2E는 vite preview에서만 로드되고 배포되지 않으며 런타임 성능을
-          #                             보지 않으므로, 압축(~120s)·Emscripten/IL2CPP -O3(~163s)를 건너뛰어
+          #                             보지 않으므로, 압축(~120s)·Emscripten/IL2CPP -O3·LTO를 건너뛰어
           #                             wallclock을 크게 단축한다. 이게 기본값(=preview/release 외 호출자).
           # ⚠️ GHA 표현식에서 빈 문자열은 falsy → `x && '' || 'y'`가 항상 'y'로 흐른다.
-          #    그래서 프로덕션 분기는 반드시 비어있지 않은 명시값(2 / false / Release)을 쓴다.
+          #    그래서 프로덕션 분기는 반드시 비어있지 않은 명시값(2 / false / Master)을 쓴다.
           AIT_COMPRESSION_FORMAT: ${{ inputs.production-build && '2' || '0' }}       # 2=Brotli / 0=Disabled
           AIT_DEVELOPMENT_BUILD: ${{ inputs.production-build && 'false' || 'true' }}
-          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Release' || 'Debug' }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Master' || 'Debug' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30
@@ -1640,7 +1641,7 @@ jobs:
           # production-build 게이트: macOS step의 동일 주석 참조.
           AIT_COMPRESSION_FORMAT: ${{ inputs.production-build && '2' || '0' }}       # 2=Brotli / 0=Disabled
           AIT_DEVELOPMENT_BUILD: ${{ inputs.production-build && 'false' || 'true' }}
-          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Release' || 'Debug' }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Master' || 'Debug' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1486,18 +1486,21 @@ jobs:
         env:
           AIT_DEBUG_CONSOLE: "true"
           # 빌드 설정은 production-build 플래그로 분기한다.
-          #  - production-build=true  → 현 SDK 권장 프로덕션 설정(Brotli + IL2CPP Master(LTO) + non-dev).
-          #                             env를 SDK 기본값(GetDefaultIl2CppConfiguration=Master)과 일치시켜
-          #                             명시 → AITBuildInitializer가 그대로 적용(Meta 로드타임 스택 L3 측정).
+          #  - production-build=true  → 현 SDK 권장 프로덕션 설정(Brotli + IL2CPP Release + non-dev).
+          #                             env를 SDK 기본값(GetDefaultIl2CppConfiguration=Release)과 일치시켜
+          #                             명시 → AITBuildInitializer가 그대로 적용.
+          #                             ⚠️ 실제 LTO 레버는 IL2CPP config(Master)가 아니라 WebGL code
+          #                             optimization=DiskSizeLTO 이며, 이는 AITBuildInitializer가 항상
+          #                             적용한다(env 불필요). WebGL에서 Master는 no-op(실측: Release와 동일).
           #  - production-build=false → E2E 빠른 빌드(무압축 / Development Build / IL2CPP Debug).
           #                             E2E는 vite preview에서만 로드되고 배포되지 않으며 런타임 성능을
-          #                             보지 않으므로, 압축(~120s)·Emscripten/IL2CPP -O3·LTO를 건너뛰어
+          #                             보지 않으므로, 압축(~120s)·Emscripten/IL2CPP -O3를 건너뛰어
           #                             wallclock을 크게 단축한다. 이게 기본값(=preview/release 외 호출자).
           # ⚠️ GHA 표현식에서 빈 문자열은 falsy → `x && '' || 'y'`가 항상 'y'로 흐른다.
-          #    그래서 프로덕션 분기는 반드시 비어있지 않은 명시값(2 / false / Master)을 쓴다.
+          #    그래서 프로덕션 분기는 반드시 비어있지 않은 명시값(2 / false / Release)을 쓴다.
           AIT_COMPRESSION_FORMAT: ${{ inputs.production-build && '2' || '0' }}       # 2=Brotli / 0=Disabled
           AIT_DEVELOPMENT_BUILD: ${{ inputs.production-build && 'false' || 'true' }}
-          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Master' || 'Debug' }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Release' || 'Debug' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30
@@ -1641,7 +1644,7 @@ jobs:
           # production-build 게이트: macOS step의 동일 주석 참조.
           AIT_COMPRESSION_FORMAT: ${{ inputs.production-build && '2' || '0' }}       # 2=Brotli / 0=Disabled
           AIT_DEVELOPMENT_BUILD: ${{ inputs.production-build && 'false' || 'true' }}
-          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Master' || 'Debug' }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.production-build && 'Release' || 'Debug' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -170,6 +170,25 @@ namespace AppsInToss.Editor
             PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.WebGL, il2cppConfig);
 #endif
 
+            // ===== IL2CPP Code Generation (Meta 로드타임 스택: OptimizeSize) =====
+            // 제네릭 인스턴스화 공유로 wasm 코드 크기 축소. Unity 6+ 전용 API.
+#if UNITY_6000_0_OR_NEWER
+            Il2CppCodeGeneration il2cppCodeGen = editorConfig.il2cppCodeGeneration >= 0
+                ? (Il2CppCodeGeneration)editorConfig.il2cppCodeGeneration
+                : AITDefaultSettings.GetDefaultIl2CppCodeGeneration();
+            PlayerSettings.SetIl2CppCodeGeneration(NamedBuildTarget.WebGL, il2cppCodeGen);
+#endif
+
+            // ===== WebAssembly 2023 (Meta 로드타임 스택: native exception/SIMD/BigInt/Table) =====
+            // 코드 크기·다운로드·시작 시간 단축. 미지원 브라우저에서는 로드 실패하므로
+            // Apps in Toss WebView min-spec(Chrome≥91 / Safari≥16.4) 충족이 전제.
+#if UNITY_6000_0_OR_NEWER
+            bool wasm2023 = editorConfig.wasm2023 >= 0
+                ? editorConfig.wasm2023 == 1
+                : AITDefaultSettings.GetDefaultWasm2023();
+            PlayerSettings.WebGL.wasm2023 = wasm2023;
+#endif
+
             // ===== Unity 6 (2023.3+) 전용 설정 =====
 #if UNITY_2023_3_OR_NEWER
             // 출처: UnityVersion.md:394-402
@@ -210,6 +229,10 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
+#if UNITY_6000_0_OR_NEWER
+            Debug.Log($"[AIT]   - IL2CPP Code Generation: {il2cppCodeGen}{(editorConfig.il2cppCodeGeneration < 0 ? " (자동)" : "")}");
+            Debug.Log($"[AIT]   - WebAssembly 2023: {wasm2023}{(editorConfig.wasm2023 < 0 ? " (자동)" : "")}");
+#endif
 #if UNITY_2023_3_OR_NEWER
             Debug.Log($"[AIT]   - Power Preference: {powerPreference}{(editorConfig.powerPreference < 0 ? " (자동)" : "")}");
 #if !UNITY_6000_0_OR_NEWER

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -189,6 +189,25 @@ namespace AppsInToss.Editor
             PlayerSettings.WebGL.wasm2023 = wasm2023;
 #endif
 
+            // ===== WebGL Code Optimization (Meta 로드타임 스택의 실제 "Disk Size with LTO" 레버) =====
+            // IL2CPP 컴파일러 config(Master)는 WebGL emscripten 최적화/LTO에 영향을 주지 않으므로(no-op),
+            // 실제 LTO는 emscripten code optimization으로 켠다. 버전별 API 차이(2022.3/6: UserBuildSettings,
+            // 구버전: PlayerSettings.WebGL) + WebGL 모듈 어셈블리 참조 보장 부재 때문에
+            // AITWebGLCodeOptimization이 reflection으로 적용한다(멤버 없는 버전은 fail-safe로 건너뜀).
+            // editorConfig.webGLCodeOptimization: -1(자동)/1 → DiskSizeLTO 적용, 0 → 미적용(Unity 설정 유지).
+            bool applyWebGLCodeOpt = editorConfig.webGLCodeOptimization != 0;
+            string webGLCodeOptTarget = AITDefaultSettings.GetDefaultWebGLCodeOptimization();
+            bool webGLCodeOptApplied = false;
+            if (applyWebGLCodeOpt)
+            {
+                webGLCodeOptApplied = AITWebGLCodeOptimization.TrySetByName(webGLCodeOptTarget);
+                if (!webGLCodeOptApplied)
+                {
+                    Debug.LogWarning(
+                        $"[AIT] WebGL Code Optimization({webGLCodeOptTarget}) 미적용 — 이 Unity 버전에서 API/멤버 부재 (빌드는 계속)");
+                }
+            }
+
             // ===== Unity 6 (2023.3+) 전용 설정 =====
 #if UNITY_2023_3_OR_NEWER
             // 출처: UnityVersion.md:394-402
@@ -229,6 +248,10 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
+            string webGLCodeOptLog = !applyWebGLCodeOpt ? "미적용 (off)"
+                : webGLCodeOptApplied ? $"{webGLCodeOptTarget}{(editorConfig.webGLCodeOptimization < 0 ? " (자동)" : "")}"
+                : "미적용 (API 부재)";
+            Debug.Log($"[AIT]   - WebGL Code Optimization: {webGLCodeOptLog}");
 #if UNITY_6000_0_OR_NEWER
             Debug.Log($"[AIT]   - IL2CPP Code Generation: {il2cppCodeGen}{(editorConfig.il2cppCodeGeneration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - WebAssembly 2023: {wasm2023}{(editorConfig.wasm2023 < 0 ? " (자동)" : "")}");

--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -24,6 +24,9 @@ namespace AppsInToss.Editor
         public WebGLExceptionSupport exceptionSupport;
         public bool decompressionFallback;
         public bool nameFilesAsHashes;
+        // WebGL code optimization(Disk Size with LTO)은 버전별 enum이 달라 멤버 "이름"으로 보관.
+        // API 부재 버전에서는 null(복원 시 no-op). 적용/읽기는 AITWebGLCodeOptimization(reflection).
+        public string webGLCodeOptimization;
 
         // 일반 설정
         public Texture2D defaultCursor;
@@ -71,6 +74,7 @@ namespace AppsInToss.Editor
                 exceptionSupport = PlayerSettings.WebGL.exceptionSupport,
                 decompressionFallback = PlayerSettings.WebGL.decompressionFallback,
                 nameFilesAsHashes = PlayerSettings.WebGL.nameFilesAsHashes,
+                webGLCodeOptimization = AITWebGLCodeOptimization.GetCurrentName(),
 
                 defaultCursor = PlayerSettings.defaultCursor,
                 cursorHotspot = PlayerSettings.cursorHotspot,
@@ -134,6 +138,9 @@ namespace AppsInToss.Editor
             PlayerSettings.WebGL.exceptionSupport = exceptionSupport;
             PlayerSettings.WebGL.decompressionFallback = decompressionFallback;
             PlayerSettings.WebGL.nameFilesAsHashes = nameFilesAsHashes;
+            // 빌드 시 DiskSizeLTO로 바꿨더라도 빌드 후 사용자의 원래 설정으로 되돌린다(영구 오염 방지).
+            // null이면(캡처 당시 API 부재) no-op.
+            AITWebGLCodeOptimization.TrySetByName(webGLCodeOptimization);
 
             PlayerSettings.defaultCursor = defaultCursor;
             PlayerSettings.cursorHotspot = cursorHotspot;

--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -35,6 +35,10 @@ namespace AppsInToss.Editor
         public ScriptingImplementation scriptingBackend;
         public ManagedStrippingLevel managedStrippingLevel;
         public Il2CppCompilerConfiguration il2cppCompilerConfiguration;
+#if UNITY_6000_0_OR_NEWER
+        public Il2CppCodeGeneration il2cppCodeGeneration;
+        public bool wasm2023;
+#endif
 
         // Stack Trace Log Type (LogType별)
         public StackTraceLogType stackTraceLogTypeError;
@@ -77,6 +81,8 @@ namespace AppsInToss.Editor
                 scriptingBackend = PlayerSettings.GetScriptingBackend(NamedBuildTarget.WebGL),
                 managedStrippingLevel = PlayerSettings.GetManagedStrippingLevel(NamedBuildTarget.WebGL),
                 il2cppCompilerConfiguration = PlayerSettings.GetIl2CppCompilerConfiguration(NamedBuildTarget.WebGL),
+                il2cppCodeGeneration = PlayerSettings.GetIl2CppCodeGeneration(NamedBuildTarget.WebGL),
+                wasm2023 = PlayerSettings.WebGL.wasm2023,
 #else
                 scriptingBackend = PlayerSettings.GetScriptingBackend(BuildTargetGroup.WebGL),
                 managedStrippingLevel = PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.WebGL),
@@ -138,6 +144,8 @@ namespace AppsInToss.Editor
             PlayerSettings.SetScriptingBackend(NamedBuildTarget.WebGL, scriptingBackend);
             PlayerSettings.SetManagedStrippingLevel(NamedBuildTarget.WebGL, managedStrippingLevel);
             PlayerSettings.SetIl2CppCompilerConfiguration(NamedBuildTarget.WebGL, il2cppCompilerConfiguration);
+            PlayerSettings.SetIl2CppCodeGeneration(NamedBuildTarget.WebGL, il2cppCodeGeneration);
+            PlayerSettings.WebGL.wasm2023 = wasm2023;
 #else
             PlayerSettings.SetScriptingBackend(BuildTargetGroup.WebGL, scriptingBackend);
             PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL, managedStrippingLevel);

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -658,6 +658,11 @@ namespace AppsInToss.Editor
             // IL2CPP 컴파일러 설정
             DrawIl2CppConfigurationSetting();
 
+#if UNITY_6000_0_OR_NEWER
+            // IL2CPP Code Generation (OptimizeSize) — Meta 로드타임 스택
+            DrawIl2CppCodeGenerationSetting();
+#endif
+
 #if UNITY_2023_3_OR_NEWER
             GUILayout.Space(10);
             EditorGUILayout.LabelField("Unity 6 전용 설정", EditorStyles.boldLabel);
@@ -665,6 +670,11 @@ namespace AppsInToss.Editor
 
             // Power Preference
             DrawPowerPreferenceSetting();
+
+#if UNITY_6000_0_OR_NEWER
+            // WebAssembly 2023 — Meta 로드타임 스택 (미지원 브라우저 로드 실패 주의)
+            DrawWasm2023Setting();
+#endif
 
 #if !UNITY_6000_0_OR_NEWER
             // WASM Streaming (Unity 6000에서 deprecated - decompressionFallback에 의해 자동 결정)
@@ -739,6 +749,70 @@ namespace AppsInToss.Editor
 
             EditorGUILayout.EndHorizontal();
         }
+
+#if UNITY_6000_0_OR_NEWER
+        private void DrawIl2CppCodeGenerationSetting()
+        {
+            UnityEditor.Build.Il2CppCodeGeneration defaultCodeGen = AITDefaultSettings.GetDefaultIl2CppCodeGeneration();
+            bool isModified = config.il2cppCodeGeneration >= 0 && (UnityEditor.Build.Il2CppCodeGeneration)config.il2cppCodeGeneration != defaultCodeGen;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.il2cppCodeGeneration < 0
+                ? $"IL2CPP 코드 생성 (자동: {defaultCodeGen})"
+                : "IL2CPP 코드 생성";
+
+            string[] options = { $"자동 ({defaultCodeGen})", "OptimizeSpeed", "OptimizeSize" };
+            int currentIndex = config.il2cppCodeGeneration < 0 ? 0 : config.il2cppCodeGeneration + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.il2cppCodeGeneration = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.il2cppCodeGeneration = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawWasm2023Setting()
+        {
+            bool defaultValue = AITDefaultSettings.GetDefaultWasm2023();
+            bool isModified = config.wasm2023 >= 0 && (config.wasm2023 == 1) != defaultValue;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.wasm2023 < 0
+                ? $"WebAssembly 2023 (자동: {(defaultValue ? "활성화" : "비활성화")})"
+                : "WebAssembly 2023";
+
+            string[] options = { $"자동 ({(defaultValue ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.wasm2023 < 0 ? 0 : config.wasm2023 + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.wasm2023 = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.wasm2023 = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            // 미지원 브라우저 하드 페일 경고 (graceful degradation 아님)
+            if (config.wasm2023 != 0)
+            {
+                EditorGUILayout.HelpBox(
+                    "WebAssembly 2023을 켜면 미지원 브라우저(대략 Chrome<91 / Safari<16.4)에서 " +
+                    "로드가 실패합니다. Apps in Toss WebView 최소 사양 충족 시에만 사용하세요.",
+                    MessageType.Warning
+                );
+            }
+        }
+#endif
 
 #if UNITY_2023_3_OR_NEWER
         private void DrawPowerPreferenceSetting()
@@ -882,6 +956,18 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndHorizontal();
+
+            // 끄면(기본값) JS 디컴프레서가 번들에서 제거되어 호스팅 CDN이 Content-Encoding: br를
+            // 직접 서빙해야 한다. AIT 플랫폼 CDN은 보장하지만, 자체 호스팅 시 미설정이면 로드 실패.
+            if (config.decompressionFallback != 1)
+            {
+                EditorGUILayout.HelpBox(
+                    "Decompression Fallback이 꺼지면 호스팅 서버가 Content-Encoding: br(또는 gzip)을 " +
+                    "직접 서빙해야 합니다. Apps in Toss 플랫폼 CDN은 보장하지만, 자체 호스팅 시 " +
+                    "압축 헤더 미설정이면 로드가 실패합니다.",
+                    MessageType.Warning
+                );
+            }
         }
 
         private void DrawRunInBackgroundSetting()
@@ -989,6 +1075,10 @@ namespace AppsInToss.Editor
             config.stripEngineCode = true;
             config.il2cppConfiguration = -1;
             config.powerPreference = -1;
+#if UNITY_6000_0_OR_NEWER
+            config.il2cppCodeGeneration = -1;
+            config.wasm2023 = -1;
+#endif
 #if !UNITY_6000_0_OR_NEWER
             config.wasmStreaming = true;
             config.webAssemblyArithmeticExceptions = -1;

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -658,6 +658,10 @@ namespace AppsInToss.Editor
             // IL2CPP 컴파일러 설정
             DrawIl2CppConfigurationSetting();
 
+            // WebGL 코드 최적화 (Disk Size with LTO) — Meta 로드타임 스택의 실제 LTO 레버
+            // (전 버전 reflection 적용이라 #if 가드 없음. API 부재 버전은 fail-safe)
+            DrawWebGLCodeOptimizationSetting();
+
 #if UNITY_6000_0_OR_NEWER
             // IL2CPP Code Generation (OptimizeSize) — Meta 로드타임 스택
             DrawIl2CppCodeGenerationSetting();
@@ -748,6 +752,43 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawWebGLCodeOptimizationSetting()
+        {
+            // 기본 동작 = 적용(DiskSizeLTO). 토글: -1=자동(적용) / 0=미적용 / 1=적용.
+            // (config.webGLCodeOptimization==1)은 기본(적용)과 동일하므로 "미적용"(0)만 modified.
+            bool isModified = config.webGLCodeOptimization == 0;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.webGLCodeOptimization < 0
+                ? "WebGL 코드 최적화 (자동: Disk Size with LTO)"
+                : "WebGL 코드 최적화";
+
+            string[] options = { "자동 (Disk Size with LTO)", "미적용", "적용 (Disk Size with LTO)" };
+            int currentIndex = config.webGLCodeOptimization < 0 ? 0 : config.webGLCodeOptimization + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.webGLCodeOptimization = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.webGLCodeOptimization = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            // 이 Unity 버전에서 codeOptimization API가 없으면 fail-safe로 무시됨을 안내
+            if (config.webGLCodeOptimization != 0 && !AITWebGLCodeOptimization.IsSupported)
+            {
+                EditorGUILayout.HelpBox(
+                    "이 Unity 버전에는 WebGL code optimization API가 없어 이 설정은 빌드 시 무시됩니다 " +
+                    "(빌드는 정상 진행, LTO 이득만 없음).",
+                    MessageType.Info
+                );
+            }
         }
 
 #if UNITY_6000_0_OR_NEWER
@@ -1074,6 +1115,7 @@ namespace AppsInToss.Editor
         {
             config.stripEngineCode = true;
             config.il2cppConfiguration = -1;
+            config.webGLCodeOptimization = -1;
             config.powerPreference = -1;
 #if UNITY_6000_0_OR_NEWER
             config.il2cppCodeGeneration = -1;

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -177,11 +177,14 @@ namespace AppsInToss
         [Header("IL2CPP/Stripping 설정")]
         public bool stripEngineCode = true;
 
-        [Tooltip("-1 = 자동 (Master, LTO)")]
+        [Tooltip("-1 = 자동 (Release). WebGL에서 Master는 emscripten 최적화/LTO에 영향을 주지 않음(no-op)")]
         public int il2cppConfiguration = -1;
 
         [Tooltip("-1 = 자동 (OptimizeSize, Unity 6+). 0 = OptimizeSpeed, 1 = OptimizeSize — 제네릭 인스턴스 공유로 wasm 코드 크기 축소")]
         public int il2cppCodeGeneration = -1;
+
+        [Tooltip("-1 = 자동 (Disk Size with LTO 적용 — Coatsink/Meta 로드타임 스택의 실제 LTO 레버). 0 = 미적용(Unity 설정 유지), 1 = 적용")]
+        public int webGLCodeOptimization = -1;
 
         [Header("Unity 6 전용 설정")]
         [Tooltip("-1 = 자동 (HighPerformance)")]
@@ -402,15 +405,29 @@ namespace AppsInToss
         }
 
         /// <summary>
-        /// 기본 IL2CPP 컴파일러 설정
-        /// Meta+Unity 로드타임 스택의 "Disk Size with LTO" — Master는 LTO + 최대 최적화로
-        /// IL2CPP 생성 C++의 cross-module dead-code 제거를 강화해 wasm 코드 크기를 축소한다.
-        /// trade-off: 빌드 시간 증가(CI 콜드 빌드 ~20-30분, Bee 캐시 무효화 시 가산).
-        /// 출처: StartupOptimization.md:85, Coatsink "Ready, Set, Cook!" 케이스 스터디
+        /// 기본 IL2CPP 컴파일러 설정: Release
+        /// 주의: 과거 이 값을 Master로 두고 Coatsink "Disk Size with LTO"의 LTO 파트라 가정했으나,
+        /// 실측 결과 WebGL에서 컴파일러 config(Master)는 emscripten 최적화/LTO에 영향을 주지 않아
+        /// Release와 바이트 단위로 동일한 산출물을 냈다(no-op). 실제 LTO 레버는
+        /// emscripten code optimization = "Disk Size with LTO"이며 GetDefaultWebGLCodeOptimization()이 담당한다.
         /// </summary>
         public static Il2CppCompilerConfiguration GetDefaultIl2CppConfiguration()
         {
-            return Il2CppCompilerConfiguration.Master;
+            return Il2CppCompilerConfiguration.Release;
+        }
+
+        /// <summary>
+        /// 기본 WebGL Code Optimization: "Disk Size with LTO"(DiskSizeLTO)
+        /// Meta+Unity 로드타임 스택의 실제 LTO 레버. emscripten Link Time Optimization으로
+        /// cross-module dead-code를 제거해 wasm 코드 크기를 추가로 축소한다(실측 기준 압축전 ~-21%).
+        /// trade-off: 빌드 시간 증가(LTO 링크). API가 버전마다 다르고(2022.3/6: UserBuildSettings,
+        /// 구버전: PlayerSettings.WebGL) 모듈 어셈블리 참조 보장이 없어 AITWebGLCodeOptimization이
+        /// reflection으로 적용한다. 멤버가 없는 버전(예: 2021.3)에서는 fail-safe로 건너뛴다.
+        /// 출처: Unity Manual web-optimization-c-sharp, Coatsink "Ready, Set, Cook!" 케이스 스터디
+        /// </summary>
+        public static string GetDefaultWebGLCodeOptimization()
+        {
+            return AppsInToss.Editor.AITWebGLCodeOptimization.DiskSizeLTO;
         }
 
 #if UNITY_6000_0_OR_NEWER

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -177,14 +177,20 @@ namespace AppsInToss
         [Header("IL2CPP/Stripping 설정")]
         public bool stripEngineCode = true;
 
-        [Tooltip("-1 = 자동 (Release)")]
+        [Tooltip("-1 = 자동 (Master, LTO)")]
         public int il2cppConfiguration = -1;
+
+        [Tooltip("-1 = 자동 (OptimizeSize, Unity 6+). 0 = OptimizeSpeed, 1 = OptimizeSize — 제네릭 인스턴스 공유로 wasm 코드 크기 축소")]
+        public int il2cppCodeGeneration = -1;
 
         [Header("Unity 6 전용 설정")]
         [Tooltip("-1 = 자동 (HighPerformance)")]
         public int powerPreference = -1;
 
         public bool wasmStreaming = true;
+
+        [Tooltip("-1 = 자동 (활성화, Unity 6+). WebAssembly 2023 기능셋(native exception/SIMD/BigInt/Table). 미지원 브라우저에서는 로드 실패")]
+        public int wasm2023 = -1;
 
         [Header("고급 설정 (주의: 변경 시 호환성 문제 발생 가능)")]
         [Tooltip("-1 = 자동 (FullWithStacktrace, Sentry 경고 방지)")]
@@ -193,7 +199,7 @@ namespace AppsInToss
         [Tooltip("-1 = 자동 (false), Unity Pro 라이선스 필요")]
         public int showUnityLogo = -1;
 
-        [Tooltip("-1 = 자동 (true)")]
+        [Tooltip("-1 = 자동 (false). 끄면 JS Brotli 디컴프레서가 번들에서 제거됨 — 플랫폼 CDN의 Content-Encoding: br 의존")]
         public int decompressionFallback = -1;
 
         [Tooltip("-1 = 자동 (false)")]
@@ -379,7 +385,7 @@ namespace AppsInToss
 
         /// <summary>
         /// 기본 압축 포맷: Brotli
-        /// decompressionFallback이 활성화되어 있으므로 모든 Unity 버전에서 Brotli 사용 가능
+        /// decompressionFallback=false이므로 브라우저/CDN이 Content-Encoding: br로 네이티브 해제 (모든 Unity 버전 Brotli)
         /// </summary>
         public static WebGLCompressionFormat GetDefaultCompressionFormat()
         {
@@ -397,12 +403,29 @@ namespace AppsInToss
 
         /// <summary>
         /// 기본 IL2CPP 컴파일러 설정
-        /// 출처: StartupOptimization.md:85
+        /// Meta+Unity 로드타임 스택의 "Disk Size with LTO" — Master는 LTO + 최대 최적화로
+        /// IL2CPP 생성 C++의 cross-module dead-code 제거를 강화해 wasm 코드 크기를 축소한다.
+        /// trade-off: 빌드 시간 증가(CI 콜드 빌드 ~20-30분, Bee 캐시 무효화 시 가산).
+        /// 출처: StartupOptimization.md:85, Coatsink "Ready, Set, Cook!" 케이스 스터디
         /// </summary>
         public static Il2CppCompilerConfiguration GetDefaultIl2CppConfiguration()
         {
-            return Il2CppCompilerConfiguration.Release;
+            return Il2CppCompilerConfiguration.Master;
         }
+
+#if UNITY_6000_0_OR_NEWER
+        /// <summary>
+        /// 기본 IL2CPP 코드 생성 방식 (Unity 6+): OptimizeSize
+        /// Meta+Unity 로드타임 스택의 "Faster (smaller) builds" — 제네릭 인스턴스화를
+        /// 공유해 제네릭 폭발(측정상 ~130k 함수)을 붕괴시켜 wasm 코드 크기를 축소한다.
+        /// trade-off: 공유 제네릭의 미세한 런타임 디스패치 비용(정확성 변화 아님).
+        /// 출처: Unity Manual web-optimization-player (IL2CPP Code Generation = Optimize for code size)
+        /// </summary>
+        public static UnityEditor.Build.Il2CppCodeGeneration GetDefaultIl2CppCodeGeneration()
+        {
+            return UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize;
+        }
+#endif
 
 #if UNITY_2023_3_OR_NEWER
         /// <summary>
@@ -438,11 +461,33 @@ namespace AppsInToss
 
         /// <summary>
         /// 기본 Decompression Fallback
+        /// Apps in Toss 플랫폼 CDN이 .unityweb를 Content-Encoding: br로 서빙하므로
+        /// 브라우저가 네이티브 해제한다. Unity가 프레임워크 번들에 굽는 JS Brotli
+        /// 디컴프레서는 불필요(죽은 무게) → 비활성화로 번들 축소 + 시작 단축.
+        /// 의존: 플랫폼 CDN의 Content-Encoding: br 보장(확인 완료). vite dev/preview는
+        /// unityWebContentEncodingPlugin이 동일 헤더를 세팅한다.
         /// 출처: StartupOptimization.md:93
         /// </summary>
         public static bool GetDefaultDecompressionFallback()
         {
+            return false;
+        }
+
+        /// <summary>
+        /// 기본 WebAssembly 2023 타겟 여부 (Unity 6+): 활성화
+        /// Meta+Unity 로드타임 최적화: native exception/SIMD/BigInt/WebAssembly.Table 등
+        /// 2023 기능셋을 번들해 코드 크기·다운로드·시작 시간을 단축한다.
+        /// 주의: 미지원 브라우저(대략 Chrome&lt;91 / Safari&lt;16.4)에서는 graceful
+        /// degradation이 아니라 로드 자체가 실패한다. Apps in Toss는 Toss 앱 WebView
+        /// 전용이라 플랫폼 min-spec이 이를 충족하는 전제에서만 기본 활성.
+        /// </summary>
+        public static bool GetDefaultWasm2023()
+        {
+#if UNITY_6000_0_OR_NEWER
             return true;
+#else
+            return false;
+#endif
         }
 
         /// <summary>

--- a/Editor/AITWebGLCodeOptimization.cs
+++ b/Editor/AITWebGLCodeOptimization.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Reflection;
+using UnityEngine;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// WebGL "code optimization" 레버(Coatsink/Meta 로드타임 스택의 "Disk Size with LTO")를
+    /// Unity 버전 차이를 흡수해 reflection으로 읽고 쓴다.
+    ///
+    /// 왜 IL2CPP 컴파일러 config(Master)가 아니라 이쪽인가:
+    /// IL2CPP 컴파일러 config(Master)는 WebGL의 emscripten 최적화/LTO에 영향을 주지 않는다.
+    /// 실측상 Master 빌드 산출물은 Release와 바이트 단위로 동일(no-op)했다. 실제로 LTO를
+    /// 켜고 wasm 코드 크기를 줄이는 레버는 emscripten code optimization = "Disk Size with LTO"다.
+    ///
+    /// 왜 reflection인가:
+    /// - Unity 2022.3/6(6000.x): UnityEditor.WebGL.UserBuildSettings.codeOptimization
+    ///   (enum UnityEditor.WebGL.WasmCodeOptimization). WebGL 모듈 어셈블리에 있어 Editor
+    ///   asmdef가 이를 참조한다는 보장이 없다 → 직접 참조 시 CS0103 위험.
+    /// - 구버전(존재 시): PlayerSettings.WebGL.codeOptimization (enum WebGLCodeOptimization).
+    ///   Unity 6에서 제거됨 → 직접 참조 시 컴파일 실패.
+    /// 두 API의 enum 멤버명(DiskSizeLTO 등)이 동일하므로 멤버 "이름"으로 다룬다.
+    ///
+    /// 멤버가 없는 버전(예: 2021.3에 codeOptimization 부재)에서는 fail-safe로 동작한다 —
+    /// 설정을 건너뛰고 경고만 남기며 빌드는 계속된다(해당 버전에서 LTO 이득만 없음).
+    /// </summary>
+    internal static class AITWebGLCodeOptimization
+    {
+        /// <summary>Coatsink/Meta 로드타임 스택의 권장값(enum 멤버 이름).</summary>
+        public const string DiskSizeLTO = "DiskSizeLTO";
+
+        private static bool _resolved;
+        private static PropertyInfo _prop;
+
+        /// <summary>
+        /// 현재 Unity 버전에서 codeOptimization 정적 프로퍼티를 찾아 캐시한다.
+        /// 신규 API(UserBuildSettings)를 먼저, 구버전 API(PlayerSettings.WebGL)를 폴백으로 본다.
+        /// API가 없으면 null을 캐시.
+        /// </summary>
+        private static PropertyInfo ResolveProperty()
+        {
+            if (_resolved) return _prop;
+            _resolved = true;
+
+            // 신규 API: UnityEditor.WebGL.UserBuildSettings.codeOptimization (static)
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type t;
+                try { t = asm.GetType("UnityEditor.WebGL.UserBuildSettings"); }
+                catch { continue; }
+                if (t == null) continue;
+
+                var p = t.GetProperty("codeOptimization",
+                    BindingFlags.Public | BindingFlags.Static);
+                if (p != null && p.PropertyType.IsEnum && p.CanRead && p.CanWrite)
+                {
+                    _prop = p;
+                    return _prop;
+                }
+            }
+
+            // 구버전 API: PlayerSettings.WebGL.codeOptimization (중첩 static 타입)
+            var webglNested = typeof(UnityEditor.PlayerSettings)
+                .GetNestedType("WebGL", BindingFlags.Public | BindingFlags.Static);
+            var legacy = webglNested?.GetProperty("codeOptimization",
+                BindingFlags.Public | BindingFlags.Static);
+            if (legacy != null && legacy.PropertyType.IsEnum && legacy.CanRead && legacy.CanWrite)
+            {
+                _prop = legacy;
+                return _prop;
+            }
+
+            return _prop; // null — 이 버전엔 API 없음
+        }
+
+        /// <summary>이 Unity 버전에서 codeOptimization 설정이 가능한지.</summary>
+        public static bool IsSupported => ResolveProperty() != null;
+
+        /// <summary>현재 값의 enum 멤버 이름. API 부재 시 null.</summary>
+        public static string GetCurrentName()
+        {
+            var p = ResolveProperty();
+            if (p == null) return null;
+            try { return p.GetValue(null)?.ToString(); }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// 멤버 이름으로 값을 설정한다. name이 null/빈 문자열이거나 API 부재/멤버 미정의 시 false.
+        /// fail-safe: 실패해도 예외를 던지지 않고 경고만 남긴다(빌드 계속).
+        /// </summary>
+        public static bool TrySetByName(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return false;
+
+            var p = ResolveProperty();
+            if (p == null) return false;
+
+            try
+            {
+                if (!Enum.IsDefined(p.PropertyType, name))
+                {
+                    Debug.LogWarning(
+                        $"[AIT] WebGL codeOptimization 멤버 미정의: '{name}' (enum={p.PropertyType.Name}) — 건너뜀");
+                    return false;
+                }
+
+                var val = Enum.Parse(p.PropertyType, name);
+                p.SetValue(null, val);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] WebGL codeOptimization 설정 실패('{name}'): {e.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/Editor/AITWebGLCodeOptimization.cs.meta
+++ b/Editor/AITWebGLCodeOptimization.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f72fe6aa56b54be79487ea3ba3f7b65e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  references: []

--- a/Tests~/.gitignore
+++ b/Tests~/.gitignore
@@ -21,6 +21,7 @@ E2E/SampleUnityProject/*.sln
 E2E/tests/playwright-report/
 E2E/tests/test-results/
 E2E/tests/benchmark-results.json
+E2E/tests/load-profile.json
 E2E/tests/node_modules/
 
 # JavaScript Test Coverage

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -382,6 +382,162 @@ async function applyMobileThrottling(page, overrideRate = undefined) {
 
 
 // ============================================================================
+// 로딩 프로파일러 (첫 프레임 렌더까지의 로드 타임라인 측정)
+// ============================================================================
+
+/**
+ * 페이지 컨텍스트에 주입되는 로딩 프로파일러.
+ * page.addInitScript로 navigation 이전에 설치되어 다음을 정밀 측정한다(performance.now 기준):
+ *  - instanceReadyMs : 템플릿이 `window.unityInstance = ...`를 세팅한 시각(엔진 준비 완료)
+ *  - firstFrameMs    : Unity 엔진이 캔버스에 최초로 그린 시각(첫 프레임 렌더 성공) = 헤드라인 지표
+ *
+ * 첫 프레임은 WebGL draw 콜을 프로토타입 레벨에서 후킹해 감지한다(최초 1회 기록 후 자가 제거 →
+ * 이후 오버헤드 0). AIT 템플릿의 로딩 화면은 HTML 오버레이라 캔버스에 그리지 않으므로,
+ * 최초 draw 콜 = 엔진의 첫 프레임이다.
+ *
+ * ⚠️ 이 함수는 브라우저 컨텍스트에서 실행되므로 Node 변수에 클로저로 접근하면 안 된다(self-contained).
+ */
+function installLoadProfiler() {
+  if (window['__AIT_LOAD_PROFILE__']) return;
+  const profile = {
+    timeOrigin: performance.timeOrigin,
+    instanceReadyMs: null,
+    firstFrameMs: null,
+    firstDrawMethod: null,
+    progress: [],
+  };
+  window['__AIT_LOAD_PROFILE__'] = profile;
+  const now = () => +performance.now().toFixed(1);
+
+  // 1) window.unityInstance 세터 트랩 → 엔진 인스턴스 준비 시각.
+  //    템플릿의 `window.unityInstance = unityInstance`는 [[Set]]이라 접근자 세터로 가로챌 수 있다.
+  try {
+    let _inst;
+    Object.defineProperty(window, 'unityInstance', {
+      configurable: true,
+      get() { return _inst; },
+      set(v) {
+        _inst = v;
+        if (profile.instanceReadyMs == null) profile.instanceReadyMs = now();
+      },
+    });
+  } catch (e) { /* 이미 정의된 경우 무시 */ }
+
+  // 2) WebGL draw 콜 후킹 → 최초 프레임 렌더 시각(자가 제거).
+  //    ⚠️ WebGL2 컨텍스트의 drawArrays/drawElements는 WebGL2RenderingContext.prototype의
+  //    고유 메서드라 WebGLRenderingContext.prototype 후킹만으로는 가로채지지 않는다 →
+  //    기본 draw 메서드를 두 프로토타입 모두에 후킹한다(가장 derived가 우선 적용됨).
+  try {
+    const targets = [];
+    const collect = (proto, names) => {
+      if (!proto) return;
+      for (const n of names) {
+        if (typeof proto[n] === 'function') targets.push([proto, n, proto[n]]);
+      }
+    };
+    collect(window.WebGLRenderingContext && window.WebGLRenderingContext.prototype,
+      ['drawArrays', 'drawElements']);
+    collect(window.WebGL2RenderingContext && window.WebGL2RenderingContext.prototype,
+      ['drawArrays', 'drawElements', 'drawArraysInstanced', 'drawElementsInstanced', 'drawRangeElements']);
+
+    const restore = () => {
+      for (const [p, n, orig] of targets) {
+        try { p[n] = orig; } catch (e) { /* noop */ }
+      }
+    };
+
+    for (const [proto, name, orig] of targets) {
+      proto[name] = function (...args) {
+        if (profile.firstFrameMs == null) {
+          profile.firstFrameMs = now();
+          profile.firstDrawMethod = name;
+          restore();
+        }
+        return orig.apply(this, args);
+      };
+    }
+  } catch (e) { /* 후킹 실패 시 firstFrameMs는 null로 남고 테스트가 실패시킨다 */ }
+}
+
+/**
+ * 페이지에서 로딩 프로파일 + Resource/Navigation Timing을 읽어 구조화된 객체로 반환.
+ * Unity 빌드 자산의 on-wire 전송 바이트(transferSize)·압축/비압축 바디·다운로드 구간을 포함한다.
+ */
+async function captureLoadProfile(page) {
+  return await page.evaluate(() => {
+    const prof = window['__AIT_LOAD_PROFILE__'] || {};
+    const nav = performance.getEntriesByType('navigation')[0];
+    const isUnityAsset = (name) =>
+      /\/Build\//.test(name) ||
+      /\.(unityweb|wasm|data|mem)$/.test(name) ||
+      /\.(loader|framework)\.js$/.test(name);
+
+    const resources = performance.getEntriesByType('resource')
+      .filter((r) => isUnityAsset(r.name))
+      .map((r) => ({
+        name: r.name.split('/').pop().split('?')[0],
+        initiatorType: r.initiatorType,
+        startMs: +r.startTime.toFixed(1),
+        responseEndMs: +r.responseEnd.toFixed(1),
+        durationMs: +r.duration.toFixed(1),
+        ttfbMs: +Math.max(0, r.responseStart - r.requestStart).toFixed(1),
+        transferSize: r.transferSize,        // on-wire(헤더 포함)
+        encodedBodySize: r.encodedBodySize,  // 압축 바디
+        decodedBodySize: r.decodedBodySize,  // 비압축 바디
+      }))
+      .sort((a, b) => a.startMs - b.startMs);
+
+    const sum = (key) => resources.reduce((s, r) => s + (r[key] || 0), 0);
+
+    return {
+      firstFrameMs: prof.firstFrameMs ?? null,
+      instanceReadyMs: prof.instanceReadyMs ?? null,
+      firstDrawMethod: prof.firstDrawMethod ?? null,
+      navigation: nav ? {
+        domContentLoadedMs: +nav.domContentLoadedEventEnd.toFixed(1),
+        domCompleteMs: +nav.domComplete.toFixed(1),
+        loadEventEndMs: +nav.loadEventEnd.toFixed(1),
+        responseEndMs: +nav.responseEnd.toFixed(1),
+      } : null,
+      resources,
+      totalTransferBytes: sum('transferSize'),
+      totalEncodedBytes: sum('encodedBodySize'),
+      totalDecodedBytes: sum('decodedBodySize'),
+    };
+  });
+}
+
+function formatBytes(n) {
+  if (n == null) return 'N/A';
+  if (n >= 1024 * 1024) return (n / (1024 * 1024)).toFixed(2) + ' MB';
+  if (n >= 1024) return (n / 1024).toFixed(1) + ' KB';
+  return n + ' B';
+}
+
+/** 베이스라인(이전 profile) 대비 before/after 델타를 콘솔에 출력. */
+function printLoadDiff(baseline, current) {
+  if (!baseline) return;
+  const b = baseline.profile || baseline;
+  const fmtDelta = (before, after, unit, lowerIsBetter = true) => {
+    if (before == null || after == null) return `${after ?? 'N/A'} (baseline N/A)`;
+    const d = after - before;
+    const pct = before !== 0 ? (d / before) * 100 : 0;
+    const sign = d > 0 ? '+' : '';
+    const better = lowerIsBetter ? (d < 0) : (d > 0);
+    const tag = d === 0 ? '=' : (better ? '✓ 개선' : '✗ 회귀');
+    return `${before}${unit} → ${after}${unit}  (${sign}${d.toFixed(1)}${unit}, ${sign}${pct.toFixed(1)}%) ${tag}`;
+  };
+  console.log('\n  ── Before → After (baseline diff) ──');
+  console.log('  첫 프레임:        ' + fmtDelta(b.firstFrameMs, current.firstFrameMs, 'ms'));
+  console.log('  인스턴스 준비:    ' + fmtDelta(b.instanceReadyMs, current.instanceReadyMs, 'ms'));
+  console.log('  on-wire 전송:     ' + fmtDelta(
+    b.totalTransferBytes != null ? +(b.totalTransferBytes / 1048576).toFixed(2) : null,
+    current.totalTransferBytes != null ? +(current.totalTransferBytes / 1048576).toFixed(2) : null,
+    'MB'));
+}
+
+
+// ============================================================================
 // Test Suite
 // ============================================================================
 
@@ -419,10 +575,27 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
         unexpectedErrorCount: testResults.tests['4_runtime_api'].unexpectedErrorCount
       } : null,
       compressionValidation: testResults.tests['1_build_validation']?.compressionValidation || null,
+      // 로딩 프로파일 헤드라인 (before/after diff용)
+      firstFrameMs: testResults.tests['3-2_load_profile']?.firstFrameMs ?? null,
+      instanceReadyMs: testResults.tests['3-2_load_profile']?.instanceReadyMs ?? null,
+      onWireTransferBytes: testResults.tests['3-2_load_profile']?.totalTransferBytes ?? null,
       testsPassed: Object.values(testResults.tests || {}).filter(t => t.passed).length,
       testsTotal: Object.keys(testResults.tests || {}).length
     };
     fs.writeFileSync(benchmarkPath, JSON.stringify(benchmarkResults, null, 2));
+
+    // 3. 로딩 프로파일 (before/after diff 베이스라인용 전용 산출물)
+    const loadProfile = testResults.tests['3-2_load_profile'];
+    if (loadProfile) {
+      const loadProfilePath = path.resolve(__dirname, 'load-profile.json');
+      const { passed, ...profile } = loadProfile;
+      fs.writeFileSync(loadProfilePath, JSON.stringify({
+        timestamp: testResults.timestamp,
+        unityProject: SAMPLE_PROJECT,
+        isDevBuild,
+        profile,
+      }, null, 2));
+    }
 
     // stdout으로 결과 출력
     console.log('\n');
@@ -440,10 +613,14 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
     const pageLoad = tests['3_production_server']?.pageLoadTimeMs;
     const unityLoad = tests['3_production_server']?.unityLoadTimeMs;
     const renderer = tests['3_production_server']?.webgl?.renderer;
+    const firstFrame = tests['3-2_load_profile']?.firstFrameMs;
+    const onWire = tests['3-2_load_profile']?.totalTransferBytes;
 
     console.log('\n  📦 Build Size:      ' + (buildSize ? buildSize.toFixed(2) + ' MB' : 'N/A'));
     console.log('  ⏱️  Page Load:       ' + (pageLoad ? pageLoad + ' ms' : 'N/A'));
     console.log('  🎮 Unity Load:      ' + (unityLoad ? unityLoad + ' ms' : 'N/A'));
+    console.log('  🎬 First Frame:     ' + (firstFrame != null ? firstFrame + ' ms' : 'N/A') + '  ← headline');
+    console.log('  📡 On-wire:         ' + (onWire != null ? formatBytes(onWire) : 'N/A'));
     console.log('  🖥️  GPU Renderer:    ' + (renderer || 'N/A'));
 
     console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
@@ -649,6 +826,8 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
     let sharedPort = serverPort;
     let pageLoadTime = 0;
     let unityLoadTime = 0;
+    /** @type {Awaited<ReturnType<typeof captureLoadProfile>> | null} */
+    let loadProfile = null;
     const preloadWarnings = [];
 
     test.beforeAll(async ({ browser }) => {
@@ -682,6 +861,9 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
       // 2. 페이지 생성 + Unity 초기화
       sharedPage = await browser.newPage();
 
+      // 로딩 프로파일러를 navigation 이전에 주입 (첫 프레임/인스턴스 준비 시각 정밀 측정)
+      await sharedPage.addInitScript(installLoadProfiler);
+
       sharedPage.on('console', msg => {
         if (msg.type() === 'warning' && msg.text().includes('credentials mode')) {
           preloadWarnings.push(msg.text());
@@ -707,6 +889,26 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
       } catch {
         unityLoadTime = Date.now() - unityStartTime;
         console.log('⚠️ Unity initialization timeout');
+      }
+
+      // 첫 프레임 렌더(최초 WebGL draw) 감지 — 헤드라인 로드 지표. 미감지 시 로드 실패로 간주.
+      try {
+        await sharedPage.waitForFunction(
+          () => window['__AIT_LOAD_PROFILE__'] && window['__AIT_LOAD_PROFILE__'].firstFrameMs != null,
+          { timeout: 30000 }
+        );
+      } catch {
+        console.log('⚠️ First frame(WebGL draw) not detected within timeout');
+      }
+
+      // 로딩 프로파일 캡처 (resource/navigation timing 포함)
+      try {
+        loadProfile = await captureLoadProfile(sharedPage);
+        if (loadProfile?.firstFrameMs != null) {
+          console.log(`🎬 First frame rendered at ${loadProfile.firstFrameMs}ms (nav start 기준, via ${loadProfile.firstDrawMethod})`);
+        }
+      } catch (e) {
+        console.log('⚠️ Load profile capture failed:', e?.message);
       }
 
       try {
@@ -766,6 +968,69 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
         pageLoadTimeMs: pageLoadTime,
         unityLoadTimeMs: unityLoadTime,
         webgl: webglInfo
+      };
+    });
+
+
+    // -------------------------------------------------------------------------
+    // Test 3-2: Load Profiling — 첫 프레임 렌더까지의 로드 타임라인
+    // before/after diff용 정밀 프로파일을 자동 수집 (헤드라인 = firstFrameMs)
+    // -------------------------------------------------------------------------
+    test('3-2. Load profiling: first-frame render time', async () => {
+      test.setTimeout(60000);
+
+      expect(loadProfile, 'load profile should have been captured in beforeAll').not.toBeNull();
+
+      // 첫 프레임이 감지되어야 한다(미감지 = WebGL 렌더 실패 = 로드 실패).
+      // wasm2023 미지원 브라우저 하드페일도 여기서 잡힌다.
+      expect(
+        loadProfile.firstFrameMs,
+        'first frame(WebGL draw)가 감지되어야 합니다 — 미감지 시 엔진 렌더 실패/하드페일'
+      ).not.toBeNull();
+
+      // 구조화된 프로파일 표 출력
+      console.log('\n  ━━━━━━━━━━━━━━━━ 🎬 Load Profile (nav start = 0ms) ━━━━━━━━━━━━━━━━');
+      console.log(`  첫 프레임 렌더(headline): ${loadProfile.firstFrameMs} ms  (via ${loadProfile.firstDrawMethod})`);
+      console.log(`  엔진 인스턴스 준비:       ${loadProfile.instanceReadyMs ?? 'N/A'} ms`);
+      if (loadProfile.navigation) {
+        console.log(`  DOMContentLoaded:         ${loadProfile.navigation.domContentLoadedMs} ms`);
+        console.log(`  load 이벤트:              ${loadProfile.navigation.loadEventEndMs} ms`);
+      }
+      console.log(`  on-wire 전송 합계:        ${formatBytes(loadProfile.totalTransferBytes)} (압축 ${formatBytes(loadProfile.totalEncodedBytes)} / 비압축 ${formatBytes(loadProfile.totalDecodedBytes)})`);
+      console.log('  ── 자산별 다운로드 ──');
+      console.log('  ' + 'asset'.padEnd(34) + 'on-wire'.padStart(11) + 'decoded'.padStart(11) + 'start'.padStart(9) + 'dur'.padStart(8));
+      for (const r of loadProfile.resources) {
+        console.log(
+          '  ' + r.name.slice(0, 33).padEnd(34) +
+          formatBytes(r.transferSize).padStart(11) +
+          formatBytes(r.decodedBodySize).padStart(11) +
+          (r.startMs + 'ms').padStart(9) +
+          (r.durationMs + 'ms').padStart(8)
+        );
+      }
+      console.log('  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+
+      // 베이스라인이 주어지면 before/after 델타 자동 출력
+      const baselinePath = process.env.AIT_LOAD_BASELINE;
+      if (baselinePath && fs.existsSync(baselinePath)) {
+        try {
+          const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+          console.log(`\n  📐 Baseline: ${baselinePath}`);
+          printLoadDiff(baseline, loadProfile);
+        } catch (e) {
+          console.log(`  ⚠️ Baseline 읽기 실패: ${e?.message}`);
+        }
+      }
+
+      // 합리적 상한 단언 (모바일 30s / 데스크톱 10s). 회귀 가드.
+      expect(
+        loadProfile.firstFrameMs,
+        `first-frame가 ${BENCHMARKS.MAX_LOAD_TIME_MS}ms 이내여야 합니다`
+      ).toBeLessThan(BENCHMARKS.MAX_LOAD_TIME_MS);
+
+      testResults.tests['3-2_load_profile'] = {
+        passed: true,
+        ...loadProfile,
       };
     });
 

--- a/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
@@ -13,16 +13,40 @@ function detectUnityWebCompression(filePath: string): 'br' | 'gzip' | null {
     // 파일 헤더의 처음 64바이트만 읽음
     const fd = openSync(filePath, 'r');
     const buffer = Buffer.alloc(64);
-    readSync(fd, buffer, 0, 64, 0);
+    const bytesRead = readSync(fd, buffer, 0, 64, 0);
     closeSync(fd);
 
     const header = buffer.toString('ascii');
 
+    // decompressionFallback=ON: Unity가 텍스트 매직 헤더를 기록
     if (header.includes('(brotli)')) return 'br';
     if (header.includes('(gzip)')) return 'gzip';
-    return null;
+
+    // decompressionFallback=OFF: 매직 헤더 없는 raw 압축 스트림.
+    // .unityweb는 항상 압축 산출물이므로(비압축 빌드는 .unityweb를 만들지 않음)
+    // gzip magic(0x1f 0x8b)이면 gzip, 그 외에는 brotli(매직 없음)로 간주한다.
+    if (bytesRead >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) return 'gzip';
+    return 'br';
   } catch {
     return null;
+  }
+}
+
+/**
+ * Unity WebGL 산출물 경로 패턴으로 Content-Type을 설정.
+ * .wasm.→application/wasm (instantiateStreaming 활성), .js.→javascript, .data.→octet-stream.
+ * .unityweb / .br / .gz 모두 ".wasm." 같은 중간 패턴을 포함하므로 한 함수로 커버된다.
+ */
+function setUnityContentType(
+  res: { setHeader(name: string, value: string): void },
+  url: string,
+): void {
+  if (url.includes('.wasm.')) {
+    res.setHeader('Content-Type', 'application/wasm');
+  } else if (url.includes('.js.')) {
+    res.setHeader('Content-Type', 'application/javascript');
+  } else if (url.includes('.data.')) {
+    res.setHeader('Content-Type', 'application/octet-stream');
   }
 }
 
@@ -69,22 +93,18 @@ function unityWebContentEncodingPlugin(): Plugin {
           res.setHeader('Content-Encoding', encoding);
         }
 
-        // Content-Type 설정
-        if (url.includes('.wasm.')) {
-          res.setHeader('Content-Type', 'application/wasm');
-        } else if (url.includes('.js.')) {
-          res.setHeader('Content-Type', 'application/javascript');
-        } else if (url.includes('.data.')) {
-          res.setHeader('Content-Type', 'application/octet-stream');
-        }
+        // Content-Type 설정 (instantiateStreaming 활성화 위해 .wasm은 application/wasm)
+        setUnityContentType(res, url);
       }
-      // 레거시 .br 파일 (Unity 2021/2022)
+      // 레거시 .br 파일 (Unity 2021/2022 — Unity 6는 .unityweb 사용)
       else if (url.endsWith('.br')) {
         res.setHeader('Content-Encoding', 'br');
+        setUnityContentType(res, url);
       }
-      // 레거시 .gz 파일 (Unity 2021/2022)
+      // 레거시 .gz 파일 (Unity 2021/2022 — Unity 6는 .unityweb 사용)
       else if (url.endsWith('.gz')) {
         res.setHeader('Content-Encoding', 'gzip');
+        setUnityContentType(res, url);
       }
 
       next();


### PR DESCRIPTION
## 배경

공개된 Unity WebGL 로드타임 최적화 스택(Instant Games 런칭 파트너 Coatsink의 *Ready, Set, Cook!* 사례)은 **time-to-interactivity를 50%+ 단축**했다([Coatsink case study](https://unity.com/resources/coatsink-ready-set-cook)): 엔진 코드 strip · Brotli · **IL2CPP code generation = OptimizeSize** · **code optimization = "Disk Size with LTO"(=Master)** · managed stripping = High.

이 SDK는 그 스택의 **절반만** 켜져 있었다(strip / Brotli / managed-stripping-High ✅). 이 PR은 **빠진 레버를 SDK 기본값으로 채운다.**

## 변경 레버 (SDK 기본값)

| 레버 | 변경 | 효과 |
|---|---|---|
| **WebAssembly 2023** | (미설정) → `true` *(Unity 6+)* | native exception/SIMD/BigInt/Table 기능셋 → 코드 크기·다운로드·시작 단축 |
| **IL2CPP Code Generation** | (미설정=OptimizeSpeed) → `OptimizeSize` *(Unity 6+)* | 제네릭 인스턴스 공유로 제네릭 폭발 붕괴 → wasm 코드 크기 축소 |
| **IL2CPP Compiler Config** | `Release` → `Master` | LTO(=Disk Size with LTO)로 cross-module dead-code 제거 강화 |
| **Decompression Fallback** | `true` → `false` | 플랫폼 CDN이 `Content-Encoding: br` 서빙 → JS 디컴프레서 죽은 무게 제거 |

## 구현

기존 **4점 세트** 패턴을 그대로 따른다 — (a) `AITDefaultSettings` 기본값 메서드, (b) `AITBuildInitializer` 빌드 시 적용, (c) `AITBuildSession` 스냅샷/복원, (d) `AITConfigurationWindow` UI 토글. (c)가 없으면 빌드가 사용자 프로젝트 설정을 영구 오염시키므로 필수. 모든 신규 레버에 `#if UNITY_6000_0_OR_NEWER` dual-target 가드 적용.

- `Editor/AITEditorScriptObject.cs` — `GetDefaultIl2CppCodeGeneration`/`GetDefaultWasm2023` 신규, `GetDefaultIl2CppConfiguration` Release→Master, `GetDefaultDecompressionFallback` true→false
- `Editor/AITBuildInitializer.cs` — `SetIl2CppCodeGeneration(OptimizeSize)` + `WebGL.wasm2023` 적용 + 로그
- `Editor/AITBuildSession.cs` — `il2cppCodeGeneration`/`wasm2023` 스냅샷·복원
- `Editor/AITConfigurationWindow.cs` — 두 토글 + 하드페일/CDN-의존 경고 HelpBox + Reset
- `WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts` — fallback-off raw 스트림 대비 파일명 기준 `Content-Encoding`/`Content-Type` 서빙
- `.github/workflows/unity-build.yml` — production-build env를 Release→**Master**로 정렬 (CI 측정이 새 기본값을 실제로 빌드)

## ⚠️ Trade-off / 위험

- **WebAssembly 2023 = 하드 페일 리스크.** 미지원 브라우저(대략 Chrome<91 / Safari<16.4)에서는 graceful degradation이 아니라 **로드 자체가 실패**한다. Apps in Toss는 Toss 앱 WebView 전용이라 플랫폼 min-spec이 이를 충족하는 전제. Configuration 윈도우에 경고 HelpBox 노출. 구형 단말 잔존 시 wasm2023만 조건부 분리 필요.
- **Master = 빌드 시간 증가** (CI 콜드 ~20-30분, Bee 캐시 무효화 시 가산). 런타임/다운로드 이득과 trade-off.
- **decompressionFallback=false = CDN `Content-Encoding: br` 의존** (프로덕션 AIT CDN 보장 확인됨, vite dev/preview는 플러그인이 동일 헤더 세팅). 자체 호스팅 시 압축 헤더 미설정이면 로드 실패 — UI 경고 노출.
- **exceptionSupport는 이 PR에서 미변경**(FullWithStacktrace 유지) — wasm2023 native exception 도입 후 None/ExplicitlyThrownOnly/Full을 실측해 별도 결정(Sentry 심볼리케이션 trade-off).

## 측정 (후속)

`production-build=true` dispatch로 B0(run 26770548654, 6000.3/macOS) 대비 레버별 marginal Δ + 누적 M_full을 측정해 "50% 목표 근접도"를 보고한다. **첫 프레임 렌더까지 로딩 시간을 자동 측정하는 Playwright 프로파일링 테스트**를 동일 PR에 추가해 before/after diff를 CI에서 재현 가능하게 만든다(후속 커밋).

## 검증

- `./run-local-tests.sh --validate` ✅ (파일 구조 + SDK 유닛 18 invariants)
- E2E(vite preview에서 wasm2023 빌드 실제 로드) + production-build dispatch는 CI에서 검증

