### PR TITLE
개선: Optimize Mesh Data 활성화

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -196,6 +196,13 @@ namespace AppsInToss.Editor
                 : AITDefaultSettings.GetDefaultDecompressionFallback();
             PlayerSettings.WebGL.decompressionFallback = decompressionFallback;
 
+            // ===== Optimize Mesh Data (빌드 산출물 .data 축소, AITBuildSession이 빌드 후 원복) =====
+            // stripUnusedMeshComponents는 프로젝트 전역 PlayerSettings라 비활성화 선택 시에도 명시 적용해 결정성 보장.
+            bool stripUnusedMeshComponents = editorConfig.stripUnusedMeshComponents >= 0
+                ? editorConfig.stripUnusedMeshComponents == 1
+                : AITDefaultSettings.GetDefaultStripUnusedMeshComponents();
+            PlayerSettings.stripUnusedMeshComponents = stripUnusedMeshComponents;
+
             // 설정 요약 로그
             Debug.Log($"[AIT] Unity {AITDefaultSettings.GetUnityVersionGroup()} 최적화 설정 적용:");
             Debug.Log($"[AIT]   - WebGL Template: {PlayerSettings.WebGL.template}");
@@ -210,6 +217,7 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
+            Debug.Log($"[AIT]   - Optimize Mesh Data: {stripUnusedMeshComponents}{(editorConfig.stripUnusedMeshComponents < 0 ? " (자동)" : "")}");
 #if UNITY_2023_3_OR_NEWER
             Debug.Log($"[AIT]   - Power Preference: {powerPreference}{(editorConfig.powerPreference < 0 ? " (자동)" : "")}");
 #if !UNITY_6000_0_OR_NEWER

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
 using UnityEditor;
 #if UNITY_6000_0_OR_NEWER
 using UnityEditor.Build;
@@ -203,6 +206,14 @@ namespace AppsInToss.Editor
                 : AITDefaultSettings.GetDefaultStripUnusedMeshComponents();
             PlayerSettings.stripUnusedMeshComponents = stripUnusedMeshComponents;
 
+            // stripUnusedMeshComponents가 활성화된 경우: 런타임 머티리얼 교체 코드 스캔
+            // false positive 허용(경고일 뿐 동작 변경 없음) — 정규식 스캔은 의미론적 분석이 아니므로
+            // 실제로 문제가 없는 코드도 검출될 수 있다. 그러나 경고를 보고 사용자가 직접 판단하도록 유도하는 것이 목적.
+            if (stripUnusedMeshComponents)
+            {
+                ScanRuntimeMaterialReplacementCode();
+            }
+
             // 설정 요약 로그
             Debug.Log($"[AIT] Unity {AITDefaultSettings.GetUnityVersionGroup()} 최적화 설정 적용:");
             Debug.Log($"[AIT]   - WebGL Template: {PlayerSettings.WebGL.template}");
@@ -386,6 +397,75 @@ namespace AppsInToss.Editor
                 : WebGLDebugSymbolMode.Embedded;
             Debug.Log($"[AIT] 디버그 심볼 모드 설정: {PlayerSettings.WebGL.debugSymbolMode}");
 #endif
