### PR TITLE
기능: 빌드 콘텐츠 축소 레버 추가 (Mip Stripping · Optimize Mesh Data)

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -234,6 +234,19 @@ namespace AppsInToss.Editor
                 : AITDefaultSettings.GetDefaultDecompressionFallback();
             PlayerSettings.WebGL.decompressionFallback = decompressionFallback;
 
+            // ===== 콘텐츠 축소 (빌드 산출물 .data 실감축, 빌드 후 스냅샷 복원) =====
+            // 두 레버 모두 프로젝트 전역 PlayerSettings이므로 PlayerSettingsSnapshot이 캡처/복원한다
+            // (영구 오염 방지). 설정 출력은 바꾸지 않고(미사용 데이터만 제거) 산출물 크기만 줄인다.
+            bool mipStripping = editorConfig.mipStripping >= 0
+                ? editorConfig.mipStripping == 1
+                : AITDefaultSettings.GetDefaultMipStripping();
+            PlayerSettings.mipStripping = mipStripping;
+
+            bool stripUnusedMeshComponents = editorConfig.stripUnusedMeshComponents >= 0
+                ? editorConfig.stripUnusedMeshComponents == 1
+                : AITDefaultSettings.GetDefaultStripUnusedMeshComponents();
+            PlayerSettings.stripUnusedMeshComponents = stripUnusedMeshComponents;
+
             // 설정 요약 로그
             Debug.Log($"[AIT] Unity {AITDefaultSettings.GetUnityVersionGroup()} 최적화 설정 적용:");
             Debug.Log($"[AIT]   - WebGL Template: {PlayerSettings.WebGL.template}");
@@ -248,6 +261,8 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
+            Debug.Log($"[AIT]   - Mip Stripping: {mipStripping}{(editorConfig.mipStripping < 0 ? " (자동)" : "")}");
+            Debug.Log($"[AIT]   - Optimize Mesh Data: {stripUnusedMeshComponents}{(editorConfig.stripUnusedMeshComponents < 0 ? " (자동)" : "")}");
             string webGLCodeOptLog = !applyWebGLCodeOpt ? "미적용 (off)"
                 : webGLCodeOptApplied ? $"{webGLCodeOptTarget}{(editorConfig.webGLCodeOptimization < 0 ? " (자동)" : "")}"
                 : "미적용 (API 부재)";

--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -33,6 +33,8 @@ namespace AppsInToss.Editor
         public Vector2 cursorHotspot;
         public bool runInBackground;
         public bool stripEngineCode;
+        public bool mipStripping;
+        public bool stripUnusedMeshComponents;
 
         // IL2CPP/Stripping 설정
         public ScriptingImplementation scriptingBackend;
@@ -80,6 +82,8 @@ namespace AppsInToss.Editor
                 cursorHotspot = PlayerSettings.cursorHotspot,
                 runInBackground = PlayerSettings.runInBackground,
                 stripEngineCode = PlayerSettings.stripEngineCode,
+                mipStripping = PlayerSettings.mipStripping,
+                stripUnusedMeshComponents = PlayerSettings.stripUnusedMeshComponents,
 
 #if UNITY_6000_0_OR_NEWER
                 scriptingBackend = PlayerSettings.GetScriptingBackend(NamedBuildTarget.WebGL),
@@ -146,6 +150,8 @@ namespace AppsInToss.Editor
             PlayerSettings.cursorHotspot = cursorHotspot;
             PlayerSettings.runInBackground = runInBackground;
             PlayerSettings.stripEngineCode = stripEngineCode;
+            PlayerSettings.mipStripping = mipStripping;
+            PlayerSettings.stripUnusedMeshComponents = stripUnusedMeshComponents;
 
 #if UNITY_6000_0_OR_NEWER
             PlayerSettings.SetScriptingBackend(NamedBuildTarget.WebGL, scriptingBackend);

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -710,6 +710,21 @@ namespace AppsInToss.Editor
             DrawRunInBackgroundSetting();
 
             GUILayout.Space(10);
+            EditorGUILayout.LabelField("콘텐츠 축소 (빌드 산출물 크기)", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(
+                "빌드 산출물(.data)에서 사용되지 않는 데이터를 제거해 다운로드/로드 시간을 줄입니다. " +
+                "프로젝트 설정은 빌드 후 원래대로 복원됩니다.",
+                MessageType.Info
+            );
+            GUILayout.Space(5);
+
+            // Mip Stripping
+            DrawMipStrippingSetting();
+
+            // Optimize Mesh Data
+            DrawStripUnusedMeshComponentsSetting();
+
+            GUILayout.Space(10);
             EditorGUILayout.LabelField("빌드 전 검사", EditorStyles.boldLabel);
 
             // 빌드 전 최적화 검사
@@ -1037,6 +1052,58 @@ namespace AppsInToss.Editor
             EditorGUILayout.EndHorizontal();
         }
 
