### PR TITLE
개선: Sentry 빌드 실패 cascade 차단 + 사용자/환경 노이즈 백스톱 + async 타임아웃 버그 수정

### DIFF
--- a/Editor/AITAsyncCommandRunner.cs
+++ b/Editor/AITAsyncCommandRunner.cs
@@ -242,7 +242,10 @@ namespace AppsInToss.Editor
                     process.BeginOutputReadLine();
                     process.BeginErrorReadLine();
 
-                    // 취소 가능한 대기
+                    // 취소 가능 + 타임아웃 대기. timeoutMs(기본 5분) 초과 시 프로세스를 강제 종료한다.
+                    // 이 루프가 timeoutMs를 무시하면 granite/pnpm 등 하위 프로세스가 hang 했을 때
+                    // 무한 대기에 빠져 빌드 세션이 영구 정지된다 (SDK-VH 근본 원인).
+                    var timeoutStopwatch = Stopwatch.StartNew();
                     while (!process.HasExited)
                     {
                         if (task.CancellationSource.Token.IsCancellationRequested)
@@ -256,6 +259,27 @@ namespace AppsInToss.Editor
                             EnqueueMainThread(() =>
                             {
                                 Debug.Log($"[AIT Async] 명령 취소됨: {task.Id}");
+                                task.OnComplete?.Invoke(result);
+                            });
+                            return;
+                        }
+
+                        if (timeoutMs > 0 && timeoutStopwatch.ElapsedMilliseconds > timeoutMs)
+                        {
+                            try { process.Kill(); } catch { /* 이미 종료된 프로세스는 무시 */ }
+                            process.WaitForExit(5000);
+                            result.Success = false;
+                            result.Error = $"명령 시간 초과 ({timeoutMs / 1000}초)";
+                            result.ExitCode = -1;
+                            task.State = CommandState.Failed;
+
+                            EnqueueMainThread(() =>
+                            {
+                                // 타임아웃은 환경(네트워크/registry/hang) 원인. 상위 빌드 흐름이 FAIL 결과로
+                                // 인지해 단일 CaptureBuildError로 캡처하므로 runner 레벨은 진단만 남긴다.
+                                AppsInToss.Editor.AITLog.Error(
+                                    $"[AIT Async] ✗ 명령 시간 초과 ({timeoutMs / 1000}초): {task.Id}",
+                                    sentryCapture: false);
                                 task.OnComplete?.Invoke(result);
                             });
                             return;
@@ -298,7 +322,11 @@ namespace AppsInToss.Editor
                         }
                         else
                         {
-                            Debug.LogError($"[AIT Async] ✗ 명령 실패 (Exit: {result.ExitCode}): {task.Id}");
+                            // task.Id(cmd_N)는 fingerprint 가치가 없고, 빌드 실패의 단일 캡처는 상위
+                            // (CaptureBuildError)가 담당하므로 runner 레벨 명령 실패는 진단만 남긴다 (SDK-VG/VD/VB).
+                            AppsInToss.Editor.AITLog.Error(
+                                $"[AIT Async] ✗ 명령 실패 (Exit: {result.ExitCode}): {task.Id}",
+                                sentryCapture: false);
                             if (!string.IsNullOrEmpty(result.Error))
                             {
                                 AppsInToss.Editor.AITLog.Error(
@@ -319,7 +347,9 @@ namespace AppsInToss.Editor
 
                 EnqueueMainThread(() =>
                 {
-                    Debug.LogError($"[AIT Async] 명령 실행 예외: {e}");
+                    // 프로세스 시작/IO 예외 — 환경 원인 cascade이며 호출자(빌드: CaptureBuildError /
+                    // pnpm 글로벌 설치: LogWarning)가 결과를 인지해 처리한다. runner 레벨은 Sentry 차단 (SDK-VB).
+                    AppsInToss.Editor.AITLog.Error($"[AIT Async] 명령 실행 예외: {e}", sentryCapture: false);
                     task.OnComplete?.Invoke(result);
                 });
             }

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -480,6 +480,15 @@ namespace AppsInToss
         /// <returns>변환 결과</returns>
         public static AITExportError DoExport(bool buildWebGL = true, bool doPackaging = true, bool cleanBuild = false, AITBuildProfile profile = null, string profileName = null, bool skipGraniteBuild = false)
         {
+            // play mode 중에는 BuildPipeline.BuildPlayer가 내부적으로 Addressables 빌드를
+            // PreprocessBuild에서 트리거하며 "This cannot be used during play mode." 에러를 낸다.
+            // SDK 버그가 아니라 사용자 조작 오류이므로 빌드 진입 자체를 막는다 (SDK-QJ/QH/QG/E1).
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                AITLog.Error("[AIT] play mode 중에는 빌드를 실행할 수 없습니다. Play 모드를 종료한 후 다시 시도하세요.", sentryCapture: false);
+                return AITExportError.CANCELLED;
+            }
+
             // 빌드 시작 전 취소 플래그 리셋
             ResetCancellation();
 
@@ -606,6 +615,15 @@ namespace AppsInToss
             Action<BuildPhase, float, string> onProgress = null,
             bool skipGraniteBuild = false)
         {
+            // play mode 중 빌드 진입 차단 (SDK-QJ/QH/QG/E1). DoExport와 동일한 가드 — 메뉴/UI 모든
+            // 진입점이 DoExport/DoExportAsync로 수렴하므로 두 곳만 막으면 전체 경로가 커버된다.
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                AITLog.Error("[AIT] play mode 중에는 빌드를 실행할 수 없습니다. Play 모드를 종료한 후 다시 시도하세요.", sentryCapture: false);
+                onComplete?.Invoke(AITExportError.CANCELLED);
+                return;
+            }
+
             // 배치 모드에서는 동기 실행
             if (Application.isBatchMode)
             {
@@ -864,10 +882,14 @@ namespace AppsInToss
             // WebGL Build Support 모듈 설치 여부 사전 체크
             if (!BuildPipeline.IsBuildTargetSupported(BuildTargetGroup.WebGL, BuildTarget.WebGL))
             {
-                Debug.LogError(
+                // 사용자 환경 문제(Unity Hub에서 WebGL Build Support 미설치)이지 SDK 버그가 아니다.
+                // 메시지 첫머리의 '[AIT' 토큰이 트래커 SDK 키워드 가드를 먼저 발동시켜 NonSdkMessagePatterns를
+                // 무력화하므로, sentryCapture:false가 Sentry 차단의 유일하게 확실한 방법이다 (SDK-DB).
+                AITLog.Error(
                     "[AIT] ✗ WebGL Build Support 모듈이 설치되지 않았습니다.\n" +
                     "Unity Hub를 열고 현재 Unity 버전(" + Application.unityVersion + ")에 WebGL Build Support를 추가 설치하세요.\n" +
-                    "Unity Hub > Installs > Unity " + Application.unityVersion + " > Add Modules > WebGL Build Support");
+                    "Unity Hub > Installs > Unity " + Application.unityVersion + " > Add Modules > WebGL Build Support",
+                    sentryCapture: false);
                 return AITExportError.BUILD_WEBGL_FAILED;
             }
 

--- a/Editor/AITSettingsHelper.cs
+++ b/Editor/AITSettingsHelper.cs
@@ -90,6 +90,12 @@ namespace AppsInToss
                 }
                 else
                 {
+                    // 빌드 실패의 단일 구조화 Sentry 이벤트(errorCode 기반 fingerprint). 메뉴 경로
+                    // (ShowBuildFailedDialog)와 동일하게 Configuration Window 경로도 여기서 캡처해야
+                    // runner 레벨 raw LogError(SDK-R5/10Q/VH)를 sentryCapture:false로 위임해도
+                    // 캡처 공백이 생기지 않는다.
+                    AppsInToss.Editor.ErrorTracker.AITEditorErrorTracker.CaptureBuildError(
+                        result, $"AIT: 빌드 실패: {result}", "Configuration Window");
                     AITPlatformHelper.ShowInfoDialog("실패", $"변환 중 오류가 발생했습니다: {result}", "확인");
                 }
             }
