### PR TITLE
개선: Decompression Fallback 비활성화(CDN br 의존)

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -887,6 +887,18 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndHorizontal();
+
+            // 끄면(기본값) JS 디컴프레서가 번들에서 제거되어 호스팅 CDN이 Content-Encoding: br를
+            // 직접 서빙해야 한다. AIT 플랫폼 CDN은 보장하지만, 자체 호스팅 시 미설정이면 로드 실패.
+            if (config.decompressionFallback != 1)
+            {
+                EditorGUILayout.HelpBox(
+                    "Decompression Fallback이 꺼지면 호스팅 서버가 Content-Encoding: br(또는 gzip)을 " +
+                    "직접 서빙해야 합니다. Apps in Toss 플랫폼 CDN은 보장하지만, 자체 호스팅 시 " +
+                    "압축 헤더 미설정이면 로드가 실패합니다.",
+                    MessageType.Warning
+                );
+            }
         }
 
         private void DrawRunInBackgroundSetting()

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -193,7 +193,7 @@ namespace AppsInToss
         [Tooltip("-1 = 자동 (false), Unity Pro 라이선스 필요")]
         public int showUnityLogo = -1;
 
-        [Tooltip("-1 = 자동 (true)")]
+        [Tooltip("-1 = 자동 (false). 끄면 JS Brotli 디컴프레서가 번들에서 제거됨 — 플랫폼 CDN의 Content-Encoding: br 의존")]
         public int decompressionFallback = -1;
 
         [Tooltip("-1 = 자동 (false)")]
@@ -383,7 +383,7 @@ namespace AppsInToss
 
         /// <summary>
         /// 기본 압축 포맷: Brotli
-        /// decompressionFallback이 활성화되어 있으므로 모든 Unity 버전에서 Brotli 사용 가능
+        /// decompressionFallback=false이므로 브라우저/CDN이 Content-Encoding: br로 네이티브 해제 (모든 Unity 버전 Brotli)
         /// </summary>
         public static WebGLCompressionFormat GetDefaultCompressionFormat()
         {
@@ -441,12 +441,14 @@ namespace AppsInToss
         }
 
         /// <summary>
-        /// 기본 Decompression Fallback
-        /// 출처: StartupOptimization.md:93
+        /// 기본 Decompression Fallback: 비활성화(false)
+        /// 끄면 Unity가 JS Brotli 디컴프레서를 프레임워크 번들에서 제외 → 다운로드/파싱 바이트 감소.
+        /// 대신 브라우저/CDN이 Content-Encoding: br로 .unityweb를 네이티브 해제하도록 의존한다.
+        /// Apps in Toss 플랫폼 CDN이 br 인코딩을 서빙하는 전제에서만 안전(자체 호스팅 시 헤더 필수).
         /// </summary>
         public static bool GetDefaultDecompressionFallback()
         {
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
@@ -13,16 +13,40 @@ function detectUnityWebCompression(filePath: string): 'br' | 'gzip' | null {
     // 파일 헤더의 처음 64바이트만 읽음
     const fd = openSync(filePath, 'r');
     const buffer = Buffer.alloc(64);
-    readSync(fd, buffer, 0, 64, 0);
+    const bytesRead = readSync(fd, buffer, 0, 64, 0);
     closeSync(fd);
 
     const header = buffer.toString('ascii');
 
+    // decompressionFallback=ON: Unity가 텍스트 매직 헤더를 기록
     if (header.includes('(brotli)')) return 'br';
     if (header.includes('(gzip)')) return 'gzip';
-    return null;
+
+    // decompressionFallback=OFF: 매직 헤더 없는 raw 압축 스트림.
+    // .unityweb는 항상 압축 산출물이므로(비압축 빌드는 .unityweb를 만들지 않음)
+    // gzip magic(0x1f 0x8b)이면 gzip, 그 외에는 brotli(매직 없음)로 간주한다.
+    if (bytesRead >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) return 'gzip';
+    return 'br';
   } catch {
     return null;
+  }
+}
+
+/**
+ * Unity WebGL 산출물 경로 패턴으로 Content-Type을 설정.
+ * .wasm.→application/wasm (instantiateStreaming 활성), .js.→javascript, .data.→octet-stream.
+ * .unityweb / .br / .gz 모두 ".wasm." 같은 중간 패턴을 포함하므로 한 함수로 커버된다.
+ */
+function setUnityContentType(
+  res: { setHeader(name: string, value: string): void },
+  url: string,
+): void {
+  if (url.includes('.wasm.')) {
+    res.setHeader('Content-Type', 'application/wasm');
+  } else if (url.includes('.js.')) {
+    res.setHeader('Content-Type', 'application/javascript');
+  } else if (url.includes('.data.')) {
+    res.setHeader('Content-Type', 'application/octet-stream');
   }
 }
 
