### PR TITLE
기능: 텍스처 Crunch 압축(빌드 시 DXT)

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -221,6 +221,12 @@ namespace AppsInToss.Editor
                 ? editorConfig.firstInteractiveLog == 1
                 : AITDefaultSettings.GetDefaultFirstInteractiveLog();
             Debug.Log($"[AIT]   - first-interactive 계측: {firstInteractiveEnabled}{(editorConfig.firstInteractiveLog < 0 ? " (자동)" : "")}");
+
+            // 텍스처 crunch 는 BuildPlayer 직전 AITTextureCrunchProcessor 에서 처리
+            bool textureCrunchEnabled = editorConfig.textureCrunch >= 0
+                ? editorConfig.textureCrunch == 1
+                : AITDefaultSettings.GetDefaultTextureCrunch();
+            Debug.Log($"[AIT]   - 텍스처 crunch: {textureCrunchEnabled}{(editorConfig.textureCrunch < 0 ? " (자동)" : "")}");
         }
 
         /// <summary>

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -456,6 +456,11 @@ namespace AppsInToss.Editor
 
             GUILayout.Space(10);
 
+            // 콘텐츠 최적화 — 텍스처 crunch (빌드 산출물 .data 축소)
+            DrawTextureCrunchSetting();
+
+            GUILayout.Space(10);
+
             // 변경된 설정 개수 표시
             int modifiedCount = CountModifiedWebGLSettings();
             if (modifiedCount > 0)
@@ -472,6 +477,49 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndVertical();
+        }
+
+        private void DrawTextureCrunchSetting()
+        {
+            EditorGUILayout.LabelField("콘텐츠 최적화 — 텍스처 crunch", EditorStyles.boldLabel);
+
+            config.enableTextureCrunch = EditorGUILayout.Toggle(
+                new GUIContent("텍스처 crunch 활성화",
+                    "대상 텍스처/SpriteAtlas를 빌드 시 crunch(DXT 위 4~8x) 압축 + maxTextureSize 캡으로 reimport하여 다운로드/.data를 줄입니다. " +
+                    "빌드 후 원본 임포트 설정으로 복원합니다. crunch reimport는 무겁습니다(에셋 수에 비례)."),
+                config.enableTextureCrunch);
+
+            if (config.enableTextureCrunch)
+            {
+                EditorGUI.indentLevel++;
+                config.textureCrunchMaxSize = EditorGUILayout.IntField(
+                    new GUIContent("최대 텍스처 크기(0=캡 안 함)", "이 값보다 큰 텍스처만 축소합니다. 예) 512, 1024"),
+                    config.textureCrunchMaxSize);
+
+                config.textureCrunchQuality = EditorGUILayout.IntSlider(
+                    new GUIContent("crunch 품질(0~100)", "낮을수록 작고 화질↓. 기본 50."),
+                    Mathf.Clamp(config.textureCrunchQuality, 0, 100), 0, 100);
+
+                config.textureCrunchAtlas = EditorGUILayout.Toggle(
+                    new GUIContent("SpriteAtlas 포함", "SpriteAtlas도 함께 crunch + WebGL repack 합니다."),
+                    config.textureCrunchAtlas);
+
+                if (config.textureCrunchAtlas)
+                {
+                    config.textureCrunchAtlasMaxSize = EditorGUILayout.IntField(
+                        new GUIContent("아틀라스 최대 크기(0=캡 안 함)", "예) 1024, 2048"),
+                        config.textureCrunchAtlasMaxSize);
+                }
+
+                config.textureCrunchDirs = EditorGUILayout.TextField(
+                    new GUIContent("대상 폴더(쉼표 구분)", "Assets/ 기준 경로. 비우면 프로젝트 전체 텍스처가 대상. 예) Assets/Art/Textures"),
+                    config.textureCrunchDirs);
+
+                EditorGUILayout.HelpBox(
+                    "crunch는 화질이 약간 떨어질 수 있습니다(특히 그라데이션/UI). 적용 후 결과를 확인하세요. 빌드 후 원본 설정은 자동 복원됩니다.",
+                    MessageType.Info);
+                EditorGUI.indentLevel--;
+            }
         }
 
         private void DrawMemorySizeSetting()

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -516,8 +516,11 @@ namespace AppsInToss.Editor
                     config.textureCrunchDirs);
 
                 EditorGUILayout.HelpBox(
-                    "crunch는 화질이 약간 떨어질 수 있습니다(특히 그라데이션/UI). 적용 후 결과를 확인하세요. 빌드 후 원본 설정은 자동 복원됩니다.",
-                    MessageType.Info);
+                    "crunch는 lossy 압축입니다. 특히 그라데이션/UI 텍스처에서 화질이 눈에 띄게 저하될 수 있으므로 " +
+                    "빌드 후 결과를 반드시 확인하세요. 빌드 후 원본 임포트 설정은 자동 복원됩니다.\n\n" +
+                    "⚠ WebGL Texture Compression을 ASTC로 설정한 경우 crunch(DXT 기반)가 동작하지 않으며 " +
+                    "오히려 RGBA32 비압축으로 팽창할 수 있습니다. 이 경우 빌드 시 자동으로 건너뜁니다(DXT 서브타겟에서만 유효).",
+                    MessageType.Warning);
                 EditorGUI.indentLevel--;
             }
         }

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -481,15 +481,40 @@ namespace AppsInToss.Editor
 
         private void DrawTextureCrunchSetting()
         {
+            bool defaultValue = AITDefaultSettings.GetDefaultTextureCrunch();
+            bool isModified = config.textureCrunch >= 0 && (config.textureCrunch == 1) != defaultValue;
+
             EditorGUILayout.LabelField("콘텐츠 최적화 — 텍스처 crunch", EditorStyles.boldLabel);
 
-            config.enableTextureCrunch = EditorGUILayout.Toggle(
-                new GUIContent("텍스처 crunch 활성화",
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string autoLabel = defaultValue ? "활성화" : "비활성화";
+            string label = config.textureCrunch < 0
+                ? $"텍스처 crunch (자동: {autoLabel})"
+                : "텍스처 crunch";
+
+            string[] options = { $"자동 ({autoLabel})", "비활성화", "활성화" };
+            int currentIndex = config.textureCrunch < 0 ? 0 : config.textureCrunch + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
                     "대상 텍스처/SpriteAtlas를 빌드 시 crunch(DXT 위 4~8x) 압축 + maxTextureSize 캡으로 reimport하여 다운로드/.data를 줄입니다. " +
                     "빌드 후 원본 임포트 설정으로 복원합니다. crunch reimport는 무겁습니다(에셋 수에 비례)."),
-                config.enableTextureCrunch);
+                currentIndex,
+                options
+            );
+            config.textureCrunch = newIndex == 0 ? -1 : newIndex - 1;
 
