### PR TITLE
테스트: E2E 검증에 apps-in-toss.config.ts 플레이스홀더 단언 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
+++ b/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
@@ -59,7 +59,7 @@ public static class BuildOutputValidator
             errors.Add("ait-build/package.json not found");
         }
 
-        // 3. granite.config.ts 존재 + 플레이스홀더 확인
+        // 3. granite.config.ts 존재 + 플레이스홀더 확인 (web-framework 2.x granite build 전용)
         string graniteConfigPath = Path.Combine(aitBuildPath, "granite.config.ts");
         if (File.Exists(graniteConfigPath))
         {
@@ -73,6 +73,26 @@ public static class BuildOutputValidator
         else
         {
             warnings.Add("granite.config.ts not found");
+        }
+
+        // 3.5. apps-in-toss.config.ts 존재 + 플레이스홀더 확인 (web-framework 3.x ait build 전용)
+        //   3.x의 `ait build`는 granite.config.ts를 무시하고 이 파일을 cosmiconfig로 탐색한다.
+        //   granite.config.ts만 검증하면 3.x가 실제로 읽는 설정의 치환이 검증되지 않아
+        //   vestigial 파일만 통과시키는 false green이 된다. 두 파일 모두 Unity 템플릿이
+        //   emit·치환하므로 채널과 무관하게 함께 검증한다 (구버전 SDK 템플릿엔 없을 수 있어 warning).
+        string appsInTossConfigPath = Path.Combine(aitBuildPath, "apps-in-toss.config.ts");
+        if (File.Exists(appsInTossConfigPath))
+        {
+            string content = File.ReadAllText(appsInTossConfigPath);
+            var placeholders = CheckForPlaceholders(content);
+            if (placeholders.Count > 0)
+            {
+                errors.Add($"apps-in-toss.config.ts has unsubstituted placeholders: {string.Join(", ", placeholders)}");
+            }
+        }
+        else
+        {
+            warnings.Add("apps-in-toss.config.ts not found");
         }
 
         // 4. node_modules/ 존재 확인

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildCleanupTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildCleanupTests.cs
@@ -89,6 +89,7 @@ public class BuildCleanupTests
         File.WriteAllText(Path.Combine(buildPath, "package-lock.json"), "{}");
         File.WriteAllText(Path.Combine(buildPath, "pnpm-lock.yaml"), "lockfile: 1");
         File.WriteAllText(Path.Combine(buildPath, "granite.config.ts"), "export default {}");
+        File.WriteAllText(Path.Combine(buildPath, "apps-in-toss.config.ts"), "export default {}");
         File.WriteAllText(Path.Combine(buildPath, "vite.config.ts"), "export default {}");
         File.WriteAllText(Path.Combine(buildPath, "tsconfig.json"), "{}");
 
@@ -111,6 +112,8 @@ public class BuildCleanupTests
             "pnpm-lock.yaml should be preserved");
         Assert.IsTrue(File.Exists(Path.Combine(buildPath, "granite.config.ts")),
             "granite.config.ts should be preserved");
+        Assert.IsTrue(File.Exists(Path.Combine(buildPath, "apps-in-toss.config.ts")),
+            "apps-in-toss.config.ts should be preserved");
         Assert.IsTrue(File.Exists(Path.Combine(buildPath, "vite.config.ts")),
             "vite.config.ts should be preserved");
         Assert.IsTrue(File.Exists(Path.Combine(buildPath, "tsconfig.json")),

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -512,12 +512,21 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
       // package.json
       expect(fileExists(path.resolve(AIT_BUILD, 'package.json')), 'package.json should exist').toBe(true);
 
-      // granite.config.ts 플레이스홀더
+      // granite.config.ts 플레이스홀더 (web-framework 2.x granite build 전용)
       const graniteConfigPath = path.resolve(AIT_BUILD, 'granite.config.ts');
       if (fileExists(graniteConfigPath)) {
         const content = fs.readFileSync(graniteConfigPath, 'utf-8');
         const placeholders = checkForPlaceholders(content);
         expect(placeholders.length, 'Should have no unsubstituted placeholders in granite.config.ts').toBe(0);
+      }
+
+      // apps-in-toss.config.ts 플레이스홀더 (web-framework 3.x ait build — cosmiconfig 탐색 대상)
+      // 3.x가 실제로 읽는 설정 파일. granite.config.ts만 검증하면 false green이 되므로 함께 검증한다.
+      const appsInTossConfigPath = path.resolve(AIT_BUILD, 'apps-in-toss.config.ts');
+      if (fileExists(appsInTossConfigPath)) {
+        const content = fs.readFileSync(appsInTossConfigPath, 'utf-8');
+        const placeholders = checkForPlaceholders(content);
+        expect(placeholders.length, 'Should have no unsubstituted placeholders in apps-in-toss.config.ts').toBe(0);
       }
 
       // node_modules


### PR DESCRIPTION
## 배경

web-framework 3.x의 `ait build`는 `granite.config.ts`를 무시하고 **cosmiconfig로 `apps-in-toss.config.ts`를 탐색**한다 (2.x `granite build`는 반대로 `granite.config.ts`만 사용). Unity 템플릿은 두 config를 함께 emit·치환하지만, 기존 E2E 검증은 **vestigial한 `granite.config.ts`의 플레이스홀더만 단언**해서 3.x가 실제로 읽는 설정 파일의 치환 누락을 잡지 못하는 **false green 공백**이 있었다.

- 3.x 베타로 full E2E를 돌려도 `granite.config.ts`(3.x가 무시하는 파일)만 보고 "통과" → 정작 3.x가 읽는 `apps-in-toss.config.ts`에 `%AIT_APP_NAME%` 같은 미치환 플레이스홀더가 남아도 검출 안 됨.

## 변경

- **`BuildOutputValidator.cs`** (primary 검증, `build-validation.json`으로 굽힘): `apps-in-toss.config.ts` 존재 시 플레이스홀더 검증 추가 (`%UNITY_*%`/`%AIT_*%` 미치환 → error).
- **`e2e-full-pipeline.test.js`** (Playwright fallback 경로): 동일 단언 추가.
- **`BuildCleanupTests.cs`** (EditMode): cleanup 후 `apps-in-toss.config.ts` 보존 단언 추가 — `WebGLBuildCopier`의 `itemsToKeep`에서 드롭되는 회귀 감지.

두 config 모두 Unity가 emit·치환하므로 **채널(2.x stable / 3.x beta)과 무관하게 함께 검증**한다. 구버전 SDK 템플릿엔 `apps-in-toss.config.ts`가 없을 수 있어 미존재 시 warning(error 아님) — `granite.config.ts` 패턴과 동일.

## 검증

- `./run-local-tests.sh --validate` 통과 (파일 구조 + Playwright 설정 + SDK invariants 18/18).
- 편집한 JS `node --check` 통과.
- C# EditMode 단언은 단순 추가(기존 보존 단언 미러)라 Unity full E2E에서 자연 검증됨.

## 범위 메모 (이 PR에 미포함, 의도적)

- **`ait deploy` 스모크**: full E2E는 빌드 산출물을 로컬 `vite preview`로 띄울 뿐 `ait deploy`(배포 API push)를 호출하지 않으므로 deploy 동작은 E2E 범위 밖. 별도 dry-run/모킹 설계가 필요해 분리.
- **`build` 스크립트의 `|| granite build` 폴백**: 3.x에선 granite 바이너리가 없어 죽은 폴백이지만, **2.x stable과 공유되는 템플릿**이라 2.x에선 여전히 유효 → 제거하지 않고 유지.