### PR TITLE
개선: WebAssembly 2023 타겟 활성화

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -170,6 +170,16 @@ namespace AppsInToss.Editor
             PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.WebGL, il2cppConfig);
 #endif
 
+            // ===== WebAssembly 2023 (Meta 로드타임 스택: native exception/SIMD/BigInt/Table) =====
+            // 코드 크기·다운로드·시작 시간 단축. 미지원 브라우저에서는 로드 실패하므로
+            // Apps in Toss WebView min-spec(Chrome≥91 / Safari≥16.4) 충족이 전제.
+#if UNITY_6000_0_OR_NEWER
+            bool wasm2023 = editorConfig.wasm2023 >= 0
+                ? editorConfig.wasm2023 == 1
+                : AITDefaultSettings.GetDefaultWasm2023();
+            PlayerSettings.WebGL.wasm2023 = wasm2023;
+#endif
+
             // ===== Unity 6 (2023.3+) 전용 설정 =====
 #if UNITY_2023_3_OR_NEWER
             // 출처: UnityVersion.md:394-402
@@ -210,6 +220,9 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
+#if UNITY_6000_0_OR_NEWER
+            Debug.Log($"[AIT]   - WebAssembly 2023: {wasm2023}{(editorConfig.wasm2023 < 0 ? " (자동)" : "")}");
+#endif
 #if UNITY_2023_3_OR_NEWER
             Debug.Log($"[AIT]   - Power Preference: {powerPreference}{(editorConfig.powerPreference < 0 ? " (자동)" : "")}");
 #if !UNITY_6000_0_OR_NEWER

--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -35,6 +35,9 @@ namespace AppsInToss.Editor
         public ScriptingImplementation scriptingBackend;
         public ManagedStrippingLevel managedStrippingLevel;
         public Il2CppCompilerConfiguration il2cppCompilerConfiguration;
+#if UNITY_6000_0_OR_NEWER
+        public bool wasm2023;
+#endif
 
         // Stack Trace Log Type (LogType별)
         public StackTraceLogType stackTraceLogTypeError;
@@ -77,6 +80,7 @@ namespace AppsInToss.Editor
                 scriptingBackend = PlayerSettings.GetScriptingBackend(NamedBuildTarget.WebGL),
                 managedStrippingLevel = PlayerSettings.GetManagedStrippingLevel(NamedBuildTarget.WebGL),
                 il2cppCompilerConfiguration = PlayerSettings.GetIl2CppCompilerConfiguration(NamedBuildTarget.WebGL),
+                wasm2023 = PlayerSettings.WebGL.wasm2023,
 #else
                 scriptingBackend = PlayerSettings.GetScriptingBackend(BuildTargetGroup.WebGL),
                 managedStrippingLevel = PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.WebGL),
@@ -138,6 +142,7 @@ namespace AppsInToss.Editor
             PlayerSettings.SetScriptingBackend(NamedBuildTarget.WebGL, scriptingBackend);
             PlayerSettings.SetManagedStrippingLevel(NamedBuildTarget.WebGL, managedStrippingLevel);
             PlayerSettings.SetIl2CppCompilerConfiguration(NamedBuildTarget.WebGL, il2cppCompilerConfiguration);
+            PlayerSettings.WebGL.wasm2023 = wasm2023;
 #else
             PlayerSettings.SetScriptingBackend(BuildTargetGroup.WebGL, scriptingBackend);
             PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL, managedStrippingLevel);

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -671,6 +671,11 @@ namespace AppsInToss.Editor
             // Power Preference
             DrawPowerPreferenceSetting();
 
+#if UNITY_6000_0_OR_NEWER
+            // WebAssembly 2023 — Meta 로드타임 스택 (미지원 브라우저 로드 실패 주의)
+            DrawWasm2023Setting();
+#endif
+
 #if !UNITY_6000_0_OR_NEWER
             // WASM Streaming (Unity 6000에서 deprecated - decompressionFallback에 의해 자동 결정)
             config.wasmStreaming = EditorGUILayout.Toggle("WASM 스트리밍", config.wasmStreaming);
@@ -744,6 +749,44 @@ namespace AppsInToss.Editor
 
             EditorGUILayout.EndHorizontal();
         }
