### PR TITLE
개선: Mip Stripping 활성화

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -203,6 +203,12 @@ namespace AppsInToss.Editor
                 : AITDefaultSettings.GetDefaultMipStripping();
             PlayerSettings.mipStripping = mipStripping;
 
+            // Mip Stripping이 활성화된 경우, 런타임 Quality 변경 코드가 있는지 경고
+            if (mipStripping)
+            {
+                WarnIfRuntimeQualityChangingCodeExists();
+            }
+
             // 설정 요약 로그
             Debug.Log($"[AIT] Unity {AITDefaultSettings.GetUnityVersionGroup()} 최적화 설정 적용:");
             Debug.Log($"[AIT]   - WebGL Template: {PlayerSettings.WebGL.template}");
@@ -252,6 +258,75 @@ namespace AppsInToss.Editor
             PlayerSettings.SetStackTraceLogType(LogType.Warning, StackTraceLogType.ScriptOnly);
             PlayerSettings.SetStackTraceLogType(LogType.Log, StackTraceLogType.ScriptOnly);
             PlayerSettings.SetStackTraceLogType(LogType.Exception, StackTraceLogType.ScriptOnly);
+        }
+
+        /// <summary>
+        /// 런타임에서 Quality 레벨을 변경하는 코드가 감지되면 경고를 출력한다.
+        /// Mip Stripping은 빌드 시점의 현재 Quality 기준으로 밉맵을 제거하므로,
+        /// 런타임에 더 낮은 Quality로 전환하면 렌더링 아티팩트가 발생할 수 있다.
+        /// 스캔 실패(IO 예외 등)는 흡수하고 빌드를 계속한다.
+        /// </summary>
+        private static void WarnIfRuntimeQualityChangingCodeExists()
+        {
+            // Quality 레벨이 1개 이하이면 런타임 변경이 무의미하므로 스캔 불필요
+            if (UnityEngine.QualitySettings.names.Length <= 1)
+                return;
+
+            try
+            {
+                string assetsPath = System.IO.Path.Combine(
+                    System.IO.Directory.GetCurrentDirectory(), "Assets");
+
+                if (!System.IO.Directory.Exists(assetsPath))
+                    return;
+
+                // Assets/ 하위 .cs 파일을 검색하되 Editor/ 폴더는 제외
+                var csFiles = System.IO.Directory.GetFiles(
+                    assetsPath, "*.cs", System.IO.SearchOption.AllDirectories);
+
+                var matchedFiles = new System.Collections.Generic.List<string>();
+
+                foreach (string filePath in csFiles)
+                {
+                    // Editor 폴더 내 파일은 런타임 코드가 아니므로 제외
+                    string normalizedPath = filePath.Replace('\\', '/');
+                    if (normalizedPath.Contains("/Editor/"))
+                        continue;
+
+                    string content = System.IO.File.ReadAllText(filePath);
+                    if (content.Contains("QualitySettings.SetQualityLevel") ||
+                        content.Contains("QualitySettings.IncreaseLevel") ||
+                        content.Contains("QualitySettings.DecreaseLevel"))
+                    {
+                        // 상대 경로로 변환해 로그를 간결하게 출력
+                        string relativePath = filePath.Replace(
+                            System.IO.Directory.GetCurrentDirectory() + System.IO.Path.DirectorySeparatorChar, "");
+                        matchedFiles.Add(relativePath.Replace('\\', '/'));
+                    }
+                }
+
+                if (matchedFiles.Count == 0)
+                    return;
+
+                // 최대 5개 파일 목록 구성
+                int displayCount = System.Math.Min(matchedFiles.Count, 5);
+                var fileList = new System.Text.StringBuilder();
+                for (int i = 0; i < displayCount; i++)
+                    fileList.AppendLine($"  - {matchedFiles[i]}");
+                if (matchedFiles.Count > 5)
+                    fileList.AppendLine($"  ... 외 {matchedFiles.Count - 5}개 파일");
+
+                Debug.LogWarning(
+                    $"[AIT] 런타임 Quality 변경 코드가 감지되었습니다({matchedFiles.Count}개 파일). " +
+                    "Mip Stripping은 현재 Quality의 텍스처 품질 기준으로 밉을 제거하므로 런타임에 Quality를 낮추면 " +
+                    "렌더링 아티팩트가 발생할 수 있습니다. 문제가 있으면 AIT Configuration에서 Mip Stripping을 비활성화하세요.\n" +
+                    fileList.ToString().TrimEnd());
+            }
+            catch (System.Exception e)
+            {
+                // IO 예외 등 스캔 실패는 흡수하고 빌드 계속
+                Debug.Log($"[AIT] Mip Stripping 런타임 Quality 변경 스캔 중 예외 발생 (무시됨): {e.Message}");
+            }
         }
 
         /// <summary>

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -196,6 +196,13 @@ namespace AppsInToss.Editor
                 : AITDefaultSettings.GetDefaultDecompressionFallback();
             PlayerSettings.WebGL.decompressionFallback = decompressionFallback;
 