+        }
+
+        /// <summary>
+        /// Assets/ 하위 런타임 C# 코드에서 머티리얼 교체 패턴을 정적으로 스캔하여 경고를 출력한다.
+        /// Optimize Mesh Data(stripUnusedMeshComponents)가 활성화될 때만 호출된다.
+        ///
+        /// 목적: 빌드 시점 머티리얼 기준으로 미사용 정점 채널을 제거하므로, 교체된 머티리얼이
+        /// 제거된 채널(노멀/탄젠트/UV 등)을 요구하면 시각 오류가 발생할 수 있다.
+        /// 이 스캔은 사용자에게 확인을 유도할 뿐, 동작을 변경하지 않는다.
+        ///
+        /// false positive 허용: 정규식 스캔은 의미론적 분석이 아니므로 실제로 문제없는
+        /// 코드(주석 내 패턴, 에디터 전용 코드 등)도 검출될 수 있다.
+        /// 스캔 실패는 try/catch로 흡수하며 빌드에 영향을 주지 않는다.
+        /// </summary>
+        private static void ScanRuntimeMaterialReplacementCode()
+        {
+            try
+            {
+                string assetsPath = Path.Combine(Application.dataPath);
+                // 머티리얼 런타임 대입 패턴: .material =, .materials =, .sharedMaterial =, .sharedMaterials =
+                var pattern = new Regex(
+                    @"\.(material|materials|sharedMaterial|sharedMaterials)\s*=",
+                    RegexOptions.Compiled);
+
+                var matchedFiles = new List<string>();
+                int totalCount = 0;
+
+                // Assets/ 하위 .cs 파일 탐색 (Editor/ 폴더 제외)
+                string[] csFiles = Directory.GetFiles(assetsPath, "*.cs", SearchOption.AllDirectories);
+                foreach (string filePath in csFiles)
+                {
+                    // Editor 폴더 경로 제외 (경로 구분자 통일 후 검사)
+                    string normalizedPath = filePath.Replace('\\', '/');
+                    if (normalizedPath.Contains("/Editor/"))
+                        continue;
+
+                    string source = File.ReadAllText(filePath, System.Text.Encoding.UTF8);
+                    var matches = pattern.Matches(source);
+                    if (matches.Count > 0)
+                    {
+                        totalCount += matches.Count;
+                        // Assets/ 기준 상대 경로로 변환
+                        string relativePath = "Assets" + normalizedPath.Substring(assetsPath.Replace('\\', '/').Length);
+                        matchedFiles.Add(relativePath);
+                    }
+                }
+
+                if (totalCount > 0)
+                {
+                    // 파일 목록은 최대 5개까지만 출력
+                    var displayFiles = matchedFiles.Count > 5
+                        ? matchedFiles.GetRange(0, 5)
+                        : matchedFiles;
+                    string fileList = string.Join("\n  - ", displayFiles);
+                    string moreNote = matchedFiles.Count > 5 ? $"\n  … 외 {matchedFiles.Count - 5}개 파일" : "";
+
+                    Debug.LogWarning(
+                        $"[AIT] 런타임 머티리얼 교체 코드가 감지되었습니다({totalCount}건).\n" +
+                        "Optimize Mesh Data는 빌드 시점 머티리얼 기준으로 미사용 정점 채널(노멀/탄젠트/UV)을 제거하므로, " +
+                        "교체된 머티리얼이 제거된 채널을 요구하면 시각 오류가 발생할 수 있습니다.\n" +
+                        "문제가 있으면 AIT Configuration에서 Optimize Mesh Data를 비활성화하세요.\n" +
+                        $"감지된 파일:\n  - {fileList}{moreNote}");
+                }
+            }
+            catch (System.Exception e)
+            {
+                // 스캔 실패는 흡수 — 빌드에 영향을 주지 않음
+                Debug.Log($"[AIT] 런타임 머티리얼 교체 코드 스캔 중 오류 발생 (무시): {e.Message}");
+            }
         }
     }
 }

--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -30,6 +30,7 @@ namespace AppsInToss.Editor
         public Vector2 cursorHotspot;
         public bool runInBackground;
         public bool stripEngineCode;
+        public bool stripUnusedMeshComponents;
 
         // IL2CPP/Stripping 설정
         public ScriptingImplementation scriptingBackend;
@@ -72,6 +73,7 @@ namespace AppsInToss.Editor
                 cursorHotspot = PlayerSettings.cursorHotspot,
                 runInBackground = PlayerSettings.runInBackground,
                 stripEngineCode = PlayerSettings.stripEngineCode,
+                stripUnusedMeshComponents = PlayerSettings.stripUnusedMeshComponents,
 
 #if UNITY_6000_0_OR_NEWER
                 scriptingBackend = PlayerSettings.GetScriptingBackend(NamedBuildTarget.WebGL),
