### PR TITLE
개선: 빌드 실패 Sentry 캡처에 명령 exit code + stderr 진단(extra) 첨부 (§5)

### DIFF
--- a/Editor/AITAsyncCommandRunner.cs
+++ b/Editor/AITAsyncCommandRunner.cs
@@ -267,9 +267,19 @@ namespace AppsInToss.Editor
                         if (timeoutMs > 0 && timeoutStopwatch.ElapsedMilliseconds > timeoutMs)
                         {
                             try { process.Kill(); } catch { /* 이미 종료된 프로세스는 무시 */ }
-                            process.WaitForExit(5000);
+                            // WaitForExit(ms)는 비동기 출력 핸들러 플러시를 보장하지 않는다. 종료가 확인되면
+                            // 무파라미터 오버로드를 한 번 더 호출해 outputBuilder/errorBuilder를 마저 채운다(.NET 권장, §5).
+                            if (process.WaitForExit(5000))
+                                process.WaitForExit();
                             result.Success = false;
-                            result.Error = $"명령 시간 초과 ({timeoutMs / 1000}초)";
+                            // 타임아웃 직전까지 누적된 stderr/stdout을 결과에 실어 상위 빌드 실패 캡처의
+                            // 진단(extra)에 hang 원인이 남도록 한다 — 동기 경로와 대칭, 빈 result.Output/Error
+                            // 회귀 방지 (§5). "명령 시간 초과" 문구를 접두로 둬 메시지 가독성을 유지한다(매칭 계약 아님).
+                            result.Output = outputBuilder.ToString();
+                            string timeoutStderr = errorBuilder.ToString();
+                            result.Error = string.IsNullOrEmpty(timeoutStderr)
+                                ? $"명령 시간 초과 ({timeoutMs / 1000}초)"
+                                : $"명령 시간 초과 ({timeoutMs / 1000}초)\n{timeoutStderr}";
                             result.ExitCode = -1;
                             task.State = CommandState.Failed;
 

--- a/Editor/AITBuildDiagnostics.cs
+++ b/Editor/AITBuildDiagnostics.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Text;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 빌드 실패 시 마지막 외부 명령(pnpm install / granite build)의 exit code + stderr 말미를 보관해,
+    /// 상위 단일 Sentry 캡처(<see cref="ErrorTracker.AITEditorErrorTracker.CaptureBuildError"/>)에
+    /// 진단 컨텍스트(extra)로 첨부하기 위한 프로세스-로컬 버퍼.
+    ///
+    /// 배경: 빌드 실패 cascade(SDK-R5/10P/10Q)는 runner 레벨에서 모두 sentryCapture:false로 Console에만
+    /// 남기고, 단일 구조화 이벤트는 errorCode 기반 fingerprint로 상위에서 캡처한다. 그 결과 Sentry 메시지에는
+    /// GetErrorMessage(errorCode)의 일반 해결책 텍스트만 담겨 pnpm/granite의 실제 실패 원인(exit code, stderr
+    /// 말미)이 빠져 triage가 불가능했다(계획 §5). 이 버퍼는 fingerprint를 errorCode로 유지(= 이슈 1개)하면서
+    /// extra로만 원인 진단을 실어 "1 이슈 + triage 가능"을 동시에 만족시킨다.
+    ///
+    /// 정책:
+    ///  - 외부 명령이 최종 실패하면 <see cref="RecordFailure"/>로 마지막 1건만 보관(중간 폴백 단계는 덮어씀).
+    ///  - 외부 명령이 성공하면 <see cref="ClearOnSuccess"/>로 직전 폴백 단계의 stale 기록을 비운다.
+    ///  - 상위 캡처가 <see cref="ConsumeForCapture"/>로 읽고 즉시 비운다(소비 후 무관한 후속 캡처에 재첨부 방지).
+    ///  - stderr은 말미 일부만, 사용자 홈 경로는 &lt;home&gt;으로 마스킹, 도메인 리로드/세션 교체 stale은 신선도 창으로 차단.
+    /// </summary>
+    internal static class AITBuildDiagnostics
+    {
+        private const int MaxStderrTailChars = 2000;
+        private const int MaxStageChars = 300;
+
+        // 동일 빌드 흐름 내 실패→상위 캡처는 보통 수 초 내 발생한다. 도메인 리로드나 세션 교체로 남은 stale
+        // 기록을 무관한 후속 빌드의 캡처에 첨부하지 않도록 신선도 창을 둔다.
+        private static readonly TimeSpan StaleThreshold = TimeSpan.FromMinutes(30);
+
+        // 신선도 창 판정용 시계. 프로덕션은 UtcNow, 테스트는 가짜 시각을 주입해 stale 경로를 검증한다.
+        internal static Func<DateTime> UtcNowProvider = () => DateTime.UtcNow;
+
+        private static readonly object _gate = new object();
+        private static bool _has;
+        private static string _stage;
+        private static int _exitCode;
+        private static string _stderrTail;
+        private static DateTime _recordedAtUtc;
+
+        /// <summary>
+        /// 외부 명령(pnpm/granite)이 실패했을 때 stage 라벨 + exit code + stderr 말미를 기록한다.
+        /// stderr이 비어 있으면 stdout 말미로 폴백한다. 마지막 1건만 유지하므로 중간 폴백 단계는 덮어쓰여
+        /// 최종적으로 가장 마지막(=터미널) 실패가 남는다.
+        /// </summary>
+        internal static void RecordFailure(string stage, int exitCode, string stderr, string stdout = null)
+        {
+            string raw = !string.IsNullOrEmpty(stderr) ? stderr : stdout;
+            string tail = BuildTail(raw);
+            string maskedStage = CapStage(MaskHome(stage));
+            lock (_gate)
+            {
+                _has = true;
+                _stage = maskedStage;
+                _exitCode = exitCode;
+                _stderrTail = tail;
+                _recordedAtUtc = UtcNowProvider();
+            }
+        }
+
+        /// <summary>
+        /// 외부 명령이 최종 성공하면 직전 폴백 단계의 실패 기록을 비운다. 복구된 단계의 stderr이 이후 무관한
+        /// 빌드 실패 캡처에 잘못 첨부되는 것을 방지한다.
+        /// </summary>
+        internal static void ClearOnSuccess()
+        {
+            lock (_gate)
+            {
+                _has = false;
+                _stage = null;
+                _stderrTail = null;
+                _exitCode = 0;
+                _recordedAtUtc = default;
+            }
+        }
+
+        /// <summary>
+        /// 상위 빌드 실패 캡처가 호출. 신선한 진단이 있으면 사람이 읽을 수 있는 블록(stage/exit_code/stderr_tail)을
+        /// 반환하고 버퍼를 비운다. 진단이 없거나 신선도 창을 벗어났으면 <c>null</c>.
+        /// </summary>
+        internal static string ConsumeForCapture()
+        {
+            lock (_gate)
+            {
+                if (!_has)
+                    return null;
+
+                bool fresh = (UtcNowProvider() - _recordedAtUtc) < StaleThreshold;
+                string block = null;
+                if (fresh)
+                {
+                    var sb = new StringBuilder();
+                    sb.Append("stage: ").Append(string.IsNullOrEmpty(_stage) ? "(unknown)" : _stage).Append('\n');
+                    sb.Append("exit_code: ").Append(_exitCode);
+                    if (!string.IsNullOrEmpty(_stderrTail))
+                        sb.Append('\n').Append("stderr_tail:\n").Append(_stderrTail);
+                    block = sb.ToString();
+                }
+
+                // 신선하든 stale이든 소비했으면 비운다(소비-once).
+                _has = false;
+                _stage = null;
+                _stderrTail = null;
+                _exitCode = 0;
+                _recordedAtUtc = default;
+                return block;
+            }
+        }
+
+        private static string BuildTail(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return null;
+            string masked = MaskHome(s.Trim());
+            if (masked.Length <= MaxStderrTailChars)
+                return masked;
+            return "…(truncated)\n" + masked.Substring(masked.Length - MaxStderrTailChars);
+        }
+
+        private static string CapStage(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return s;
+            return s.Length <= MaxStageChars ? s : s.Substring(0, MaxStageChars) + "…";
+        }
+
+        // 사용자 홈 경로를 <home>으로 마스킹해 Sentry extra의 PII를 최소화한다.
+        private static string MaskHome(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return s;
+            try
+            {
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                if (!string.IsNullOrEmpty(home))
+                    s = s.Replace(home, "<home>");
+            }
+            catch
+            {
+                // 환경 조회 실패는 무시 — 마스킹은 best-effort.
+            }
+            return s;
+        }
+    }
+}