@@ -103,6 +109,9 @@ namespace AppsInToss
                 }
                 else
                 {
+                    // 위와 동일 — Configuration Window WebGL 빌드 실패도 단일 구조화 이벤트로 캡처.
+                    AppsInToss.Editor.ErrorTracker.AITEditorErrorTracker.CaptureBuildError(
+                        result, $"AIT: 빌드 실패: {result}", "Configuration Window (WebGL)");
                     AITPlatformHelper.ShowInfoDialog("실패", $"빌드 중 오류가 발생했습니다: {result}", "확인");
                 }
             }

--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -2,3 +2,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AppsInTossSDKEditor.Tests")]
 [assembly: InternalsVisibleTo("AppsInTossEditModeTests")]
+// E2E 빌드 러너(테스트 인프라)가 AITLog.Error(sentryCapture:false)로 빌드 실패 로그를
+// Sentry에 흘리지 않고 Console에만 남길 수 있도록 internal 접근 허용. E2E 실패는 CI exit
+// code로 검출되므로 Sentry 캡처 대상이 아니다 (SDK-10P cascade 차단).
+[assembly: InternalsVisibleTo("AppsInTossTestScripts.Editor")]

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -260,6 +260,36 @@ namespace AppsInToss.Editor.ErrorTracker
             // 이 경고 문자열을 직접 출력하지 않고 Unity 엔진이 출력하므로 AitKeywords 보호 가드와 충돌 없음.
             // Sentry APPS-IN-TOSS-UNITY-SDK-ZZ.
             "AssetDatabase.FindAssets: Folder not found",
