### PR TITLE
[auto-resolve] 테스트: ZM 이슈 fingerprint 메시지 형식 교정 + framework.js 누락 회귀 가드

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -138,6 +138,41 @@ public class BuildFileSelectionTests
     }
 
     // =====================================================
+    // Sentry SDK-ZM 회귀: *.framework.js* 누락 시 에러 로그 방출
+    // WebGLBuildCopier가 "isRequired: true"로 검색해 빈 문자열을 받으면
+    // FindFileInBuild 내부에서 "[AIT] ✗ 필수 파일을 찾을 수 없습니다" 에러가 발생한다.
+    // 이 테스트는 framework.js 파일이 Build/ 폴더에 없는 상황에서 해당 에러가
+    // 정확히 방출되는지 보장한다.
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_MissingFrameworkJs_EmitsRequiredErrorLog()
+    {
+        // Build/ 폴더에 loader.js, data, wasm만 있고 framework.js 파일은 없음
+        File.WriteAllText(Path.Combine(tempDir, "build.loader.js"), "loader");
+        File.WriteAllText(Path.Combine(tempDir, "build.data"), "data");
+        File.WriteAllText(Path.Combine(tempDir, "build.wasm"), "wasm");
+        // framework.js 의도적으로 생성 안 함
+
+        string result = null;
+        var logs = CollectLogs(() =>
+            result = AITBuildValidator.FindFileInBuild(tempDir, "*.framework.js*", isRequired: true));
+
+        // 빈 문자열 반환 → missingFiles.Add("*.framework.js") 로 이어짐 (WebGLBuildCopier.cs)
+        Assert.AreEqual("", result,
+            "framework.js 파일이 없으면 빈 문자열을 반환해야 함");
+
+        // "[AIT] ✗ 필수 파일을 찾을 수 없습니다: *.framework.js*" 에러 로그 방출 확인
+        bool emittedRequiredError = logs.Exists(l =>
+            l.type == LogType.Error &&
+            l.message.Contains("필수 파일을 찾을 수 없습니다") &&
+            l.message.Contains("*.framework.js*"));
+        Assert.IsTrue(emittedRequiredError,
+            "isRequired:true 이면서 파일이 없으면 에러 로그가 방출되어야 함. " +
+            "실제 로그: " + string.Join(" | ", logs.ConvertAll(l => $"[{l.type}] {l.message}")));
+    }
+
+    // =====================================================
     // GetFilePatterns — decompressionFallback=true 시 .unityweb 패턴 반환
     // =====================================================
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/FingerprintNormalizationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/FingerprintNormalizationTests.cs
@@ -32,14 +32,15 @@ public class FingerprintNormalizationTests
     [Test]
     public void GlobFileList_CollapsesToSingleFingerprint()
     {
-        // Sentry SDK-ZM: "필수 파일 누락! {목록}" — 누락 파일 조합이 달라도(1개 vs 여러 개) 같은 이슈로 수렴해야 한다.
+        // Sentry SDK-ZM: "필수 파일 누락! 누락된 필수 파일: {목록}" — 누락 파일 조합이 달라도(1개 vs 여러 개) 같은 이슈로 수렴해야 한다.
         // glob 파일명 → <file>, 나열된 "<file>, <file>, ..." → <file> 로 접힘.
+        // 실제 WebGLBuildCopier.cs 에서 생성되는 메시지 형식: "누락된 필수 파일: *.framework.js"
         var single = AITEditorErrorTracker.BuildNormalizedFingerprint(
             "Error",
-            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js");
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js");
         var many = AITEditorErrorTracker.BuildNormalizedFingerprint(
             "Error",
-            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js, *.loader.js, *.data.gz");
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js, *.loader.js, *.data.gz");
 
         Assert.IsNotNull(single);
         Assert.IsNotNull(many);
@@ -72,7 +73,7 @@ public class FingerprintNormalizationTests
         // 누락 파일(ZM)과 폴더 삭제 실패는 서로 다른 이슈로 유지되어야 한다(과도한 병합 방지).
         var missing = AITEditorErrorTracker.BuildNormalizedFingerprint(
             "Error",
-            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js");
+            "[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js");
         var deleteFail = AITEditorErrorTracker.BuildNormalizedFingerprint(
             "Error",
             @"[AIT] 이전 빌드 잔여물 정리 실패: C:\proj\ait-build");


### PR DESCRIPTION
**범위**: 원 이슈 `APPS-IN-TOSS-UNITY-SDK-ZM`의 실제 증상(WebGL 빌드 시 *.framework.js 파일 누락)은 미해결 — 참조만. 별도 조사 필요

## 변경 내용

### 문제
`FingerprintNormalizationTests.GlobFileList_CollapsesToSingleFingerprint`가 실제 프로덕션 코드(`WebGLBuildCopier.cs` 109번 줄)의 에러 메시지와 다른 형식을 사용하고 있었음.

- 테스트에서 사용한 메시지: `"[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! *.framework.js"`
- 실제 프로덕션 메시지: `"[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js"`

`"누락된 필수 파일: "` 접두사가 빠져 있어 실제 Sentry ZM 이슈에서 발생하는 정확한 메시지를 테스트가 검증하지 못하는 상태였음.

### 수정
1. `FingerprintNormalizationTests.cs`: SDK-ZM 관련 3개 테스트 메시지를 실제 `WebGLBuildCopier.cs` 생성 메시지 형식으로 교정
2. `BuildFileSelectionTests.cs`: `*.framework.js*` 파일 누락 시 `isRequired: true` 조건에서 에러 로그가 정확히 방출되는지 검증하는 회귀 테스트 추가

## 원 이슈 분석

`APPS-IN-TOSS-UNITY-SDK-ZM`: WebGL 빌드 시 `*.framework.js` 필수 파일 누락 오류

- 에러 발생 위치: `Editor/Package/WebGLBuildCopier.cs:109`
- 조건: `CopyWebGLToPublic` 호출 시 `Build/` 폴더에 `*.framework.js*` 패턴 파일이 없는 경우
- 원인: Unity WebGL 빌드가 불완전하게 완료되었거나, Build 폴더가 부분적으로만 존재하는 사용자 환경 문제
- SDK 코드 자체는 올바르게 오류를 감지하고 보고함

EditMode 테스트로 실제 `*.framework.js` 파일 누락을 유발하는 `CopyWebGLToPublic` 전체 플로우를 재현하기 위해서는 `UnityUtil.GetEditorConf()` 등 Unity 에디터 의존성이 필요하며, 직접 재현은 로컬 EditMode 테스트 범위를 벗어남.

## 검증

- SDK Generator Unit Tests (`sdk-runtime-generator~/vitest`): 18/18 통과
- `./run-local-tests.sh --validate`: E2E 파일 검증, Playwright 설정 검증 통과