### PR TITLE
문서: stable 배포에 불변 릴리즈 태그(#release/vX.Y.Z) 핀 권장 명시

### DIFF
--- a/Docs~/GettingStarted.md
+++ b/Docs~/GettingStarted.md
@@ -36,7 +36,9 @@ https://github.com/toss/apps-in-toss-unity-sdk.git#release/v2.6.1
 }
 ```
 
-> **버전 고정**: 특정 버전을 고정하려면 `#main` 대신 `#release/v1.9.2`와 같이 릴리즈 태그를 사용하세요. 릴리즈 목록은 [GitHub Releases](https://github.com/toss/apps-in-toss-unity-sdk/releases)에서 확인할 수 있습니다.
+> **버전 고정 (서비스 배포 권장)**: 위 예시처럼 **불변 릴리즈 태그** `#release/vX.Y.Z`(예: `#release/v2.6.1`)로 핀하세요. 릴리즈 태그는 특정 커밋을 영구히 가리키는 불변 ref라, 재현 가능한 빌드를 보장하고 의도치 않은 업데이트로부터 가장 강하게 격리됩니다.
+>
+> 반면 `#main` 같은 **브랜치**로 핀하면 HEAD가 이동할 때마다 자동 업데이터가 변경을 감지해 업데이트 프롬프트를 띄웁니다 — 최신을 따라가고 싶을 때만 사용하세요. 릴리즈 목록은 [GitHub Releases](https://github.com/toss/apps-in-toss-unity-sdk/releases)에서 확인할 수 있습니다.
 
 ### 지원 Unity 버전
 


### PR DESCRIPTION
## 배경

`AITAutoUpdater`는 사용자가 핀한 UPM git fragment를 추적합니다:

- **불변 릴리즈 태그**(`#release/vX.Y.Z`) → 특정 커밋을 영구히 가리키므로 HEAD가 움직이지 않음 → 자동 업데이트 프롬프트가 절대 뜨지 않고, 재현 가능한 빌드가 보장됨 (최강 격리).
- **브랜치**(`#main` 등) → HEAD가 이동할 때마다 자동 업데이터가 변경을 감지해 업데이트 프롬프트를 띄움.

기존 "버전 고정" 안내는 이 차이를 명확히 설명하지 않았고, 예시 버전이 stale(`v1.9.2`)했습니다.

## 변경

`Docs~/GettingStarted.md` 설치 가이드의 "버전 고정" 블록쿼트를 보강:

- **서비스 배포에는 불변 릴리즈 태그(`#release/vX.Y.Z`) 핀을 권장**으로 명시.
- 브랜치 핀(`#main`)은 자동 추적·프롬프트 대상임을 설명 — "최신을 따라가고 싶을 때만".
- 예시 버전을 현행(`v2.6.1`, 본문 manifest 예시와 일치)으로 갱신.

문서 전용 변경(코드/빌드 영향 없음).