### PR TITLE
개선: IL2CPP OptimizeSize로 제네릭 폭발 억제

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -170,6 +170,15 @@ namespace AppsInToss.Editor
             PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.WebGL, il2cppConfig);
 #endif
 
+            // ===== IL2CPP Code Generation (Meta 로드타임 스택: OptimizeSize) =====
+            // 제네릭 인스턴스화 공유로 wasm 코드 크기 축소. Unity 6+ 전용 API.
+#if UNITY_6000_0_OR_NEWER
+            Il2CppCodeGeneration il2cppCodeGen = editorConfig.il2cppCodeGeneration >= 0
+                ? (Il2CppCodeGeneration)editorConfig.il2cppCodeGeneration
+                : AITDefaultSettings.GetDefaultIl2CppCodeGeneration();
+            PlayerSettings.SetIl2CppCodeGeneration(NamedBuildTarget.WebGL, il2cppCodeGen);
+#endif
+
             // ===== Unity 6 (2023.3+) 전용 설정 =====
 #if UNITY_2023_3_OR_NEWER
             // 출처: UnityVersion.md:394-402
@@ -210,6 +219,9 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
+#if UNITY_6000_0_OR_NEWER
+            Debug.Log($"[AIT]   - IL2CPP Code Generation: {il2cppCodeGen}{(editorConfig.il2cppCodeGeneration < 0 ? " (자동)" : "")}");
+#endif
 #if UNITY_2023_3_OR_NEWER
             Debug.Log($"[AIT]   - Power Preference: {powerPreference}{(editorConfig.powerPreference < 0 ? " (자동)" : "")}");
 #if !UNITY_6000_0_OR_NEWER

--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -35,6 +35,9 @@ namespace AppsInToss.Editor
         public ScriptingImplementation scriptingBackend;
         public ManagedStrippingLevel managedStrippingLevel;
         public Il2CppCompilerConfiguration il2cppCompilerConfiguration;
+#if UNITY_6000_0_OR_NEWER
+        public Il2CppCodeGeneration il2cppCodeGeneration;
+#endif
 
         // Stack Trace Log Type (LogType별)
         public StackTraceLogType stackTraceLogTypeError;
@@ -77,6 +80,7 @@ namespace AppsInToss.Editor
                 scriptingBackend = PlayerSettings.GetScriptingBackend(NamedBuildTarget.WebGL),
                 managedStrippingLevel = PlayerSettings.GetManagedStrippingLevel(NamedBuildTarget.WebGL),
                 il2cppCompilerConfiguration = PlayerSettings.GetIl2CppCompilerConfiguration(NamedBuildTarget.WebGL),
+                il2cppCodeGeneration = PlayerSettings.GetIl2CppCodeGeneration(NamedBuildTarget.WebGL),
 #else
                 scriptingBackend = PlayerSettings.GetScriptingBackend(BuildTargetGroup.WebGL),
                 managedStrippingLevel = PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.WebGL),
@@ -138,6 +142,7 @@ namespace AppsInToss.Editor
             PlayerSettings.SetScriptingBackend(NamedBuildTarget.WebGL, scriptingBackend);
             PlayerSettings.SetManagedStrippingLevel(NamedBuildTarget.WebGL, managedStrippingLevel);
             PlayerSettings.SetIl2CppCompilerConfiguration(NamedBuildTarget.WebGL, il2cppCompilerConfiguration);
+            PlayerSettings.SetIl2CppCodeGeneration(NamedBuildTarget.WebGL, il2cppCodeGeneration);
 #else
             PlayerSettings.SetScriptingBackend(BuildTargetGroup.WebGL, scriptingBackend);
             PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL, managedStrippingLevel);

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -663,6 +663,11 @@ namespace AppsInToss.Editor
             // IL2CPP 컴파일러 설정
             DrawIl2CppConfigurationSetting();
 
+#if UNITY_6000_0_OR_NEWER
+            // IL2CPP Code Generation (OptimizeSize) — Meta 로드타임 스택
+            DrawIl2CppCodeGenerationSetting();
+#endif
+
 #if UNITY_2023_3_OR_NEWER
             GUILayout.Space(10);
             EditorGUILayout.LabelField("Unity 6 전용 설정", EditorStyles.boldLabel);
@@ -744,6 +749,34 @@ namespace AppsInToss.Editor
 
             EditorGUILayout.EndHorizontal();
         }
