### PR TITLE
수정: Sentry 노이즈 차단 — 정상 fallback warning 3건 sentryCapture:false 전환

### DIFF
--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -167,8 +167,10 @@ namespace AppsInToss.Editor
             }
             else
             {
-                // SDK 템플릿을 찾지 못함 (경고만 출력, 빌드 시 다시 시도됨)
-                Debug.LogWarning("[AIT] SDK 로딩 화면 템플릿을 찾을 수 없습니다. 첫 빌드 시 다시 시도됩니다.");
+                // 정상 흐름의 예측된 분기 — SDK 로딩 화면 템플릿을 아직 못 찾으면 첫 빌드 시 다시 시도된다.
+                // SDK 결함 조사가 필요 없는 fallback이므로 Sentry에는 전송하지 않는다(Console warning만).
+                // (Sentry APPS-IN-TOSS-UNITY-SDK-10R)
+                AITLog.Warning("[AIT] SDK 로딩 화면 템플릿을 찾을 수 없습니다. 첫 빌드 시 다시 시도됩니다.", sentryCapture: false);
             }
         }
 

--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -246,7 +246,9 @@ namespace AppsInToss.Editor
                 }
                 else
                 {
-                    Debug.LogWarning("[AIT] package.json 템플릿을 찾을 수 없습니다. 첫 빌드 시 자동으로 설치됩니다.");
+                    // 정상 흐름의 예측된 분기 — package.json 템플릿이 아직 없으면 첫 빌드 시 자동 설치된다.
+                    // SDK 결함 조사가 필요 없는 fallback이므로 Sentry에는 전송하지 않는다(Console warning만).
+                    AITLog.Warning("[AIT] package.json 템플릿을 찾을 수 없습니다. 첫 빌드 시 자동으로 설치됩니다.", sentryCapture: false);
                 }
             }
             catch (Exception e)

--- a/Editor/AITPackagePathResolver.cs
+++ b/Editor/AITPackagePathResolver.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEditor.PackageManager;
 using UnityEngine;
