### PR TITLE
개선: Sentry 노이즈 차단 보강 + 로그 캡처 fingerprint 정규화

### DIFF
--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -103,8 +103,8 @@ namespace AppsInToss.Editor
                 }
                 catch (Exception e)
                 {
-                    // 초기화 실패해도 Unity는 정상 작동해야 함
-                    Debug.LogWarning($"[AIT] SDK 초기화 중 예외 발생 (무시됨): {e}");
+                    // 초기화 실패해도 Unity는 정상 작동해야 함 — 복구 가능 경로이므로 Sentry 전송 안 함.
+                    AITLog.Warning($"[AIT] SDK 초기화 중 예외 발생 (무시됨): {e}", sentryCapture: false);
                 }
             };
         }
@@ -251,7 +251,9 @@ namespace AppsInToss.Editor
             }
             catch (Exception e)
             {
-                Debug.LogError($"[AIT] 패키지 매니저 체크 중 예외 발생: {e}");
+                // 사용자 환경(FS 권한/락, 동시 설치)에서 발생하는 복구 가능 예외 — finally에서 정상 복구되므로
+                // Sentry 전송 안 함. (Sentry APPS-IN-TOSS-UNITY-SDK-100: IOException "Access to the path ... is denied")
+                AITLog.Error($"[AIT] 패키지 매니저 체크 중 예외 발생: {e}", sentryCapture: false);
             }
             finally
             {

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 
@@ -115,17 +116,10 @@ namespace AppsInToss.Editor.ErrorTracker
             //     "A meta data file (.meta) exists but its asset can't be found. ..."
             // 위 "exists but its folder"와 동일한 Unity 메시지 계열로, asset 경로 유무·버전 차이와 무관하게
             // 핵심 문구 "exists but its asset" 만으로 두 변형을 모두 매칭. SDK는 이 문자열을 출력하지 않음.
+            // 사용자가 Unity 외부에서 자산을 이동/삭제해 .meta만 고아로 남은 변형(asset 경로가 Assets/ 또는
+            // Packages/...로 가변, "...please ensure that the corresponding .meta file is moved..." 안내 포함)도
+            // 동일 substring으로 매칭되므로 별도 항목이 필요 없다. (이전 중복 항목 1개 제거.)
             // Sentry APPS-IN-TOSS-UNITY-SDK-ZQ, APPS-IN-TOSS-UNITY-SDK-ZS
-            "exists but its asset",
-
-            // 위 "exists but its folder"의 에셋 변형 — 사용자가 Unity 외부에서 자산을 이동/삭제해
-            // .meta만 고아로 남은 경우 Unity 에디터가 직접 출력하는 표준 경고.
-            // 예: "A meta data file (.meta) exists but its asset 'Assets/.../Foo.cs' can't be found.
-            //      When moving or deleting files outside of Unity, please ensure that the corresponding
-            //      .meta file is moved or deleted along with it."
-            // 자산 경로(Assets/ 또는 Packages/...)가 가변이라 불변 핵심 문구만 추출.
-            // SDK는 이 문구를 출력하지 않으므로(grep 확인) AitKeywords 보호 가드와 충돌 없음.
-            // Sentry APPS-IN-TOSS-UNITY-SDK-ZS, APPS-IN-TOSS-UNITY-SDK-ZQ.
             "exists but its asset",
 
             // 외부 UPM 패키지(immutable 폴더)의 에셋에 .meta 파일이 없을 때 Unity 에디터가 직접 출력하는 표준 경고.
@@ -302,6 +296,10 @@ namespace AppsInToss.Editor.ErrorTracker
             // SDK는 IAPGetPendingOrders API는 제공하지만 "[AppsInTossIAPManager]" prefix는 출력하지 않으며(grep 확인),
             // "AppsInToss"가 "IAPManager"와 붙어 단어 경계가 깨져 AitKeywords 가드에도 안 걸리므로 ExternalAitPrefixes로 분류.
             "[AppsInTossIAPManager]",
+            // SDK-NB: [AIT_Auth] Custom Token 발급 실패 — 로컬 모드로 동작. 사용자 게임의 인증 래퍼 로그.
+            // SDK 코드는 "[AIT_Auth]" prefix를 출력하지 않음(grep 확인). 단, "[AIT"로 시작해 AitKeywords 가드에
+            // 걸려 NonSdkMessagePatterns로는 드롭 불가하므로, 가드보다 먼저 매칭되는 ExternalAitPrefixes로 분류.
+            "[AIT_Auth]",
         };
 
         #endregion