+
+#if UNITY_6000_0_OR_NEWER
+        private void DrawIl2CppCodeGenerationSetting()
+        {
+            UnityEditor.Build.Il2CppCodeGeneration defaultCodeGen = AITDefaultSettings.GetDefaultIl2CppCodeGeneration();
+            bool isModified = config.il2cppCodeGeneration >= 0 && (UnityEditor.Build.Il2CppCodeGeneration)config.il2cppCodeGeneration != defaultCodeGen;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.il2cppCodeGeneration < 0
+                ? $"IL2CPP 코드 생성 (자동: {defaultCodeGen})"
+                : "IL2CPP 코드 생성";
+
+            string[] options = { $"자동 ({defaultCodeGen})", "OptimizeSpeed", "OptimizeSize" };
+            int currentIndex = config.il2cppCodeGeneration < 0 ? 0 : config.il2cppCodeGeneration + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.il2cppCodeGeneration = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.il2cppCodeGeneration = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+#endif
 
 #if UNITY_2023_3_OR_NEWER
         private void DrawPowerPreferenceSetting()
@@ -1029,6 +1062,9 @@ namespace AppsInToss.Editor
             config.stripEngineCode = true;
             config.il2cppConfiguration = -1;
             config.powerPreference = -1;
+#if UNITY_6000_0_OR_NEWER
+            config.il2cppCodeGeneration = -1;
+#endif
 #if !UNITY_6000_0_OR_NEWER
             config.wasmStreaming = true;
             config.webAssemblyArithmeticExceptions = -1;

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -180,6 +180,9 @@ namespace AppsInToss
         [Tooltip("-1 = 자동 (Release)")]
         public int il2cppConfiguration = -1;
 
+        [Tooltip("-1 = 자동 (OptimizeSize, Unity 6+). 0 = OptimizeSpeed, 1 = OptimizeSize — 제네릭 인스턴스 공유로 wasm 코드 크기 축소")]
+        public int il2cppCodeGeneration = -1;
+
         [Header("Unity 6 전용 설정")]
         [Tooltip("-1 = 자동 (HighPerformance)")]
         public int powerPreference = -1;
@@ -407,6 +410,20 @@ namespace AppsInToss
         {
             return Il2CppCompilerConfiguration.Release;
         }
+
+#if UNITY_6000_0_OR_NEWER
+        /// <summary>
+        /// 기본 IL2CPP 코드 생성 방식 (Unity 6+): OptimizeSize
+        /// Meta+Unity 로드타임 스택의 "Faster (smaller) builds" — 제네릭 인스턴스화를
+        /// 공유해 제네릭 폭발(측정상 ~130k 함수)을 붕괴시켜 wasm 코드 크기를 축소한다.
+        /// trade-off: 공유 제네릭의 미세한 런타임 디스패치 비용(정확성 변화 아님).
+        /// 출처: Unity Manual web-optimization-player (IL2CPP Code Generation = Optimize for code size)
+        /// </summary>
+        public static UnityEditor.Build.Il2CppCodeGeneration GetDefaultIl2CppCodeGeneration()
+        {
+            return UnityEditor.Build.Il2CppCodeGeneration.OptimizeSize;
+        }
+#endif
 
 #if UNITY_2023_3_OR_NEWER
         /// <summary>


### PR DESCRIPTION
## 개요
Unity 6+에서 **IL2CPP Code Generation = OptimizeSize**(Optimize for code size)를 기본 적용합니다. 제네릭 인스턴스화를 공유해 제네릭 폭발(측정상 ~130k 함수)을 붕괴시켜 **wasm 코드 크기를 축소**하고, 다운로드 바이트·시작 시간을 줄여 TTFF(첫 WebGL draw)에 기여합니다.

WebGL 로드타임 최적화 레버를 **1기법=1PR**로 분할한 캠페인의 한 갈래입니다(OptimizeSize).

## 변경 내용
| 파일 | 역할 |
|------|------|
| `Editor/AITEditorScriptObject.cs` | `il2cppCodeGeneration` 필드 + `GetDefaultIl2CppCodeGeneration()`(=OptimizeSize) |
| `Editor/AITBuildInitializer.cs` | 빌드 직전 `SetIl2CppCodeGeneration` 적용 + 로그 |
| `Editor/AITBuildSession.cs` | 빌드 전 값 스냅샷/빌드 후 복원(영구 오염 방지) |
| `Editor/AITConfigurationWindow.cs` | `DrawIl2CppCodeGenerationSetting()` 토글(자동/Speed/Size) |

## 적용 조건 / 안전성
- **Unity 6 전용**(`#if UNITY_6000_0_OR_NEWER`). 2021.3 등 하위 버전에서는 컴파일 자체에서 제외되어 영향 없음.
- **기본 적용(자동)**. 토글로 OptimizeSpeed 선택 가능.
- **비파괴**: `AITBuildSession`이 빌드 전 `Il2CppCodeGeneration`을 스냅샷하고 빌드 후 복원합니다.
- **trade-off**: 공유 제네릭의 미세한 런타임 디스패치 비용(정확성 변화 아님).

## 측정 Δ (perf CI가 채움)
`perf` 라벨이 부착되면 perf CI가 이 PR 브랜치를 main 위에서 빌드해 **단일 레버 Δ**를 코멘트로 게시합니다.

| Unity | TTFF Δ | on-wire Δ | wasm/data Δ |
|-------|--------|-----------|-------------|
| 2021.3 | _측정 대기 (Unity 6+ 전용 — 무시 예상)_ | _측정 대기_ | _측정 대기_ |
| 6000.0 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |

## 관련
- 측정 하네스: #754