-using Debug = UnityEngine.Debug;
 
 namespace AppsInToss.Editor
 {
@@ -46,10 +45,14 @@ namespace AppsInToss.Editor
             else if (!_warningLogged)
             {
                 _warningLogged = true;
-                Debug.LogWarning(
+                // 패키지 해석 실패는 호출부의 물리 경로 폴백(GetSDKResolvedPath)으로 복구된다 —
+                // 이 warning이 떠도 SDK가 정상 동작하는 경우가 많아 Sentry에는 전송하지 않는다(Console warning만).
+                // 진짜 실패라면 다운스트림 빌드 에러가 구조화 이벤트로 별도 캡처된다.
+                AITLog.Warning(
                     $"[AIT] SDK 패키지를 찾을 수 없습니다. " +
                     $"시도: FindForAssetPath({AITVersion.PackageAssetPath}, {AITVersion.LegacyPackageAssetPath}), FindForAssembly. " +
-                    "패키지 설치 상태를 확인하세요.");
+                    "패키지 설치 상태를 확인하세요.",
+                    sentryCapture: false);
             }
 
             return info;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs
@@ -1,0 +1,216 @@
+// -----------------------------------------------------------------------
+// SentryNoiseSuppressionCallsiteTests.cs - 정상 fallback warning 콜사이트 Sentry 억제 회귀 가드
+// Level 0: PR #733에서 sentryCapture:false로 전환한 3개 콜사이트가 raw Debug.LogWarning/
+//          LogError로 되돌아가지 않고 AITLog.Warning(..., sentryCapture: false) 형태를
+//          유지하는지 소스 정적 스캔으로 보장한다 (CleanMenuSafetyTests #711 양식).
+//
+// 회귀 대상 Sentry 이슈 (모두 정상 흐름의 예측된 fallback — 호출부가 자가 복구, SDK 결함 아님):
+//   - APPS-IN-TOSS-UNITY-SDK-QB : "[AIT] package.json 템플릿을 찾을 수 없습니다. 첫 빌드 시 자동으로 설치됩니다."
+//   - APPS-IN-TOSS-UNITY-SDK-Q2 : "[AIT] SDK 패키지를 찾을 수 없습니다. … 패키지 설치 상태를 확인하세요."
+//   - APPS-IN-TOSS-UNITY-SDK-10R: "[AIT] SDK 로딩 화면 템플릿을 찾을 수 없습니다. 첫 빌드 시 다시 시도됩니다."
+//
+// 진짜 빌드 실패는 다운스트림 CaptureBuildError(구조화 이벤트, errorCode fingerprint)가 별도로
+// 캡처하므로, 이 fallback warning들을 Sentry에서 억제해도 가시성을 잃지 않는다.
+//
+// IL/리플렉션 대신 정적 소스 스캔을 쓰는 이유: 의존이 적고, Unity가 패키지를 어떤 경로로
+// 마운트하든 AssetDatabase로 실제 .cs 경로를 얻을 수 있다 (#711과 동일).
+// -----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEditor;
+
+[TestFixture]
+[Category("Unit")]
+public class SentryNoiseSuppressionCallsiteTests
+{
+    [Test]
+    public void QB_PackageJsonTemplateWarning_StaysSentrySuppressed()
+        => AssertCallsiteSuppressed(
+            "AITPackageInitializer.cs",
+            "package.json 템플릿을 찾을 수 없습니다. 첫 빌드 시 자동으로 설치됩니다.",
+            "QB");
+
+    [Test]
+    public void Q2_SdkPackageNotFoundWarning_StaysSentrySuppressed()
+        => AssertCallsiteSuppressed(
+            "AITPackagePathResolver.cs",
+            "SDK 패키지를 찾을 수 없습니다.",
+            "Q2");
+
+    [Test]
+    public void TenR_LoadingScreenTemplateWarning_StaysSentrySuppressed()
+        => AssertCallsiteSuppressed(
+            "AITPackageInitializer.cs",
+            "SDK 로딩 화면 템플릿을 찾을 수 없습니다. 첫 빌드 시 다시 시도됩니다.",
+            "10R");
+
+    /// <summary>
+    /// fileName 소스에서 messageAnchor를 내보내는 가장 가까운 선행 로그 호출이
+    /// AITLog.Warning(...)이고, 그 호출 인자에 sentryCapture: false가 포함됨을 정적으로 검증한다.
+    /// </summary>
+    private static void AssertCallsiteSuppressed(string fileName, string messageAnchor, string sentryIssue)
+    {
+        string path = LocateEditorSource(fileName);
+        Assert.IsNotNull(path,
+            $"{fileName} 소스 경로를 찾을 수 없음 (AssetDatabase 및 알려진 후보 경로 모두 실패).");
+        Assert.IsTrue(File.Exists(path), $"{fileName}가 존재해야 함: {path}");
+
+        string source = File.ReadAllText(path);
+
+        // (1) 메시지 존재 — 메시지가 통째로 바뀌면 앵커도 함께 갱신해야 한다는 신호.
+        int anchorIdx = source.IndexOf(messageAnchor, StringComparison.Ordinal);
+        Assert.GreaterOrEqual(anchorIdx, 0,
+            $"[{sentryIssue}] {fileName}에서 메시지를 찾을 수 없음: \"{messageAnchor}\". " +
+            "메시지가 변경되었다면 이 가드의 앵커도 함께 갱신할 것.");
+
+        // (2) 앵커 유일성 — 중복이면 회귀 검출이 모호해지므로 단일 출현을 요구.
+        int secondIdx = source.IndexOf(messageAnchor, anchorIdx + 1, StringComparison.Ordinal);
+        Assert.AreEqual(-1, secondIdx,
+            $"[{sentryIssue}] 메시지 앵커가 {fileName}에 2회 이상 등장 — 더 구체적인 앵커가 필요.");
+
+        // (3) 메시지를 내보내는 '가장 가까운 선행 호출'이 AITLog.Warning(이어야 함.
+        //     raw Debug.Log* 직호출은 SuppressScope를 거치지 않아 Sentry로 전송된다.
+        string[] emitTokens =
+        {
+            "AITLog.Warning(", "AITLog.Error(",
+            "Debug.LogWarning(", "Debug.LogError(", "Debug.Log(",
+        };
+        int bestIdx = -1;
+        string bestTok = null;
+        foreach (var tok in emitTokens)
+        {
+            int idx = source.LastIndexOf(tok, anchorIdx, StringComparison.Ordinal);
+            if (idx > bestIdx) { bestIdx = idx; bestTok = tok; }
+        }
+        Assert.AreEqual("AITLog.Warning(", bestTok,
+            $"[{sentryIssue}] '{messageAnchor}' 메시지는 AITLog.Warning(...)으로 내보내야 함. " +
+            $"가장 가까운 선행 호출이 '{bestTok ?? "(없음)"}'임 — raw Debug.Log* 직호출은 " +
+            "SuppressScope를 거치지 않아 Sentry 노이즈로 전송된다.");
+
+        // (4) 호출 인자 영역(여는 괄호 ~ 매칭 닫는 괄호)을 문자열 리터럴 인식 스캐너로 추출.
+        int openParen = bestIdx + bestTok.Length - 1; // bestTok 끝의 '(' 위치
+        int closeParen = FindMatchingParen(source, openParen);
+        Assert.Greater(closeParen, openParen,
+            $"[{sentryIssue}] AITLog.Warning(...) 호출의 닫는 괄호를 찾지 못함 (소스 구조 확인 필요).");
+
+        // 앵커가 이 호출 인자 범위 안에 있어야 함 — 메시지가 정말 이 호출에 속함을 확인.
+        Assert.IsTrue(anchorIdx > openParen && anchorIdx < closeParen,
+            $"[{sentryIssue}] 메시지 앵커가 가장 가까운 AITLog.Warning(...) 인자 범위 밖 — 스캔 가정 위반.");
+
+        string callArgs = source.Substring(openParen, closeParen - openParen + 1);
+
+        // (5) 핵심 회귀 가드: sentryCapture: false (공백/개행 무관) 가 인자에 포함되어야 함.
+        string normalized = Regex.Replace(callArgs, @"\s+", "");
+        Assert.IsTrue(normalized.Contains("sentryCapture:false"),
+            $"[{sentryIssue}] {fileName}의 정상 fallback warning은 sentryCapture: false 여야 함. " +
+            "이 단언이 깨지면 정상 fallback이 다시 Sentry로 전송되는 노이즈 회귀다 " +
+            $"(Sentry APPS-IN-TOSS-UNITY-SDK-{sentryIssue}). 호출: {callArgs.Trim()}");
+    }
+
+    /// <summary>
+    /// fileName(예: "AITPackageInitializer.cs") 의 실제 디스크 경로를 해석한다.
+    /// 1) AssetDatabase MonoScript 검색(가장 견고) → 2) 알려진 후보 상대 경로 → 3) PackageCache glob.
+    /// (#711 LocateAppsInTossMenuSource를 파일명 파라미터로 일반화. typeof 체크는 internal/static
+    ///  타입 접근성 문제를 피하려고 생략하고 파일명 일치만으로 식별 — 파일명이 저장소 내 유일.)
+    /// </summary>
+    private static string LocateEditorSource(string fileName)
+    {
+        string nameNoExt = Path.GetFileNameWithoutExtension(fileName);
+        foreach (var guid in AssetDatabase.FindAssets(nameNoExt + " t:MonoScript"))
+        {
+            string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+            if (string.IsNullOrEmpty(assetPath)) continue;
+            if (Path.GetFileName(assetPath) == fileName && File.Exists(assetPath))
+                return assetPath;
+        }
+
+        string[] candidates =
+        {
+            "Editor/" + fileName,
+            "Packages/im.toss.apps-in-toss-unity-sdk/Editor/" + fileName,
+        };
+        foreach (var c in candidates)
+            if (File.Exists(c)) return c;
+
+        const string packageCache = "Library/PackageCache";
+        if (Directory.Exists(packageCache))
+        {
+            foreach (var d in Directory.GetDirectories(packageCache, "im.toss.apps-in-toss-unity-sdk*"))
+            {
+                string p = Path.Combine(d, "Editor", fileName);
+                if (File.Exists(p)) return p;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// openIdx('(')에 대응하는 닫는 괄호 인덱스를 반환. 문자열("...", $"...")·문자('...')
+    /// 리터럴과 //·/* */ 주석 내부의 괄호는 무시한다.
+    ///
+    /// 한계(#711 ExtractMethodBody와 동일한 실용적 단순화): 보간 문자열 $"...{Foo(")")}..."처럼
+    /// 보간 구멍 안에 따옴표가 들어간 경우는 정확히 처리하지 못한다. 대상 3개 콜사이트에는
+    /// 그런 패턴이 없으므로 충분하다(Q2의 보간 구멍은 단순 프로퍼티 접근뿐).
+    /// </summary>
+    private static int FindMatchingParen(string s, int openIdx)
+    {
+        int depth = 0;
+        for (int i = openIdx; i < s.Length; i++)
+        {
+            char c = s[i];
+
+            if (c == '/' && i + 1 < s.Length && s[i + 1] == '/')
+            {
+                int nl = s.IndexOf('\n', i);
+                if (nl < 0) return -1;
+                i = nl;
+                continue;
+            }
+            if (c == '/' && i + 1 < s.Length && s[i + 1] == '*')
+            {
+                int end = s.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                if (end < 0) return -1;
+                i = end + 1;
+                continue;
+            }
+            if (c == '"')
+            {
+                i = SkipLiteral(s, i, '"');
+                if (i < 0) return -1;
+                continue;
+            }
+            if (c == '\'')
+            {
+                i = SkipLiteral(s, i, '\'');
+                if (i < 0) return -1;
+                continue;
+            }
+
+            if (c == '(') depth++;
+            else if (c == ')')
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// quoteIdx(여는 따옴표)에 대응하는 닫는 따옴표 인덱스를 반환. \ 이스케이프를 건너뛴다.
+    /// </summary>
+    private static int SkipLiteral(string s, int quoteIdx, char quote)
+    {
+        for (int i = quoteIdx + 1; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c == '\\') { i++; continue; }
+            if (c == quote) return i;
+        }
+        return -1;
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f8d3a2367b045c7ad1108ea6aad1012
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 범위

SDK 정상 흐름의 **예측된 fallback 분기**에서 발생하는 warning 3건이 Sentry에 노이즈로 등록되고 있다. Console 출력(개발자 가시성)은 그대로 유지한 채 Sentry 전송만 억제한다.

판정 기준(`docs/claude/sentry-known-issues.md`): *"이 메시지가 Sentry 이슈로 등록되었을 때 SDK 결함 조사가 필요한가?"* — 세 건 모두 불필요(호출부가 자동 복구).

Fixes APPS-IN-TOSS-UNITY-SDK-QB
Fixes APPS-IN-TOSS-UNITY-SDK-Q2
Fixes APPS-IN-TOSS-UNITY-SDK-10R

## 변경

| 이슈 | 파일 | 메시지(요지) | 근거 |
|---|---|---|---|
| **QB** (UnityWarning, 2 events) | `Editor/AITPackageInitializer.cs` | `package.json 템플릿을 찾을 수 없습니다. 첫 빌드 시 자동으로 설치됩니다.` | 템플릿 미존재는 첫 빌드 자동 설치로 복구되는 예측된 분기. 메시지 자체가 "자동 설치됨"을 명시. |
| **Q2** (UnityWarning, 3 events) | `Editor/AITPackagePathResolver.cs` | `SDK 패키지를 찾을 수 없습니다. … 패키지 설치 상태를 확인하세요.` | `FindForAssetPath`/`FindForAssembly` 3중 해석 실패 시에도 호출부(`GetSDKResolvedPath`)가 프로젝트 루트 물리 경로로 폴백 복구. warning이 떠도 SDK가 정상 동작하는 경우가 다수. |
| **10R** (UnityWarning, 1 event) | `Editor/AITPackageInitializer.cs` | `SDK 로딩 화면 템플릿을 찾을 수 없습니다. 첫 빌드 시 다시 시도됩니다.` | `EnsureLoadingScreenTemplate()`의 else 분기 — 로딩 화면 템플릿을 아직 못 찾은 정상 흐름. 첫 빌드 시 자동 재시도로 자가 치유되며 메시지 자체가 "다시 시도됩니다"를 명시. |

세 건 모두 `Debug.LogWarning(...)` → `AITLog.Warning(..., sentryCapture: false)`로 전환(기존 컨벤션, `AITPackageInitializer.cs`의 다른 fallback 분기와 동일 패턴). Q2 파일은 더 이상 사용하지 않는 `using Debug = UnityEngine.Debug;` 별칭도 정리.

## 회귀 가드 (테스트)

`Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs` 추가 (CleanMenuSafetyTests #711 양식). 세 콜사이트(QB/Q2/10R)가 raw `Debug.LogWarning`/`LogError`로 되돌아가지 않고 `AITLog.Warning(..., sentryCapture: false)` 형태를 유지하는지 **소스 정적 스캔**으로 검증한다.

- 각 메시지를 내보내는 *가장 가까운 선행 호출*이 `AITLog.Warning(`인지 확인(raw `Debug.Log*` 직호출 회귀 차단).
- 멀티라인 콜사이트(Q2)는 문자열 리터럴 인식 괄호 매칭으로 호출 인자 영역을 추출해 `sentryCapture: false` 포함을 단언.
- EditMode 테스트는 E2E 빌드 잡(`run-editmode-test: true`)에서 macOS·Windows 전 Unity 버전에 대해 실행된다.

## R5는 코드 변경 없음

`APPS-IN-TOSS-UNITY-SDK-R5`(`pnpm install 실패 (모든 재시도 후에도 실패)`, UnityError, 17 events)는 **이미** `Editor/Package/PnpmRunner.cs`의 3개 호출부 모두 `sentryCapture: false`로 처리되어 있다. 빌드 실패의 단일 구조화 이벤트는 상위 진입점(`CaptureBuildError`, errorCode fingerprint)이 캡처한다. 잔여 Sentry 이벤트는 구버전(≤2.4.x) 클라이언트발이라 코드 변경이 불필요 — 잔여 이벤트는 별도로 수동 resolve 처리한다.

## 주의

- **진짜 결함은 가시성을 잃지 않는다.** 예컨대 Q2에서 패키지를 정말 못 찾아 빌드가 실패하면, 다운스트림 빌드 에러가 `CaptureBuildError`로 별도 캡처된다.
- 업데이트된 클라이언트에서는 신규 이벤트가 중단되지만, **구버전 클라이언트 잔여 이벤트로 QB/Q2/10R이 다시 regression될 수 있다**(R5와 동일 패턴). 그 경우 Sentry에서 다시 resolve 처리.

## 검증

- `./run-local-tests.sh --validate` 통과 (SDK generator invariants 18/18, 구조 검증 통과).
- C# 변경은 기존 `AITLog.Warning(sentryCapture: false)` 패턴과 동일하며 동작 변화 없음(로그 캡처 경로만 변경).
- **E2E + EditMode**: PR 대상으로 E2E 워크플로우를 트리거 — macOS·Windows × Unity 2021.3/2022.3/6000.0/6000.2/6000.3 빌드 잡에서 신규 회귀 가드를 포함한 EditMode 테스트가 실행/통과해야 머지.