+
+            // 사용자 게임의 이미지 유틸리티가 출력하는 sprite 미할당 경고 — SDK 영역 아님.
+            // 예: "[ImageUtil] Icon_1 sprite is null", "[ImageUtil] Body_7 sprite is null", "[ImageUtil] Weapon_3 sprite is null"
+            // 에셋명만 가변이고 "[ImageUtil]" prefix가 불변. SDK는 이 prefix를 출력하지 않으며(grep 확인)
+            // AitKeywords에도 없어 보호 가드와 충돌 없음.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-W1, W2, W3.
+            "[ImageUtil]",
+
+            // Unity AssetDatabase가 프로젝트 폴더 밖/절대 경로로 호출될 때 직접 출력하는 엔진 경고 — 사용자 코드의 경로 사용 오류.
+            // 예: "Invalid AssetDatabase path: /Scripts/CameraController.cs. Use path relative to the project folder."
+            // SDK가 잘못된 경로로 호출하면 경로에 AppsInToss/ait-build 토큰이 들어가 키워드 가드로 보호되므로 안전.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-QK.
+            "Invalid AssetDatabase path:",
+
+            // play mode 중 빌드/Addressables 트리거 시 Unity 엔진이 직접 출력하는 제약 에러.
+            // 현행 SDK는 DoExport/DoExportAsync 진입에서 isPlayingOrWillChangePlaymode 가드로 차단
+            // (AITConvertCore.cs, sentryCapture:false)하지만, 구버전 클라이언트 잔여 이벤트 및 Addressables 외
+            // 경로의 변형을 backstop으로 흡수한다. Unity 엔진 영문 문구이며 SDK는 이 문자열을 직접 출력하지 않는다.
+            // 예: 'Failed to build Addressables content ... "This cannot be used during play mode."'
+            //     (SDK-QJ는 기존 "Failed to build Addressables content" 패턴으로도 커버됨)
+            // Sentry APPS-IN-TOSS-UNITY-SDK-QJ/QH/QG.
+            "This cannot be used during play mode",
+
+            // pnpm/granite 명령 실패 — 현행 SDK는 source에서 sentryCapture:false로 차단하고(AITNpmRunner.cs:335/414)
+            // 터미널 단일 캡처는 상위 CaptureBuildError가 담당한다. 구버전(≤2.4.x) 클라이언트가 캡처한 채 보낸
+            // 잔여 이벤트를 backstop으로 흡수한다. "[pnpm]"은 AitKeywords에 없어 보호 가드와 충돌 없음.
+            // 예: "[pnpm] 명령 실패 (Exit Code: 1): pnpm exec ait build" (SDK-RJ)
+            //     "[pnpm] 비동기 명령 실패 (Exit Code: -1): pnpm exec granite build" (SDK-VG/VD/VB)
+            "[pnpm] 명령 실패 (Exit Code:",
+            "[pnpm] 비동기 명령 실패",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.
@@ -1094,6 +1124,22 @@ namespace AppsInToss.Editor.ErrorTracker
             // 사용자 폴더명에 'AppsInToss'가 포함돼 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다(Assets/ 경로 + .cs(L,C)).
             // SDK 자체 코드는 Packages/ 또는 Library/PackageCache/ 경로로 출력되어 Assets/ 가드와 충돌 없음.
             if (message.IndexOf("warning CS1998", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
+            // 사용자 코드의 obsolete API 사용 경고 (CS0618) — Unity 컴파일러가 직접 출력.
+            // 예: "Assets\Editor\AppsInTossWebGLProjectSetup.cs(64,9): warning CS0618:
+            //       'PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup, ManagedStrippingLevel)' is obsolete: ..."
+            //     "...(65,9): warning CS0618: 'PlayerSettings.SetScriptingBackend(BuildTargetGroup, ...)' is obsolete: ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-WN, APPS-IN-TOSS-UNITY-SDK-WM.
+            // 현행 SDK 자체는 동일 API를 #if UNITY_6000_0_OR_NEWER로 버전 분기해 obsolete 경고를 내지 않는다
+            // (AITBuildSession.cs:137-145, AITBuildInitializer.cs). 사용자 프로젝트 파일(Assets/)의 obsolete 사용만 드롭한다.
+            // 파일명에 'AppsInToss'가 단어 경계 없이 붙어(AppsInTossWebGLProjectSetup) 키워드 가드를 우회하므로
+            // 가드보다 먼저 Assets/ 경로 + .cs(L,C) 합성으로 좁혀 매칭한다. SDK 패키지(Packages/) 경로의 경고는
+            // Assets/ 가드에 걸리지 않아 키워드 가드로 보호된다.
+            if (message.IndexOf("warning CS0618", StringComparison.Ordinal) >= 0
                 && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
                     || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)

--- a/Editor/Package/GraniteBuildRunner.cs
+++ b/Editor/Package/GraniteBuildRunner.cs
@@ -41,7 +41,9 @@ namespace AppsInToss.Editor.Package
             }
             else
             {
-                Debug.LogError("[AIT] granite build 재시도도 실패");
+                // 동기 재시도 실패 — Console 진단만. Sentry 단일 이벤트는 상위
+                // (ShowBuildFailedDialog → CaptureBuildError)에 위임 (cascade 중복 방지, SDK-10Q).
+                AITLog.Error("[AIT] granite build 재시도도 실패", sentryCapture: false);
             }
             return result;
         }
