### PR TITLE
수정: Node.js 설치 Directory.Move를 일시적 잠금에 retry-with-backoff로 하드닝 (SDK-100)

### DIFF
--- a/Editor/AITFileSystemHelper.cs
+++ b/Editor/AITFileSystemHelper.cs
@@ -22,6 +22,13 @@ namespace AppsInToss.Editor
         // 마지막 시도에서 동일 예외가 다시 던져져 호출자에게 결과가 전달됨.
         private static readonly int[] DeleteRetryDelaysMs = { 50, 100, 200, 400 };
 
+        // 원자적 디렉토리 이동(Directory.Move) 회복용 지수 백오프.
+        // Windows AV/Defender가 추출 직후 staging dir 내 파일 핸들을 점유하면 rename이
+        // IOException("Access denied")으로 실패하는데, 보통 수백 ms 안에 핸들이 풀린다.
+        // 삭제(DeleteRetryDelaysMs)보다 다소 길게 잡는다 — 이동 실패는 Node.js 설치 자체를
+        // 무산시키는 치명적 경로라 회복 가치가 더 크고, 1회성 설치라 합계 ~1.85s도 수용 가능.
+        private static readonly int[] MoveRetryDelaysMs = { 100, 250, 500, 1000 };
+
         /// <summary>
         /// 파일을 삭제합니다. 존재하지 않으면 조용히 true를 반환합니다.
         /// Unity `.meta` 파일이 있으면 함께 삭제합니다.
@@ -147,6 +154,95 @@ namespace AppsInToss.Editor
                     $"{logPrefix} 디렉토리 삭제 실패: {path} ({lastException.GetType().Name}: {lastException.Message})",
                     sentryCapture: false);
             return false;