--- a/Editor/AITBuildDiagnostics.cs.meta
+++ b/Editor/AITBuildDiagnostics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6d3cbf4804c4b0788fed33a51fdb138
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/AITNpmRunner.cs
+++ b/Editor/AITNpmRunner.cs
@@ -282,6 +282,9 @@ namespace AppsInToss.Editor
                                 AITLog.Error($"[{pmName}] 출력:\n{timeoutOutput.Trim()}", sentryCapture: false);
                             if (!string.IsNullOrEmpty(timeoutError))
                                 AITLog.Error($"[{pmName}] 오류:\n{timeoutError.Trim()}", sentryCapture: false);
+                            // 상위 단일 빌드 실패 캡처(CaptureBuildError)에 exit/stderr 진단을 실어줄 수 있도록 기록 (§5).
+                            AITBuildDiagnostics.RecordFailure(
+                                $"{pmName} {arguments} (timeout {maxWaitMs / 1000}s)", -1, timeoutError, timeoutOutput);
                             return AITConvertCore.AITExportError.FAIL_NPM_BUILD;
                         }
 
@@ -320,6 +323,8 @@ namespace AppsInToss.Editor
 
                     if (success)
                     {
+                        // 명령이 성공하면 직전 폴백 단계의 실패 진단을 비운다 (복구된 단계 stderr 오첨부 방지, §5).
+                        AITBuildDiagnostics.ClearOnSuccess();
                         Debug.Log($"[Platform] ✓ 명령 성공 (Exit Code: {process.ExitCode})");
                         if (!string.IsNullOrEmpty(output))
                         {
@@ -341,6 +346,9 @@ namespace AppsInToss.Editor
                         {
                             AITLog.Error($"[{pmName}] 오류:\n{error}", sentryCapture: false);
                         }
+                        // 상위 단일 빌드 실패 캡처(CaptureBuildError)에 exit/stderr 진단을 실어줄 수 있도록 기록 (§5).
+                        AITBuildDiagnostics.RecordFailure(
+                            $"{pmName} {arguments}", process.ExitCode, error, output);
                         return AITConvertCore.AITExportError.FAIL_NPM_BUILD;
                     }
                 }
