### PR TITLE
빌드: 베타 채널 게시를 Playwright E2E 게이트로 보호

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -267,40 +267,11 @@ jobs:
           pnpm install --no-frozen-lockfile
           echo "BuildConfig pnpm-lock.yaml 업데이트 완료"
 
-      - name: 릴리즈용 테스트 코드 제외
-        run: |
-          echo "=== 릴리즈 빌드용 테스트 코드 제외 ==="
-
-          SHARED_RUNTIME="Tests~/E2E/SharedScripts/Runtime"
-
-          if [ -d "$SHARED_RUNTIME" ]; then
-            echo "SharedScripts/Runtime .cs 파일 삭제 중..."
-            find "$SHARED_RUNTIME" -name "*.cs" -type f -delete
-
-            # E2EBuildRunner.cs가 의존하는 최소 스텁 파일 생성
-            cat > "${SHARED_RUNTIME}/E2EBootstrapperHelper.cs" << 'STUB_EOF'
-          using UnityEngine;
-          // 릴리즈 빌드용 스텁 - 실제 기능 없음
-          public class E2EBootstrapperHelper : MonoBehaviour
-          {
-              void Start() { }
-          }
-          STUB_EOF
-
-            cat > "${SHARED_RUNTIME}/E2EBootstrapper.cs" << 'STUB_EOF'
-          using UnityEngine;
-          // 릴리즈 빌드용 스텁 - 실제 기능 없음
-          public static class E2EBootstrapper
-          {
-              public static void Initialize() { }
-          }
-          STUB_EOF
-          fi
-
-          SHARED_PLUGINS="Tests~/E2E/SharedScripts/Plugins"
-          if [ -d "$SHARED_PLUGINS" ]; then
-            find "$SHARED_PLUGINS" -name "*.cs" -type f -delete
-          fi
+      # 주의: 과거에는 여기서 E2E 테스트 코드(SharedScripts/Runtime·Plugins)를 stub으로
+      # strip 했으나, 이제 staging 트리를 Playwright E2E 게이트(e2e-beta-*)로 검증하므로
+      # E2E 부트스트랩이 빌드에 그대로 살아 있어야 한다. 게시 패키지에는 publish-beta의
+      # `rm -rf Tests~/` 가 SharedScripts를 통째로 제거하므로 테스트 코드가 새어 나가지 않는다
+      # (E2EBootstrapper/E2EBuildRunner 참조는 전부 Tests~/ 내부에만 존재 — shipped SDK 무관).
 
       - name: Staging Orphan Commit 생성 및 push
         id: stage
@@ -388,18 +359,165 @@ jobs:
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
 
   # =====================================================