@@ -90,7 +92,8 @@ namespace AppsInToss.Editor.Package
                         var distValidation = AITBuildValidator.ValidateDistOutput(ctx.BuildProjectPath);
                         if (distValidation != AITConvertCore.AITExportError.SUCCEED)
                         {
-                            Debug.LogError("[AIT] granite build가 exit code 0으로 완료되었으나 출력물 검증 실패. 재시도합니다...");
+                            // 출력물 검증 실패 → 재시도 진입(중간 단계). Sentry 캡처 불필요 (상위 단일 캡처에 위임).
+                            AITLog.Error("[AIT] granite build가 exit code 0으로 완료되었으나 출력물 검증 실패. 재시도합니다...", sentryCapture: false);
                             RetryGraniteBuildAsync(ctx, ct, onProgress, onComplete);
                             return;
                         }
@@ -184,9 +187,10 @@ namespace AppsInToss.Editor.Package
                 {
                     if (retryInstallResult != AITConvertCore.AITExportError.SUCCEED)
                     {
-                        // 실제 터미널 실패 경로 — 캡처 유지. 단일 이슈(Sentry SDK-VH) 안에서 원인 구분이
-                        // 가능하도록 실패 카테고리(AITExportError)를 함께 남긴다.
-                        Debug.LogError($"[AIT] granite build 실패 후 pnpm install 재시도도 실패 (결과: {retryInstallResult})");
+                        // granite build 실패 후 재설치까지 실패한 경로. Console 진단용으로 실패
+                        // 카테고리(AITExportError)를 남기되, Sentry 단일 이벤트는 상위
+                        // (ShowBuildFailedDialog → CaptureBuildError)에 위임한다 (SDK-VH cascade 중복 방지).
+                        AITLog.Error($"[AIT] granite build 실패 후 pnpm install 재시도도 실패 (결과: {retryInstallResult})", sentryCapture: false);
                         onComplete?.Invoke(retryInstallResult);
                         return;
                     }
@@ -204,7 +208,8 @@ namespace AppsInToss.Editor.Package
                                 var distValidation = AITBuildValidator.ValidateDistOutput(ctx.BuildProjectPath);
                                 if (distValidation != AITConvertCore.AITExportError.SUCCEED)
                                 {
-                                    Debug.LogError($"[AIT] granite build 재시도도 출력물 검증 실패 (결과: {distValidation})");
+                                    // 재시도 출력물 검증 실패 — Console 진단만, Sentry는 상위 단일 캡처에 위임.
+                                    AITLog.Error($"[AIT] granite build 재시도도 출력물 검증 실패 (결과: {distValidation})", sentryCapture: false);
                                     onComplete?.Invoke(distValidation);
                                     return;
                                 }
@@ -214,7 +219,8 @@ namespace AppsInToss.Editor.Package
                             }
                             else
                             {
-                                Debug.LogError($"[AIT] granite build 재시도도 실패 (결과: {retryBuildResult})");
+                                // 비동기 재시도 실패 — Console 진단만, Sentry는 상위 단일 캡처에 위임 (SDK-10Q).
+                                AITLog.Error($"[AIT] granite build 재시도도 실패 (결과: {retryBuildResult})", sentryCapture: false);
                             }
                             onComplete?.Invoke(retryBuildResult);
                         }

--- a/Editor/Package/PnpmRunner.cs
+++ b/Editor/Package/PnpmRunner.cs
@@ -10,9 +10,10 @@ namespace AppsInToss.Editor.Package
     /// PnpmStoreManager의 InstallStages 정책을 기반으로 frozen → lockfile 갱신 → lockfile 폐기 → clean 재시도 순으로 진행.
     /// 실패 시 NodeModulesValidator.CleanNodeModules로 복구 후 재시도.
     ///
-    /// Sentry 캡처 정책: 중간 단계 실패는 정상 fallback이므로 LogError가 발생해도 Sentry로
-    /// 보내지 않는다 (BeginSuppressLogCapture). 모든 단계가 실패한 최종 LogError만 캡처되도록
-    /// 한다 — false positive(SDK-B8/SDK-HB) 방지.
+    /// Sentry 캡처 정책: 중간/최종 단계 LogError는 모두 Console 진단 전용(sentryCapture:false)이다.
+    /// 빌드 실패의 단일 구조화 Sentry 이벤트는 상위 진입점(ShowBuildFailedDialog /
+    /// AITSettingsHelper → CaptureBuildError)이 errorCode 기반 fingerprint로 캡처한다.
+    /// — runner 레벨 cascade(SDK-R5) 및 중간 단계 false positive(SDK-B8/SDK-HB) 동시 방지.
     /// </summary>
     internal static class PnpmRunner
     {
@@ -47,7 +48,9 @@ namespace AppsInToss.Editor.Package
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"[AIT] [병렬] 백그라운드 pnpm install 예외: {e}");
+                    // 백그라운드 install 예외는 메인 빌드 흐름이 결과(FAIL_NPM_BUILD)를 인지해
+                    // 재시도/터미널 처리하므로 cascade다. Sentry 단일 이벤트는 상위 CaptureBuildError에 위임.
+                    AITLog.Error($"[AIT] [병렬] 백그라운드 pnpm install 예외: {e}", sentryCapture: false);
                     earlyCtx.PnpmInstallResult = AITConvertCore.AITExportError.FAIL_NPM_BUILD;
                 }
             });