@@ -354,6 +362,8 @@ namespace AppsInToss.Editor
                 // 동기 npm 실행 예외 — 호출자가 NODE_NOT_FOUND로 인지 후 상위 가이드 출력.
                 // 예외 본문에 명령줄/path가 들어가 fingerprint가 폭주하므로 Sentry 차단.
                 AITLog.Error($"[{pmName}] 명령 실행 오류: {e}", sentryCapture: false);
+                // 상위 캡처(NODE_NOT_FOUND)에 예외 요지를 진단으로 실어줄 수 있도록 기록 (§5).
+                AITBuildDiagnostics.RecordFailure($"{pmName} {arguments} (exception)", -1, e.Message);
                 return AITConvertCore.AITExportError.NODE_NOT_FOUND;
             }
         }
@@ -404,6 +414,8 @@ namespace AppsInToss.Editor
 
                     if (result.Success)
                     {
+                        // 성공 시 직전 폴백 단계 실패 진단을 비운다 (§5).
+                        AITBuildDiagnostics.ClearOnSuccess();
                         Debug.Log($"[{pmName}] ✓ 비동기 명령 성공: {pmName} {arguments}");
                         onComplete?.Invoke(AITConvertCore.AITExportError.SUCCEED);
                     }
@@ -416,6 +428,9 @@ namespace AppsInToss.Editor
                         {
                             AITLog.Warning($"[{pmName}] 오류:\n{result.Error}", sentryCapture: false);
                         }