+        private void DrawMipStrippingSetting()
+        {
+            bool defaultValue = AITDefaultSettings.GetDefaultMipStripping();
+            bool isModified = config.mipStripping >= 0 && (config.mipStripping == 1) != defaultValue;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.mipStripping < 0
+                ? $"Mip Stripping (자동: {(defaultValue ? "활성화" : "비활성화")})"
+                : "Mip Stripping";
+
+            string[] options = { $"자동 ({(defaultValue ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.mipStripping < 0 ? 0 : config.mipStripping + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.mipStripping = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.mipStripping = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawStripUnusedMeshComponentsSetting()
+        {
+            bool defaultValue = AITDefaultSettings.GetDefaultStripUnusedMeshComponents();
+            bool isModified = config.stripUnusedMeshComponents >= 0 && (config.stripUnusedMeshComponents == 1) != defaultValue;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.stripUnusedMeshComponents < 0
+                ? $"Optimize Mesh Data (자동: {(defaultValue ? "활성화" : "비활성화")})"
+                : "Optimize Mesh Data";
+
+            string[] options = { $"자동 ({(defaultValue ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.stripUnusedMeshComponents < 0 ? 0 : config.stripUnusedMeshComponents + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.stripUnusedMeshComponents = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.stripUnusedMeshComponents = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
         // ===== 유틸리티 메서드 =====
 
         private void DrawModifiedIndicator(bool isModified)
@@ -1129,6 +1196,8 @@ namespace AppsInToss.Editor
             config.showUnityLogo = -1;
             config.decompressionFallback = -1;
             config.runInBackground = -1;
+            config.mipStripping = -1;
+            config.stripUnusedMeshComponents = -1;
             config.enableBuildOptimizationCheck = true;
         }
 

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -211,6 +211,13 @@ namespace AppsInToss
         [Tooltip("-1 = 자동 (false, Unity 6+)")]
         public int webAssemblyArithmeticExceptions = -1;
 
+        [Header("콘텐츠 축소 (빌드 산출물 .data/.wasm 실감축, 빌드 후 원복)")]
+        [Tooltip("-1 = 자동 (true). 사용하지 않는 텍스처 밉맵 레벨을 빌드 산출물에서 제거 — .data 축소. 설정된 품질의 출력은 불변(미사용 밉만 제거).")]
+        public int mipStripping = -1;
+
+        [Tooltip("-1 = 자동 (true). 어떤 머티리얼도 쓰지 않는 메시 정점 채널(노멀/탄젠트/UV 등)을 제거 — .data 축소. 주의: 런타임에 머티리얼을 교체해 제거된 채널을 요구하면 시각 오류 가능.")]
+        public int stripUnusedMeshComponents = -1;
+
         [Header("빌드 전 검사 설정")]
         [Tooltip("빌드 전 에셋 최적화 검사를 활성화합니다")]
         public bool enableBuildOptimizationCheck = true;
@@ -514,6 +521,33 @@ namespace AppsInToss
         public static bool GetDefaultRunInBackground()
         {
             return false;
+        }
+
+        /// <summary>
+        /// 기본 Mip Stripping: 활성화
+        /// 빌드 시 어떤 QualitySettings 레벨도 사용하지 않는 상위 밉맵 레벨을 산출물에서 제거해
+        /// .data 크기를 줄인다. 설정된 품질의 화면 출력은 바뀌지 않는다(사용되지 않는 밉만 제거).
+        /// QualitySettings가 텍스처 해상도를 제한하지 않으면 제거 대상이 없어 no-op(무해).
+        /// 빌드 후 PlayerSettingsSnapshot.Restore()가 사용자 원래 값으로 되돌린다.
+        /// 출처: Unity Manual reduce-the-file-size-of-your-build (Mipmap Stripping)
+        /// </summary>
+        public static bool GetDefaultMipStripping()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// 기본 Optimize Mesh Data(stripUnusedMeshComponents): 활성화
+        /// 빌드에 포함된 어떤 머티리얼/셰이더도 참조하지 않는 메시 정점 채널(노멀·탄젠트·컬러·여분 UV 등)을
+        /// 제거해 .data 메시 크기를 줄인다. Unity가 필요한 채널을 정적으로 산출하므로 일반적으로 안전.
+        /// 주의(좁은 위험): 런타임에 머티리얼을 빌드시점에 미사용이던 채널을 요구하는 것으로 교체하면
+        /// 시각 오류 가능 — 동적 머티리얼 스왑 게임은 토글로 비활성 가능.
+        /// 빌드 후 PlayerSettingsSnapshot.Restore()가 사용자 원래 값으로 되돌린다.
+        /// 출처: Unity Manual class-PlayerSettings (Optimize Mesh Data)
+        /// </summary>
+        public static bool GetDefaultStripUnusedMeshComponents()
+        {
+            return true;
         }
 
 #if UNITY_2023_3_OR_NEWER && !UNITY_6000_0_OR_NEWER


### PR DESCRIPTION
## 요약

빌드 산출물(`.data`)에서 **실제로 사용되지 않는 콘텐츠를 제거**하는 두 PlayerSettings 레버를 SDK 기본값(자동 활성)으로 추가합니다. PR #714가 전송/컴파일 계층(WebAssembly 2023·OptimizeSize·LTO·decompression-fallback off)을 다뤘다면, 이 PR은 **`.data`에 실제로 들어가는 미사용 컴포넌트를 줄이는 콘텐츠 계층**을 다룹니다.

> ⚠️ **이 PR은 #714 위에 stacked** 되어 있습니다 (base = `feature/webgl-meta-load-time`). #714가 머지되면 base가 자동으로 `main`으로 재지정됩니다.

## 레버

| 레버 | PlayerSettings | 효과 | 안전성 |
|------|----------------|------|--------|
| **Mip Stripping** | `mipStripping` | 어떤 QualitySettings 레벨도 사용하지 않는 상위 밉맵 레벨을 산출물에서 제거 → `.data` 텍스처 축소 | 설정된 품질의 출력 **불변**(미사용 밉만 제거). 런타임에 스트립된 밉 요청 시 Unity가 인접 밉으로 **대체**(graceful, 크래시 아님). QualitySettings 텍스처 제한이 없으면 **no-op**. |
| **Optimize Mesh Data** | `stripUnusedMeshComponents` | 어떤 머티리얼/셰이더도 참조하지 않는 메시 정점 채널(노멀·탄젠트·컬러·여분 UV 등) 제거 → `.data` 메시 축소 | Unity가 필요 채널을 정적 산출. **좁은 위험**: 런타임에 빌드시점 미사용 채널을 요구하는 머티리얼로 교체 시 시각 오류 가능 → 동적 머티리얼 스왑 게임은 토글로 비활성 가능. |

두 레버 모두 graceful degradation 또는 no-op 특성을 가져 **기본값 활성**이 안전합니다.

## 구현 (기존 4점 레버 패턴 준수)

- **`AITEditorScriptObject.cs`** — `mipStripping`/`stripUnusedMeshComponents` int 설정 필드(-1=자동) + `GetDefaultMipStripping()`/`GetDefaultStripUnusedMeshComponents()` 기본값 메서드(둘 다 `true`).
- **`AITBuildInitializer.cs`** — 빌드 시 `PlayerSettings`에 적용 + 요약 로그.
- **`AITBuildSession.cs`** — `PlayerSettingsSnapshot` 캡처/복원에 추가. **빌드 후 사용자 프로젝트 설정을 원래대로 복원**(영구 오염 방지).
- **`AITConfigurationWindow.cs`** — tri-state UI 토글(자동/비활성/활성) + "Reset to Defaults" 반영.

## 검증

- ✅ `./run-local-tests.sh --validate` (파일 구조 + SDK 유닛 18 invariants) 통과.
- ✅ `PlayerSettings.mipStripping` Unity 2021.3(SDK 최소 버전) 존재 확인 — [공식 docs](https://docs.unity3d.com/2021.3/Documentation/ScriptReference/PlayerSettings-mipStripping.html). 버전 가드 불필요.
- ⏳ **실 산출물 `.data` 축소량 측정 보류** — 콘텐츠 레버라 실제 에셋을 가진 Unity 빌드가 있어야 효과 측정 가능. 로컬 Unity 빌드(`./run-local-tests.sh --unity-build`)로 산출물 `.data` Δ 확인 예정. 이 때문에 **Draft**로 둡니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
