### PR TITLE
기능: Sentry environment/release를 SDK 버전에서 자동 파생 (prerelease 분리)

### DIFF
--- a/Docs~/SentryIntegration.md
+++ b/Docs~/SentryIntegration.md
@@ -120,10 +120,24 @@ AIT SDK는 WebGL 빌드 시 `SENTRY_DSN` 환경변수에서 `SentryOptions.asset
 | 변수 | 용도 | 예시 |
 |------|------|------|
 | `SENTRY_DSN` | DSN → `SentryOptions.asset` 자동 생성 | `https://key@sentry.io/123` |
-| `SENTRY_ENVIRONMENT` | 환경 식별자 (자동 주입) | `production`, `staging` |
-| `SENTRY_RELEASE` | 릴리즈 버전 (자동 주입) | `my-app@1.0.0` |
+| `SENTRY_ENVIRONMENT` | 환경 override (선택 — 미지정 시 SDK 버전에서 자동 파생) | `production`, `staging` |
+| `SENTRY_RELEASE` | 릴리즈 override (선택 — 미지정 시 `apps-in-toss.unity@{버전}` 자동 파생) | `my-app@1.0.0` |
 
 > **자동 주입 동작**: WebGL 빌드 시 `AITSentryDsnInjector`(`IPreprocessBuildWithReport`, callbackOrder=0)가 `SENTRY_DSN` 환경변수를 감지하면 `SentryOptions.asset`을 Unity API로 생성합니다. 이미 asset이 존재하면 사용자 설정을 보호하기 위해 건너뜁니다.
+
+#### environment / release 자동 파생 (prerelease 분리)
+
+`SENTRY_ENVIRONMENT` / `SENTRY_RELEASE`를 명시하지 않으면, `AITSentryDsnInjector`는 SDK 버전(`AITVersion.Version`)에서 두 값을 자동 파생합니다 (`AITSentryReleaseResolver`). Sentry의 `environment`/`release`는 init-time(`BeforeSceneLoad`) 전용 옵션이라 런타임 scope로 바꿀 수 없으므로, 빌드 시점에 asset으로 bake 합니다.
+
+| SDK 버전 | environment | release |
+|----------|-------------|---------|
+| stable (예: `2.6.1`, `3.0.0`) | *(미설정 → Sentry 기본값 `production`)* | `apps-in-toss.unity@2.6.1` |
+| prerelease (예: `3.0.0-beta.9d42c0b`) | `beta` | `apps-in-toss.unity@3.0.0-beta.9d42c0b` |
+| unknown (패키지 정보 없음) | *(미설정)* | *(미설정)* |
+
+- **목적**: 베타 파일럿(`#beta`) 빌드의 에러가 `environment:beta`로 분리되어 **stable triage·알림·release-health를 오염시키지 않습니다**. stable 빌드는 environment를 설정하지 않아 기존 동작(`production`)이 그대로 유지됩니다.
+- **우선순위**: 명시된 `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` env가 있으면 **항상 그 값이 자동 파생을 이깁니다**. CI에서 임의 환경 라벨을 강제하고 싶을 때 사용하세요.
+- **release 정합**: 자동 파생된 release(`apps-in-toss.unity@{버전}`)는 `release.yml`이 생성하는 Sentry release 식별자와 동일한 prefix를 사용하므로, release-health 및 `Fixes` trailer 기반 auto-resolve 연결이 정확해집니다.
 
 ### sentry-cli (빌드 타임)
 
@@ -198,7 +212,7 @@ PlayerSettings.SetIl2CppStacktraceInformation(WebGL, MethodFileLineNumber)
 
 1. **DSN 확인**: `Tools > Sentry`에서 DSN이 올바르게 설정되어 있는지 확인
 2. **로그 확인**: 콘솔에 `[AIT:Sentry] Sentry is not enabled` 메시지가 있으면 Sentry SDK가 비활성 상태