+                        // 상위 단일 빌드 실패 캡처에 exit/stderr 진단을 실어줄 수 있도록 기록 (§5).
+                        AITBuildDiagnostics.RecordFailure(
+                            $"{pmName} {arguments} (async)", result.ExitCode, result.Error, result.Output);
                         onComplete?.Invoke(AITConvertCore.AITExportError.FAIL_NPM_BUILD);
                     }
                 },

--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -572,7 +572,8 @@ namespace AppsInToss.Editor.ErrorTracker
             string stackTrace,
             string level = "error",
             Dictionary<string, string> extraTags = null,
-            string[] fingerprint = null)
+            string[] fingerprint = null,
+            Dictionary<string, string> extra = null)
         {
             if (!AITErrorTrackerConsent.IsEnabled())
                 return;
@@ -630,6 +631,7 @@ namespace AppsInToss.Editor.ErrorTracker
                 eventId: out string capturedEventId,
                 level: level,
                 tags: tags,
+                extra: extra,
                 breadcrumbs: _breadcrumbs.Count > 0 ? new List<AITSentryEnvelope.Breadcrumb>(_breadcrumbs) : null,
                 fingerprint: fingerprint,
                 release: GetRelease(),
@@ -775,6 +777,22 @@ namespace AppsInToss.Editor.ErrorTracker
                 extraTags["build_profile"] = profileName;
             }
 
+            // pnpm/granite 등 외부 명령이 남긴 마지막 실패 진단(exit code + stderr 말미)을 extra로 첨부한다 (§5).
+            // fingerprint는 여전히 errorCode 기반이므로 그룹화(이슈 1개)는 유지되고, 진단만 이벤트에 실린다.
+            // extra(인덱싱되지 않는 자유 컨텍스트)에 담으므로 tag 길이/cardinality 제약과 무관하다.
+            // 소비-once 정책상, 동일 세션에서 같은 errorCode가 CaptureError의 dedup으로 드롭되는 후속 캡처는
+            // 진단도 함께 비워진다. 드롭된 이벤트엔 어차피 첨부할 곳이 없고, 먼저 전송된 대표 이벤트가 진단을
+            // 이미 실어 보냈으므로 triage에는 영향이 없다(이슈당 대표 1건 + 진단 보존).
+            Dictionary<string, string> extra = null;
+            string buildDiag = AITBuildDiagnostics.ConsumeForCapture();
+            if (!string.IsNullOrEmpty(buildDiag))
+            {
+                extra = new Dictionary<string, string>
+                {
+                    { "build_command_diagnostics", buildDiag }
+                };
+            }
+
             var fingerprint = new[] { "{{ default }}", errorCode.ToString() };
 
             CaptureError(
@@ -783,7 +801,8 @@ namespace AppsInToss.Editor.ErrorTracker
                 stackTrace: null,
                 level: "error",
                 extraTags: extraTags,
-                fingerprint: fingerprint
+                fingerprint: fingerprint,
+                extra: extra
             );
         }
 

--- a/Editor/Package/PnpmRunner.cs
+++ b/Editor/Package/PnpmRunner.cs
@@ -118,6 +118,7 @@ namespace AppsInToss.Editor.Package
                                 // HasExited 폴링 + CancellationToken 체크
                                 int maxWaitMs = 300000; // 5분
                                 var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                                bool timedOut = false;
 
                                 while (!process.HasExited)
                                 {
@@ -136,19 +137,27 @@ namespace AppsInToss.Editor.Package
                                         // 5분 타임아웃은 환경(네트워크/registry) 원인이며 다음 폴백
                                         // 단계로 진행됨. Sentry로 fingerprint를 흘리지 않음.
                                         AITLog.Error($"[AIT] [병렬] pnpm {label} 시간 초과 ({maxWaitMs / 1000}초)", sentryCapture: false);
+                                        // 모든 단계가 타임아웃으로 끝나도 상위 캡처에 진단이 남도록 기록 (§5).
+                                        AITBuildDiagnostics.RecordFailure(
+                                            $"pnpm {label} (timeout {maxWaitMs / 1000}s)", -1,
+                                            errorBuilder.ToString(), outputBuilder.ToString());
+                                        timedOut = true;
                                         break; // 다음 단계로
                                     }
 
                                     Thread.Sleep(200);
                                 }
 
