### PR TITLE
수정: 베타 빌드 BuildConfig가 web-analytics를 prerelease 버전으로 덮어쓰지 않도록

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -679,11 +679,17 @@ jobs:
 
           console.log(`Updating @apps-in-toss/web-framework to ${version}`);
 
+          // web-framework 버전만 동기화한다. @apps-in-toss/web-analytics는 별도 버전
+          // 라인(latest=2.6.1)이라 web-framework의 prerelease 버전(예: 3.0.0-beta.<hash>)이
+          // npm에 존재하지 않으며, web-framework 3.x는 web-analytics에 의존하지도 않는다(검증됨).
+          // web-analytics까지 덮으면 아래 pnpm install이 ERR_PNPM_NO_MATCHING_VERSION으로
+          // 실패하므로, bridge-core와 동일하게 BuildConfig 기본 핀을 그대로 둔다.
+          // (위 "Regenerate SDK" 스텝의 BuildConfig 동기화와 동일 정책.)
           const pkg = JSON.parse(fs.readFileSync(buildConfig, 'utf8'));
           for (const section of ['dependencies', 'devDependencies']) {
             if (!pkg[section]) continue;
-            for (const name of ['@apps-in-toss/web-framework', '@apps-in-toss/web-analytics']) {
-              if (pkg[section][name]) pkg[section][name] = version;
+            if (pkg[section]['@apps-in-toss/web-framework']) {
+              pkg[section]['@apps-in-toss/web-framework'] = version;
             }
           }
           fs.writeFileSync(buildConfig, JSON.stringify(pkg, null, 2) + '\n');


### PR DESCRIPTION
## 목적

베타 채널 첫 검증 디스패치(run #7, `beta v3.0.0-beta.9d42c0b`, `build_strategy=minimal`)가 macOS 빌드의 **"Update BuildConfig SDK Version"** 스텝에서 실패한 것을 수정한다.

## 근본 원인

`build-beta-macos`/`build-beta-windows`가 호출하는 `unity-build.yml`의 "Update BuildConfig SDK Version" 스텝이 `web-framework-version` 입력(`3.0.0-beta.9d42c0b`)을 **web-framework와 web-analytics 양쪽**에 적용했다:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @apps-in-toss/web-analytics@3.0.0-beta.9d42c0b
The latest release of @apps-in-toss/web-analytics is "2.6.1".
```

`@apps-in-toss/web-analytics`는 **3.0.0-beta 라인이 publish되지 않았다**(latest=2.6.1). web-framework만 3.x로 올라간 major 베타에서 둘이 갈라지면서 `pnpm install --lockfile-only`가 exit 1로 실패 → 빌드 게이트에서 차단(`publish-beta`/`sentry-release`/`notify-beta` 전부 skipped).

## 수정

해당 스텝이 **web-framework만** 동기화하고 web-analytics는 BuildConfig 커밋 핀(2.6.1)을 유지하도록 변경. 이는:
- 같은 파일의 **"Regenerate SDK" 스텝(L381-386)**이 이미 채택한 정책과 동일 (해당 주석: "web-analytics까지 override로 덮으면 ERR_PNPM_NO_MATCHING_VERSION으로 실패")
- **bridge-core**가 두 스텝 어디서도 덮어쓰이지 않고 커밋 핀을 유지하는 것과 동일한 취급

## stable 무영향

- stable은 web-analytics를 `update.yml` / `sdk-update-rebase.yml`이 **커밋된 BuildConfig에서** lockstep으로 bump한다. 따라서 이 스텝의 web-analytics 덮어쓰기는 stable에선 **중복**(이미 커밋 파일에 올바른 버전이 들어와 있음)이었고, 제거해도 결과가 동일하다.
- stable 입력(예 `2.6.1`): web-framework→2.6.1(no-op), web-analytics는 커밋 핀(2.6.1) 유지 → 변경 전과 동일.
- beta 입력(`3.0.0-beta.<sha>`): web-framework→3.0.0-beta, web-analytics는 2.6.1 유지 → lockfile 해석 성공(web-framework 3.x는 web-analytics에 의존하지 않음, 검증됨).

## 검증

- `actionlint`: 스키마/표현식/구문 에러 0 (shellcheck `info/style` 노이즈만, 수정 부분은 `shell: node {0}` 블록이라 shellcheck 비대상).
- 편집 JS 스니펫 `node --check` 통과.
- 머지 후 동일 입력(`beta v3.0.0-beta.9d42c0b`, `minimal`)으로 재디스패치하여 macOS 빌드 통과 확인 예정.

> 베타 채널 격리 불변식(INV1~INV5)에는 영향 없음 — BuildConfig 의존성 핀만 조정.