-3. **WebGL CI/CD**: `SENTRY_DSN` 환경변수를 설정하면 빌드 시 `SentryOptions.asset`이 자동 생성됩니다. 빌드 로그에서 `[AITSentry] SentryOptions.asset을 환경변수에서 생성했습니다`를 확인하세요.
+3. **WebGL CI/CD**: `SENTRY_DSN` 환경변수를 설정하면 빌드 시 `SentryOptions.asset`이 자동 생성됩니다. 빌드 로그에서 `[AITSentry] SentryOptions.asset을 생성했습니다:`로 시작하는 줄을 확인하세요. 같은 블록의 `Environment` / `Release` 줄에서 자동 파생된 값도 함께 확인할 수 있습니다.
 
 ### IL2CPP 빌드에서 AIT 태그가 없음
 

--- a/Editor/Sentry/AITSentryDsnInjector.cs
+++ b/Editor/Sentry/AITSentryDsnInjector.cs
@@ -12,6 +12,7 @@ using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEngine;
 using Sentry.Unity;
+using AppsInToss;
 
 namespace AppsInToss.Sentry.Editor
 {
@@ -67,13 +68,31 @@ namespace AppsInToss.Sentry.Editor
             options.Enabled = true;
             options.Dsn = dsn;
 
-            string environment = Environment.GetEnvironmentVariable("SENTRY_ENVIRONMENT");
+            // environment / release 결정 (AITSentryReleaseResolver):
+            //   - 명시된 SENTRY_ENVIRONMENT / SENTRY_RELEASE env가 있으면 그 값을 우선 사용
+            //   - 없으면 SDK 버전(AITVersion.Version)에서 자동 파생:
+            //       · prerelease 빌드(예: 3.0.0-beta.x) → environment "beta" (stable triage 오염 방지)
+            //       · release 식별자 → "apps-in-toss.unity@{버전}" (release.yml의 Sentry release 컨벤션과 정합)
+            //   - stable 빌드는 environment를 설정하지 않아 Sentry 기본값("production")을 그대로 사용 (동작 불변)
+            string sdkVersion = AITVersion.Version;
+            string environment = AITSentryReleaseResolver.ResolveEnvironment(
+                sdkVersion, Environment.GetEnvironmentVariable("SENTRY_ENVIRONMENT"));
+            string release = AITSentryReleaseResolver.ResolveRelease(
+                sdkVersion, Environment.GetEnvironmentVariable("SENTRY_RELEASE"));
+
+            // release가 비어 있으면(override 없음 + SDK 버전이 unknown) environment/release를 bake할 수 없다.
+            // 이 경우 Sentry가 기본값(environment="production", release=Application.version)을 사용하므로,
+            // prerelease 빌드라면 이벤트가 stable("production") triage로 흘러갈 수 있어 경고로 가시화한다.
+            if (string.IsNullOrEmpty(release))
+            {
+                Debug.LogWarning($"{Tag} SDK 버전을 확인할 수 없어(unknown) environment/release를 SentryOptions.asset에 bake하지 않습니다 - 이벤트가 의도한 Sentry environment로 분리되지 않을 수 있습니다");
+            }
+
             if (!string.IsNullOrEmpty(environment))
             {
                 options.EnvironmentOverride = environment;
             }
 
-            string release = Environment.GetEnvironmentVariable("SENTRY_RELEASE");
             if (!string.IsNullOrEmpty(release))
             {
                 options.ReleaseOverride = release;
@@ -82,7 +101,7 @@ namespace AppsInToss.Sentry.Editor
             AssetDatabase.CreateAsset(options, configPath);
             AssetDatabase.SaveAssets();
 
-            Debug.Log($"{Tag} SentryOptions.asset을 환경변수에서 생성했습니다: {configPath}");
+            Debug.Log($"{Tag} SentryOptions.asset을 생성했습니다: {configPath}");
             Debug.Log($"{Tag}   DSN: {MaskDsn(dsn)}");
             if (!string.IsNullOrEmpty(environment))
                 Debug.Log($"{Tag}   Environment: {environment}");

--- a/Runtime/Helpers/AITSentryReleaseResolver.cs
+++ b/Runtime/Helpers/AITSentryReleaseResolver.cs
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITSentryReleaseResolver.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Sentry environment/release 파생 로직
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+// 빌드 전처리기(AppsInToss.Sentry.Editor)와 EditMode 테스트가 internal 파생 로직에 접근합니다.
+[assembly: InternalsVisibleTo("AppsInToss.Sentry.Editor")]
+[assembly: InternalsVisibleTo("AppsInTossEditModeTests")]
+
+namespace AppsInToss
+{
+    /// <summary>
+    /// SDK 버전 문자열로부터 Sentry environment / release 식별자를 파생하는 순수 로직.
+    /// 문자열 연산만 수행하므로 Sentry 패키지에 의존하지 않으며, Sentry 미설치 환경에서도 단위 테스트가 가능합니다.
+    /// </summary>
+    /// <remarks>
+    /// 사용처: <c>AITSentryDsnInjector</c>가 WebGL 빌드 시 <c>SentryOptions.asset</c>에 bake 합니다.
+    /// Sentry의 environment/release는 init-time(BeforeSceneLoad) 전용 옵션이라 런타임 scope로 변경할 수 없으므로,
+    /// 빌드 시점에 결정해 asset으로 구워야 합니다. prerelease SDK(베타 파일럿) 빌드의 에러가 stable triage를
+    /// 오염시키지 않도록 environment를 분리하는 것이 목적입니다.
+    /// </remarks>
+    internal static class AITSentryReleaseResolver
+    {
+        /// <summary>prerelease 빌드에 부여되는 Sentry environment 이름.</summary>
+        internal const string BetaEnvironment = "beta";
+
+        /// <summary>release 식별자 prefix. release.yml의 getsentry/action-release 컨벤션(apps-in-toss.unity@X.Y.Z)과 동일.</summary>
+        internal const string ReleasePrefix = "apps-in-toss.unity@";
+
+        // AITVersion.Version이 패키지 정보를 찾지 못했을 때 반환하는 폴백 값.
+        private const string UnknownVersion = "unknown";
+
+        /// <summary>
+        /// 버전 문자열이 semver prerelease(예: "3.0.0-beta.9d42c0b", "3.0.0-rc.1")인지 판정합니다.
+        /// </summary>
+        /// <remarks>
+        /// SemVer 2.0 규칙을 따릅니다:
+        ///   - build metadata("+..." 뒤)는 판정에서 제외 (예: "2.6.1+build-20240101"은 stable).
+        ///   - '-' 뒤에 비어 있지 않은 prerelease 식별자가 있어야 prerelease (예: "3.0.0-"은 stable로 취급).
+        /// </remarks>
+        internal static bool IsPrerelease(string sdkVersion)
+        {
+            if (string.IsNullOrWhiteSpace(sdkVersion) || sdkVersion == UnknownVersion)
+            {
+                return false;
+            }
+
+            // build metadata("+...")는 prerelease 판정에서 제외하고 core 부분만 검사한다.
+            string core = sdkVersion.Split('+')[0];
+            int dash = core.IndexOf('-');
+            return dash >= 0 && dash < core.Length - 1;
+        }
+
+        /// <summary>
+        /// Sentry environment를 결정합니다.
+        /// 명시된 <paramref name="envOverride"/>가 있으면 그 값을 우선하고, 없으면 prerelease 빌드일 때만 "beta"를 반환합니다.
+        /// stable 빌드는 <c>null</c>을 반환하여 environment를 설정하지 않으므로 Sentry 기본값("production")을 그대로 사용합니다(동작 불변).
+        /// </summary>
+        /// <param name="sdkVersion">SDK 버전 문자열(<c>AITVersion.Version</c>).</param>
+        /// <param name="envOverride">명시적 환경변수(<c>SENTRY_ENVIRONMENT</c>). 비어 있으면 무시됩니다.</param>
+        /// <returns>설정할 environment 문자열. <c>null</c>이면 override 하지 않음.</returns>
+        internal static string ResolveEnvironment(string sdkVersion, string envOverride)
+        {
+            if (!string.IsNullOrEmpty(envOverride))
+            {
+                return envOverride;
+            }
+
+            return IsPrerelease(sdkVersion) ? BetaEnvironment : null;
+        }
+
+        /// <summary>
+        /// Sentry release를 결정합니다.
+        /// 명시된 <paramref name="releaseOverride"/>가 있으면 그 값을 우선하고, 없으면 버전을 알 때 "apps-in-toss.unity@{버전}"을 반환합니다.
+        /// 이는 release.yml이 생성하는 Sentry release 식별자와 정합하여 release-health/auto-resolve 연결을 정확하게 합니다.
+        /// </summary>
+        /// <param name="sdkVersion">SDK 버전 문자열(<c>AITVersion.Version</c>).</param>
+        /// <param name="releaseOverride">명시적 환경변수(<c>SENTRY_RELEASE</c>). 비어 있으면 무시됩니다.</param>
+        /// <returns>설정할 release 문자열. <c>null</c>이면 override 하지 않음(Sentry 기본값 Application.version 사용).</returns>
+        internal static string ResolveRelease(string sdkVersion, string releaseOverride)
+        {
+            if (!string.IsNullOrEmpty(releaseOverride))
+            {
+                return releaseOverride;
+            }
+
+            if (string.IsNullOrWhiteSpace(sdkVersion) || sdkVersion == UnknownVersion)
+            {
+                return null;
+            }
+
+            return ReleasePrefix + sdkVersion;
+        }
+    }
+}

--- a/Runtime/Helpers/AITSentryReleaseResolver.cs.meta
+++ b/Runtime/Helpers/AITSentryReleaseResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eafc56166466497386c6c74773a32382
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/SentryReleaseResolverTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/SentryReleaseResolverTests.cs
@@ -1,0 +1,158 @@
+// -----------------------------------------------------------------------
+// SentryReleaseResolverTests.cs - EditMode AITSentryReleaseResolver 단위 테스트
+// Level 0: prerelease SDK 빌드 시 Sentry environment/release 자동 분리 로직 검증
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss;
+
+[TestFixture]
+public class SentryReleaseResolverTests
+{
+    // =====================================================
+    // IsPrerelease: prerelease 버전 (true 기대)
+    // =====================================================
+
+    [TestCase("3.0.0-beta.9d42c0b")]
+    [TestCase("3.0.0-rc.1")]
+    [TestCase("3.0.0-alpha")]
+    [TestCase("1.0.0-next.5")]
+    [TestCase("3.0.0-beta.9d42c0b+20240101")]   // prerelease + build metadata → prerelease
+    public void IsPrerelease_PrereleaseVersions_ReturnsTrue(string version)
+    {
+        Assert.IsTrue(
+            AITSentryReleaseResolver.IsPrerelease(version),
+            $"'{version}' should be classified as prerelease");
+    }
+
+    // =====================================================
+    // IsPrerelease: stable 버전 (false 기대)
+    // =====================================================
+
+    [TestCase("2.6.1")]
+    [TestCase("3.0.0")]
+    [TestCase("10.20.30")]
+    [TestCase("3.0.0-")]                   // 빈 trailing hyphen → SemVer상 prerelease 식별자 없음 → stable
+    [TestCase("2.6.1+build")]              // build metadata만 → stable
+    [TestCase("2.6.1+build-20240101")]     // build metadata 내 hyphen은 무시 → stable
+    public void IsPrerelease_StableVersions_ReturnsFalse(string version)
+    {
+        Assert.IsFalse(
+            AITSentryReleaseResolver.IsPrerelease(version),
+            $"'{version}' should be classified as stable");
+    }
+
+    // =====================================================
+    // IsPrerelease: 누락/unknown/공백 (false 기대)
+    // =====================================================
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("unknown")]
+    public void IsPrerelease_MissingOrUnknown_ReturnsFalse(string version)
+    {
+        Assert.IsFalse(
+            AITSentryReleaseResolver.IsPrerelease(version),
+            $"'{version}' should not be treated as prerelease");
+    }
+
+    // =====================================================
+    // ResolveEnvironment: 자동 파생 (override 없음)
+    // =====================================================
+
+    [Test]
+    public void ResolveEnvironment_Prerelease_NoOverride_ReturnsBeta()
+    {
+        Assert.AreEqual(
+            "beta",
+            AITSentryReleaseResolver.ResolveEnvironment("3.0.0-beta.9d42c0b", null));
+    }
+
+    [TestCase("2.6.1")]
+    [TestCase("3.0.0")]
+    public void ResolveEnvironment_Stable_NoOverride_ReturnsNull(string version)
+    {
+        // stable은 null → Sentry 기본값 "production" 유지 (동작 불변)
+        Assert.IsNull(AITSentryReleaseResolver.ResolveEnvironment(version, null));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("unknown")]
+    [TestCase("3.0.0-")]   // prerelease 식별자가 비어 있어 stable로 취급 → environment 미설정
+    public void ResolveEnvironment_UnknownVersion_NoOverride_ReturnsNull(string version)
+    {
+        Assert.IsNull(AITSentryReleaseResolver.ResolveEnvironment(version, null));
+    }
+
+    // =====================================================
+    // ResolveEnvironment: 명시 override 우선
+    // =====================================================
+
+    [TestCase("3.0.0-beta.9d42c0b")]   // prerelease여도 override가 이김
+    [TestCase("2.6.1")]
+    [TestCase("unknown")]
+    [TestCase(null)]
+    public void ResolveEnvironment_ExplicitOverride_Wins(string version)
+    {
+        Assert.AreEqual(
+            "staging",
+            AITSentryReleaseResolver.ResolveEnvironment(version, "staging"));
+    }
+
+    // =====================================================
+    // ResolveRelease: 자동 파생 (override 없음)
+    // =====================================================
+
+    [Test]
+    public void ResolveRelease_Prerelease_NoOverride_PrefixesVersion()
+    {
+        Assert.AreEqual(
+            "apps-in-toss.unity@3.0.0-beta.9d42c0b",
+            AITSentryReleaseResolver.ResolveRelease("3.0.0-beta.9d42c0b", null));
+    }
+
+    [Test]
+    public void ResolveRelease_Stable_NoOverride_PrefixesVersion()
+    {
+        Assert.AreEqual(
+            "apps-in-toss.unity@2.6.1",
+            AITSentryReleaseResolver.ResolveRelease("2.6.1", null));
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("unknown")]
+    public void ResolveRelease_UnknownVersion_NoOverride_ReturnsNull(string version)
+    {
+        Assert.IsNull(AITSentryReleaseResolver.ResolveRelease(version, null));
+    }
+
+    [Test]
+    public void ResolveRelease_TrailingHyphenVersion_PassesThroughFaithfully()
+    {
+        // "3.0.0-"은 stable로 분류(environment 미설정)되지만, release는 실제 버전 문자열을 그대로 반영한다.
+        Assert.AreEqual(
+            "apps-in-toss.unity@3.0.0-",
+            AITSentryReleaseResolver.ResolveRelease("3.0.0-", null));
+    }
+
+    // =====================================================
+    // ResolveRelease: 명시 override 우선
+    // =====================================================
+
+    [TestCase("3.0.0-beta.9d42c0b")]
+    [TestCase("2.6.1")]
+    [TestCase("unknown")]
+    [TestCase(null)]
+    public void ResolveRelease_ExplicitOverride_Wins(string version)
+    {
+        // 버전을 알 수 없어도(override가 있으면) override가 이김
+        Assert.AreEqual(
+            "my-app@1.2.3",
+            AITSentryReleaseResolver.ResolveRelease(version, "my-app@1.2.3"));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/SentryReleaseResolverTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/SentryReleaseResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8968b746b7dc4ac38fc1d0ce63c93e16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경

`SENTRY_ENVIRONMENT` / `SENTRY_RELEASE`는 CI 어디에서도 설정되지 않아 사실상 **미사용** 상태였습니다 (`SENTRY_DSN`만 unity-build/test-e2e/preview에서 주입). 그 결과:

- 모든 빌드 이벤트가 동일한 Sentry `environment`(기본값 `production`)로 유입 → 베타 파일럿(`#beta`) 에러가 stable triage/알림/release-health를 오염시킬 위험.
- 런타임 envelope의 release가 Sentry 기본값(`Application.version`)이라 `release.yml`(line 653)이 만드는 Sentry release `apps-in-toss.unity@<version>`과 **불일치** — release.yml:630 주석이 가정하던 정합이 실제로는 성립하지 않던 잠재 갭.

## 변경

`AITSentryDsnInjector`가 SDK 버전(`AITVersion.Version`)에서 두 값을 자동 파생:

| SDK 버전 | environment | release |
|----------|-------------|---------|
| stable (`2.6.1`, `3.0.0`) | *(미설정 → Sentry 기본값 `production`)* | `apps-in-toss.unity@2.6.1` |
| prerelease (`3.0.0-beta.9d42c0b`) | `beta` | `apps-in-toss.unity@3.0.0-beta.9d42c0b` |
| unknown | *(미설정, 경고 로그)* | *(미설정)* |

- **명시된 `SENTRY_ENVIRONMENT`/`SENTRY_RELEASE` env가 있으면 항상 자동 파생을 우선**합니다 (CI 강제 라벨용).
- 순수 로직을 `AITSentryReleaseResolver`(`AppsInToss.Helpers`, **Sentry 비의존**)로 분리 → Sentry 미설치 환경에서도 EditMode 단위 테스트 가능. internal 메서드는 IVT로 injector·테스트 어셈블리에 노출.
- **SemVer 2.0 정합**: build metadata(`+...`)는 prerelease 판정에서 제외, 빈 trailing hyphen(`X.Y.Z-`)은 stable로 취급.

## 영향 범위 (정확한 스코핑)

`SENTRY_DSN`이 설정된 빌드만 해당하며, injector는 DSN이 없거나 `SentryOptions.asset`이 이미 있으면 early-bail합니다.

- **stable end-user 빌드 (SENTRY_DSN 없음)**: injector early-bail → **완전 불변 (byte-identical)**.
- **stable Toss 내부 CI 빌드 (SENTRY_DSN 있음)**: release가 `Application.version` → `apps-in-toss.unity@{버전}`으로 변경됨 (**의도된 정합 개선**, release.yml과 일치). environment는 기존대로 `production`.
- **prerelease 빌드**: environment `beta` + release `apps-in-toss.unity@{버전}`으로 분리.

## 테스트

- 신규 `SentryReleaseResolverTests` (EditMode, Level 0): `IsPrerelease` / `ResolveEnvironment` / `ResolveRelease` — happy path + 엣지(빈 trailing hyphen, build metadata, 공백, override 우선).
- `./run-local-tests.sh --validate` 통과 (invariants 18/18). EditMode는 CI self-hosted runner에서 실행.

## 검토

ultracode 적대적 검토(compile/semantics/docs 3-lens) 결과의 blocker/major/minor를 모두 반영:
- (compile) `using AppsInToss;` 명시 추가 — cross-assembly namespace 참조 명확화.
- (semantics) SemVer 정합 `IsPrerelease`, `IsNullOrWhiteSpace` 가드, unknown 버전 경고 로그.
- (docs) 트러블슈팅 로그 문자열을 실제 출력과 동기화.

## 문서

`Docs~/SentryIntegration.md`에 자동 파생 동작/우선순위/영향 범위 표 추가.