@@ -64,7 +67,7 @@ namespace AppsInToss.Editor.Package
             var additionalPaths = AITNpmRunner.BuildAdditionalPaths(earlyCtx.PnpmPath);
 
             // 중간 단계의 실행 오류/시간 초과 LogError는 정상 fallback의 일부라 Sentry로 보내지 않는다.
-            // 모든 단계가 실패한 경우에만 스코프 밖에서 단일 LogError를 발생시킨다.
+            // 최종 실패 LogError도 sentryCapture:false이며, 빌드 실패 캡처는 상위 CaptureBuildError가 담당한다.
             AITEditorErrorTracker.BeginSuppressLogCapture();
             try
             {
@@ -178,7 +181,9 @@ namespace AppsInToss.Editor.Package
                 AITEditorErrorTracker.EndSuppressLogCapture();
             }
 
-            Debug.LogError("[AIT] [병렬] pnpm install 실패 (모든 재시도 후에도 실패)");
+            // 백그라운드 install 최종 실패 — 메인 빌드 흐름이 재설치/터미널 실패로 인지한다.
+            // Sentry 단일 이벤트는 상위(ShowBuildFailedDialog → CaptureBuildError)에 위임 (SDK-R5 cascade 방지).
+            AITLog.Error("[AIT] [병렬] pnpm install 실패 (모든 재시도 후에도 실패)", sentryCapture: false);
             return AITConvertCore.AITExportError.FAIL_NPM_BUILD;
         }
 
@@ -188,7 +193,7 @@ namespace AppsInToss.Editor.Package
         internal static AITConvertCore.AITExportError RunPnpmInstallSync(AITPackageBuilder.PackageContext ctx)
         {
             // 중간 단계 실패는 정상 fallback이라 Sentry로 보내지 않는다.
-            // 마지막 단계까지 실패하면 스코프 밖에서 단일 LogError를 발생시켜 Sentry가 캡처하게 한다.
+            // 최종 실패 LogError도 sentryCapture:false이며, 빌드 실패 캡처는 상위 CaptureBuildError가 담당한다.
             AITEditorErrorTracker.BeginSuppressLogCapture();
             try
             {
@@ -209,7 +214,8 @@ namespace AppsInToss.Editor.Package
                 AITEditorErrorTracker.EndSuppressLogCapture();
             }
 
-            Debug.LogError(FinalFailureMessage);
+            // 동기 install 최종 실패 — Sentry 단일 이벤트는 상위 CaptureBuildError에 위임 (SDK-R5 cascade 방지).
+            AITLog.Error(FinalFailureMessage, sentryCapture: false);
             return AITConvertCore.AITExportError.FAIL_NPM_BUILD;
         }
 