@@ -133,6 +135,7 @@ namespace AppsInToss.Editor
             PlayerSettings.cursorHotspot = cursorHotspot;
             PlayerSettings.runInBackground = runInBackground;
             PlayerSettings.stripEngineCode = stripEngineCode;
+            PlayerSettings.stripUnusedMeshComponents = stripUnusedMeshComponents;
 
 #if UNITY_6000_0_OR_NEWER
             PlayerSettings.SetScriptingBackend(NamedBuildTarget.WebGL, scriptingBackend);

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -701,6 +701,18 @@ namespace AppsInToss.Editor
             DrawRunInBackgroundSetting();
 
             GUILayout.Space(10);
+            EditorGUILayout.LabelField("콘텐츠 축소 (빌드 산출물 크기)", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(
+                "빌드 산출물(.data)에서 사용되지 않는 데이터를 제거해 다운로드/로드 시간을 줄입니다. " +
+                "프로젝트 설정은 빌드 후 원래대로 복원됩니다.",
+                MessageType.Info
+            );
+            GUILayout.Space(5);
+
+            // Optimize Mesh Data
+            DrawStripUnusedMeshComponentsSetting();
+
+            GUILayout.Space(10);
             EditorGUILayout.LabelField("빌드 전 검사", EditorStyles.boldLabel);
 
             // 빌드 전 최적화 검사
@@ -915,6 +927,32 @@ namespace AppsInToss.Editor
             EditorGUILayout.EndHorizontal();
         }
 