-  # 베타 게시: 빌드 성공 후 staging 트리를 channel_ref로 승격
-  # 빌드 실패 시 게시하지 않음 → 베타 채널이 깨진 SDK로 갱신되는 것 방지.
+  # 베타 E2E 게이트 - macOS 빌드 산출물 (Playwright, ubuntu-latest)
+  # build-beta-macos가 올린 ait-build 아티팩트(베타 재생성 SDK + E2E 부트스트랩)를
+  # 받아 vite preview로 띄우고 Playwright로 검증한다. test-e2e.yml의 e2e-macos와 동일
+  # 경로이며, 매트릭스는 beta-prepare의 macos_versions(build_strategy 비례)를 그대로 사용.
+  # INV3 보존: 배포(ait deploy) 없음 — 로컬 preview 서버에서만 로드하며 AIT_DEPLOY_KEY 불사용.
+  # =====================================================
+  e2e-beta-macos:
+    name: 베타 E2E (macOS, Unity ${{ matrix.unity-version }})
+    needs: [beta-prepare, build-beta-macos]
+    if: needs.beta-prepare.outputs.skip_build != 'true' && needs.build-beta-macos.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    concurrency:
+      group: beta-e2e-${{ github.workflow }}-${{ needs.beta-prepare.outputs.staging_ref }}-macos-${{ matrix.unity-version }}
+      cancel-in-progress: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        unity-version: ${{ fromJSON(needs.beta-prepare.outputs.macos_versions) }}
+
+    env:
+      MOBILE_EMULATION: "true"
+      TEST_LEVEL: "2"
+      AIT_BUILD_DIR: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build
+
+    steps:
+      - name: Checkout (staging ref)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.beta-prepare.outputs.staging_ref }}
+
+      - name: Download AIT Build Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ait-build-macos-${{ matrix.unity-version }}-v${{ needs.beta-prepare.outputs.pkg_version }}
+          path: ${{ env.AIT_BUILD_DIR }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install AIT Build Dependencies
+        working-directory: ${{ env.AIT_BUILD_DIR }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Test Dependencies
+        working-directory: Tests~/E2E/tests
+        # 브라우저는 runner image의 시스템 Chrome 사용 (playwright.config.ts: channel='chrome').
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Playwright E2E
+        working-directory: Tests~/E2E/tests
+        env:
+          UNITY_PROJECT_PATH: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}
+          AIT_DEVELOPMENT_BUILD: "true"
+          AIT_COMPRESSION_FORMAT: "0"
+        run: pnpm test
+
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: beta-playwright-report-macos-${{ matrix.unity-version }}
+          path: Tests~/E2E/tests/playwright-report/
+          if-no-files-found: ignore
+          compression-level: 9
+          retention-days: 7
+
+  # =====================================================
+  # 베타 E2E 게이트 - Windows 빌드 산출물 (Playwright, ubuntu-latest)
+  # skip_windows(예: minimal 전략)면 build-beta-windows가 스킵되고 이 잡도 스킵된다.
+  # =====================================================
+  e2e-beta-windows:
+    name: 베타 E2E (Windows, Unity ${{ matrix.unity-version }})
+    needs: [beta-prepare, build-beta-windows]
+    if: needs.beta-prepare.outputs.skip_build != 'true' && needs.beta-prepare.outputs.skip_windows != 'true' && needs.build-beta-windows.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    concurrency:
+      group: beta-e2e-${{ github.workflow }}-${{ needs.beta-prepare.outputs.staging_ref }}-windows-${{ matrix.unity-version }}
+      cancel-in-progress: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        unity-version: ${{ fromJSON(needs.beta-prepare.outputs.windows_versions) }}
+
+    env:
+      TEST_LEVEL: "2"
+      AIT_BUILD_DIR: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}/ait-build
+
+    steps:
+      - name: Checkout (staging ref)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.beta-prepare.outputs.staging_ref }}
+
+      - name: Download AIT Build Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ait-build-windows-${{ matrix.unity-version }}-v${{ needs.beta-prepare.outputs.pkg_version }}
+          path: ${{ env.AIT_BUILD_DIR }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install AIT Build Dependencies
+        working-directory: ${{ env.AIT_BUILD_DIR }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Test Dependencies
+        working-directory: Tests~/E2E/tests
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Playwright E2E
+        working-directory: Tests~/E2E/tests
+        env:
+          UNITY_PROJECT_PATH: ${{ github.workspace }}/Tests~/E2E/SampleUnityProject-${{ matrix.unity-version }}
+          AIT_DEVELOPMENT_BUILD: "true"
+          AIT_COMPRESSION_FORMAT: "0"
+        run: pnpm test
+
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: beta-playwright-report-windows-${{ matrix.unity-version }}
+          path: Tests~/E2E/tests/playwright-report/
+          if-no-files-found: ignore
+          compression-level: 9
+          retention-days: 7
+
+  # =====================================================
+  # 베타 게시: 빌드 + E2E 성공 후 staging 트리를 channel_ref로 승격
+  # 빌드/E2E 실패 시 게시하지 않음 → 베타 채널이 깨진 SDK로 갱신되는 것 방지.
   # =====================================================
   publish-beta:
     name: 베타 채널 게시
     runs-on: ubuntu-latest
-    needs: [beta-prepare, build-beta-macos, build-beta-windows]
+    needs: [beta-prepare, build-beta-macos, build-beta-windows, e2e-beta-macos, e2e-beta-windows]
     if: |
       always() &&
       needs.beta-prepare.result == 'success' &&
       (needs.build-beta-macos.result == 'success' || needs.build-beta-macos.result == 'skipped') &&
-      (needs.build-beta-windows.result == 'success' || needs.build-beta-windows.result == 'skipped')
+      (needs.build-beta-windows.result == 'success' || needs.build-beta-windows.result == 'skipped') &&
+      (needs.e2e-beta-macos.result == 'success' || needs.e2e-beta-macos.result == 'skipped') &&
+      (needs.e2e-beta-windows.result == 'success' || needs.e2e-beta-windows.result == 'skipped')
 
     outputs:
       pkg_version: ${{ needs.beta-prepare.outputs.pkg_version }}


### PR DESCRIPTION
## 배경

베타 채널(`beta-release.yml`)은 **3.x로 재생성된 SDK**를 게시한다. 그런데 지금까지 `publish-beta`는 `build-beta-*`(Unity WebGL 빌드 + EditMode 검증)의 **성공만으로** 진행되어, 앱이 실제로 브라우저에서 뜨고 SDK 호출이 동작하는지(**Playwright E2E**)는 한 번도 검증하지 않았다.

- `main`의 E2E는 stable(2.6.1) 표면만 돌므로, 베타 재생성 SDK는 **E2E 검증 공백** 상태였다.
- stable `release.yml`은 PR에서 이미 E2E된 SDK를 그대로 내므로 재검증이 불필요하지만, 베타는 main에 없는 재생성 SDK라 사정이 다르다.

## 변경

| | before | after |
|---|---|---|
| `publish-beta` 게이트 | build(+EditMode) 성공 | build + **Playwright E2E** 성공 |

1. **beta-prepare의 `릴리즈용 테스트 코드 제외` strip 제거** — staging 트리가 E2E 부트스트랩을 유지(=`test-e2e.yml`과 동일한 빌드). 게시 패키지에는 `publish-beta`의 `rm -rf Tests~/`가 `SharedScripts`를 통째로 제거하므로 영향 없음. (`E2EBootstrapper`/`E2EBuildRunner` 참조는 전부 `Tests~/` 내부에만 존재 — shipped SDK 무관함을 확인)
2. **`e2e-beta-macos` / `e2e-beta-windows` 잡 추가** — `build-beta-*`가 올린 `ait-build` 아티팩트(베타 SDK + E2E 부트스트랩)를 받아 `vite preview`로 띄우고 Playwright(`pnpm test`)로 검증. 매트릭스는 `beta-prepare`의 `macos_versions`/`windows_versions`를 그대로 사용 → **`build_strategy`에 비례**(minimal=macOS 1종, full=전체).
3. **`publish-beta` `needs`/`if` 갱신** — `e2e-beta-*` 성공(또는 skip-build/skip_windows 시 `skipped`)에 의존. E2E 실패 시 베타 채널 미갱신.

### DAG
```
beta-prepare
  → build-beta-macos ─┐        → e2e-beta-macos ─┐
  → build-beta-windows┘(skip_windows시 생략) → e2e-beta-windows┘ → publish-beta → sentry-release / notify-beta
```

## 격리 불변식

- **INV3 보존** — E2E는 `vite preview` 로컬 로드만 수행하며 `AIT_DEPLOY_KEY`를 일절 쓰지 않음(배포 없음).
- **INV1/2/4/5 불변** — main 무변경, prerelease 릴리즈(`--prerelease --latest=false`), `.version` 유지, Sentry `set_commits: skip`.

## 게이트 정합성

- `e2e-beta-*` 실패 → `result=failure` → `publish-beta` 차단 ✅
- `build-beta-*` 실패 → `e2e-beta-*` `skipped` → publish는 build 절(`success||skipped`)에서 차단 ✅
- `skip-build` 전략 → build/E2E 모두 `skipped` → 재게시 경로 정상 진행 ✅
- `minimal`(skip_windows) → windows build/E2E `skipped`, macOS build+E2E 필수 ✅

## 검증

- `actionlint`로 워크플로 구문 정상 파싱(에러 0; 보고된 shellcheck info/style는 전부 기존 스텝).
- 잡 그래프·`needs`/`if`·매트릭스 소스·아티팩트 이름(`ait-build-{os}-{ver}-v{pkg_version}`, `unity-build.yml` 네이밍 규칙과 일치) 확인.

## 후속(별도)

- `unity-build.yml`의 `Upload AIT Build` path 목록에 `apps-in-toss.config.ts`가 빠져 있음(PR #748에서 검증 추가했으나 아티팩트엔 미포함). E2E는 `dist/web`만 서빙하므로 게이트엔 영향 없지만, 완전성 차원에서 추후 추가 검토.