+
+#if UNITY_6000_0_OR_NEWER
+        private void DrawWasm2023Setting()
+        {
+            bool defaultValue = AITDefaultSettings.GetDefaultWasm2023();
+            bool isModified = config.wasm2023 >= 0 && (config.wasm2023 == 1) != defaultValue;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.wasm2023 < 0
+                ? $"WebAssembly 2023 (자동: {(defaultValue ? "활성화" : "비활성화")})"
+                : "WebAssembly 2023";
+
+            string[] options = { $"자동 ({(defaultValue ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.wasm2023 < 0 ? 0 : config.wasm2023 + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.wasm2023 = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.wasm2023 = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            // 미지원 브라우저 하드 페일 경고 (graceful degradation 아님)
+            if (config.wasm2023 != 0)
+            {
+                EditorGUILayout.HelpBox(
+                    "WebAssembly 2023을 켜면 미지원 브라우저(대략 Chrome<91 / Safari<16.4)에서 " +
+                    "로드가 실패합니다. Apps in Toss WebView 최소 사양 충족 시에만 사용하세요.",
+                    MessageType.Warning
+                );
+            }
+        }
+#endif
 
 #if UNITY_2023_3_OR_NEWER
         private void DrawPowerPreferenceSetting()
@@ -1029,6 +1072,9 @@ namespace AppsInToss.Editor
             config.stripEngineCode = true;
             config.il2cppConfiguration = -1;
             config.powerPreference = -1;
+#if UNITY_6000_0_OR_NEWER
+            config.wasm2023 = -1;
+#endif
 #if !UNITY_6000_0_OR_NEWER
             config.wasmStreaming = true;
             config.webAssemblyArithmeticExceptions = -1;

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -186,6 +186,9 @@ namespace AppsInToss
 
         public bool wasmStreaming = true;
 
+        [Tooltip("-1 = 자동 (활성화, Unity 6+). WebAssembly 2023 기능셋(native exception/SIMD/BigInt/Table). 미지원 브라우저에서는 로드 실패")]
+        public int wasm2023 = -1;
+
         [Header("고급 설정 (주의: 변경 시 호환성 문제 발생 가능)")]
         [Tooltip("-1 = 자동 (FullWithStacktrace, Sentry 경고 방지)")]
         public int exceptionSupport = -1;
@@ -406,6 +409,23 @@ namespace AppsInToss
         public static Il2CppCompilerConfiguration GetDefaultIl2CppConfiguration()
         {
             return Il2CppCompilerConfiguration.Release;
+        }
+
+        /// <summary>
+        /// 기본 WebAssembly 2023 타겟 여부 (Unity 6+): 활성화
+        /// Meta+Unity 로드타임 최적화: native exception/SIMD/BigInt/WebAssembly.Table 등
+        /// 2023 기능셋을 번들해 코드 크기·다운로드·시작 시간을 단축한다.
+        /// 주의: 미지원 브라우저(대략 Chrome&lt;91 / Safari&lt;16.4)에서는 graceful
+        /// degradation이 아니라 로드 자체가 실패한다. Apps in Toss는 Toss 앱 WebView
+        /// 전용이라 플랫폼 min-spec이 이를 충족하는 전제에서만 기본 활성.
+        /// </summary>
+        public static bool GetDefaultWasm2023()
+        {
+#if UNITY_6000_0_OR_NEWER
+            return true;
+#else
+            return false;
+#endif
         }
 
 #if UNITY_2023_3_OR_NEWER


### PR DESCRIPTION
## 개요

WebGL 빌드에 **WebAssembly 2023 기능셋**(native exception handling · SIMD · BigInt↔i64 · `WebAssembly.Table` 등)을 타겟으로 활성화합니다(Unity 6+). 더 현대적인 wasm 명령셋을 사용해 **코드 크기·다운로드·시작 시간**을 줄여 TTFF(첫 WebGL draw)에 기여합니다.

WebGL 로드타임 최적화 레버를 **1기법=1PR**로 분할한 캠페인의 한 갈래입니다(wasm2023).

> ⚠ **하드 페일 주의**: WebAssembly 2023은 미지원 브라우저(대략 Chrome<91 / Safari<16.4)에서 graceful degradation이 아니라 **로드 자체가 실패**합니다. Apps in Toss는 Toss 앱 WebView 전용이며 플랫폼 최소 사양이 이 기능셋을 충족하는 전제에서만 기본 활성합니다. 충족이 의심되면 토글로 비활성(0) 하십시오.

## 변경 내용

| 파일 | 역할 |
|------|------|
| `Editor/AITEditorScriptObject.cs` | `wasm2023` 필드 + `GetDefaultWasm2023()`(Unity 6+ true / 그 외 false) |
| `Editor/AITBuildInitializer.cs` | 빌드 직전 `PlayerSettings.WebGL.wasm2023` 적용 + 로그 (Unity 6+ 가드) |
| `Editor/AITBuildSession.cs` | 멤버 스냅샷/복원(영구 오염 방지, Unity 6+ 가드) |
| `Editor/AITConfigurationWindow.cs` | `DrawWasm2023Setting()` 토글 + 하드 페일 경고 HelpBox |

## 적용 조건 / 안전성

- **Unity 6+ 전용**: 모든 코드가 `#if UNITY_6000_0_OR_NEWER`로 가드됩니다. 2021.3 등 구버전은 API 부재로 컴파일에서 제외(빌드 정상, 효과 없음).
- **기본 적용(자동)**. 토글로 미적용(0) 선택 가능.
- **비파괴**: `AITBuildSession`이 빌드 전 값을 스냅샷하고 빌드 후 복원합니다.

## 측정 Δ (perf CI가 채움)

`perf` 라벨이 부착되면 perf CI가 이 PR 브랜치를 main 위에서 빌드해 **단일 레버 Δ**를 코멘트로 게시합니다.

| Unity | TTFF Δ | on-wire Δ | wasm Δ |
|-------|--------|-----------|--------|
| 2021.3 | _Unity 6+ 전용 — 무시 예상_ | _무시 예상_ | _무시 예상_ |
| 6000.0 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |

## 관련

- 측정 하네스: #754