@@ -527,7 +525,12 @@ namespace AppsInToss.Editor.ErrorTracker
                 level = "warning";
             }
 
-            CaptureError(exceptionType, message, stackTrace, level);
+            // 가변 토큰(경로/해시/버전/숫자/GUID)을 정규화한 안정적 fingerprint를 부여해
+            // 동일 root cause가 Sentry에서 여러 이슈로 쪼개지는 fingerprint explosion을 방지한다.
+            // 가변 토큰이 없는 메시지는 null을 반환하므로 기본 그룹화 동작은 그대로 유지된다.
+            string[] fingerprint = BuildNormalizedFingerprint(exceptionType, message);
+
+            CaptureError(exceptionType, message, stackTrace, level, fingerprint: fingerprint);
         }
 
         /// <summary>
@@ -605,6 +608,71 @@ namespace AppsInToss.Editor.ErrorTracker
 
             _lastEventId = capturedEventId;
             AITSentryTransport.SendEnvelope(envelope);
+        }
+
+        // === fingerprint explosion 방지용 정규화 규칙 ===
+        // 메시지에 박히는 가변 토큰(파일 경로, 해시, 버전, 숫자, GUID, glob 파일명)을 placeholder로 치환해
+        // 같은 root cause의 변형들이 단일 Sentry 이슈로 묶이도록 한다. 에러 경로에서만 호출되므로(핫패스 아님)
+        // Compiled 정규식을 정적으로 캐시한다. 치환 순서 중요: 긴 토큰(경로/GUID/버전)을 숫자보다 먼저 소비.
+        private static readonly Regex _fpGuid =
+            new Regex(@"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", RegexOptions.Compiled);
+        private static readonly Regex _fpWinPath =
+            new Regex(@"[A-Za-z]:\\[^\s""'<>|]+", RegexOptions.Compiled);
+        private static readonly Regex _fpUnixPath =
+            new Regex(@"/(?:[\w.\-]+/)+[\w.\-]+", RegexOptions.Compiled);
+        private static readonly Regex _fpHexHash =
+            new Regex(@"\b[0-9a-fA-F]{16,}\b", RegexOptions.Compiled);
+        private static readonly Regex _fpVersion =
+            new Regex(@"\bv?\d+\.\d+(?:\.\d+)+(?:[\-+][0-9A-Za-z.\-]+)?\b", RegexOptions.Compiled);
+        private static readonly Regex _fpGlobFile =
+            new Regex(@"\*\.[A-Za-z][\w.]*", RegexOptions.Compiled);
+        private static readonly Regex _fpNumber =
+            new Regex(@"\d+", RegexOptions.Compiled);
+        private static readonly Regex _fpCollapseFiles =
+            new Regex(@"<file>(?:[,\s]+<file>)+", RegexOptions.Compiled);
+        private static readonly Regex _fpWhitespace =
+            new Regex(@"\s+", RegexOptions.Compiled);
+
+        /// <summary>
+        /// 로그 캡처 이벤트의 메시지에서 가변 토큰을 정규화해 안정적인 fingerprint를 생성합니다.
+        /// 가변 토큰이 하나도 없으면(정규화 결과가 원본과 동일) <c>null</c>을 반환하여 Sentry 기본 그룹화를 그대로 둡니다.
+        /// 반환 형식: <c>{ "ait-log", exceptionType, 정규화된 메시지 }</c> — "{{ default }}"를 포함하지 않으므로
+        /// 가변 텍스트가 그룹화에 다시 끼어들지 않고 동일 root cause가 단일 이슈로 묶입니다.
+        /// (빌드 에러 경로의 <see cref="CaptureBuildErrorInternal"/>는 errorCode 기반 fingerprint를 별도로 사용.)
+        /// </summary>
+        internal static string[] BuildNormalizedFingerprint(string exceptionType, string message)
+        {
+            if (string.IsNullOrEmpty(message))
+                return null;
+
+            string normalized = message;
+            normalized = _fpGuid.Replace(normalized, "<guid>");
+            normalized = _fpWinPath.Replace(normalized, "<path>");
+            normalized = _fpUnixPath.Replace(normalized, "<path>");
+            normalized = _fpHexHash.Replace(normalized, "<hash>");
+            normalized = _fpVersion.Replace(normalized, "<ver>");
+            normalized = _fpGlobFile.Replace(normalized, "<file>");
+            normalized = _fpNumber.Replace(normalized, "<n>");
+
+            // 가변 토큰이 전혀 치환되지 않았다면 fingerprint를 덮어쓰지 않고 기본 그룹화를 유지(기존 동작 불변).
+            if (string.Equals(normalized, message, StringComparison.Ordinal))
+                return null;
+
+            // "<file>, <file>, <file>"처럼 나열된 누락 파일 목록을 하나로 접어 조합 폭발(예: SDK-ZM)을 방지.
+            normalized = _fpCollapseFiles.Replace(normalized, "<file>");
+            // 줄바꿈/연속 공백 정리로 동일 메시지의 미세 변형까지 같은 키로 수렴.
+            normalized = _fpWhitespace.Replace(normalized, " ").Trim();
+
+            // 정규화 결과가 과도하게 길면 상한을 둔다(긴 경로/스택 혼입 방지).
+            if (normalized.Length > 200)
+                normalized = normalized.Substring(0, 200);
+
+            return new[]
+            {
+                "ait-log",
+                string.IsNullOrEmpty(exceptionType) ? "unknown" : exceptionType,
+                normalized
+            };
         }
 
         /// <summary>