@@ -69,22 +93,18 @@ function unityWebContentEncodingPlugin(): Plugin {
           res.setHeader('Content-Encoding', encoding);
         }
 
-        // Content-Type 설정
-        if (url.includes('.wasm.')) {
-          res.setHeader('Content-Type', 'application/wasm');
-        } else if (url.includes('.js.')) {
-          res.setHeader('Content-Type', 'application/javascript');
-        } else if (url.includes('.data.')) {
-          res.setHeader('Content-Type', 'application/octet-stream');
-        }
+        // Content-Type 설정 (instantiateStreaming 활성화 위해 .wasm은 application/wasm)
+        setUnityContentType(res, url);
       }
-      // 레거시 .br 파일 (Unity 2021/2022)
+      // 레거시 .br 파일 (Unity 2021/2022 — Unity 6는 .unityweb 사용)
       else if (url.endsWith('.br')) {
         res.setHeader('Content-Encoding', 'br');
+        setUnityContentType(res, url);
       }
-      // 레거시 .gz 파일 (Unity 2021/2022)
+      // 레거시 .gz 파일 (Unity 2021/2022 — Unity 6는 .unityweb 사용)
       else if (url.endsWith('.gz')) {
         res.setHeader('Content-Encoding', 'gzip');
+        setUnityContentType(res, url);
       }
 
       next();


### PR DESCRIPTION
## 개요

WebGL **Decompression Fallback의 기본값을 `false`(비활성)로 전환**합니다. 켜져 있으면 Unity는 빌드 산출물에 **JS Brotli 디컴프레서**를 번들해 브라우저가 압축을 직접 못 풀 때를 대비합니다. 끄면 이 디컴프레서가 프레임워크 번들에서 **제거**되어 다운로드·파싱 바이트가 줄고, 대신 **브라우저/CDN이 `Content-Encoding: br`로 네이티브 해제**하도록 의존합니다. 네이티브 디코드는 JS 디코드보다 빠르고 메인스레드를 막지 않아 TTFF에 기여합니다.

WebGL 로드타임 최적화 레버를 **1기법=1PR**로 분할한 캠페인의 한 갈래입니다(decompression fallback off).

> ⚠ **호스팅 의존성**: OFF 빌드는 호스팅 서버가 반드시 `Content-Encoding: br`(또는 gzip)을 서빙해야 로드됩니다. **Apps in Toss 플랫폼 CDN은 이를 보장**합니다. 자체 호스팅 시 압축 헤더 미설정이면 로드가 실패하므로, 그 경우 토글로 활성(1) 하십시오. Configuration 윈도우에 경고 HelpBox를 추가했습니다.

## 변경 내용

| 파일 | 역할 |
|------|------|
| `Editor/AITEditorScriptObject.cs` | `GetDefaultDecompressionFallback()` 기본값 `true`→`false` + 툴팁/docstring 갱신 |
| `WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts` | **(원자 동반)** 헤더 없는 raw br/gzip 스트림 감지 + `Content-Encoding`/`Content-Type` 서빙 — OFF 빌드를 preview/host에서 로드 가능하게 |
| `Editor/AITConfigurationWindow.cs` | 자체 호스팅 시 압축 헤더 필요 경고 HelpBox |

## 적용 조건 / 안전성

- **전 Unity 버전 적용**. 기본 적용(자동=false). 토글로 활성(1) 선택 가능.
- **vite.config.ts 동반 변경이 원자적으로 포함**되어, 헤더 매직(`(brotli)`/`(gzip)`)이 없는 OFF 빌드 산출물도 preview 서버가 올바른 인코딩으로 서빙합니다(gzip 매직 `0x1f8b` 외에는 brotli로 간주).
- **비파괴**: 기존 `AITBuildInitializer`의 적용 로직(`PlayerSettings.WebGL.decompressionFallback`)과 `AITBuildSession` 스냅샷/복원을 그대로 사용 — 기본값 전환만 수행.

## 측정 Δ (perf CI가 채움)

`perf` 라벨이 부착되면 perf CI가 이 PR 브랜치를 main 위에서 빌드해 **단일 레버 Δ**를 코멘트로 게시합니다.

| Unity | TTFF Δ | on-wire Δ | wasm Δ |
|-------|--------|-----------|--------|
| 2021.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.0 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |

## 관련

- 측정 하네스: #754