+        }
+
+        /// <summary>
+        /// 디렉토리를 최종 경로로 원자적 이동(rename)합니다. Windows의 일시적 잠금
+        /// (AV/Defender가 추출 직후 staging dir 내 파일 핸들을 점유하는 경우 등)으로 인한
+        /// <see cref="IOException"/>에 대해 지수 백오프로 재시도합니다.
+        /// <para>
+        /// 동시 설치 경합 대응: 매 시도 전에 <paramref name="targetPath"/> 존재를 확인하여,
+        /// 다른 프로세스가 먼저(또는 재시도 도중) 설치를 완료하면(race winner) 이동을 건너뛰고
+        /// <c>false</c>를 반환합니다. 이 경우 <paramref name="stagingPath"/> 정리는 호출자가
+        /// 담당합니다(이 메서드는 stagingPath를 삭제하지 않음).
+        /// </para>
+        /// <para>
+        /// 삭제 유틸(<see cref="SafeDeleteDirectory"/>)과 달리 이동 실패는 치명적이므로
+        /// (Node.js 설치 자체가 무산됨) 전체 재시도 윈도우를 소진해도 실패하면 마지막
+        /// <see cref="IOException"/>을 다시 던집니다 — 호출자가 결과를 인지하고 사용자에게
+        /// 안내/정리하도록. 실패 직전 경고 로그 1회를 남기되 Sentry 전송은 억제합니다.
+        /// </para>
+        /// </summary>
+        /// <param name="stagingPath">이동할 원본(스테이징) 경로</param>
+        /// <param name="targetPath">이동 대상(최종) 경로</param>
+        /// <param name="logPrefix">로그 메시지 접두사 (예: "[NodeJS]"). 기본값은 "[AIT]"</param>
+        /// <returns>이동을 수행했으면 true, 다른 프로세스가 이미 target을 완성해 이동을 건너뛰었으면 false</returns>
+        /// <exception cref="IOException">전체 재시도 윈도우를 소진해도 이동에 실패한 경우</exception>
+        public static bool MoveDirectoryWithRetry(string stagingPath, string targetPath, string logPrefix = DefaultLogPrefix)
+        {
+            return MoveDirectoryWithRetryCore(
+                stagingPath,
+                targetPath,
+                logPrefix,
+                move: () => Directory.Move(stagingPath, targetPath),
+                targetExists: () => Directory.Exists(targetPath),
+                sleep: ms => Thread.Sleep(ms));
+        }
+
+        /// <summary>
+        /// <see cref="MoveDirectoryWithRetry"/>의 테스트 가능한 코어. 파일시스템·시간 의존성을
+        /// 델리게이트로 주입받아 재시도/백오프/경합(race winner)/소진 흐름만 결정적으로 검증할 수 있다.
+        /// 프로덕션 호출은 <see cref="MoveDirectoryWithRetry"/>가 실제 <see cref="Directory"/>/
+        /// <see cref="Thread.Sleep(int)"/>를 주입한다.
+        /// </summary>
+        /// <param name="move">이동 시도(성공 시 정상 반환, 일시적 실패 시 <see cref="IOException"/>)</param>
+        /// <param name="targetExists">대상 경로 존재 여부(다른 프로세스의 동시 설치 감지)</param>
+        /// <param name="sleep">백오프 대기(ms) — 테스트에서는 실제 대기 없이 호출 인자만 기록 가능</param>
+        internal static bool MoveDirectoryWithRetryCore(
+            string stagingPath,
+            string targetPath,
+            string logPrefix,
+            Action move,
+            Func<bool> targetExists,
+            Action<int> sleep)
+        {
+            int totalAttempts = MoveRetryDelaysMs.Length + 1; // 즉시 1회 + 백오프 횟수
+            IOException lastException = null;
+
+            for (int attempt = 0; attempt < totalAttempts; attempt++)
+            {
+                // 다른 프로세스가 먼저(또는 재시도 도중) 설치를 완료했으면 이동 불필요 — race winner.
+                if (targetExists())
+                    return false;
+
+                try
+                {
+                    move();
+                    return true;
+                }
+                catch (IOException ex)
+                {
+                    // targetPath가 아직 없는 상태의 IOException = staging 측 핸들 점유(주로 AV 스캔)
+                    // 가능성이 높다. 다음 반복 진입 시 targetExists()로 race winner도 함께 재확인된다.
+                    lastException = ex;
+                    if (attempt < MoveRetryDelaysMs.Length)
+                    {
+                        try { sleep(MoveRetryDelaysMs[attempt]); }
+                        catch (ThreadInterruptedException) { break; }
+                    }
+                }
+            }
+
+            // 재시도 도중 race winner가 target을 완성했을 수 있으니 마지막으로 한 번 더 확인.
+            if (targetExists())
+                return false;
+
+            // 전체 재시도 소진 — 이동 실패는 치명적이므로 호출자에게 마지막 예외를 전파.
+            AITLog.Warning(
+                $"{logPrefix} 디렉토리 이동 재시도 {totalAttempts}회 모두 실패: {stagingPath} → {targetPath} " +
+                $"({lastException?.GetType().Name}: {lastException?.Message})",
+                sentryCapture: false);
+            throw lastException ?? new IOException($"디렉토리 이동 실패: {stagingPath} → {targetPath}");
         }
 
         /// <summary>

--- a/Editor/AITNodeJSDownloader.cs
+++ b/Editor/AITNodeJSDownloader.cs
@@ -264,34 +264,18 @@ namespace AppsInToss.Editor
                 // pnpm 자동 설치 (스테이징 경로에서)
                 bool pnpmInstalled = InstallPnpm(stagingPath);
 