@@ -1175,6 +1243,23 @@ namespace AppsInToss.Editor.ErrorTracker
             // Sentry APPS-IN-TOSS-UNITY-SDK-RG.
             if (message.IndexOf("AIT: [std", StringComparison.Ordinal) >= 0
                 && message.IndexOf("is not recognized as an internal or external command", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 번들 Node.js(libuv)가 종료 시점에 출력하는 내부 assertion crash — SDK 코드로 분기/조치할 정보가 아님.
+            // 예: "AIT: [stderr] Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\\win\\async.c, line 76"
+            // "AIT: [std" prefix가 SDK 키워드 가드("AIT:")에 막히므로 가드보다 먼저 매칭한다.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-BE.
+            if (message.IndexOf("AIT: [std", StringComparison.Ordinal) >= 0
+                && message.IndexOf("Assertion failed:", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 게임의 FPS 모니터가 SDK의 "[AIT]" prefix를 그대로 사용해 출력하는 성능 경고.
+            // SDK 코드는 "평균 FPS"/"목표 30+ 미달" 문자열을 출력하지 않음(grep 확인). 사용자 코드가 SDK prefix를
+            // 흉내내 AitKeywords 가드("[AIT")를 우회하므로, 가드보다 먼저 두 핵심 문구의 합성으로 좁혀 드롭한다.
+            // (FPS 수치는 가변이므로 불변 문구 "평균 FPS" + "미달"만 검사 — 정상 SDK 경고는 이 조합을 출력하지 않음.)
+            // Sentry APPS-IN-TOSS-UNITY-SDK-WK.
+            if (message.IndexOf("평균 FPS", StringComparison.Ordinal) >= 0
+                && message.IndexOf("미달", StringComparison.Ordinal) >= 0)
                 return true;
 
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용

--- a/Editor/Package/GraniteBuildRunner.cs
+++ b/Editor/Package/GraniteBuildRunner.cs
@@ -184,7 +184,9 @@ namespace AppsInToss.Editor.Package
                 {
                     if (retryInstallResult != AITConvertCore.AITExportError.SUCCEED)
                     {
-                        Debug.LogError("[AIT] granite build 실패 후 pnpm install 재시도도 실패");
+                        // 실제 터미널 실패 경로 — 캡처 유지. 단일 이슈(Sentry SDK-VH) 안에서 원인 구분이
+                        // 가능하도록 실패 카테고리(AITExportError)를 함께 남긴다.
+                        Debug.LogError($"[AIT] granite build 실패 후 pnpm install 재시도도 실패 (결과: {retryInstallResult})");
                         onComplete?.Invoke(retryInstallResult);
                         return;
                     }
@@ -202,7 +204,7 @@ namespace AppsInToss.Editor.Package
                                 var distValidation = AITBuildValidator.ValidateDistOutput(ctx.BuildProjectPath);
                                 if (distValidation != AITConvertCore.AITExportError.SUCCEED)
                                 {
-                                    Debug.LogError("[AIT] granite build 재시도도 출력물 검증 실패");
+                                    Debug.LogError($"[AIT] granite build 재시도도 출력물 검증 실패 (결과: {distValidation})");
                                     onComplete?.Invoke(distValidation);
                                     return;
                                 }
@@ -212,7 +214,7 @@ namespace AppsInToss.Editor.Package
                             }
                             else
                             {
-                                Debug.LogError("[AIT] granite build 재시도도 실패");
+                                Debug.LogError($"[AIT] granite build 재시도도 실패 (결과: {retryBuildResult})");
                             }
                             onComplete?.Invoke(retryBuildResult);
                         }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/FingerprintNormalizationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/FingerprintNormalizationTests.cs
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------------------
+// FingerprintNormalizationTests.cs - BuildNormalizedFingerprint 단위 테스트
+// 로그 캡처 이벤트의 가변 토큰(경로/해시/버전/숫자/glob 파일명)을 정규화해
+// 동일 root cause가 단일 Sentry 이슈로 묶이는지(fingerprint explosion 방지) 검증.
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+[Category("Unit")]
+public class FingerprintNormalizationTests
+{
+    #region 같은 root cause → 동일 fingerprint (explosion 수렴)
+
+    [Test]
+    public void WindowsPathVariants_ProduceSameFingerprint()
+    {
+        // Sentry SDK-100 류: 사용자/머신마다 경로가 달라도 같은 예외는 하나의 이슈로 묶여야 한다.
+        var a = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "IOException",
+            @"[AIT] 패키지 매니저 체크 중 예외: Access to the path C:\Users\alice\AppData\node-x64-installing-12345 is denied");
+        var b = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "IOException",
+            @"[AIT] 패키지 매니저 체크 중 예외: Access to the path C:\Users\bob\AppData\node-x64-installing-67890 is denied");
+
+        Assert.IsNotNull(a);
+        Assert.IsNotNull(b);
+        CollectionAssert.AreEqual(a, b);
+    }
+
+    [Test]
+    public void GlobFileList_CollapsesToSingleFingerprint()
+    {
+        // Sentry SDK-ZM: "필수 파일 누락! {목록}" — 누락 파일 조합이 달라도(1개 vs 여러 개) 같은 이슈로 수렴해야 한다.
+        // glob 파일명 → <file>, 나열된 "<file>, <file>, ..." → <file> 로 접힘.
+        var single = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "Error",
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js");
+        var many = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "Error",
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js, *.loader.js, *.data.gz");
+
+        Assert.IsNotNull(single);
+        Assert.IsNotNull(many);
+        CollectionAssert.AreEqual(single, many);
+    }
+
+    [Test]
+    public void UnixPathVariants_ProduceSameFingerprint()
+    {
+        // Sentry Bee 패밀리: artifacts 하위 경로/오브젝트 파일명이 달라도 같은 빌드 실패로 묶여야 한다.
+        var a = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "BuildError",
+            "Building Library/Bee/artifacts/abc/foo.o failed");
+        var b = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "BuildError",
+            "Building Library/Bee/artifacts/xyz/bar.o failed");
+
+        Assert.IsNotNull(a);
+        Assert.IsNotNull(b);
+        CollectionAssert.AreEqual(a, b);
+    }
+
+    #endregion
+
+    #region 다른 root cause → 다른 fingerprint (오버그룹화 방지)
+
+    [Test]
+    public void DifferentMessageFamilies_ProduceDifferentFingerprint()
+    {
+        // 누락 파일(ZM)과 폴더 삭제 실패는 서로 다른 이슈로 유지되어야 한다(과도한 병합 방지).
+        var missing = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "Error",
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js");
+        var deleteFail = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "Error",
+            @"[AIT] 이전 빌드 잔여물 정리 실패: C:\proj\ait-build");
+
+        Assert.IsNotNull(missing);
+        Assert.IsNotNull(deleteFail);
+        CollectionAssert.AreNotEqual(missing, deleteFail);
+    }
+
+    [Test]
+    public void DifferentExceptionType_ProduceDifferentFingerprint()
+    {
+        // 메시지가 동일하게 정규화돼도 예외 타입이 다르면 fingerprint도 달라야 한다(slot[1]에 타입 포함).
+        var io = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "IOException", @"삭제 실패: C:\a\b\c");
+        var unauthorized = AITEditorErrorTracker.BuildNormalizedFingerprint(
+            "UnauthorizedAccessException", @"삭제 실패: C:\a\b\c");
+
+        Assert.IsNotNull(io);
+        Assert.IsNotNull(unauthorized);
+        Assert.AreEqual(io[2], unauthorized[2]); // 정규화된 메시지는 동일
+        CollectionAssert.AreNotEqual(io, unauthorized); // 그러나 타입 slot이 달라 전체는 다름
+    }
+
+    #endregion
+
+    #region 가변 토큰 없음 / null → 기본 그룹화 유지
+
+    [Test]
+    public void CleanMessage_WithoutVariableTokens_ReturnsNull()
+    {
+        // 치환할 가변 토큰이 전혀 없으면 null을 반환해 Sentry 기본(메시지 텍스트) 그룹화를 그대로 둔다.
+        Assert.IsNull(AITEditorErrorTracker.BuildNormalizedFingerprint("Error", "[AIT] 빌드 검증 실패"));
+    }
+
+    [Test]
+    public void NullOrEmptyMessage_ReturnsNull()
+    {
+        Assert.IsNull(AITEditorErrorTracker.BuildNormalizedFingerprint("Error", null));
+        Assert.IsNull(AITEditorErrorTracker.BuildNormalizedFingerprint("Error", ""));
+    }
+
+    #endregion
+
+    #region fingerprint 형식
+
+    [Test]
+    public void Fingerprint_HasAitLogPrefixAndTypeSlot()
+    {
+        var fp = AITEditorErrorTracker.BuildNormalizedFingerprint("IOException", @"삭제 실패: C:\a\b");
+        Assert.IsNotNull(fp);
+        Assert.AreEqual(3, fp.Length);
+        Assert.AreEqual("ait-log", fp[0]);
+        Assert.AreEqual("IOException", fp[1]);
+    }
+
+    [Test]
+    public void EmptyExceptionType_FallsBackToUnknownSlot()
+    {
+        var fp = AITEditorErrorTracker.BuildNormalizedFingerprint("", @"삭제 실패: C:\a\b");
+        Assert.IsNotNull(fp);
+        Assert.AreEqual("ait-log", fp[0]);
+        Assert.AreEqual("unknown", fp[1]);
+    }
+
+    #endregion
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/FingerprintNormalizationTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/FingerprintNormalizationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec392991d42a40489f2cbf736e4e834c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2084,6 +2084,73 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 신규 노이즈: AIT_Auth prefix / FPS 모니터 / libuv assertion (Sentry SDK-NB/WK/BE)
+
+    [Test]
+    public void ExternalAitAuthPrefix_CustomTokenFailure_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-NB — 사용자 게임 인증 래퍼가 "[AIT_Auth]" prefix로 출력하는 경고.
+        // SDK 코드에는 "[AIT_Auth]" prefix가 없음(grep 확인). "[AIT"로 시작해 AitKeywords 가드에 걸리므로
+        // ExternalAitPrefixes로 가드보다 먼저 드롭되어야 한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT_Auth] Custom Token 발급 실패 — 로컬 모드로 동작"));
+    }
+
+    [Test]
+    public void RegularAitPrefix_NotAitAuth_StillProtected()
+    {
+        // "[AIT_Auth]"가 아닌 일반 "[AIT]" SDK 로그는 보호되어야 함 — 새 prefix가 과도하게 넓지 않음을 검증.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Custom Token 발급 성공"));
+    }
+
+    [Test]
+    public void FpsMonitor_AverageFpsBelowTarget_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-WK — 사용자 게임 FPS 모니터가 SDK의 "[AIT]" prefix를 흉내내 출력.
+        // SDK 코드에는 "평균 FPS"/"미달" 성능 경고 문자열이 없음(grep 확인). "[AIT]"가 AitKeywords 가드에
+        // 걸리므로 "평균 FPS" + "미달" 합성 복합 검사가 가드보다 먼저 드롭한다(FPS 수치는 가변).
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 평균 FPS 20.4 — 목표 30+ 미달"));
+    }
+
+    [Test]
+    public void FpsMonitor_UnityWarningWrapped_ReturnsTrue()
+    {
+        // Unity 로그 핸들러가 "UnityWarning:" prefix를 덧붙인 변형도 동일 복합 검사로 드롭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [AIT] 평균 FPS 18.0 — 목표 30+ 미달"));
+    }
+
+    [Test]
+    public void NormalAitFpsLog_WithoutBelowTarget_StillProtected()
+    {
+        // "평균 FPS"만 있고 "미달"이 없으면 복합 AND의 한쪽만 충족 → SDK 키워드 보호 가드가 정상 동작해야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 평균 FPS 60.0 (정상)"));
+    }
+
+    [Test]
+    public void LibuvAssertionCrash_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-BE — 번들 Node.js(libuv)가 종료 시점에 출력하는 내부 assertion crash.
+        // "AIT: [stderr]" prefix가 SDK 키워드("AIT:") 가드에 걸리므로 "AIT: [std" + "Assertion failed:" 합성으로
+        // 가드보다 먼저 드롭한다. SDK 코드로 분기/조치할 정보가 아님.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: [stderr] Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\\win\\async.c, line 76"));
+    }
+
+    [Test]
+    public void NormalAitStderr_WithoutAssertion_StillProtected()
+    {
+        // "AIT: [stderr]"이지만 어떤 복합 검사 문구(Assertion failed/is not recognized/Unknown Syntax Error/[?25)도
+        // 없는 일반 SDK stderr 전달 로그는 보호되어야 함 — SDK 키워드("AIT:") 가드로 통과.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "AIT: [stderr] granite build progress: 50%"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
## 개요

Sentry 이슈 전수 점검 결과, 진짜 SDK 버그는 사실상 0건이고 노이즈가 (a) 현행에서 새는 소수 active noise, (b) 압도적 구버전(≤2.4.x) 잔여 백로그, (c) fingerprint explosion으로 부풀려진 이슈 수로 분류됨. 이 PR은 **클라이언트 코드로 차단 가능한 (a)·(c)**를 다룬다. 모든 변경은 `Editor/` 하위이며 `Runtime/SDK/`(자동 생성)는 건드리지 않는다.

## 변경 내용

### §1 콜사이트 `sentryCapture:false` 정리 (active noise)
- `AITPackageInitializer.cs`의 복구 가능 catch 2곳(`SDK 초기화`, `패키지 매니저 체크`)을 `AITLog.Warning/Error(..., sentryCapture: false)`로 전환.
- 두 경로 모두 사용자 환경(FS 권한/락) 기인 복구 가능 예외이며 `finally`/재시도로 정상 복구 → Sentry 전송 불필요. (`SDK-100`: `IOException "Access to the path ... is denied"`)

### §2 오분류 노이즈 — prefix/복합 패턴
- `ExternalAitPrefixes`에 `"[AIT_Auth]"` 추가 — 사용자 게임 인증 래퍼 로그(`SDK-NB`). SDK는 이 prefix를 출력하지 않음(grep 확인).
- 키워드 가드 **앞**에 복합 드롭 2개 추가:
  - libuv assertion crash (`"AIT: [std"` + `"Assertion failed:"`) — 번들 Node.js 종료 시점 내부 크래시(`SDK-BE`).
  - FPS 모니터 (`"평균 FPS"` + `"미달"`) — 사용자 코드가 `[AIT]` prefix를 흉내내 가드를 우회(`SDK-WK`).
- 중복된 `"exists but its asset"` 패턴 1개 제거(런타임 동작 불변).

### §4 fingerprint 정규화 (systemic — explosion 차단)
- 신규 `BuildNormalizedFingerprint(exceptionType, message)`: 메시지의 가변 토큰(경로/해시/버전/숫자/GUID/glob 파일명)을 placeholder로 치환해 동일 root cause를 **단일 이슈**로 수렴.
- 로그 캡처 경로(`OnLogMessageReceived`)에 fingerprint 부여 — 기존엔 `fingerprint=null`이라 Sentry 기본 텍스트 그룹화가 경로/해시별로 이슈를 쪼갰음(`ZM` 누락목록, Bee `.o`, apple-signin `.png`).
- 가변 토큰이 하나도 없으면 `null` 반환 → 기본 그룹화 그대로 유지(기존 동작 불변). `"{{ default }}"`를 쓰지 않아 가변 텍스트가 그룹화에 재진입하지 않음.

### §5 VH 진단 강화
- `GraniteBuildRunner.cs` granite build 최종 실패 로그에 실패 카테고리(`AITExportError`) 부착 — 단일 이슈(`SDK-VH`) 안에서 원인 구분. **캡처는 유지**(실제 터미널 실패 경로).

### §7 회귀 테스트
- `IsKnownNonSdkMessageTests.cs` — NB/BE/WK positive + negative(정상 `[AIT]` 로그가 드롭되지 않는지) 케이스.
- 신규 `FingerprintNormalizationTests.cs` — 같은 패밀리 다른 경로/해시 → 동일 fingerprint, 다른 패밀리 → 다른 fingerprint, 가변 토큰 없음 → null.

## 검증

- 로컬 `--validate`는 현재 환경(pnpm install 단계 tarball fetch 정체)에서 실행 불가 — **이 변경셋과 무관한 환경 이슈**(C# 변경은 SDK-generator vitest 경로를 건드리지 않음).
- 대신 **CI에서 검증**: push 시 Validate/Lint 자동 트리거 + E2E(EditMode 포함) 수동 트리거. 신규/기존 ErrorTracker 테스트(`IsKnownNonSdkMessageTests`, `FingerprintNormalizationTests`, `StrictErrorSourceGateTests`)로 회귀 가드.
- push 전 adversarial multi-agent 코드 리뷰(컴파일/오버매칭/ReDoS/테스트 정합성/회귀 5개 차원, 각 발견을 독립 skeptic이 재검증) 통과 — blocker/major 0건, nit 2건은 검토 후 현행 유지가 정확하다고 판단.

## 자동 resolve (release-gated)

아래 active 이슈는 squash 머지 커밋의 `Fixes` trailer가 다음 `apps-in-toss.unity@X.Y.Z` 릴리즈 cut 시점에 release-gated로 resolve한다(머지 직후가 아님).

Fixes APPS-IN-TOSS-UNITY-SDK-ZM
Fixes APPS-IN-TOSS-UNITY-SDK-100
Fixes APPS-IN-TOSS-UNITY-SDK-NB
Fixes APPS-IN-TOSS-UNITY-SDK-WK
Fixes APPS-IN-TOSS-UNITY-SDK-BE

## 후속 핸드오프 (이 PR 범위 밖)

구버전 잔여 백로그(7J/AA/C0/K5/K6/10N/WJ/V6/Z3/Z4 + apple-signin·Bee 패밀리)는 클라이언트 코드로 소급 차단 불가 → **Sentry 콘솔 작업** 필요:
1. (§6) Project Settings → Inbound Filters에 구버전 release glob(`apps-in-toss.unity@2.0.*`~`2.4.*`) 추가 — `project:write` 권한 필요(현재 MCP 도구로 불가).
2. (§3) §6 적용 후 잔여 이슈 일괄 수동 resolve — §6 선행 필수(regression-unresolve 방지, 특히 7J=283건).