-                                // 아직 종료 안 된 경우 (타임아웃으로 빠져나온 경우) → 다음 단계
-                                if (!process.HasExited) continue;
+                                // 타임아웃으로 Kill한 경우 process.HasExited가 true가 되어 아래 exit-code 경로로
+                                // 떨어지면 위 (timeout) 진단을 일반 라벨로 덮어쓴다. timedOut이면 곧장 다음 단계로 (§5).
+                                if (timedOut || !process.HasExited) continue;
 
                                 process.WaitForExit(5000); // 출력 버퍼 플러시
 
                                 if (process.ExitCode == 0)
                                 {
+                                    // 성공 시 직전 폴백 단계의 실패 진단을 비운다 (§5).
+                                    AITBuildDiagnostics.ClearOnSuccess();
                                     Debug.Log($"[AIT] [병렬] ✓ pnpm {label} 성공");
                                     return AITConvertCore.AITExportError.SUCCEED;
                                 }
@@ -160,6 +169,8 @@ namespace AppsInToss.Editor.Package
                                     Debug.Log($"[AIT] [병렬] 출력:\n{output.Trim()}");
                                 if (!string.IsNullOrEmpty(error))
                                     Debug.Log($"[AIT] [병렬] 오류:\n{error.Trim()}");
+                                // 상위 단일 빌드 실패 캡처(CaptureBuildError)에 exit/stderr 진단을 실어줄 수 있도록 기록 (§5).
+                                AITBuildDiagnostics.RecordFailure($"pnpm {label}", process.ExitCode, error, output);
                             }
                             finally
                             {
@@ -171,6 +182,8 @@ namespace AppsInToss.Editor.Package
                     {
                         // 프로세스 시작/IO 예외 — 다음 폴백 단계로 진행. 환경 원인 cascade이므로 Sentry 차단.
                         AITLog.Error($"[AIT] [병렬] pnpm {label} 실행 오류: {e}", sentryCapture: false);
+                        // 모든 단계가 시작 단계 예외로 끝나도 상위 캡처가 원인을 받도록 진단 기록 (§5).
+                        AITBuildDiagnostics.RecordFailure($"pnpm {label} (process-start exception)", -1, e.Message);
                     }
 
                     Debug.Log($"[AIT] [병렬] pnpm install ({label}) 실패, 다음 단계로...");

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/BuildDiagnosticsTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/BuildDiagnosticsTests.cs
@@ -1,0 +1,243 @@
+// ---------------------------------------------------------------------------
+// BuildDiagnosticsTests.cs - AITBuildDiagnostics 단위 테스트 (계획 §5)
+// pnpm/granite 등 외부 명령의 마지막 실패(exit code + stderr 말미)를 보관해
+// 상위 단일 빌드 실패 Sentry 캡처(CaptureBuildError)에 extra로 첨부하는 버퍼 검증.
+// 정책: 실패 시 RecordFailure(마지막 1건), 성공 시 ClearOnSuccess, 캡처 시 ConsumeForCapture(소비-once).
+// ---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor;
+
+[TestFixture]
+[Category("Unit")]
+public class BuildDiagnosticsTests
+{
+    [SetUp]
+    public void Reset()
+    {
+        // 정적 시계 시드를 실제 시각으로 복원(직전 테스트가 가짜 시각을 주입했을 수 있음).
+        AITBuildDiagnostics.UtcNowProvider = () => System.DateTime.UtcNow;
+        // 정적 버퍼이므로 각 테스트 전에 비워 상호 간섭을 막는다.
+        AITBuildDiagnostics.ClearOnSuccess();
+    }
+
+    [TearDown]
+    public void Drain()
+    {
+        // 혹시 남은 기록이 다음 테스트로 새지 않도록 소비.
+        AITBuildDiagnostics.ConsumeForCapture();
+        // 가짜 시계가 다음 테스트로 누수되지 않도록 복원.
+        AITBuildDiagnostics.UtcNowProvider = () => System.DateTime.UtcNow;
+    }
+
+    #region 기본 기록/소비
+
+    [Test]
+    public void NoFailureRecorded_ConsumeReturnsNull()
+    {
+        Assert.IsNull(AITBuildDiagnostics.ConsumeForCapture());
+    }
+
+    [Test]
+    public void RecordFailure_ConsumeReturnsStageExitAndStderr()
+    {
+        AITBuildDiagnostics.RecordFailure("pnpm install", 1, "ERR_PNPM_FROZEN_LOCKFILE: lockfile drift");
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("stage: pnpm install", diag);
+        StringAssert.Contains("exit_code: 1", diag);
+        StringAssert.Contains("stderr_tail:", diag);
+        StringAssert.Contains("ERR_PNPM_FROZEN_LOCKFILE", diag);
+    }
+
+    [Test]
+    public void Consume_IsConsumeOnce()
+    {
+        AITBuildDiagnostics.RecordFailure("granite build", 2, "some build error");
+
+        Assert.IsNotNull(AITBuildDiagnostics.ConsumeForCapture());
+        // 두 번째 호출은 비어 있어야 한다(소비-once) — 무관한 후속 캡처에 재첨부 방지.
+        Assert.IsNull(AITBuildDiagnostics.ConsumeForCapture());
+    }
+
+    #endregion
+
+    #region 성공 시 초기화 (복구된 폴백 단계 stale 제거)
+
+    [Test]
+    public void ClearOnSuccess_DiscardsPriorFailure()
+    {
+        AITBuildDiagnostics.RecordFailure("pnpm install (frozen)", 1, "frozen lockfile failed");
+        AITBuildDiagnostics.ClearOnSuccess();
+
+        Assert.IsNull(AITBuildDiagnostics.ConsumeForCapture(),
+            "성공으로 복구되면 직전 폴백 단계 실패 진단은 비워져야 한다.");
+    }
+
+    #endregion
+
+    #region 마지막 1건 유지 (터미널 실패가 남음)
+
+    [Test]
+    public void RecordFailure_KeepsMostRecent()
+    {
+        AITBuildDiagnostics.RecordFailure("pnpm install (frozen)", 1, "first stage stderr");
+        AITBuildDiagnostics.RecordFailure("pnpm install (clean retry)", 7, "final stage stderr");
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("stage: pnpm install (clean retry)", diag);
+        StringAssert.Contains("exit_code: 7", diag);
+        StringAssert.Contains("final stage stderr", diag);
+        StringAssert.DoesNotContain("first stage stderr", diag);
+    }
+
+    #endregion
+
+    #region stderr 폴백 / 마스킹 / 절단
+
+    [Test]
+    public void EmptyStderr_FallsBackToStdout()
+    {
+        AITBuildDiagnostics.RecordFailure("granite build", 1, stderr: "", stdout: "only on stdout");
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("only on stdout", diag);
+    }
+
+    [Test]
+    public void StderrAndStdoutEmpty_StillRecordsStageAndExit()
+    {
+        AITBuildDiagnostics.RecordFailure("pnpm install (timeout 300s)", -1, stderr: null, stdout: null);
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("stage: pnpm install (timeout 300s)", diag);
+        StringAssert.Contains("exit_code: -1", diag);
+        // stderr이 없으면 stderr_tail 섹션은 생략된다.
+        StringAssert.DoesNotContain("stderr_tail:", diag);
+    }
+
+    [Test]
+    public void UserHomePath_IsMasked()
+    {
+        string home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home))
+            Assert.Ignore("이 환경에서는 홈 경로를 조회할 수 없어 마스킹 검증을 건너뜀.");
+
+        AITBuildDiagnostics.RecordFailure("pnpm install", 1,
+            $"ENOENT: no such file at {home}/proj/node_modules/.bin");
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("<home>", diag);
+        StringAssert.DoesNotContain(home, diag);
+    }
+
+    [Test]
+    public void LongStderr_IsTruncatedToTail()
+    {
+        // 앞부분은 잘리고 말미만 남아야 한다 — 절단 마커 + 말미 보존 검증.
+        string head = new string('A', 4000);
+        string tail = "TAIL_MARKER_END_OF_STDERR";
+        AITBuildDiagnostics.RecordFailure("pnpm install", 1, head + tail);
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("…(truncated)", diag);
+        StringAssert.Contains(tail, diag, "stderr 말미는 보존되어야 한다.");
+        Assert.Less(diag.Length, head.Length, "절단으로 전체 길이가 원본보다 짧아야 한다.");
+    }
+
+    #endregion
+
+    #region stage 캡 / 마스킹 / sentinel
+
+    [Test]
+    public void LongStage_IsCapped()
+    {
+        // stage 라벨이 비정상적으로 길어도(외부 명령 인자 폭주 등) extra가 부풀지 않도록 캡된다.
+        string longStage = new string('S', 500);
+        AITBuildDiagnostics.RecordFailure(longStage, 1, "short err");
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("…", diag, "캡 시 절단 마커(…)가 붙어야 한다.");
+        StringAssert.DoesNotContain(longStage, diag, "원본 길이의 stage가 그대로 실리면 안 된다.");
+    }
+
+    [Test]
+    public void UserHomePath_InStage_IsMasked()
+    {
+        string home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home))
+            Assert.Ignore("이 환경에서는 홈 경로를 조회할 수 없어 stage 마스킹 검증을 건너뜀.");
+
+        AITBuildDiagnostics.RecordFailure($"pnpm install (cwd {home}/proj)", 1, "boom");
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("<home>", diag);
+        StringAssert.DoesNotContain(home, diag, "stage에 박힌 홈 경로도 마스킹되어야 한다.");
+    }
+
+    [Test]
+    public void NullStage_RendersUnknownSentinel()
+    {
+        AITBuildDiagnostics.RecordFailure(null, 5, "some error");
+
+        string diag = AITBuildDiagnostics.ConsumeForCapture();
+
+        Assert.IsNotNull(diag);
+        StringAssert.Contains("stage: (unknown)", diag);
+        StringAssert.Contains("exit_code: 5", diag);
+    }
+
+    #endregion
+
+    #region 신선도 창 (도메인 리로드 / 세션 교체 stale 차단)
+
+    [Test]
+    public void FreshWithinWindow_ReturnsContent()
+    {
+        var t0 = new System.DateTime(2026, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
+        AITBuildDiagnostics.UtcNowProvider = () => t0;
+        AITBuildDiagnostics.RecordFailure("pnpm install", 1, "boom");
+
+        // 임계(30분) 직전 — 여전히 신선.
+        AITBuildDiagnostics.UtcNowProvider = () => t0.AddMinutes(29);
+
+        Assert.IsNotNull(AITBuildDiagnostics.ConsumeForCapture(),
+            "신선도 창 안의 진단은 반환되어야 한다.");
+    }
+
+    [Test]
+    public void StaleBeyondWindow_ReturnsNullAndClears()
+    {
+        var t0 = new System.DateTime(2026, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
+        AITBuildDiagnostics.UtcNowProvider = () => t0;
+        AITBuildDiagnostics.RecordFailure("pnpm install", 1, "boom");
+
+        // 임계(30분) 초과 — 도메인 리로드/세션 교체로 남은 stale로 간주.
+        AITBuildDiagnostics.UtcNowProvider = () => t0.AddMinutes(31);
+
+        Assert.IsNull(AITBuildDiagnostics.ConsumeForCapture(),
+            "신선도 창을 벗어난 진단은 무관한 후속 빌드에 첨부되면 안 된다.");
+        // stale도 소비-once로 비워져, 시계를 되돌려도 재등장하지 않아야 한다.
+        AITBuildDiagnostics.UtcNowProvider = () => t0;
+        Assert.IsNull(AITBuildDiagnostics.ConsumeForCapture(),
+            "stale 소비 후 버퍼는 비워져야 한다.");
+    }
+
+    #endregion
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/BuildDiagnosticsTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/BuildDiagnosticsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9bed329977445e3802a05ecc27ba1d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경

빌드 실패 cascade(SDK-R5/10P FAIL_NPM_BUILD/10Q granite)는 runner 레벨에서 모두 `sentryCapture:false`로 Console에만 남기고, 단일 구조화 이벤트만 errorCode 기반 fingerprint로 상위(`CaptureBuildErrorInternal`)에서 캡처한다(PR #721). 그 결과 Sentry 메시지에는 `GetErrorMessage(errorCode)`의 일반 해결책 텍스트만 담겨 **pnpm/granite의 실제 실패 원인(exit code, stderr 말미)이 빠져 triage가 불가능**했다.

## 변경 (계획 §5)

외부 명령의 마지막 실패를 프로세스-로컬 버퍼에 보관했다가 상위 단일 캡처에 **Sentry `extra`**로 첨부한다. **fingerprint는 errorCode 기반을 그대로 유지** → "이슈 1개" 그룹화는 변하지 않고, 진단만 이벤트에 실린다.

- **`Editor/AITBuildDiagnostics.cs`** (신규) — `stage` + `exit_code` + `stderr_tail` 버퍼.
  - 정책: 실패 시 `RecordFailure`(마지막 1건 유지) · 성공 시 `ClearOnSuccess`(복구된 폴백 단계 stale 제거) · 캡처 시 `ConsumeForCapture`(소비-once).
  - 안전장치: 홈 경로 `<home>` 마스킹(PII 최소화), stderr 말미 절단(~2KB), stage 캡(300자), **30분 신선도 창**(도메인 리로드/세션 교체 stale 차단), `lock` 단일 동기화(동기/EnqueueMainThread/ThreadPool writer).
- **`AITNpmRunner` / `PnpmRunner`** — 동기·비동기·타임아웃·예외 실패 경로에 `RecordFailure`, 성공 경로에 `ClearOnSuccess` 배선.
- **`AITAsyncCommandRunner`** — 비동기 타임아웃 시 누적 `stderr/stdout`을 `result`에 실어 진단 유실 방지(동기 경로와 대칭). `WaitForExit(ms)` 후 무파라미터 오버로드를 호출해 비동기 스트림 플러시 보장(.NET 권장).
- **`PnpmRunner`** — 타임아웃 후 exit-code 경로가 `(timeout)` 라벨을 일반 라벨로 덮어쓰는 중복 기록을 `timedOut` 플래그로 차단.
- **`AITEditorErrorTracker.CaptureBuildErrorInternal`** — `ConsumeForCapture()` 결과를 `extra["build_command_diagnostics"]`로 첨부. `CaptureError`에 `extra` 파라미터 추가(fingerprint 뒤). `extra`는 인덱싱되지 않는 자유 컨텍스트라 tag 길이/cardinality 제약과 무관.

## 의도적으로 `Fixes` 트레일러 없음

§5는 **진단 강화이지 노이즈 suppression이 아니다.** 10P/10Q/R5/VH는 실제 빌드 실패 경로이므로 캡처를 **유지**하고 원인 가시성만 높인다(계획 §5: "캡처는 유지, 모니터링 대상"). 자동 resolve 대상이 아니다.

## 검증

- `./run-local-tests.sh --validate` ✅ (3/3, SDK 18 invariants 포함)
- EditMode 단위 테스트 신규: `BuildDiagnosticsTests` — 기록/소비-once/`ClearOnSuccess`/마지막1건/stdout 폴백/홈 마스킹/stderr·stage 절단/null stage sentinel/신선도 창. (Unity 미설치 로컬이라 컴파일·EditMode는 CI에서 실행)
- 어셈블리 접근: 테스트는 `AppsInTossEditModeTests`(InternalsVisibleTo 대상, `AppsInTossSDKEditor` 참조)에 속해 `internal` 멤버 접근 가능.

## 영향 범위

- `Editor/` 하위만 변경, `Runtime/SDK/`(자동 생성) 무관 → 생성기 재생성 불필요.
- 런타임/빌드 파이프라인 동작 변화 없음(실패 시 진단 기록만 추가).