### PR TITLE
[auto-resolve] 테스트: SDK-ZM fingerprint 테스트를 실제 오류 메시지 형식에 일치

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/FingerprintNormalizationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/FingerprintNormalizationTests.cs
@@ -32,14 +32,15 @@ public class FingerprintNormalizationTests
     [Test]
     public void GlobFileList_CollapsesToSingleFingerprint()
     {
-        // Sentry SDK-ZM: "필수 파일 누락! {목록}" — 누락 파일 조합이 달라도(1개 vs 여러 개) 같은 이슈로 수렴해야 한다.
+        // Sentry SDK-ZM: "필수 파일 누락! 누락된 필수 파일: {목록}" — 누락 파일 조합이 달라도(1개 vs 여러 개) 같은 이슈로 수렴해야 한다.
+        // 실제 WebGLBuildCopier.cs 오류 메시지 형식: "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: {목록}"
         // glob 파일명 → <file>, 나열된 "<file>, <file>, ..." → <file> 로 접힘.
         var single = AITEditorErrorTracker.BuildNormalizedFingerprint(
             "Error",
-            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js");
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js");
         var many = AITEditorErrorTracker.BuildNormalizedFingerprint(
             "Error",
-            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js, *.loader.js, *.data.gz");
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js, *.loader.js, *.data.gz");
 
         Assert.IsNotNull(single);
         Assert.IsNotNull(many);
@@ -70,9 +71,10 @@ public class FingerprintNormalizationTests
     public void DifferentMessageFamilies_ProduceDifferentFingerprint()
     {
         // 누락 파일(ZM)과 폴더 삭제 실패는 서로 다른 이슈로 유지되어야 한다(과도한 병합 방지).
+        // 실제 WebGLBuildCopier.cs 오류 메시지 형식 사용.
         var missing = AITEditorErrorTracker.BuildNormalizedFingerprint(
             "Error",
-            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js");
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js");
         var deleteFail = AITEditorErrorTracker.BuildNormalizedFingerprint(
             "Error",
             @"[AIT] 이전 빌드 잔여물 정리 실패: C:\proj\ait-build");


### PR DESCRIPTION
## 범위 (중요)

이 PR은 **SDK-ZM의 실제 빌드 실패(WebGL 빌드 시 `*.framework.js` 미생성)를 해결하지 않습니다.** fingerprint 정규화 **테스트가 실제 오류 메시지 형식과 불일치**하던 것을 바로잡는 테스트 충실도 개선입니다. 따라서 Sentry 이슈 **SDK-ZM은 자동으로 닫지 않습니다** (실제 빌드 파이프라인 원인은 별도 조사 필요).

## 참조 이슈

| 이슈 ID | 제목 |
|---------|------|
| APPS-IN-TOSS-UNITY-SDK-ZM (참조만) | UnityError: [AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js |

## 발견

`FingerprintNormalizationTests.cs`의 SDK-ZM 관련 테스트가 사용하는 메시지 형식이 실제 `WebGLBuildCopier.cs:109` 출력과 불일치:

- **실제** (`WebGLBuildCopier.cs`): `[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js`
- **테스트(수정 전)**: `[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js`

→ 실제 Sentry에 보고되는 메시지 형식에 대한 fingerprint 수렴 커버리지가 없는 상태였음.

## 수정

`GlobFileList_CollapsesToSingleFingerprint`, `DifferentMessageFamilies_ProduceDifferentFingerprint` 두 테스트의 입력 메시지를 실제 출력 형식에 맞춤. **프로덕션 로직(`BuildNormalizedFingerprint`)은 변경 없음** — 테스트 입력 문자열만 수정.

## 검증

`./run-local-tests.sh --validate` → Passed: 3 / Failed: 0

---
🤖 auto-resolve Workflow 생성. 사람 머지 검토 필요 · auto-merge 안 함.