+            // ===== Mip Stripping (빌드 산출물 .data 축소, AITBuildSession이 빌드 후 원복) =====
+            // mipStripping은 프로젝트 전역 PlayerSettings라 비활성화 선택 시에도 명시 적용해 결정성 보장.
+            bool mipStripping = editorConfig.mipStripping >= 0
+                ? editorConfig.mipStripping == 1
+                : AITDefaultSettings.GetDefaultMipStripping();
+            PlayerSettings.mipStripping = mipStripping;
+
             // 설정 요약 로그
             Debug.Log($"[AIT] Unity {AITDefaultSettings.GetUnityVersionGroup()} 최적화 설정 적용:");
             Debug.Log($"[AIT]   - WebGL Template: {PlayerSettings.WebGL.template}");
@@ -210,6 +217,7 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
+            Debug.Log($"[AIT]   - Mip Stripping: {mipStripping}{(editorConfig.mipStripping < 0 ? " (자동)" : "")}");
 #if UNITY_2023_3_OR_NEWER
             Debug.Log($"[AIT]   - Power Preference: {powerPreference}{(editorConfig.powerPreference < 0 ? " (자동)" : "")}");
 #if !UNITY_6000_0_OR_NEWER

--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -30,6 +30,7 @@ namespace AppsInToss.Editor
         public Vector2 cursorHotspot;
         public bool runInBackground;
         public bool stripEngineCode;
+        public bool mipStripping;
 
         // IL2CPP/Stripping 설정
         public ScriptingImplementation scriptingBackend;
@@ -72,6 +73,7 @@ namespace AppsInToss.Editor
                 cursorHotspot = PlayerSettings.cursorHotspot,
                 runInBackground = PlayerSettings.runInBackground,
                 stripEngineCode = PlayerSettings.stripEngineCode,
+                mipStripping = PlayerSettings.mipStripping,
 
 #if UNITY_6000_0_OR_NEWER
                 scriptingBackend = PlayerSettings.GetScriptingBackend(NamedBuildTarget.WebGL),
@@ -133,6 +135,7 @@ namespace AppsInToss.Editor
             PlayerSettings.cursorHotspot = cursorHotspot;
             PlayerSettings.runInBackground = runInBackground;
             PlayerSettings.stripEngineCode = stripEngineCode;
+            PlayerSettings.mipStripping = mipStripping;
 
 #if UNITY_6000_0_OR_NEWER
             PlayerSettings.SetScriptingBackend(NamedBuildTarget.WebGL, scriptingBackend);

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -701,6 +701,18 @@ namespace AppsInToss.Editor
             DrawRunInBackgroundSetting();
 
             GUILayout.Space(10);
+            EditorGUILayout.LabelField("콘텐츠 축소 (빌드 산출물 크기)", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(
+                "빌드 산출물(.data)에서 사용되지 않는 데이터를 제거해 다운로드/로드 시간을 줄입니다. " +
+                "프로젝트 설정은 빌드 후 원래대로 복원됩니다.",
+                MessageType.Info
+            );
+            GUILayout.Space(5);
+
+            // Mip Stripping
+            DrawMipStrippingSetting();
+
+            GUILayout.Space(10);
             EditorGUILayout.LabelField("빌드 전 검사", EditorStyles.boldLabel);
 
             // 빌드 전 최적화 검사
@@ -915,6 +927,32 @@ namespace AppsInToss.Editor
             EditorGUILayout.EndHorizontal();
         }
 