-            if (config.enableTextureCrunch)
+            if (isModified && DrawResetButton())
+            {
+                config.textureCrunch = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            bool effectiveEnabled = config.textureCrunch >= 0 ? config.textureCrunch == 1 : defaultValue;
+            if (effectiveEnabled)
             {
                 EditorGUI.indentLevel++;
                 config.textureCrunchMaxSize = EditorGUILayout.IntField(
@@ -1064,6 +1089,9 @@ namespace AppsInToss.Editor
             bool defaultFirstInteractive = AITDefaultSettings.GetDefaultFirstInteractiveLog();
             if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
 
+            bool defaultCrunch = AITDefaultSettings.GetDefaultTextureCrunch();
+            if (config.textureCrunch >= 0 && (config.textureCrunch == 1) != defaultCrunch) count++;
+
             return count;
         }
 
@@ -1073,6 +1101,7 @@ namespace AppsInToss.Editor
             config.threadsSupport = -1;
             config.dataCaching = -1;
             config.firstInteractiveLog = -1;
+            config.textureCrunch = -1;
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -993,6 +993,9 @@ namespace AppsInToss
             // .cs 파일 수정과 달리 .json은 스크립트 컴파일을 유발하지 않으므로 도메인 리로드 없음
             bool versionInfoWritten = WriteVersionInfoJson(out bool createdResourcesDir);
 
+            // 콘텐츠 최적화 — 텍스처 crunch (빌드 산출물 .data 축소, 빌드 후 임포터 원복)
+            var textureCrunchHandle = Editor.AITTextureCrunchProcessor.ApplyForBuild(config);
+
             UnityEditor.Build.Reporting.BuildReport result;
             try
             {
@@ -1000,6 +1003,9 @@ namespace AppsInToss
             }
             finally
             {
+                // 콘텐츠 최적화 — 텍스처 crunch 임포터 설정 원복 (빌드 성공/실패 무관)
+                Editor.AITTextureCrunchProcessor.RestoreForBuild(textureCrunchHandle);
+
                 // 빌드 완료 후 (성공/실패 무관) 생성한 JSON 제거 — 사용자 프로젝트에 산출물 남기지 않음
                 if (versionInfoWritten)
                 {

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -211,10 +211,11 @@ namespace AppsInToss
         public int firstInteractiveLog = -1;
 
         [Header("콘텐츠 최적화 — 텍스처 crunch")]
-        [Tooltip("대상 텍스처/SpriteAtlas 를 빌드 시 일시적으로 crunch(DXT 위 4~8x) 압축 + maxTextureSize 캡으로 reimport 하여 " +
-                 "다운로드/.data 를 줄입니다. 빌드 후 원본 임포트 설정으로 복원하므로 명시적 opt-in 으로 기본 비활성입니다. " +
+        [Tooltip("-1 = 자동 (true), 0 = 비활성, 1 = 활성. " +
+                 "대상 텍스처/SpriteAtlas 를 빌드 시 일시적으로 crunch(DXT 위 4~8x) 압축 + maxTextureSize 캡으로 reimport 하여 " +
+                 "다운로드/.data 를 줄입니다. 빌드 후 원본 임포트 설정으로 복원합니다. " +
                  "crunch reimport 는 무겁습니다(에셋 수에 비례).")]
-        public bool enableTextureCrunch = false;
+        public int textureCrunch = -1;
 
         [Tooltip("텍스처 maxTextureSize 상한(0=캡 안 함). 이 값보다 큰 텍스처만 축소합니다. 예) 512, 1024")]
         public int textureCrunchMaxSize = 0;
@@ -231,7 +232,6 @@ namespace AppsInToss
 
         [Tooltip("대상 폴더(쉼표 구분, Assets/ 기준). 비우면 프로젝트 전체 텍스처가 대상입니다. 예) Assets/Art/Textures")]
         public string textureCrunchDirs = "";
->>>>>>> 1bccfce (기능: 텍스처 Crunch 압축 빌드 프로세서 추가 (빌드 시 DXT crunch, 빌드 후 임포터 원복))
 
         [Header("권한 설정")]
         public AITPermissionConfig permissionConfig = new AITPermissionConfig();
@@ -498,6 +498,16 @@ namespace AppsInToss
         /// 픽셀 불변·세션당 1회 단일 이벤트·호스트 로딩 지표 표준화에 해당하므로 기본 ON.
         /// </summary>
         public static bool GetDefaultFirstInteractiveLog()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// 기본 텍스처 crunch 활성화 여부.
+        /// crunch(DXT 위 4~8x)는 q=50 기준 시각 저하가 통상 미미한 반면 다운로드/.data 절감이 커 기본 ON.
+        /// ASTC 서브타겟에서는 빌드 시 자동으로 건너뛰고(no-op), 빌드 후 임포터 설정은 항상 원상 복원된다.
+        /// </summary>
+        public static bool GetDefaultTextureCrunch()
         {
             return true;
         }

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -210,6 +210,29 @@ namespace AppsInToss
         [Tooltip("first-interactive 계측: -1 = 자동 (활성), 0 = 비활성, 1 = 활성")]
         public int firstInteractiveLog = -1;
 
+        [Header("콘텐츠 최적화 — 텍스처 crunch")]
+        [Tooltip("대상 텍스처/SpriteAtlas 를 빌드 시 일시적으로 crunch(DXT 위 4~8x) 압축 + maxTextureSize 캡으로 reimport 하여 " +
+                 "다운로드/.data 를 줄입니다. 빌드 후 원본 임포트 설정으로 복원하므로 명시적 opt-in 으로 기본 비활성입니다. " +
+                 "crunch reimport 는 무겁습니다(에셋 수에 비례).")]
+        public bool enableTextureCrunch = false;
+
+        [Tooltip("텍스처 maxTextureSize 상한(0=캡 안 함). 이 값보다 큰 텍스처만 축소합니다. 예) 512, 1024")]
+        public int textureCrunchMaxSize = 0;
+
+        [Range(0, 100)]
+        [Tooltip("crunch 압축 품질(0~100). 낮을수록 작고 화질↓. 기본 50.")]
+        public int textureCrunchQuality = 50;
+
+        [Tooltip("SpriteAtlas 도 함께 crunch + WebGL repack 합니다(기본 true).")]
+        public bool textureCrunchAtlas = true;
+
+        [Tooltip("SpriteAtlas maxTextureSize 상한(0=캡 안 함). 예) 1024, 2048")]
+        public int textureCrunchAtlasMaxSize = 0;
+
+        [Tooltip("대상 폴더(쉼표 구분, Assets/ 기준). 비우면 프로젝트 전체 텍스처가 대상입니다. 예) Assets/Art/Textures")]
+        public string textureCrunchDirs = "";
+>>>>>>> 1bccfce (기능: 텍스처 Crunch 압축 빌드 프로세서 추가 (빌드 시 DXT crunch, 빌드 후 임포터 원복))
+
         [Header("권한 설정")]
         public AITPermissionConfig permissionConfig = new AITPermissionConfig();
 

--- a/Editor/AITTextureCrunchProcessor.cs
+++ b/Editor/AITTextureCrunchProcessor.cs
@@ -68,18 +68,39 @@ namespace AppsInToss.Editor
             EditorApplication.delayCall += SafetyNetRestore;
         }
 
+        /// <summary>후보 스캔 상한. 이 수를 넘으면 스캔을 중단하고 "N+개" 로 표기한다.</summary>
+        private const int CandidateScanLimit = 2000;
+
         /// <summary>
         /// 빌드 직전 호출: 설정이 켜져 있으면 대상 텍스처/아틀라스를 crunch 로 reimport 한다.
+        /// 설정이 꺼져 있으면 후보 스캔 후 절감 가능 여부를 Debug.Log 1줄로 안내한다.
         /// </summary>
-        /// <param name="config">프로젝트 에디터 설정. null 이거나 기능이 꺼져 있으면 no-op.</param>
+        /// <param name="config">프로젝트 에디터 설정. null 이거나 기능이 꺼져 있으면 no-op(단, 후보 안내는 수행).</param>
         /// <returns>복원에 사용할 핸들(항상 non-null).</returns>
         public static CrunchHandle ApplyForBuild(AITEditorScriptObject config)
         {
             var handle = new CrunchHandle();
             if (config == null || !config.enableTextureCrunch)
             {
+                // crunch 비활성 — 후보 스캔 후 절감 가능 여부를 1줄 안내(후보 0이면 침묵).
+                if (config != null)
+                {
+                    ReportCandidateHint(config);
+                }
+
                 return handle;
             }
+
+            // ASTC 서브타겟 감지: crunch(DXT 위 압축)가 효과 없고 오히려 RGBA32 팽창 위험.
+#if UNITY_2022_3_OR_NEWER
+            if (EditorUserBuildSettings.webGLBuildSubtarget == WebGLTextureSubtarget.ASTC)
+            {
+                Debug.LogWarning("[AIT-TextureCrunch] WebGL Texture Compression이 ASTC라 crunch를 건너뜁니다. " +
+                    "ASTC 환경에서는 crunch(DXT 기반 압축)가 동작하지 않으며 오히려 RGBA32 비압축으로 팽창할 수 있습니다. " +
+                    "DXT(기본) 서브타겟에서만 crunch가 유효합니다.");
+                return handle;
+            }
+#endif
 
             try
             {
@@ -162,6 +183,75 @@ namespace AppsInToss.Editor
             catch (Exception e)
             {
                 Debug.LogWarning($"[AIT-TextureCrunch] 안전망 복원 중 예외(무시): {e}");
+            }
+        }
+
+        // ─────────────────────────── 후보 스캔 안내 ───────────────────────────
+
+        /// <summary>
+        /// crunch 비활성 빌드에서 절감 후보 텍스처 수를 빠르게 세어
+        /// 후보가 1개 이상이면 Debug.Log 1줄로 opt-in 안내를 출력한다.
+        /// 스캔 비용을 제한하기 위해 <see cref="CandidateScanLimit"/>개를 초과하면 중단.
+        /// </summary>
+        private static void ReportCandidateHint(AITEditorScriptObject config)
+        {
+            try
+            {
+                string[] dirs = SplitDirs(config.textureCrunchDirs);
+                var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets" });
+
+                int candidates = 0;
+                int scanned = 0;
+                bool hitLimit = false;
+
+                foreach (var g in guids)
+                {
+                    if (scanned >= CandidateScanLimit)
+                    {
+                        hitLimit = true;
+                        break;
+                    }
+
+                    string path = AssetDatabase.GUIDToAssetPath(g);
+                    if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/"))
+                    {
+                        continue;
+                    }
+
+                    if (dirs != null && !UnderAny(path, dirs))
+                    {
+                        continue;
+                    }
+
+                    var ti = AssetImporter.GetAtPath(path) as TextureImporter;
+                    if (ti == null)
+                    {
+                        continue;
+                    }
+
+                    // 후보 기준: crunch 미적용 + DXT 계열(compressed, 비압축 포함) — ASTC 제외.
+                    // 비압축(Uncompressed) 텍스처는 DXT+crunch 적용 경로가 있으므로 후보에 포함한다.
+                    bool isCrunchTarget = !ti.crunchedCompression;
+                    if (isCrunchTarget)
+                    {
+                        candidates++;
+                    }
+
+                    scanned++;
+                }
+
+                if (candidates > 0)
+                {
+                    string countStr = hitLimit ? $"{CandidateScanLimit}+개" : $"{candidates}개";
+                    Debug.Log($"[AIT] 텍스처 Crunch(opt-in): 후보 {countStr} 발견. " +
+                        "AIT Configuration에서 활성화하면 .data 크기를 줄일 수 있습니다" +
+                        "(품질 트레이드오프 있음 — lossy).");
+                }
+            }
+            catch (Exception e)
+            {
+                // 후보 스캔 실패는 빌드 차단이 아님(안내용).
+                Debug.LogWarning($"[AIT-TextureCrunch] 후보 스캔 중 예외(무시): {e.Message}");
             }
         }
 

--- a/Editor/AITTextureCrunchProcessor.cs
+++ b/Editor/AITTextureCrunchProcessor.cs
@@ -14,6 +14,10 @@
 //   WebGL 플랫폼 오버라이드를 "생성"하면 format 이 RGBA32(비압축)로 리셋돼 오히려 팽창하므로,
 //   오버라이드를 만들지 않고 기본 임포터 설정(textureCompression/crunchedCompression/compressionQuality)
 //   과 maxTextureSize 만 조정한다(빌드는 WebGL fallback 으로 기본 format=DXT 를 쓰고 거기에 crunch).
+//   다만 텍스처가 "이미" WebGL 오버라이드(overridden=true)를 가진 경우, 빌드는 그 오버라이드를
+//   우선하므로 기본 임포터 crunch 가 무시된다 → 이때는 (신규 생성이 아니라) 기존 오버라이드를
+//   in-place 갱신해 crunch 를 반영한다(명시 DXT 포맷 → 대응 Crunched 변형, 포맷 리셋 없음).
+//   비-DXT 오버라이드(ASTC/비압축)는 crunch 불가라 maxSize 만 반영하고 포맷은 보존한다.
 //   SpriteAtlas 는 DefaultTexturePlatform(마스터) 설정만 조정 후 WebGL 타깃으로 repack.
 //
 // 비파괴: 각 에셋의 원본 .meta(텍스처) / .spriteatlasv2(아틀라스) 를 <path>.aittexbak 로 백업,
@@ -283,11 +287,16 @@ namespace AppsInToss.Editor
                     continue;
                 }
 
+                // 기존 WebGL 오버라이드가 crunch 미적용 상태인지(=빌드가 기본 crunch 를 무시하는지) 검사.
+                var webPs = ti.GetPlatformTextureSettings("WebGL");
+                bool webOverrideNeedsCrunch = WebGLOverrideNeedsCrunch(webPs, maxSize, quality);
+
                 bool wouldChange =
                     (maxSize > 0 && ti.maxTextureSize > maxSize)
                     || ti.textureCompression == TextureImporterCompression.Uncompressed
                     || !ti.crunchedCompression
-                    || ti.compressionQuality != quality;
+                    || ti.compressionQuality != quality
+                    || webOverrideNeedsCrunch;
                 if (!wouldChange)
                 {
                     continue; // 이미 목표 상태(예: 재진입) → 백업/리임포트 비용 회피
@@ -311,11 +320,103 @@ namespace AppsInToss.Editor
 
                 ti.crunchedCompression = true;
                 ti.compressionQuality = quality;
+
+                // 기존 WebGL 오버라이드가 있으면 빌드가 그것을 우선하므로, 위 기본 설정만으로는
+                // crunch 가 무시된다 → 오버라이드를 in-place 갱신(신규 생성 금지)해 crunch 반영.
+                if (webPs != null && webPs.overridden)
+                {
+                    ApplyCrunchToExistingWebGLOverride(ti, webPs, maxSize, quality);
+                }
+
                 ti.SaveAndReimport();
                 n++;
             }
 
             return n;
+        }
+
+        // 기존(overridden=true) WebGL 오버라이드 설정이 crunch 미반영 상태인지 판정.
+        // 신규 오버라이드 생성은 하지 않으므로 overridden=false 면 항상 false(기본 crunch fallback 사용).
+        private static bool WebGLOverrideNeedsCrunch(
+            TextureImporterPlatformSettings ps, int maxSize, int quality)
+        {
+            if (ps == null || !ps.overridden)
+            {
+                return false;
+            }
+
+            if (maxSize > 0 && ps.maxTextureSize > maxSize)
+            {
+                return true;
+            }
+
+            // crunch 적용 가능 포맷(명시 DXT / Automatic / 이미 Crunched)에 한해 crunch 상태를 본다.
+            if (IsCrunchApplicableFormat(ps.format))
+            {
+                return !ps.crunchedCompression
+                    || ps.compressionQuality != quality
+                    || ToCrunchedDxtFormat(ps.format) != ps.format; // 명시 DXT → Crunched 변형 필요
+            }
+
+            return false; // ASTC/비압축 등: crunch 불가 → maxSize 외 변경 없음
+        }
+
+        // 기존 WebGL 오버라이드에 crunch 를 in-place 반영한다(format 리셋·신규 생성 없음).
+        private static void ApplyCrunchToExistingWebGLOverride(
+            TextureImporter ti, TextureImporterPlatformSettings ps, int maxSize, int quality)
+        {
+            bool changed = false;
+
+            if (maxSize > 0 && ps.maxTextureSize > maxSize)
+            {
+                ps.maxTextureSize = maxSize;
+                changed = true;
+            }
+
+            if (IsCrunchApplicableFormat(ps.format))
+            {
+                var crunched = ToCrunchedDxtFormat(ps.format);
+                if (crunched != ps.format)
+                {
+                    ps.format = crunched; // DXT1/DXT5 → DXT1Crunched/DXT5Crunched (비압축 리셋 아님)
+                    changed = true;
+                }
+                if (!ps.crunchedCompression || ps.compressionQuality != quality)
+                {
+                    ps.crunchedCompression = true;
+                    ps.compressionQuality = quality;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                ti.SetPlatformTextureSettings(ps);
+            }
+        }
+
+        // crunch 는 DXT 계열에만 적용 가능. Automatic 은 빌드가 crunched 포맷을 자동 선택,
+        // 이미 *Crunched 포맷은 idempotent 보장. 그 외(ASTC/RGBA32 등)는 crunch 불가.
+        private static bool IsCrunchApplicableFormat(TextureImporterFormat f)
+        {
+            return f == TextureImporterFormat.Automatic
+                || f == TextureImporterFormat.DXT1
+                || f == TextureImporterFormat.DXT5
+                || f == TextureImporterFormat.DXT1Crunched
+                || f == TextureImporterFormat.DXT5Crunched;
+        }
+
+        private static TextureImporterFormat ToCrunchedDxtFormat(TextureImporterFormat f)
+        {
+            switch (f)
+            {
+                case TextureImporterFormat.DXT1:
+                    return TextureImporterFormat.DXT1Crunched;
+                case TextureImporterFormat.DXT5:
+                    return TextureImporterFormat.DXT5Crunched;
+                default:
+                    return f; // Automatic / 이미 Crunched / 비-DXT → 그대로
+            }
         }
 
         // ─────────────────────────── SpriteAtlas ───────────────────────────

--- a/Editor/AITTextureCrunchProcessor.cs
+++ b/Editor/AITTextureCrunchProcessor.cs
@@ -24,8 +24,8 @@
 //   try/finally 의 finally 에서 RestoreForBuild 를 호출한다(오디오 스트리밍과 동일 패턴).
 //
 // ⚠ 비용: crunch reimport 는 무겁다(에셋 수에 비례). 빌드 시 apply + 복원으로 2회 reimport 가
-//   발생하므로, 명시적 opt-in 으로 기본 비활성이다. 대용량 텍스처가 많은 프로젝트의 다운로드
-//   최적화용이다.
+//   발생한다. 기본은 자동 ON이며, 대용량 텍스처 프로젝트에서 다운로드/.data 를 실감한다.
+//   필요시 AIT Configuration에서 비활성화할 수 있다.
 
 using System;
 using System.Collections.Generic;
@@ -38,7 +38,7 @@ using UnityEngine.U2D;
 namespace AppsInToss.Editor
 {
     /// <summary>
-    /// 빌드 단계 텍스처 crunch 처리기. <see cref="AITEditorScriptObject.enableTextureCrunch"/>
+    /// 빌드 단계 텍스처 crunch 처리기. <see cref="AITEditorScriptObject.textureCrunch"/>
     /// 설정에 따라 동작한다. 런타임 컴포넌트는 없다(빌드 산출물만 작아질 뿐, 런타임 동작 동일).
     /// </summary>
     [InitializeOnLoad]
@@ -80,7 +80,10 @@ namespace AppsInToss.Editor
         public static CrunchHandle ApplyForBuild(AITEditorScriptObject config)
         {
             var handle = new CrunchHandle();
-            if (config == null || !config.enableTextureCrunch)
+            bool enabled = config != null && (config.textureCrunch >= 0
+                ? config.textureCrunch == 1
+                : AITDefaultSettings.GetDefaultTextureCrunch());
+            if (config == null || !enabled)
             {
                 // crunch 비활성 — 후보 스캔 후 절감 가능 여부를 1줄 안내(후보 0이면 침묵).
                 if (config != null)
@@ -126,7 +129,7 @@ namespace AppsInToss.Editor
                     RemoveMarker();
                 }
 
-                Debug.Log($"[AIT-TextureCrunch] ✓ 텍스처 {tex}개 + 아틀라스 {atl}개 crunch(q={quality}, maxSize≤{(maxSize > 0 ? maxSize.ToString() : "원본")}) 적용.");
+                Debug.Log($"[AIT-TextureCrunch] ✓ 텍스처 {tex}개 + 아틀라스 {atl}개 crunch(q={quality}, maxSize≤{(maxSize > 0 ? maxSize.ToString() : "원본")}) 적용{(config.textureCrunch < 0 ? " (자동)" : "")}.");
                 return handle;
             }
             catch (Exception e)
@@ -189,8 +192,8 @@ namespace AppsInToss.Editor
         // ─────────────────────────── 후보 스캔 안내 ───────────────────────────
 
         /// <summary>
-        /// crunch 비활성 빌드에서 절감 후보 텍스처 수를 빠르게 세어
-        /// 후보가 1개 이상이면 Debug.Log 1줄로 opt-in 안내를 출력한다.
+        /// crunch 비활성화 빌드에서 절감 후보 텍스처 수를 빠르게 세어
+        /// 후보가 1개 이상이면 Debug.Log 1줄로 재활성화 안내를 출력한다.
         /// 스캔 비용을 제한하기 위해 <see cref="CandidateScanLimit"/>개를 초과하면 중단.
         /// </summary>
         private static void ReportCandidateHint(AITEditorScriptObject config)
@@ -243,8 +246,8 @@ namespace AppsInToss.Editor
                 if (candidates > 0)
                 {
                     string countStr = hitLimit ? $"{CandidateScanLimit}+개" : $"{candidates}개";
-                    Debug.Log($"[AIT] 텍스처 Crunch(opt-in): 후보 {countStr} 발견. " +
-                        "AIT Configuration에서 활성화하면 .data 크기를 줄일 수 있습니다" +
+                    Debug.Log($"[AIT] 텍스처 Crunch 비활성화됨: 후보 {countStr} 존재. " +
+                        "AIT Configuration에서 자동/활성화로 되돌리면 .data 크기를 줄일 수 있습니다" +
                         "(품질 트레이드오프 있음 — lossy).");
                 }
             }

--- a/Editor/AITTextureCrunchProcessor.cs
+++ b/Editor/AITTextureCrunchProcessor.cs
@@ -1,0 +1,448 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITTextureCrunchProcessor.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Texture Crunch (build-time importer override)
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 빌드 직전, 대상 Texture2D / SpriteAtlas 의 임포터 설정을 일시적으로
+//   (1) maxTextureSize 캡  (2) crunch 압축 + 품질 하향
+// 으로 바꿔 reimport 하여, Unity 가 더 작은 텍스처를 .data 에 굽도록 한다.
+// 빌드 종료(성공/실패 무관) 후 원본 임포트 설정으로 원상 복원한다.
+//
+// 효과: crunch 는 DXT 위에 적용되는 강력한 코덱(4~8x). 다운로드(on-wire) 와 .data 를 실감.
+//   WebGL 플랫폼 오버라이드를 "생성"하면 format 이 RGBA32(비압축)로 리셋돼 오히려 팽창하므로,
+//   오버라이드를 만들지 않고 기본 임포터 설정(textureCompression/crunchedCompression/compressionQuality)
+//   과 maxTextureSize 만 조정한다(빌드는 WebGL fallback 으로 기본 format=DXT 를 쓰고 거기에 crunch).
+//   SpriteAtlas 는 DefaultTexturePlatform(마스터) 설정만 조정 후 WebGL 타깃으로 repack.
+//
+// 비파괴: 각 에셋의 원본 .meta(텍스처) / .spriteatlasv2(아틀라스) 를 <path>.aittexbak 로 백업,
+//   빌드 후 원본을 그대로 복원한다. 빌드가 비정상 종료되어 복원이 누락돼도, 다음 에디터 로드 시
+//   안전망(SafetyNetRestore)이 잔존 백업을 자동 복원한다.
+//
+// 통합: AITConvertCore.BuildWebGL 가 BuildPipeline.BuildPlayer 직전에 ApplyForBuild,
+//   try/finally 의 finally 에서 RestoreForBuild 를 호출한다(오디오 스트리밍과 동일 패턴).
+//
+// ⚠ 비용: crunch reimport 는 무겁다(에셋 수에 비례). 빌드 시 apply + 복원으로 2회 reimport 가
+//   발생하므로, 명시적 opt-in 으로 기본 비활성이다. 대용량 텍스처가 많은 프로젝트의 다운로드
+//   최적화용이다.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.U2D;
+using UnityEngine;
+using UnityEngine.U2D;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 빌드 단계 텍스처 crunch 처리기. <see cref="AITEditorScriptObject.enableTextureCrunch"/>
+    /// 설정에 따라 동작한다. 런타임 컴포넌트는 없다(빌드 산출물만 작아질 뿐, 런타임 동작 동일).
+    /// </summary>
+    [InitializeOnLoad]
+    public static class AITTextureCrunchProcessor
+    {
+        /// <summary>원본 .meta / .spriteatlasv2 를 보관하는 백업 접미사.</summary>
+        private const string BackupSuffix = ".aittexbak";
+
+        /// <summary>apply 가 진행 중임을 표시하는 마커(Unity 가 무시하는 '.' 접두 숨김 파일).</summary>
+        private const string MarkerRelative = "Assets/.ait-texcrunch-active";
+
+        /// <summary>한 번의 crunch 적용 결과 핸들. finally 에서 정확한 복원에 사용.</summary>
+        public sealed class CrunchHandle
+        {
+            /// <summary>이번 빌드에서 crunch 가 실제로 수행되었는지.</summary>
+            public bool Active;
+
+            /// <summary>처리된 텍스처 개수.</summary>
+            public int TextureCount;
+
+            /// <summary>처리된 SpriteAtlas 개수.</summary>
+            public int AtlasCount;
+        }
+
+        static AITTextureCrunchProcessor()
+        {
+            EditorApplication.delayCall += SafetyNetRestore;
+        }
+
+        /// <summary>
+        /// 빌드 직전 호출: 설정이 켜져 있으면 대상 텍스처/아틀라스를 crunch 로 reimport 한다.
+        /// </summary>
+        /// <param name="config">프로젝트 에디터 설정. null 이거나 기능이 꺼져 있으면 no-op.</param>
+        /// <returns>복원에 사용할 핸들(항상 non-null).</returns>
+        public static CrunchHandle ApplyForBuild(AITEditorScriptObject config)
+        {
+            var handle = new CrunchHandle();
+            if (config == null || !config.enableTextureCrunch)
+            {
+                return handle;
+            }
+
+            try
+            {
+                int maxSize = config.textureCrunchMaxSize;          // 0 = 캡 안 함
+                int quality = Mathf.Clamp(config.textureCrunchQuality, 0, 100);
+                string[] dirs = SplitDirs(config.textureCrunchDirs); // null = 전체 Assets
+                bool doAtlas = config.textureCrunchAtlas;
+                int atlasMax = config.textureCrunchAtlasMaxSize;     // 0 = 캡 안 함
+
+                CreateMarker();
+
+                int tex = ApplyTexture2D(maxSize, quality, dirs);
+                int atl = doAtlas ? ApplySpriteAtlases(atlasMax, quality, dirs) : 0;
+
+                AssetDatabase.Refresh();
+
+                handle.Active = (tex + atl) > 0;
+                handle.TextureCount = tex;
+                handle.AtlasCount = atl;
+                if (!handle.Active)
+                {
+                    // 대상 0건 → 마커 제거(복원할 것 없음).
+                    RemoveMarker();
+                }
+
+                Debug.Log($"[AIT-TextureCrunch] ✓ 텍스처 {tex}개 + 아틀라스 {atl}개 crunch(q={quality}, maxSize≤{(maxSize > 0 ? maxSize.ToString() : "원본")}) 적용.");
+                return handle;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-TextureCrunch] 적용 예외 → 복원 후 건너뜀: {e}");
+                RestoreAllBackups();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                return new CrunchHandle();
+            }
+        }
+
+        /// <summary>빌드 종료 후(성공/실패 무관) 호출: 원본 임포트 설정으로 복원한다.</summary>
+        public static void RestoreForBuild(CrunchHandle handle)
+        {
+            if (handle == null || !handle.Active)
+            {
+                return;
+            }
+
+            try
+            {
+                int restored = RestoreAllBackups();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                Debug.Log($"[AIT-TextureCrunch] 복원 완료: {restored}개 에셋 원본 임포트 설정 원상.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-TextureCrunch] 복원 예외: {e}");
+            }
+        }
+
+        /// <summary>에디터 로드 시 안전망. 마커가 잔존하면(=이전 빌드가 복원 전에 종료) 백업을 자동 복원.</summary>
+        private static void SafetyNetRestore()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string markerFull = Path.Combine(projectRoot, MarkerRelative);
+                if (!File.Exists(markerFull))
+                {
+                    return; // 공통 경로: 잔존물 없음(빠른 반환)
+                }
+
+                int restored = RestoreAllBackups();
+                RemoveMarker();
+                if (restored > 0)
+                {
+                    AssetDatabase.Refresh();
+                    Debug.LogWarning($"[AIT-TextureCrunch] 안전망: 이전 빌드 잔존 백업 {restored}개를 복원했습니다.");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-TextureCrunch] 안전망 복원 중 예외(무시): {e}");
+            }
+        }
+
+        // ─────────────────────────── Texture2D ───────────────────────────
+        private static int ApplyTexture2D(int maxSize, int quality, string[] dirs)
+        {
+            int n = 0;
+            var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets" });
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+            foreach (var g in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(g);
+                if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/"))
+                {
+                    continue;
+                }
+
+                if (dirs != null && !UnderAny(path, dirs))
+                {
+                    continue;
+                }
+
+                var ti = AssetImporter.GetAtPath(path) as TextureImporter;
+                if (ti == null)
+                {
+                    continue;
+                }
+
+                bool wouldChange =
+                    (maxSize > 0 && ti.maxTextureSize > maxSize)
+                    || ti.textureCompression == TextureImporterCompression.Uncompressed
+                    || !ti.crunchedCompression
+                    || ti.compressionQuality != quality;
+                if (!wouldChange)
+                {
+                    continue; // 이미 목표 상태(예: 재진입) → 백업/리임포트 비용 회피
+                }
+
+                // 원본 .meta 백업(verbatim 복원용).
+                if (!BackupAssetMeta(path, projectRoot))
+                {
+                    continue;
+                }
+
+                if (maxSize > 0 && ti.maxTextureSize > maxSize)
+                {
+                    ti.maxTextureSize = maxSize;
+                }
+
+                if (ti.textureCompression == TextureImporterCompression.Uncompressed)
+                {
+                    ti.textureCompression = TextureImporterCompression.Compressed; // crunch 전제
+                }
+
+                ti.crunchedCompression = true;
+                ti.compressionQuality = quality;
+                ti.SaveAndReimport();
+                n++;
+            }
+
+            return n;
+        }
+
+        // ─────────────────────────── SpriteAtlas ───────────────────────────
+        private static int ApplySpriteAtlases(int atlasMax, int quality, string[] dirs)
+        {
+            int n = 0;
+            var guids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { "Assets" });
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+            foreach (var g in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(g);
+                if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/"))
+                {
+                    continue;
+                }
+
+                if (dirs != null && !UnderAny(path, dirs))
+                {
+                    continue;
+                }
+
+                var atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(path);
+                if (atlas == null)
+                {
+                    continue;
+                }
+
+                // 아틀라스 에셋 파일 자체를 백업(플랫폼 설정이 .spriteatlasv2 안에 직렬화됨).
+                if (!BackupAssetFile(path, projectRoot))
+                {
+                    continue;
+                }
+
+                // DefaultTexturePlatform(마스터). format 필드는 보존(=null/Automatic 유지).
+                var def = atlas.GetPlatformSettings("DefaultTexturePlatform");
+                if (atlasMax > 0 && def.maxTextureSize > atlasMax)
+                {
+                    def.maxTextureSize = atlasMax;
+                }
+
+                if (def.textureCompression == TextureImporterCompression.Uncompressed)
+                {
+                    def.textureCompression = TextureImporterCompression.Compressed;
+                }
+
+                def.crunchedCompression = true;
+                def.compressionQuality = quality;
+                atlas.SetPlatformSettings(def);
+                EditorUtility.SetDirty(atlas);
+                n++;
+            }
+
+            if (n > 0)
+            {
+                AssetDatabase.SaveAssets();
+                try
+                {
+                    SpriteAtlasUtility.PackAllAtlases(BuildTarget.WebGL);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-TextureCrunch]   PackAllAtlases 경고: {e.Message}");
+                }
+            }
+
+            return n;
+        }
+
+        // ─────────────────────────── 백업/복원 ───────────────────────────
+
+        /// <summary>에셋의 .meta 파일을 <path>.meta.aittexbak 로 백업.</summary>
+        private static bool BackupAssetMeta(string assetPath, string projectRoot)
+        {
+            try
+            {
+                string metaFull = Path.Combine(projectRoot, assetPath + ".meta");
+                if (!File.Exists(metaFull))
+                {
+                    return false;
+                }
+
+                string bak = metaFull + BackupSuffix;
+                if (!File.Exists(bak))
+                {
+                    File.Copy(metaFull, bak, true);
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-TextureCrunch] .meta 백업 실패({assetPath}): {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>에셋 본체 파일을 <path>.aittexbak 로 백업(SpriteAtlas 용).</summary>
+        private static bool BackupAssetFile(string assetPath, string projectRoot)
+        {
+            try
+            {
+                string full = Path.Combine(projectRoot, assetPath);
+                if (!File.Exists(full))
+                {
+                    return false;
+                }
+
+                string bak = full + BackupSuffix;
+                if (!File.Exists(bak))
+                {
+                    File.Copy(full, bak, true);
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-TextureCrunch] 에셋 백업 실패({assetPath}): {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>Assets 트리의 모든 *.aittexbak 를 원본으로 되돌리고 백업을 삭제한다. 복원 개수 반환.</summary>
+        private static int RestoreAllBackups()
+        {
+            int restored = 0;
+            string assetsPath = Application.dataPath;
+            string projectRoot = Directory.GetParent(assetsPath).FullName;
+            string[] backups;
+            try
+            {
+                backups = Directory.GetFiles(assetsPath, "*" + BackupSuffix, SearchOption.AllDirectories);
+            }
+            catch
+            {
+                return 0;
+            }
+
+            foreach (var bak in backups)
+            {
+                // bak = "<original>.aittexbak" → original 은 .meta(텍스처) 또는 .spriteatlasv2(아틀라스).
+                string original = bak.Substring(0, bak.Length - BackupSuffix.Length);
+                try
+                {
+                    File.Copy(bak, original, true);
+                    File.Delete(bak);
+
+                    // reimport 대상 에셋 경로 산출: .meta 면 본체, 아니면 그 파일 자체.
+                    string assetFull = original.EndsWith(".meta")
+                        ? original.Substring(0, original.Length - ".meta".Length)
+                        : original;
+                    string rel = AbsoluteToProjectRelative(assetFull, projectRoot);
+                    if (!string.IsNullOrEmpty(rel))
+                    {
+                        AssetDatabase.ImportAsset(rel, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                    }
+
+                    restored++;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-TextureCrunch] 백업 복원 실패({bak}): {e.Message}");
+                }
+            }
+
+            return restored;
+        }
+
+        private static void CreateMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                File.WriteAllText(Path.Combine(projectRoot, MarkerRelative), "active");
+            }
+            catch
+            {
+                // 마커 생성 실패는 치명적이지 않음(안전망 가속용일 뿐).
+            }
+        }
+
+        private static void RemoveMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string m = Path.Combine(projectRoot, MarkerRelative);
+                if (File.Exists(m))
+                {
+                    File.Delete(m);
+                }
+            }
+            catch
+            {
+                // 무시
+            }
+        }
+
+        private static string AbsoluteToProjectRelative(string absolute, string projectRoot)
+        {
+            string norm = absolute.Replace('\\', '/');
+            string root = projectRoot.Replace('\\', '/').TrimEnd('/') + "/";
+            return norm.StartsWith(root) ? norm.Substring(root.Length) : null;
+        }
+
+        private static string[] SplitDirs(string v)
+            => string.IsNullOrEmpty(v) ? null : v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+        private static bool UnderAny(string path, string[] dirs)
+        {
+            foreach (var d in dirs)
+            {
+                var t = d.Trim().TrimEnd('/');
+                if (path.StartsWith(t + "/") || path == t)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Editor/AITTextureCrunchProcessor.cs.meta
+++ b/Editor/AITTextureCrunchProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd17ff82b0e134866b0d37a6c05baf48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 개요

빌드 시 대상 텍스처/SpriteAtlas를 **crunch(DXT 위 추가 4~8x) 압축 + maxTextureSize 캡**으로 일시 reimport해 `.data`/다운로드를 줄이는 **빌드 프로세서**(`AITTextureCrunchProcessor`)를 추가합니다. 빌드 후 **원본 임포트 설정으로 자동 복원**합니다. 초기 다운로드 축소가 TTFF에 기여합니다.

WebGL 로드타임 최적화 레버를 **1기법=1PR**로 분할한 캠페인의 한 갈래입니다(texture crunch).

> ✅ **기본 ON (자동) — opt-out 가능**: 팀 성능 최적화 레버 기본 정책(zero-config: 기본 ON + 자동 안전장치)에 따라 이 레버도 **트라이스테이트 `textureCrunch = -1`(자동: 활성)** 으로 기본 동작합니다. crunch는 lossy(손실 압축)이므로 Configuration 윈도우의 HelpBox(Warning)로 화질 트레이드오프를 항시 고지하며, **"비활성화" 한 번으로 opt-out** 할 수 있습니다. 대상 폴더·품질·크기 캡도 같은 윈도우에서 지정합니다.

## 변경 내용

| 파일 | 역할 |
|------|------|
| `Editor/AITTextureCrunchProcessor.cs` (신규) | 빌드 시 crunch reimport + 빌드 후 원본 임포터 복원(`CrunchHandle`) |
| `Editor/AITEditorScriptObject.cs` | crunch 설정 6필드 — `textureCrunch` 트라이스테이트(-1=자동/0=비활성/1=활성) + maxSize/quality/atlas/atlasMaxSize/dirs, `GetDefaultTextureCrunch()` |
| `Editor/AITConfigurationWindow.cs` | `DrawTextureCrunchSetting()` — 자동/비활성화/활성화 Popup + 변경 표시 + 리셋 버튼, lossy 경고 HelpBox(`MessageType.Warning`) |
| `Editor/AITConvertCore.cs` | 빌드 직전 `ApplyForBuild` / `finally`에서 `RestoreForBuild` 한 쌍 |
| `Editor/AITBuildInitializer.cs` | 빌드 설정 요약 로그에 `텍스처 crunch: True (자동)` 라인 추가 |

## 적용 조건 / 안전성

- **기본 ON(자동)**: `textureCrunch = -1`이면 `GetDefaultTextureCrunch()`(=true)를 따릅니다. lossy가 우려되면 Configuration 윈도우에서 **비활성화(opt-out)** 하면 됩니다.
- **비파괴**: 활성 시에도 빌드 후 임포터 설정을 **try/finally로 원복**. 비정상 종료 시 다음 에디터 로드에서 안전망(`SafetyNetRestore`)이 잔존 백업을 자동 복원.
- **ASTC 자동 감지**: Unity 2022.3+에서 `EditorUserBuildSettings.webGLBuildSubtarget == WebGLTextureSubtarget.ASTC`이면 `LogWarning` 출력 후 no-op 핸들 반환(빌드 차단 없음). ASTC 경로에서 crunch(DXT 기반)는 오히려 RGBA32 비압축 팽창을 유발할 수 있으므로 자동 스킵.
- **opt-out 빌드 안내(자동 스캔)**: 명시적으로 비활성화한 빌드에서 crunch 미적용 Texture2D 후보를 최대 2000개 상한으로 스캔 후, 후보 1개 이상이면 `Debug.Log` 1줄로 재활성화 시 절감 가능함을 안내(후보 0개면 침묵 — 노이즈 없음).
- **빌드 리포트**: 빌드 설정 요약 로그에 유효 상태를 출력(`(자동)` 접미로 자동 모드 식별), 적용 성공 시 텍스처/아틀라스 처리 개수를 로그로 보고.
- **빌드 시간 증가**: crunch reimport는 에셋 수에 비례해 무겁습니다.

## 측정 Δ (perf CI가 채움)

`perf` 라벨이 부착되면 perf CI가 이 PR 브랜치를 main 위에서 빌드해 **단일 레버 Δ**를 코멘트로 게시합니다.

| Unity | TTFF Δ | on-wire Δ | data Δ |
|-------|--------|-----------|--------|
| 2021.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.0 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |

## 관련

- 측정 하네스: #754
- 머지 순서: 본 PR(L9)을 **대형 텍스처 스트리밍(L11)보다 먼저** 머지 권장.