@@ -227,7 +233,8 @@ namespace AppsInToss.Editor.Package
         {
             if (stageIndex >= PnpmStoreManager.InstallStages.Count)
             {
-                Debug.LogError(FinalFailureMessage);
+                // 비동기 install 최종 실패 — Sentry 단일 이벤트는 상위 CaptureBuildError에 위임 (SDK-R5 cascade 방지).
+                AITLog.Error(FinalFailureMessage, sentryCapture: false);
                 onComplete?.Invoke(AITConvertCore.AITExportError.FAIL_NPM_BUILD);
                 return;
             }

--- a/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
+++ b/Tests~/E2E/SharedScripts/Editor/E2EBuildRunner.cs
@@ -3,6 +3,7 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using System.IO;
 using AppsInToss;
+using AppsInToss.Editor;
 
 /// <summary>
 /// E2E 테스트용 빌드 스크립트 - SDK API를 직접 호출
@@ -128,8 +129,11 @@ public class E2EBuildRunner
 
             if (!validation.passed)
             {
+                // 검증 에러 메시지에 ait-build 경로 등 AIT 키워드가 섞여 들어가면 SDK 에러 트래커가
+                // 캡처(IsAitRelated 통과)하므로 sentryCapture:false로 차단. E2E 검증 실패는 CI exit
+                // code 2로 검출되며 Sentry 대상이 아니다.
                 foreach (var err in validation.errors)
-                    Debug.LogError($"[Validation] {err}");
+                    AITLog.Error($"[Validation] {err}", sentryCapture: false);
                 Debug.LogError("========================================");
                 Debug.LogError("E2E Build Complete - VALIDATION FAILED");
                 Debug.LogError("========================================");
@@ -149,7 +153,10 @@ public class E2EBuildRunner
         else
         {
             string errorMessage = AITConvertCore.GetErrorMessage(result);
-            Debug.LogError($"✗ SDK build failed: {errorMessage}");
+            // errorMessage에는 "ait-build" 등 AIT 키워드가 포함되어 SDK 에러 트래커가 이 콘솔
+            // 로그를 캡처(SDK-10P cascade)한다. E2E 빌드 실패는 CI exit code 1로 검출되므로
+            // Sentry 캡처 대상이 아니다 — sentryCapture:false로 차단.
+            AITLog.Error($"✗ SDK build failed: {errorMessage}", sentryCapture: false);
             Debug.LogError("========================================");
             Debug.LogError("E2E Build Complete - FAILED");
             Debug.LogError("========================================");

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2151,6 +2151,132 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region A-5 백스톱: ImageUtil / AssetDatabase path / play mode / pnpm 실패 / CS0618 (SDK-W1~W3, QK, QJ/QH/QG, RJ, VG/VD/VB, WN/WM)
+
+    [Test]
+    public void ImageUtilSpriteNull_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-W1/W2/W3 — 사용자 게임 이미지 유틸리티의 sprite 미할당 경고.
+        // 에셋명만 가변이고 "[ImageUtil]" prefix가 불변. SDK는 이 prefix를 출력하지 않으며 AitKeywords에도 없다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[ImageUtil] Icon_1 sprite is null"));
+    }
+
+    [Test]
+    public void ImageUtilSpriteNull_OtherAssetName_ReturnsTrue()
+    {
+        // 에셋명 변형(가변 토큰)도 동일 prefix로 흡수.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[ImageUtil] Weapon_3 sprite is null"));
+    }
+
+    [Test]
+    public void SdkSpriteLog_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 자체 sprite 관련 로그("[AIT]" prefix)는 "[ImageUtil]" 패턴과 무관 — 보호되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] 스프라이트 아틀라스 빌드 완료"));
+    }
+
+    [Test]
+    public void InvalidAssetDatabasePath_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-QK — 사용자 코드가 프로젝트 폴더 밖/절대 경로로 AssetDatabase 호출.
+        // Unity 엔진이 직접 출력하는 영문 경고. SDK는 이 문구를 출력하지 않는다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Invalid AssetDatabase path: /Scripts/CameraController.cs. Use path relative to the project folder."));
+    }
+
+    [Test]
+    public void InvalidAssetDatabasePath_AitBuildToken_NeverFiltered()
+    {
+        // SDK가 잘못된 경로로 호출하면 경로에 "ait-build" 토큰이 들어가 키워드 가드가 먼저 보호한다(array 도달 전).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Invalid AssetDatabase path: ait-build/dist/index.html. Use path relative to the project folder."));
+    }
+
+    [Test]
+    public void PlayModeRestriction_AddressablesWrapped_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-QJ/QH/QG — play mode 중 Addressables/빌드 트리거 시 Unity 엔진 제약 에러.
+        // 현행 SDK는 DoExport 진입에서 play mode 가드로 차단(sentryCapture:false)하지만 구버전 잔여 이벤트를 backstop으로 흡수.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Failed to build Addressables content, content not included in Player Build. \"This cannot be used during play mode.\""));
+    }
+
+    [Test]
+    public void SdkPlayModeGuardLog_WithAitPrefix_NeverFiltered()
+    {
+        // SDK 자체 play mode 가드 메시지("[AIT]" prefix, 한글)는 "This cannot be used during play mode" 문구가 없어
+        // 자연히 통과하지만, 보호 의도를 명시적으로 검증한다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] play mode 중에는 빌드를 실행할 수 없습니다. 재생을 종료한 뒤 다시 시도하세요."));
+    }
+
+    [Test]
+    public void PnpmCommandFailed_ExitCode_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-RJ — 구버전(≤2.4.x)이 캡처한 채 보낸 "[pnpm] 명령 실패" 잔여 이벤트.
+        // 현행 SDK는 AITNpmRunner.cs:335에서 sentryCapture:false로 source 차단(이 패턴은 backstop).
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[pnpm] 명령 실패 (Exit Code: 1): pnpm exec ait build"));
+    }
+
+    [Test]
+    public void PnpmAsyncCommandFailed_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-VG/VD/VB — "[pnpm] 비동기 명령 실패" 잔여 이벤트.
+        // 현행 SDK는 AITNpmRunner.cs:414에서 sentryCapture:false로 source 차단(이 패턴은 backstop).
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[pnpm] 비동기 명령 실패 (Exit Code: -1): pnpm exec granite build"));
+    }
+
+    [Test]
+    public void PnpmCommandFailed_WithAitPrefix_NeverFiltered()
+    {
+        // SDK가 직접 "[AIT...]" prefix로 출력한 pnpm 실패 로그는 보호되어야 함(키워드 가드).
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] [pnpm] 명령 실패 (Exit Code: 1): pnpm exec ait build"));
+    }
+
+    [Test]
+    public void UserCodeCs0618_AssetsBackslashPath_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-WN — 사용자 프로젝트(Assets/) 코드의 obsolete API 사용 경고.
+        // 파일명 'AppsInTossWebGLProjectSetup'이 단어 경계 없이 붙어 키워드 가드를 우회하므로 Assets/ + .cs(L,C) 합성으로 좁혀 매칭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\Editor\\AppsInTossWebGLProjectSetup.cs(64,9): warning CS0618: 'PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup, ManagedStrippingLevel)' is obsolete: 'Use SetManagedStrippingLevel(NamedBuildTarget, ManagedStrippingLevel) instead.'"));
+    }
+
+    [Test]
+    public void UserCodeCs0618_AssetsForwardSlashPath_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-WM — POSIX 경로 변형(SetScriptingBackend).
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/Editor/AppsInTossWebGLProjectSetup.cs(65,9): warning CS0618: 'PlayerSettings.SetScriptingBackend(BuildTargetGroup, ScriptingImplementation)' is obsolete: 'Use SetScriptingBackend(NamedBuildTarget, ScriptingImplementation) instead.'"));
+    }
+
+    [Test]
+    public void Cs0618_SdkPackagePath_NeverFiltered()
+    {
+        // SDK 자체 .cs의 CS0618은 Packages/com.toss.apps-in-toss 경로로 출력 → Assets/ 가드 미충족 +
+        // "apps-in-toss" 키워드 가드 보호. 현행 SDK는 #if UNITY_6000_0_OR_NEWER로 obsolete API를 피하지만
+        // 만약 출력되더라도 SDK 코드 경고는 절대 드롭하지 않는다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/com.toss.apps-in-toss/Editor/Foo.cs(10,5): warning CS0618: 'X' is obsolete: 'use Y'"));
+    }
+
+    [Test]
+    public void Cs0618_NoAssetsPath_NotFiltered()
+    {
+        // Assets/ 경로도 .cs(L,C)도 없는 일반 CS0618(예: 사전 컴파일된 dll)은 합성 가드가 매칭되지 않아 통과.
+        // CS0618을 무차별 드롭하지 않음을 검증.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SomeLib.dll: warning CS0618: 'Z' is obsolete"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
## 배경

Sentry 이슈 전수 점검 후속 — PR #715(노이즈 차단 보강 + fingerprint 정규화)에 이어, **남은 실(real) 이슈들의 근본 원인을 코드 레벨에서 차단**한다. 핵심은 빌드 실패 시 runner 레벨 raw `LogError`가 상위 `CaptureBuildError`와 **중복 캡처(cascade)** 되어 단일 빌드 실패가 Sentry에 여러 이벤트로 쪼개지던 구조다.

방침: runner 레벨 진단 로그는 모두 `sentryCapture:false`(Console 전용)로 전환하고, 빌드 실패의 **단일 구조화 이벤트**(errorCode 기반 fingerprint)는 진입점(`ShowBuildFailedDialog` / `AITSettingsHelper` → `CaptureBuildError`)에서만 캡처한다. 사용자/Unity 엔진이 직접 출력하는 노이즈는 필터 백스톱으로 흡수한다.

> 모든 변경은 `Editor/`(+ E2E 테스트 인프라)이며 `Runtime/SDK/`(자동 생성)는 건드리지 않음 → 생성기 재생성 불필요.

## 변경 내용

- **A-1 `GraniteBuildRunner`** — 동기/비동기 재시도·출력물 검증 실패 `LogError`를 `sentryCapture:false`로 전환. 빌드 실패 단일 캡처는 상위에 위임 (cascade 중복 제거). → `10Q`, `VH`
- **A-2 `AITAsyncCommandRunner`** — **무한 대기 버그 수정**: 대기 루프가 `timeoutMs`(기본 5분)를 무시해 하위 프로세스(granite/pnpm) hang 시 빌드 세션이 영구 정지하던 문제를 고침(초과 시 `process.Kill()`). 명령/예외 실패 로그는 `sentryCapture:false`. → `VG`/`VD`/`VB`, `VH` 근본 원인
- **A-3 `PnpmRunner`** — 중간/최종 단계 `LogError`를 모두 `sentryCapture:false`로 통일(기존엔 최종 단계만 캡처되어 cascade 발생). → `R5`
- **A-4 `AITConvertCore`** — play mode 중 빌드 진입을 `DoExport`/`DoExportAsync` 두 진입점에서 차단(`isPlayingOrWillChangePlaymode` 가드). WebGL Build Support 미설치 안내도 `sentryCapture:false`. → `QJ`/`QH`/`QG`(play-mode 클러스터), `DB`
- **A-4 `AITSettingsHelper`** — Configuration Window 빌드 실패도 `CaptureBuildError`로 단일 캡처(메뉴 경로와 동일) — runner 로그를 `sentryCapture:false`로 위임해도 캡처 공백이 안 생기게.
- **A-5 `AITEditorErrorTracker`** — 사용자/Unity 엔진 노이즈 백스톱:
  - 배열 패턴: `[ImageUtil]`(W1/W2/W3), `Invalid AssetDatabase path:`(QK), `This cannot be used during play mode`(QJ/QH backstop), `[pnpm] 명령 실패 (Exit Code:`(RJ), `[pnpm] 비동기 명령 실패`(VG/VD/VB) — 모두 구버전(≤2.4.x) 잔여 이벤트 backstop (현행 SDK는 source에서 이미 차단)
  - **CS0618 복합 가드**: `Assets/` 사용자 코드 한정 obsolete 경고 드롭(WN/WM). 파일명 `AppsInTossWebGLProjectSetup`이 단어 경계 없이 `AppsInToss`를 포함해 `error_source:sdk`로 오분류 → 키워드 가드 우회 → **복합 가드가 유일한 차단 경로**. SDK 패키지(`Packages/`) 경고는 보호.
- **A-6 `E2EBuildRunner`** — 빌드/검증 실패 `LogError`를 `sentryCapture:false`로 전환(E2E 실패는 CI exit code로 검출되므로 Sentry 대상 아님). `AssemblyInfo`에 `InternalsVisibleTo("AppsInTossTestScripts.Editor")` 추가. → `10P`
- **회귀 테스트** — `IsKnownNonSdkMessageTests`에 신규 패턴 positive/negative 케이스 추가. 특히 **AIT 키워드가 섞여도 SDK 로그는 드롭되지 않는지** negative 검증(`[AIT] [pnpm] ...`, `Packages/...CS0618`, `ait-build` 경로 등).

## 대상 이슈 (모두 Sentry 메시지 대조 확인)

| 이슈 | 메시지 | 유입 release | 조치 |
|---|---|---|---|
| 10Q | `[AIT] granite build 재시도도 실패` | 3.0.0-beta (47, escalating) | A-1 |
| R5 | `[AIT] pnpm install 실패 (모든 재시도...)` | 3.0.0-beta (17, escalating) | A-3 |
| 10P | `✗ SDK build failed:` (E2E 러너) | 3.0.0-beta (62, escalating) | A-6 |
| VH | `granite build 실패 후 pnpm install 재시도도 실패` | 2.4.7 | A-1/A-2 |
| VG/VD/VB | `[pnpm] 비동기 명령 실패 ...` | 2.4.7 | A-2 |
| RJ | `[pnpm] 명령 실패 (Exit Code: 1)` | 2.4.7 | A-5 |
| DB | `✗ WebGL Build Support 모듈이...` | 2.4.7 | A-4 |
| QJ/QH/QG | play-mode Addressables 클러스터 | 2.4.7 | A-4 |
| QK | `Invalid AssetDatabase path:` | 2.4.7 | A-5 |
| W1/W2/W3 | `[ImageUtil] ... sprite is null` | 2.4.6 | A-5 |
| WN/WM | `...AppsInTossWebGLProjectSetup.cs ... CS0618` | 2.4.7 (`error_source:sdk` 오분류) | A-5 |

## 주의 / 후속

- **auto-resolve는 release-gated**: 아래 `Fixes` trailer는 squash 커밋에 들어가지만 실제 close는 **다음 `apps-in-toss.unity` 릴리즈 cut 시점**에 발생. 머지 직후엔 unresolved가 정상.
- **구버전(≤2.4.x) 잔여 이벤트**는 릴리즈 후에도 구버전 클라이언트가 계속 보내면 regression-unresolve될 수 있음 → 서버단 Inbound Filter(구버전 release glob, `project:write` 필요)는 본 PR 범위 밖. 코드 변경 없는 순수 잔여 백로그(7J/AA/C0/K5/K6/10N/WJ/V6/Z3/Z4, apple-signin·Bee 패밀리)는 수동 resolve로 별도 정리.
- **3.0.0-beta E2E 빌드 실패 관찰**: 10P/10Q/R5는 모두 현행 `3.0.0-beta.9d42c0b` 채널에서 escalating 중 — 이는 **베타 E2E CI 빌드가 실제로 실패(`pnpm 빌드에 실패했습니다.`)** 하고 있다는 신호다. 본 PR은 그 **Sentry cascade 노이즈**를 차단하며(빌드 실패 자체는 CI exit code로 여전히 검출), 베타 빌드 실패의 근본 원인은 별도 조사 대상(로컬 Unity 재현 필요).

## 테스트

- `./run-local-tests.sh --validate` ✅ (파일 구조 + Playwright + SDK 유닛 invariants 18 passed)
- EditMode(`IsKnownNonSdkMessageTests` 회귀) — 로컬에 Unity 미설치로 CI EditMode job에서 검증. 필터 체인 순서(ExternalAitPrefixes → 복합 가드 → 키워드 가드 → 배열 루프) 대조로 신규 15개 케이스 expectation 수동 검증 완료.

Fixes APPS-IN-TOSS-UNITY-SDK-10Q
Fixes APPS-IN-TOSS-UNITY-SDK-10P
Fixes APPS-IN-TOSS-UNITY-SDK-VH
Fixes APPS-IN-TOSS-UNITY-SDK-VG
Fixes APPS-IN-TOSS-UNITY-SDK-VD
Fixes APPS-IN-TOSS-UNITY-SDK-VB
Fixes APPS-IN-TOSS-UNITY-SDK-R5
Fixes APPS-IN-TOSS-UNITY-SDK-RJ
Fixes APPS-IN-TOSS-UNITY-SDK-DB
Fixes APPS-IN-TOSS-UNITY-SDK-QJ
Fixes APPS-IN-TOSS-UNITY-SDK-QH
Fixes APPS-IN-TOSS-UNITY-SDK-QG
Fixes APPS-IN-TOSS-UNITY-SDK-QK
Fixes APPS-IN-TOSS-UNITY-SDK-W1
Fixes APPS-IN-TOSS-UNITY-SDK-W2
Fixes APPS-IN-TOSS-UNITY-SDK-W3
Fixes APPS-IN-TOSS-UNITY-SDK-WN
Fixes APPS-IN-TOSS-UNITY-SDK-WM