+        private void DrawStripUnusedMeshComponentsSetting()
+        {
+            bool defaultValue = AITDefaultSettings.GetDefaultStripUnusedMeshComponents();
+            bool isModified = config.stripUnusedMeshComponents >= 0 && (config.stripUnusedMeshComponents == 1) != defaultValue;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.stripUnusedMeshComponents < 0
+                ? $"Optimize Mesh Data (자동: {(defaultValue ? "활성화" : "비활성화")})"
+                : "Optimize Mesh Data";
+
+            string[] options = { $"자동 ({(defaultValue ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.stripUnusedMeshComponents < 0 ? 0 : config.stripUnusedMeshComponents + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.stripUnusedMeshComponents = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.stripUnusedMeshComponents = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
         // ===== 유틸리티 메서드 =====
 
         private void DrawModifiedIndicator(bool isModified)
@@ -1037,6 +1075,7 @@ namespace AppsInToss.Editor
             config.showUnityLogo = -1;
             config.decompressionFallback = -1;
             config.runInBackground = -1;
+            config.stripUnusedMeshComponents = -1;
             config.enableBuildOptimizationCheck = true;
         }
 

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -202,6 +202,10 @@ namespace AppsInToss
         [Tooltip("-1 = 자동 (false, Unity 6+)")]
         public int webAssemblyArithmeticExceptions = -1;
 
+        [Header("콘텐츠 축소 (빌드 산출물 .data/.wasm 실감축, 빌드 후 원복)")]
+        [Tooltip("-1 = 자동 (true). 어떤 머티리얼도 쓰지 않는 메시 정점 채널(노멀/탄젠트/UV 등)을 제거 — .data 축소. 주의: 런타임에 머티리얼을 교체해 제거된 채널을 요구하면 시각 오류 가능.")]
+        public int stripUnusedMeshComponents = -1;
+
         [Header("빌드 전 검사 설정")]
         [Tooltip("빌드 전 에셋 최적화 검사를 활성화합니다")]
         public bool enableBuildOptimizationCheck = true;
@@ -456,6 +460,16 @@ namespace AppsInToss
         public static bool GetDefaultRunInBackground()
         {
             return false;
+        }
+
+        /// <summary>
+        /// 기본 Optimize Mesh Data(Strip Unused Mesh Components): 활성화(true)
+        /// 어떤 머티리얼도 참조하지 않는 메시 정점 채널(노멀/탄젠트/UV 등)을 빌드 산출물에서 제거해 .data를 줄인다.
+        /// 주의: 런타임에 머티리얼을 교체해 제거된 채널을 요구하면 시각 오류가 발생할 수 있다.
+        /// </summary>
+        public static bool GetDefaultStripUnusedMeshComponents()
+        {
+            return true;
         }
 
 #if UNITY_2023_3_OR_NEWER && !UNITY_6000_0_OR_NEWER


### PR DESCRIPTION
## 개요

WebGL 빌드에 **Optimize Mesh Data**(Strip Unused Mesh Components)를 활성화합니다. 어떤 머티리얼도 참조하지 않는 **메시 정점 채널**(노멀·탄젠트·추가 UV 등)을 빌드 산출물(`.data`)에서 제거해 다운로드/로드 바이트를 줄입니다. on-wire/`.data` 축소가 TTFF에 기여합니다.

WebGL 로드타임 최적화 레버를 **1기법=1PR**로 분할한 캠페인의 한 갈래입니다(optimize mesh data).

**팀 정책**: zero-config — 개발자의 깊은 이해 없이 자동 적용. 기본 ON + 자동 안전장치(빌드 시점 정적 스캔 / 빌드 리포트 / opt-out 토글).

> ⚠ **동적 머티리얼 주의**: 런타임에 머티리얼을 교체해 빌드 시 제거된 정점 채널을 요구하면 시각 오류가 발생할 수 있습니다. 그런 워크플로가 있으면 토글로 미적용(0) 하십시오.

## 변경 내용

| 파일 | 역할 |
|------|------|
| `Editor/AITEditorScriptObject.cs` | `stripUnusedMeshComponents` 필드 + `GetDefaultStripUnusedMeshComponents()`(기본 true) |
| `Editor/AITBuildInitializer.cs` | 빌드 직전 `PlayerSettings.stripUnusedMeshComponents` 적용 + 로그 + 런타임 머티리얼 교체 정적 스캔 경고 |
| `Editor/AITBuildSession.cs` | 멤버 스냅샷/복원(프로젝트 전역 설정 영구 오염 방지) |
| `Editor/AITConfigurationWindow.cs` | "콘텐츠 축소" 섹션 + `DrawStripUnusedMeshComponentsSetting()` 토글 |

## 적용 조건 / 안전성

- **전 Unity 버전 적용**. 기본 적용(자동=true). 토글로 미적용(0) 선택 가능.
- **비파괴**: 프로젝트 전역 설정이므로 `AITBuildSession`이 빌드 전 값을 스냅샷하고 빌드 후 복원합니다.
- **2D-only 프로젝트**: 메시가 거의 없어 효과가 미미할 수 있습니다(0에 수렴 가능).

## 자동 안전장치 — 런타임 머티리얼 교체 정적 스캔

`stripUnusedMeshComponents`가 활성화될 때 `AITBuildInitializer`가 빌드 직전 `Assets/` 하위 런타임 C# 파일(Editor/ 제외)을 정규식으로 자동 스캔합니다.

- **검출 패턴**: `.material =`, `.materials =`, `.sharedMaterial =`, `.sharedMaterials =`
- **1건 이상 감지 시**: `Debug.LogWarning`으로 파일 목록(최대 5개)과 함께 경고 출력
- **동작 변경 없음**: 경고 전용. 빌드는 그대로 계속됩니다.
- **스캔 실패 무해**: `try/catch`로 흡수 — 빌드에 영향을 주지 않습니다.
- **false positive 허용**: 정규식 스캔은 의미론적 분석이 아니므로 주석 내 패턴·에디터 전용 코드도 검출될 수 있습니다. 경고를 보고 사용자가 직접 판단하는 것이 목적입니다.

## 측정 Δ (perf CI가 채움)

`perf` 라벨이 부착되면 perf CI가 이 PR 브랜치를 main 위에서 빌드해 **단일 레버 Δ**를 코멘트로 게시합니다.

| Unity | TTFF Δ | on-wire Δ | wasm Δ |
|-------|--------|-----------|--------|
| 2021.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.0 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |

## 관련

- 측정 하네스: #754