-                // atomic 이동: 스테이징 → 최종 경로
-                // 다른 프로세스가 먼저 설치를 완료했을 수 있으므로 확인
-                if (Directory.Exists(targetPath))
+                // atomic 이동: 스테이징 → 최종 경로.
+                // Windows AV가 추출 직후 staging 핸들을 점유해 rename이 일시적 IOException으로
+                // 실패하는 경우(Sentry APPS-IN-TOSS-UNITY-SDK-100)에 지수 백오프로 재시도한다.
+                // 다른 프로세스가 먼저/동시에 설치를 완료하면(race winner) false가 반환되며,
+                // 어느 경로든 stagingPath는 아래 finally의 SafeDeleteDirectory가 정리한다.
+                if (AITFileSystemHelper.MoveDirectoryWithRetry(stagingPath, targetPath, logPrefix: "[NodeJS]"))
                 {
-                    // 이미 설치됨 - 스테이징 삭제
-                    Debug.Log($"[NodeJS] 다른 프로세스가 이미 설치를 완료함. 스테이징 삭제: {stagingPath}");
-                    AITFileSystemHelper.SafeDeleteDirectory(stagingPath, logPrefix: "[NodeJS]");
+                    Debug.Log($"[NodeJS] Node.js 설치 완료 (atomic move): {targetPath}");
                 }
                 else
                 {
-                    try
-                    {
-                        Directory.Move(stagingPath, targetPath);
-                        Debug.Log($"[NodeJS] Node.js 설치 완료 (atomic move): {targetPath}");
-                    }
-                    catch (IOException)
-                    {
-                        // Move 실패 = 다른 프로세스가 동시에 이동 성공
-                        if (Directory.Exists(targetPath))
-                        {
-                            Debug.Log($"[NodeJS] 다른 프로세스가 동시에 설치 완료함. 스테이징 삭제.");
-                            AITFileSystemHelper.SafeDeleteDirectory(stagingPath, logPrefix: "[NodeJS]");
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
+                    Debug.Log($"[NodeJS] 다른 프로세스가 이미/동시에 설치를 완료함. 스테이징은 정리됨: {stagingPath}");
                 }
 
                 Debug.Log($"[NodeJS] Node.js 다운로드 및 설치 완료: {targetPath}");

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/MoveDirectoryWithRetryTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/MoveDirectoryWithRetryTests.cs
@@ -1,0 +1,263 @@
+// -----------------------------------------------------------------------
+// MoveDirectoryWithRetryTests.cs - AITFileSystemHelper.MoveDirectoryWithRetry 검증
+// Level 0: Node.js 설치 원자적 이동(rename)의 재시도/경합/실패 경계 케이스
+//
+// 회귀: Sentry APPS-IN-TOSS-UNITY-SDK-100
+//   "[AIT] 패키지 매니저 체크 중 예외: System.IO.IOException: Access to the path
+//    '...nodejs...win-x64-installing-<hash>' is denied."
+//   Windows AV/Defender가 추출 직후 staging dir 핸들을 점유하면 Directory.Move가
+//   일시적 IOException으로 실패 → Node.js 설치 무산. 지수 백오프 재시도로 회복한다.
+//
+// 테스트 전략:
+//   - 기본 경로(target 없음/이미 존재)는 실제 FS로 공개 API(MoveDirectoryWithRetry) 검증.
+//   - 재시도/백오프/경합/소진 흐름은 파일잠금 대신 internal core(MoveDirectoryWithRetryCore)에
+//     move/targetExists/sleep 델리게이트를 주입해 결정적·크로스플랫폼·고속으로 검증한다.
+//     (Windows에서 디렉토리 rename은 자식 파일 핸들이 열려 있어도 허용될 수 있어 파일잠금 기반
+//      재현은 신뢰도가 낮고, "실패 후 회복" 경로는 FS로는 결정적 재현이 불가하기 때문.)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class MoveDirectoryWithRetryTests
+{
+    private string tempDir;
+    private MethodInfo moveMethod;
+    private MethodInfo coreMethod;
+
+    // 프로덕션 백오프 스케줄과 동일해야 하는 기대값 (AITFileSystemHelper.MoveRetryDelaysMs).
+    private static readonly int[] ExpectedBackoffMs = { 100, 250, 500, 1000 };
+
+    [SetUp]
+    public void Setup()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "ait-test-move-retry-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+        Directory.CreateDirectory(tempDir);
+
+        // AITFileSystemHelper는 internal 클래스이므로 리플렉션으로 접근.
+        // 접근자 변경(public ↔ internal)에도 견고하도록 Public|NonPublic 모두 탐색.
+        var helperType = typeof(AITBuildValidator).Assembly
+            .GetType("AppsInToss.Editor.AITFileSystemHelper");
+        Assert.IsNotNull(helperType, "AITFileSystemHelper type should exist in AppsInTossSDKEditor assembly");
+
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        moveMethod = helperType.GetMethod("MoveDirectoryWithRetry", flags);
+        Assert.IsNotNull(moveMethod, "MoveDirectoryWithRetry method should exist");
+        coreMethod = helperType.GetMethod("MoveDirectoryWithRetryCore", flags);
+        Assert.IsNotNull(coreMethod, "MoveDirectoryWithRetryCore method should exist");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+        {
+            // 잔여 read-only 속성 해제 후 정리 (실패 케이스 대비)
+            foreach (var f in Directory.GetFiles(tempDir, "*", SearchOption.AllDirectories))
+            {
+                try { File.SetAttributes(f, FileAttributes.Normal); } catch { /* best-effort */ }
+            }
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private bool InvokeMove(string stagingPath, string targetPath, string logPrefix = "[NodeJS]")
+    {
+        return Unwrap(() => (bool)moveMethod.Invoke(null, new object[] { stagingPath, targetPath, logPrefix }));
+    }
+
+    private bool InvokeCore(string stagingPath, string targetPath, string logPrefix,
+        Action move, Func<bool> targetExists, Action<int> sleep)
+    {
+        return Unwrap(() => (bool)coreMethod.Invoke(null,
+            new object[] { stagingPath, targetPath, logPrefix, move, targetExists, sleep }));
+    }
+
+    // 리플렉션 래핑(TargetInvocationException)을 벗겨 원래 예외를 그대로 전파 —
+    // Assert.Throws<T>가 직접 잡을 수 있도록 스택까지 보존.
+    private static bool Unwrap(Func<bool> invoke)
+    {
+        try
+        {
+            return invoke();
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw; // unreachable
+        }
+    }
+
+    private static void CreateStagingWithContent(string stagingPath)
+    {
+        Directory.CreateDirectory(stagingPath);
+        Directory.CreateDirectory(Path.Combine(stagingPath, "bin"));
+        File.WriteAllText(Path.Combine(stagingPath, "bin", "node"), "#!/bin/sh");
+        File.WriteAllText(Path.Combine(stagingPath, "README.md"), "node");
+    }
+
+    // =====================================================
+    // 기본 경로 — 실제 FS, 공개 API (cross-platform)
+    // =====================================================
+
+    [Test]
+    public void MoveDirectoryWithRetry_TargetAbsent_MovesAndReturnsTrue()
+    {
+        string staging = Path.Combine(tempDir, "win-x64-installing-abc123");
+        string target = Path.Combine(tempDir, "win-x64");
+        CreateStagingWithContent(staging);
+
+        bool moved = InvokeMove(staging, target);
+
+        Assert.IsTrue(moved, "target이 없으면 이동을 수행하고 true를 반환해야 함");
+        Assert.IsFalse(Directory.Exists(staging), "이동 후 staging은 사라져야 함");
+        Assert.IsTrue(Directory.Exists(target), "target에 디렉토리가 존재해야 함");
+        Assert.IsTrue(File.Exists(Path.Combine(target, "bin", "node")), "내용물이 함께 이동되어야 함");
+    }
+
+    [Test]
+    public void MoveDirectoryWithRetry_TargetAlreadyExists_ReturnsFalseWithoutMoving()
+    {
+        // 다른 프로세스가 먼저 설치를 완료한 경합(race winner) 상황 —
+        // 이동을 건너뛰고 false를 반환하며 기존 target을 건드리지 않아야 한다.
+        string staging = Path.Combine(tempDir, "win-x64-installing-def456");
+        string target = Path.Combine(tempDir, "win-x64");
+        CreateStagingWithContent(staging);
+        Directory.CreateDirectory(target);
+        File.WriteAllText(Path.Combine(target, "EXISTING.txt"), "winner");
+
+        bool moved = InvokeMove(staging, target);
+
+        Assert.IsFalse(moved, "target이 이미 있으면 이동을 건너뛰고 false를 반환해야 함");
+        Assert.IsTrue(File.Exists(Path.Combine(target, "EXISTING.txt")), "기존 target 내용이 보존되어야 함");
+        Assert.IsTrue(Directory.Exists(staging), "이동을 건너뛰었으므로 staging 정리는 호출자(finally) 몫 — 메서드가 삭제하지 않음");
+    }
+
+    // =====================================================
+    // 재시도/백오프/경합/소진 — 주입식 core (결정적, cross-platform, 실제 sleep 없음)
+    // =====================================================
+
+    [Test]
+    public void Core_TargetAbsent_MovesFirstTryWithoutSleeping()
+    {
+        var sleeps = new List<int>();
+        int moveCalls = 0;
+
+        bool moved = InvokeCore("staging", "target", "[NodeJS]",
+            move: () => moveCalls++,
+            targetExists: () => false,
+            sleep: ms => sleeps.Add(ms));
+
+        Assert.IsTrue(moved, "첫 시도에 이동이 성공하면 true");
+        Assert.AreEqual(1, moveCalls, "이동은 한 번만 시도되어야 함");
+        Assert.AreEqual(0, sleeps.Count, "성공 시 백오프 대기는 발생하지 않아야 함");
+    }
+
+    [Test]
+    public void Core_TransientFailure_RecoversAfterBackoff()
+    {
+        // 회귀(SDK-100): 첫 2회는 일시적 IOException(AV 핸들 점유), 3번째에 풀려 성공.
+        var sleeps = new List<int>();
+        int moveCalls = 0;
+
+        bool moved = InvokeCore("staging", "target", "[NodeJS]",
+            move: () =>
+            {
+                moveCalls++;
+                if (moveCalls <= 2) throw new IOException("transient lock");
+                // 3번째 호출은 성공
+            },
+            targetExists: () => false,
+            sleep: ms => sleeps.Add(ms));
+
+        Assert.IsTrue(moved, "백오프 재시도로 일시적 잠금에서 회복해 true를 반환해야 함");
+        Assert.AreEqual(3, moveCalls, "2회 실패 후 3번째에 성공");
+        CollectionAssert.AreEqual(new[] { 100, 250 }, sleeps,
+            "실패한 두 시도 후 백오프가 순서대로(100ms, 250ms) 적용되어야 함");
+    }
+
+    [Test]
+    public void Core_RaceWinnerDuringRetry_ReturnsFalse()
+    {
+        // 첫 시도는 IOException으로 실패하지만, 백오프 후 재진입 시점에 다른 프로세스가
+        // target을 완성(race winner) → 이동을 포기하고 false를 반환해야 한다.
+        var sleeps = new List<int>();
+        int moveCalls = 0;
+        int existsCalls = 0;
+
+        bool moved = InvokeCore("staging", "target", "[NodeJS]",
+            move: () =>
+            {
+                moveCalls++;
+                throw new IOException("locked");
+            },
+            targetExists: () =>
+            {
+                existsCalls++;
+                // 1번째 확인(attempt 0): 아직 없음 → 이동 시도 → 실패 → sleep
+                // 2번째 확인(attempt 1): race winner가 완성 → true
+                return existsCalls >= 2;
+            },
+            sleep: ms => sleeps.Add(ms));
+
+        Assert.IsFalse(moved, "재시도 중 target이 완성되면 false(race winner)");
+        Assert.AreEqual(1, moveCalls, "두 번째 진입에서 target 존재로 이동을 시도하지 않아야 함");
+        CollectionAssert.AreEqual(new[] { 100 }, sleeps, "첫 실패 후 한 번만 백오프");
+    }
+
+    [Test]
+    public void Core_UnrecoverableFailure_ExhaustsBackoffThenThrowsWithWarning()
+    {
+        // 전체 재시도 윈도우 동안 계속 실패 → 백오프 4회를 모두 소진(100→250→500→1000)하고
+        // 경고 1회 출력 후 마지막 IOException을 호출자에게 다시 던져야 한다(이동 실패는 치명적).
+        var sleeps = new List<int>();
+        int moveCalls = 0;
+
+        LogAssert.Expect(LogType.Warning,
+            new System.Text.RegularExpressions.Regex(@"\[NodeJS\] 디렉토리 이동 재시도 5회 모두 실패"));
+
+        var ex = Assert.Throws<IOException>(() => InvokeCore("staging", "target", "[NodeJS]",
+            move: () =>
+            {
+                moveCalls++;
+                throw new IOException("permanent lock #" + moveCalls);
+            },
+            targetExists: () => false,
+            sleep: ms => sleeps.Add(ms)));
+
+        Assert.AreEqual(5, moveCalls, "즉시 1회 + 백오프 4회 = 총 5회 시도");
+        CollectionAssert.AreEqual(ExpectedBackoffMs, sleeps,
+            "백오프가 100→250→500→1000ms 순서로 정확히 4회 적용되어야 함");
+        StringAssert.Contains("permanent lock #5", ex.Message,
+            "마지막(5번째) 시도의 예외가 전파되어야 함");
+    }
+
+    [Test]
+    public void Core_NonIOException_PropagatesImmediatelyWithoutRetry()
+    {
+        // IOException이 아닌 예외(예: 권한/ACL 문제의 UnauthorizedAccessException)는
+        // 일시적 잠금이 아니므로 재시도하지 않고 즉시 전파해야 한다 — 무의미한 ~1.85s 지연 방지.
+        var sleeps = new List<int>();
+        int moveCalls = 0;
+
+        Assert.Throws<UnauthorizedAccessException>(() => InvokeCore("staging", "target", "[NodeJS]",
+            move: () =>
+            {
+                moveCalls++;
+                throw new UnauthorizedAccessException("ACL denied");
+            },
+            targetExists: () => false,
+            sleep: ms => sleeps.Add(ms)));
+
+        Assert.AreEqual(1, moveCalls, "IOException이 아니면 재시도 없이 1회만 시도");
+        Assert.AreEqual(0, sleeps.Count, "재시도하지 않으므로 백오프 대기도 없어야 함");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/MoveDirectoryWithRetryTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/MoveDirectoryWithRetryTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c9b0d6ccffa4cc89e69563cbf264be4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경 (Sentry APPS-IN-TOSS-UNITY-SDK-100)

```
[AIT] 패키지 매니저 체크 중 예외: System.IO.IOException:
  Access to the path '...nodejs...win-x64-installing-<hash>' is denied.
```

Windows AV/Defender가 ZIP 추출 직후 staging 디렉토리 내 파일 핸들을 잠깐 점유하면,
`staging → 최종 경로` rename(`Directory.Move`)이 일시적 `IOException`으로 실패해
**Node.js 설치 자체가 무산**된다. 핸들은 보통 수백 ms 안에 풀리므로 짧은 재시도로 회복 가능하다.

기존 #715는 이 경로의 Sentry 캡처를 `sentryCapture:false`로 **억제**(노이즈 차단)했을 뿐,
설치가 실패하는 **기능 결함은 그대로**였다. 본 PR은 설치 실패 자체를 회복한다.

## 변경

**`Editor/AITFileSystemHelper.cs`** — `MoveDirectoryWithRetry` 추가
- 지수 백오프(100→250→500→1000ms, 즉시 1회 포함 총 5회)로 `Directory.Move` 재시도.
- 기존 `SafeDeleteDirectory` retry 선례와 동일 패턴이되, **이동 실패는 설치를 무산시키는 치명적
  경로**라 소진 시 마지막 예외를 호출자에게 다시 던진다(삭제는 best-effort로 삼키는 것과 대비).
- 재시도 진입마다 target 존재를 재확인해 다른 프로세스가 먼저 설치한 **경합(race winner)**을
  감지하면 `false` 반환(이동 생략) — 기존 동시성 처리 동작 보존.
- `IOException`만 재시도. `UnauthorizedAccessException`(ACL 등)은 일시적 잠금이 아니므로 즉시 전파.
- 테스트 가능한 `internal` core(`MoveDirectoryWithRetryCore`)로 분리 — `move`/`targetExists`/`sleep`
  델리게이트 주입으로 재시도/백오프/경합/소진 흐름을 결정적으로 검증.

**`Editor/AITNodeJSDownloader.cs`**
- 인라인 `Directory.Move` + 동시성 처리 블록을 헬퍼 호출로 대체.
- staging 정리는 기존 `finally`의 `SafeDeleteDirectory`가 모든 경로에서 담당(동작 동일).

**`Tests~/.../EditModeTests/MoveDirectoryWithRetryTests.cs`** (신규, Level 0) — 6건
- 실제 FS happy-path 2건: target 없음→이동·`true`, target 존재→race winner `false`(기존 보존).
- 주입식 core 4건: 첫 시도 성공 / 일시 실패 후 회복(백오프 순서 검증) / 재시도 중 race winner /
  소진→경고 1회+`throw` / 비-`IOException` 즉시 전파.
- 실제 sleep·파일잠금 없이 결정적·크로스플랫폼.

## 검증

- `./run-local-tests.sh --validate` 통과 (파일 구조 + SDK invariants 18/18).
- EditMode/C# 컴파일은 **CI에서 실행** (로컬 Unity 미설치).
- `Editor/` 하위 변경이라 SDK 재생성 불필요 (`Runtime/SDK/` 무관).

Fixes APPS-IN-TOSS-UNITY-SDK-100