+        private void DrawMipStrippingSetting()
+        {
+            bool defaultValue = AITDefaultSettings.GetDefaultMipStripping();
+            bool isModified = config.mipStripping >= 0 && (config.mipStripping == 1) != defaultValue;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.mipStripping < 0
+                ? $"Mip Stripping (자동: {(defaultValue ? "활성화" : "비활성화")})"
+                : "Mip Stripping";
+
+            string[] options = { $"자동 ({(defaultValue ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.mipStripping < 0 ? 0 : config.mipStripping + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.mipStripping = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.mipStripping = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
         // ===== 유틸리티 메서드 =====
 
         private void DrawModifiedIndicator(bool isModified)
@@ -1037,6 +1075,7 @@ namespace AppsInToss.Editor
             config.showUnityLogo = -1;
             config.decompressionFallback = -1;
             config.runInBackground = -1;
+            config.mipStripping = -1;
             config.enableBuildOptimizationCheck = true;
         }
 

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -202,6 +202,10 @@ namespace AppsInToss
         [Tooltip("-1 = 자동 (false, Unity 6+)")]
         public int webAssemblyArithmeticExceptions = -1;
 
+        [Header("콘텐츠 축소 (빌드 산출물 .data/.wasm 실감축, 빌드 후 원복)")]
+        [Tooltip("-1 = 자동 (true). 사용하지 않는 텍스처 밉맵 레벨을 빌드 산출물에서 제거 — .data 축소. 설정된 품질의 출력은 불변(미사용 밉만 제거).")]
+        public int mipStripping = -1;
+
         [Header("빌드 전 검사 설정")]
         [Tooltip("빌드 전 에셋 최적화 검사를 활성화합니다")]
         public bool enableBuildOptimizationCheck = true;
@@ -456,6 +460,16 @@ namespace AppsInToss
         public static bool GetDefaultRunInBackground()
         {
             return false;
+        }
+
+        /// <summary>
+        /// 기본 Mip Stripping: 활성화(true)
+        /// 빌드 산출물에서 실제로 참조되지 않는 텍스처 밉맵 레벨을 제거해 .data 크기를 줄인다.
+        /// 설정된 품질의 출력은 불변(쓰이지 않는 밉만 제거되므로 시각적 변화 없음).
+        /// </summary>
+        public static bool GetDefaultMipStripping()
+        {
+            return true;
         }
 
 #if UNITY_2023_3_OR_NEWER && !UNITY_6000_0_OR_NEWER


### PR DESCRIPTION
## 개요

WebGL 빌드에 **Mip Stripping**을 활성화합니다. 빌드 산출물(`.data`)에서 **실제로 참조되지 않는 텍스처 밉맵 레벨**을 제거해 다운로드/로드 바이트를 줄입니다. 설정된 품질의 출력은 변하지 않습니다(쓰이지 않는 밉만 제거 — 시각적 변화 없음). on-wire/`.data` 축소가 TTFF에 기여합니다.

**팀 정책**: zero-config 기본 ON + 자동 안전장치(런타임 Quality 변경 코드 스캔/빌드 리포트/opt-out). 개발자의 별도 설정 없이 자동 적용됩니다.

WebGL 로드타임 최적화 레버를 **1기법=1PR**로 분할한 캠페인의 한 갈래입니다(mip stripping).

## 변경 내용

| 파일 | 역할 |
|------|------|
| `Editor/AITEditorScriptObject.cs` | `mipStripping` 필드 + `GetDefaultMipStripping()`(기본 true) |
| `Editor/AITBuildInitializer.cs` | 빌드 직전 `PlayerSettings.mipStripping` 적용 + 로그, **런타임 Quality 변경 코드 자동 감지 경고** |
| `Editor/AITBuildSession.cs` | 멤버 스냅샷/복원(프로젝트 전역 설정 영구 오염 방지) |
| `Editor/AITConfigurationWindow.cs` | "콘텐츠 축소" 섹션 + `DrawMipStrippingSetting()` 토글 |

## 적용 조건 / 안전성

- **전 Unity 버전 적용**. 기본 적용(자동=true). 토글로 미적용(0) 선택 가능.
- **비파괴**: `PlayerSettings.mipStripping`은 프로젝트 전역 설정이므로 `AITBuildSession`이 빌드 전 값을 스냅샷하고 빌드 후 복원합니다.
- **품질 불변**: 사용되는 밉 레벨은 그대로 유지 — 미사용 밉만 산출물에서 제거됩니다.
- **자동 안전장치**: Mip Stripping이 활성화된 빌드 시점에 `Assets/` 하위 런타임 `.cs` 파일(`Editor/` 제외)을 자동 스캔합니다. `QualitySettings.SetQualityLevel` / `IncreaseLevel` / `DecreaseLevel` 호출이 감지되면 파일 목록(최대 5개)과 함께 `Debug.LogWarning`을 출력합니다. Quality 레벨이 1개 이하인 프로젝트는 스캔을 건너뜁니다. IO 예외는 흡수해 빌드를 계속합니다.
  > Mip Stripping은 **빌드 시점의 현재 Quality 기준**으로 밉맵을 제거합니다. 런타임에 더 낮은 Quality로 전환하면 해당 레벨에 필요한 밉이 산출물에 없어 렌더링 아티팩트가 발생할 수 있습니다. 경고 발생 시 AIT Configuration에서 Mip Stripping을 비활성화하거나, 최저 Quality 기준으로 빌드하도록 조정하세요.

## 측정 Δ (perf CI가 채움)

`perf` 라벨이 부착되면 perf CI가 이 PR 브랜치를 main 위에서 빌드해 **단일 레버 Δ**를 코멘트로 게시합니다.

| Unity | TTFF Δ | on-wire Δ | wasm Δ |
|-------|--------|-----------|--------|
| 2021.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.0 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |

## 관련

- 측정 하네스: #754
