### PR TITLE
기능: 폰트 CJK Subset(유니코드 범위 축소)

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -480,30 +480,97 @@ namespace AppsInToss.Editor
         {
             EditorGUILayout.LabelField("콘텐츠 최적화 — 폰트 CJK subset", EditorStyles.boldLabel);
 
-            config.enableFontSubset = EditorGUILayout.Toggle(
-                new GUIContent("폰트 subset 활성화",
-                    "지정한 .ttf/.otf를 빌드 시 '보존 유니코드 범위'만 남기도록 subset하여 .data의 폰트 데이터를 급감시킵니다(CJK 풀 폰트 5~15MB → ~0.1MB). " +
-                    "빌드 후 원본 폰트로 복원합니다. SDK 내장 Node.js로 동작합니다."),
-                config.enableFontSubset);
+            bool defaultValue = AITDefaultSettings.GetDefaultFontSubset();
+            // 수동 설정 모드: targetPaths 또는 unicodeRanges 가 채워져 있으면 override(수동) 모드로 간주.
+            bool hasManualOverride = !string.IsNullOrEmpty(config.fontSubsetTargetPaths)
+                || !string.IsNullOrEmpty(config.fontSubsetUnicodeRanges);
 
-            if (config.enableFontSubset)
+            // tri-state 매핑: 0=자동, 1=비활성화, 2=수동 설정.
+            int currentIndex;
+            if (config.fontSubset == 0)
+            {
+                currentIndex = 1;
+            }
+            else if (hasManualOverride)
+            {
+                currentIndex = 2;
+            }
+            else
+            {
+                currentIndex = 0;
+            }
+
+            EditorGUILayout.BeginHorizontal();
+
+            bool isModified = config.fontSubset == 0 || hasManualOverride;
+            DrawModifiedIndicator(isModified);
+
+            string label = currentIndex == 0
+                ? $"폰트 subset (자동: {(defaultValue ? "활성화" : "비활성화")})"
+                : "폰트 subset";
+            string[] options = { $"자동 ({(defaultValue ? "활성화" : "비활성화")})", "비활성화", "수동 설정" };
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "zero-config: 자동 모드는 크고(≥1MB) 빌드 포함 가능한 폰트를 탐지하고, 프로젝트에 등장하는 " +
+                    "문자체계의 유니코드 블록 전체를 보존하도록 subset합니다(동적 텍스트도 □가 되지 않음). " +
+                    "수동 설정은 대상/범위를 직접 지정합니다."),
+                currentIndex, options);
+
+            if (newIndex != currentIndex)
+            {
+                switch (newIndex)
+                {
+                    case 0: // 자동
+                        config.fontSubset = -1;
+                        config.fontSubsetTargetPaths = string.Empty;
+                        config.fontSubsetUnicodeRanges = string.Empty;
+                        break;
+                    case 1: // 비활성화
+                        config.fontSubset = 0;
+                        break;
+                    case 2: // 수동 설정
+                        config.fontSubset = 1;
+                        break;
+                }
+
+                currentIndex = newIndex;
+            }
+
+            if (isModified && DrawResetButton())
+            {
+                config.fontSubset = -1;
+                config.fontSubsetTargetPaths = string.Empty;
+                config.fontSubsetUnicodeRanges = string.Empty;
+                currentIndex = 0;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            if (currentIndex == 0)
+            {
+                EditorGUILayout.HelpBox(
+                    "자동 모드: 대상 폰트를 탐지하고, 씬/프리팹/asset/스크립트/로컬라이제이션에 등장하는 " +
+                    "문자체계의 유니코드 블록 전체를 보존하도록 subset합니다. " +
+                    "한자는 KS X 1001 상용 한자(4,888자) + 감지된 한자를 보존하며, ASCII·한글 등 베이스라인은 항상 포함됩니다. " +
+                    "빌드 로그에 드롭 리포트가 출력됩니다.",
+                    MessageType.Info);
+            }
+            else if (currentIndex == 2)
             {
                 EditorGUI.indentLevel++;
                 config.fontSubsetTargetPaths = EditorGUILayout.TextField(
-                    new GUIContent("대상 폰트 경로(쉼표 구분)", "Assets/ 기준의 .ttf/.otf. 비우면 아무 폰트도 건드리지 않습니다(안전 기본값). 예) Assets/Fonts/NotoSansKR.ttf"),
+                    new GUIContent("대상 폰트 경로(쉼표 구분)", "Assets/ 기준의 .ttf/.otf. 비우면 자동 탐지로 폴백됩니다. 예) Assets/Fonts/NotoSansKR.ttf"),
                     config.fontSubsetTargetPaths);
 
                 config.fontSubsetUnicodeRanges = EditorGUILayout.TextField(
-                    new GUIContent("보존 유니코드 범위", "쉼표 구분(fontTools 표기). 기본: ASCII+Latin-1+한글+CJK 기호+전각."),
+                    new GUIContent("보존 유니코드 범위", "쉼표 구분(fontTools 표기). 비우면 Auto 스캔이 범위를 결정합니다. 예) U+0020-007E,U+AC00-D7A3"),
                     config.fontSubsetUnicodeRanges);
                 EditorGUI.indentLevel--;
 
-                bool ready = !string.IsNullOrEmpty(config.fontSubsetTargetPaths) && !string.IsNullOrEmpty(config.fontSubsetUnicodeRanges);
                 EditorGUILayout.HelpBox(
-                    "⚠ subset에 포함되지 않은 글자(희귀 한자/이모지/런타임 동적 텍스트)는 □로 렌더됩니다. " +
-                    "닉네임·채팅 등 임의 문자가 표시되는 폰트에는 사용하지 마세요. " +
-                    (ready ? "빌드 시 대상 폰트가 subset됩니다." : "대상 폰트와 보존 범위를 모두 지정해야 동작합니다(현재 no-op)."),
-                    ready ? MessageType.Warning : MessageType.Info);
+                    "⚠ 수동 보존 범위를 지정하면 그 범위만 남고 나머지 글자(희귀 한자/이모지/동적 텍스트)는 □로 렌더됩니다. " +
+                    "범위를 비우면 Auto 스캔이 등장 문자체계를 보존하므로 더 안전합니다.",
+                    MessageType.Warning);
             }
         }
 
@@ -1045,6 +1112,13 @@ namespace AppsInToss.Editor
 
             bool defaultFirstInteractive = AITDefaultSettings.GetDefaultFirstInteractiveLog();
             if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
+            // 폰트 subset: 비활성(0)이거나 수동 override(target/range 지정)면 변경으로 집계.
+            if (config.fontSubset == 0
+                || !string.IsNullOrEmpty(config.fontSubsetTargetPaths)
+                || !string.IsNullOrEmpty(config.fontSubsetUnicodeRanges))
+            {
+                count++;
+            }
 
             return count;
         }
@@ -1055,6 +1129,9 @@ namespace AppsInToss.Editor
             config.threadsSupport = -1;
             config.dataCaching = -1;
             config.firstInteractiveLog = -1;
+            config.fontSubset = -1;
+            config.fontSubsetTargetPaths = string.Empty;
+            config.fontSubsetUnicodeRanges = string.Empty;
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -453,6 +453,8 @@ namespace AppsInToss.Editor
 
             // first-interactive 계측
             DrawFirstInteractiveLogSetting();
+            // 콘텐츠 최적화 — 폰트 CJK subset (.data 폰트 데이터 축소)
+            DrawFontSubsetSetting();
 
             GUILayout.Space(10);
 
@@ -472,6 +474,37 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndVertical();
+        }
+
+        private void DrawFontSubsetSetting()
+        {
+            EditorGUILayout.LabelField("콘텐츠 최적화 — 폰트 CJK subset", EditorStyles.boldLabel);
+
+            config.enableFontSubset = EditorGUILayout.Toggle(
+                new GUIContent("폰트 subset 활성화",
+                    "지정한 .ttf/.otf를 빌드 시 '보존 유니코드 범위'만 남기도록 subset하여 .data의 폰트 데이터를 급감시킵니다(CJK 풀 폰트 5~15MB → ~0.1MB). " +
+                    "빌드 후 원본 폰트로 복원합니다. SDK 내장 Node.js로 동작합니다."),
+                config.enableFontSubset);
+
+            if (config.enableFontSubset)
+            {
+                EditorGUI.indentLevel++;
+                config.fontSubsetTargetPaths = EditorGUILayout.TextField(
+                    new GUIContent("대상 폰트 경로(쉼표 구분)", "Assets/ 기준의 .ttf/.otf. 비우면 아무 폰트도 건드리지 않습니다(안전 기본값). 예) Assets/Fonts/NotoSansKR.ttf"),
+                    config.fontSubsetTargetPaths);
+
+                config.fontSubsetUnicodeRanges = EditorGUILayout.TextField(
+                    new GUIContent("보존 유니코드 범위", "쉼표 구분(fontTools 표기). 기본: ASCII+Latin-1+한글+CJK 기호+전각."),
+                    config.fontSubsetUnicodeRanges);
+                EditorGUI.indentLevel--;
+
+                bool ready = !string.IsNullOrEmpty(config.fontSubsetTargetPaths) && !string.IsNullOrEmpty(config.fontSubsetUnicodeRanges);
+                EditorGUILayout.HelpBox(
+                    "⚠ subset에 포함되지 않은 글자(희귀 한자/이모지/런타임 동적 텍스트)는 □로 렌더됩니다. " +
+                    "닉네임·채팅 등 임의 문자가 표시되는 폰트에는 사용하지 마세요. " +
+                    (ready ? "빌드 시 대상 폰트가 subset됩니다." : "대상 폰트와 보존 범위를 모두 지정해야 동작합니다(현재 no-op)."),
+                    ready ? MessageType.Warning : MessageType.Info);
+            }
         }
 
         private void DrawMemorySizeSetting()

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -993,6 +993,9 @@ namespace AppsInToss
             // .cs 파일 수정과 달리 .json은 스크립트 컴파일을 유발하지 않으므로 도메인 리로드 없음
             bool versionInfoWritten = WriteVersionInfoJson(out bool createdResourcesDir);
 
+            // 콘텐츠 최적화 — 폰트 CJK subset (.data 폰트 데이터 축소, 빌드 후 원본 폰트 복원)
+            var fontSubsetHandle = Editor.AITFontSubsetProcessor.ApplyForBuild(config);
+
             UnityEditor.Build.Reporting.BuildReport result;
             try
             {
@@ -1000,6 +1003,9 @@ namespace AppsInToss
             }
             finally
             {
+                // 콘텐츠 최적화 — 폰트 subset 원본 폰트 복원 (빌드 성공/실패 무관)
+                Editor.AITFontSubsetProcessor.RestoreForBuild(fontSubsetHandle);
+
                 // 빌드 완료 후 (성공/실패 무관) 생성한 JSON 제거 — 사용자 프로젝트에 산출물 남기지 않음
                 if (versionInfoWritten)
                 {

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -210,15 +210,18 @@ namespace AppsInToss
         [Tooltip("first-interactive 계측: -1 = 자동 (활성), 0 = 비활성, 1 = 활성")]
         public int firstInteractiveLog = -1;
         [Header("콘텐츠 최적화 — 폰트 CJK subset")]
-        [Tooltip("지정한 .ttf/.otf 를 빌드 시 '보존 유니코드 범위'만 남기도록 subset 하여 .data 의 폰트 데이터를 급감시킵니다(CJK 풀 폰트 5~15MB → ~0.1MB). " +
-                 "빌드 후 원본 폰트로 복원합니다. ⚠ subset 에 없는 글자(희귀 한자/이모지/동적 텍스트)는 □ 로 렌더되므로, " +
-                 "대상 폰트(fontSubsetTargetPaths)와 보존 범위(fontSubsetUnicodeRanges)를 모두 명시해야만 동작합니다(둘 중 하나라도 비면 no-op).")]
-        public bool enableFontSubset = false;
+        [Tooltip("크고(≥1MB) 빌드에 포함될 가능성이 있는 .ttf/.otf 를 자동 탐지해, 프로젝트에 실제 등장하는 " +
+                 "문자체계의 유니코드 블록 전체를 보존하도록 subset 합니다(.data 폰트 데이터 급감, CJK 풀 폰트 5~15MB → ~0.1MB). " +
+                 "빌드 후 원본 폰트로 복원합니다. zero-config: -1=자동(권장), 0=비활성, 1=자동(명시). " +
+                 "수동 제어가 필요하면 fontSubsetTargetPaths/fontSubsetUnicodeRanges 로 override 합니다.")]
+        public int fontSubset = -1; // -1=자동, 0=비활성, 1=자동(명시적 ON)
 
-        [Tooltip("보존할 유니코드 범위(쉼표 구분, fontTools 표기). 기본: ASCII+Latin-1+한글 음절/자모+CJK 기호+전각. 비우면 no-op.")]
-        public string fontSubsetUnicodeRanges = "U+0020-007E,U+00A0-00FF,U+AC00-D7A3,U+1100-11FF,U+3000-303F,U+FF00-FFEF";
+        [Tooltip("(override) 보존할 유니코드 범위를 직접 지정(쉼표 구분, fontTools 표기). 비우면 Auto 스캔이 범위를 결정합니다. " +
+                 "값을 넣으면 그 범위만 보존하는 수동 모드가 됩니다(스캔 생략).")]
+        public string fontSubsetUnicodeRanges = "";
 
-        [Tooltip("subset 대상 폰트 에셋 경로(쉼표 구분, Assets/ 기준의 .ttf/.otf). 안전을 위해 비우면 아무 폰트도 건드리지 않습니다. 예) Assets/Fonts/NotoSansKR.ttf")]
+        [Tooltip("(override) subset 대상 폰트 에셋 경로(쉼표 구분, Assets/ 기준의 .ttf/.otf). 비우면 Auto 탐지가 대상을 정합니다. " +
+                 "값을 넣으면 그 폰트만 대상이 되는 수동 모드가 됩니다. 예) Assets/Fonts/NotoSansKR.ttf")]
         public string fontSubsetTargetPaths = "";
 
         [Header("권한 설정")]
@@ -467,6 +470,16 @@ namespace AppsInToss
         public static bool GetDefaultRunInBackground()
         {
             return false;
+        }
+
+        /// <summary>
+        /// 기본 폰트 CJK subset 활성화 여부.
+        /// zero-config 철학: 기본 ON + 자동 안전장치(스캔/블록 완성/보수적 베이스라인/빌드 리포트/opt-out).
+        /// 스캔이 등장 문자체계의 블록 전체를 보존하므로 동적 텍스트(닉네임/채팅)도 정확성이 보존된다.
+        /// </summary>
+        public static bool GetDefaultFontSubset()
+        {
+            return true;
         }
 
 #if UNITY_2023_3_OR_NEWER && !UNITY_6000_0_OR_NEWER

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -209,6 +209,17 @@ namespace AppsInToss
         [Header("계측 설정")]
         [Tooltip("first-interactive 계측: -1 = 자동 (활성), 0 = 비활성, 1 = 활성")]
         public int firstInteractiveLog = -1;
+        [Header("콘텐츠 최적화 — 폰트 CJK subset")]
+        [Tooltip("지정한 .ttf/.otf 를 빌드 시 '보존 유니코드 범위'만 남기도록 subset 하여 .data 의 폰트 데이터를 급감시킵니다(CJK 풀 폰트 5~15MB → ~0.1MB). " +
+                 "빌드 후 원본 폰트로 복원합니다. ⚠ subset 에 없는 글자(희귀 한자/이모지/동적 텍스트)는 □ 로 렌더되므로, " +
+                 "대상 폰트(fontSubsetTargetPaths)와 보존 범위(fontSubsetUnicodeRanges)를 모두 명시해야만 동작합니다(둘 중 하나라도 비면 no-op).")]
+        public bool enableFontSubset = false;
+
+        [Tooltip("보존할 유니코드 범위(쉼표 구분, fontTools 표기). 기본: ASCII+Latin-1+한글 음절/자모+CJK 기호+전각. 비우면 no-op.")]
+        public string fontSubsetUnicodeRanges = "U+0020-007E,U+00A0-00FF,U+AC00-D7A3,U+1100-11FF,U+3000-303F,U+FF00-FFEF";
+
+        [Tooltip("subset 대상 폰트 에셋 경로(쉼표 구분, Assets/ 기준의 .ttf/.otf). 안전을 위해 비우면 아무 폰트도 건드리지 않습니다. 예) Assets/Fonts/NotoSansKR.ttf")]
+        public string fontSubsetTargetPaths = "";
 
         [Header("권한 설정")]
         public AITPermissionConfig permissionConfig = new AITPermissionConfig();

--- a/Editor/AITFontSubsetProcessor.cs
+++ b/Editor/AITFontSubsetProcessor.cs
@@ -5,18 +5,27 @@
 // </copyright>
 // -----------------------------------------------------------------------
 //
-// 빌드 직전, 지정한 .ttf/.otf 소스를 "보존할 유니코드 범위"만 남기도록 subset 하여
-// Unity 가 .data 에 굽는 폰트 데이터를 급감시킨다(CJK 전체 폰트는 5~15MB → subset 후 ~0.1MB).
+// 빌드 직전, 크고 빌드에 포함될 가능성이 있는 .ttf/.otf 소스를 "보존할 유니코드 범위"만 남기도록
+// subset 하여 Unity 가 .data 에 굽는 폰트 데이터를 급감시킨다(CJK 전체 폰트는 5~15MB → subset 후 ~0.1MB).
 // 빌드 종료(성공/실패 무관) 후 원본 폰트로 원상 복원한다.
 //
 // 효과: Unity 의 동적 폰트는 소스 .ttf 전체를 빌드에 포함시켜 런타임에 임의 글자를 래스터화한다.
 //   필요한 범위(예: 한글 음절 + ASCII)만 남기면 .data 의 폰트 바이트가 사라져 초기 다운로드/TTI 급감.
 //
-// ⚠ 동적 텍스트 리스크(이 기능만의 고유 위험): subset 에 포함되지 않은 글자(희귀 한자, 이모지,
-//   런타임 동적 텍스트)는 □(누락 글리프)로 렌더된다. 따라서 본 기능은
-//     (1) 대상 폰트 경로(fontSubsetTargetPaths) 를 명시적으로 지정해야만 동작하고(비우면 no-op),
-//     (2) 보존 범위(fontSubsetUnicodeRanges) 도 명시 필요,
-//   두 화이트리스트가 모두 채워졌을 때만 적용된다(프로젝트 전체 폰트 자동 스캔 금지).
+// ─── zero-config(Auto 모드) 철학 ───
+//   모든 성능 최적화 레버는 개발자의 깊은 이해 없이 자동 적용된다: 기본 ON + 자동 안전장치.
+//   폰트 subset 은 본래 lossy(보존 범위에 없는 글자는 □)지만, 다음 자동 안전장치로 정확성을 보존한다.
+//     (1) 자동 대상 탐지: ≥1MB 이고 빌드에 포함될 가능성이 있는 폰트만(활성 씬 의존성 + Resources/ + TMP 소스).
+//     (2) 전 프로젝트 사용 문자 스캔(AITFontUsedCharScanner): 씬/프리팹/asset/C#/로컬라이제이션 텍스트.
+//     (3) ★ 블록 완성 규칙(AITFontUnicodeBlocks): 등장한 문자체계의 유니코드 블록 전체를 보존.
+//         → "가" 한 글자만 써도 한글 음절 전체가 살아남아 동적 닉네임/채팅이 □ 가 되지 않는다.
+//     (4) Han 예외: 한자 블록(2만+자)은 전체 대신 [감지 한자 + KS X 1001 상용 한자 4,888자 패드]만.
+//     (5) 항시 베이스라인: ASCII+Latin-1+한글+CJK 기호+전각은 스캔 결과와 무관하게 항상 포함.
+//     (6) 빌드 드롭 리포트: 폰트별 원본→subset 크기, 보존 블록, 감지 문자체계 요약.
+//     (7) opt-out: fontSubset=0(완전 no-op). override: 수동 대상/범위 지정 시 Auto 스캔 생략.
+//
+//   레버 상태(tri-state): fontSubset = -1(자동, 기본) | 0(비활성) | 1(자동, 명시적 ON).
+//     -1/1 → Auto 동작, 0 → 완전 no-op. 수동 필드(targetPaths/unicodeRanges)는 Auto 의 override.
 //
 // 도구: harfbuzz(hb-subset, wasm) 를 래핑한 `subset-font`(npm). Google Fonts 와 동일 코덱.
 //   SDK 내장 Node.js(AITNodeJSDownloader)로 실행하며, 최초 1회 ~/.ait-unity-sdk/font-subset/ 에
@@ -39,8 +48,9 @@ using Debug = UnityEngine.Debug;
 namespace AppsInToss.Editor
 {
     /// <summary>
-    /// 빌드 단계 폰트 CJK subset 처리기. <see cref="AITEditorScriptObject.enableFontSubset"/>
-    /// 설정에 따라 동작한다. 런타임 컴포넌트는 없다(빌드 산출물만 작아질 뿐, 런타임 렌더 경로 동일).
+    /// 빌드 단계 폰트 CJK subset 처리기. <see cref="AITEditorScriptObject.fontSubset"/>
+    /// tri-state(-1=자동/0=비활성/1=자동 명시) 설정에 따라 동작한다.
+    /// 런타임 컴포넌트는 없다(빌드 산출물만 작아질 뿐, 런타임 렌더 경로 동일).
     /// </summary>
     [InitializeOnLoad]
     public static class AITFontSubsetProcessor
@@ -72,33 +82,78 @@ namespace AppsInToss.Editor
             EditorApplication.delayCall += SafetyNetRestore;
         }
 
+        /// <summary>크기 자동 탐지 하한(바이트). 이보다 작은 폰트는 절감 효과가 미미해 대상에서 제외.</summary>
+        private const long AutoTargetMinBytes = 1L * 1024 * 1024; // 1MB
+
         /// <summary>
-        /// 빌드 직전 호출: 설정이 켜져 있고 대상/범위가 지정돼 있으면 대상 폰트를 subset 한다.
+        /// 빌드 직전 호출: tri-state 설정에 따라 Auto 모드(또는 수동 override)로 대상 폰트를 subset 한다.
+        ///
+        /// - fontSubset == 0: 완전 no-op.
+        /// - fontSubset == -1/1: Auto 동작. fontSubsetTargetPaths 비면 자동 대상 탐지, 지정 시 수동 대상.
+        ///   fontSubsetUnicodeRanges 비면 Auto 스캔으로 범위 결정, 지정 시 수동 범위(스캔 생략).
         /// </summary>
-        /// <param name="config">프로젝트 에디터 설정. null·비활성·화이트리스트 미지정 시 no-op.</param>
+        /// <param name="config">프로젝트 에디터 설정. null·비활성 시 no-op.</param>
         /// <returns>복원에 사용할 핸들(항상 non-null).</returns>
         public static FontHandle ApplyForBuild(AITEditorScriptObject config)
         {
             var handle = new FontHandle();
-            if (config == null || !config.enableFontSubset)
+            if (config == null)
             {
                 return handle;
             }
 
-            string ranges = (config.fontSubsetUnicodeRanges ?? string.Empty).Trim();
+            // tri-state: 0 = 완전 비활성(no-op), -1/1 = Auto 동작.
+            bool enabled = config.fontSubset >= 0
+                ? config.fontSubset == 1
+                : AITDefaultSettings.GetDefaultFontSubset();
+            if (!enabled)
+            {
+                if (config.fontSubset == 0)
+                {
+                    Debug.Log("[AIT-FontSubset] 폰트 subset 비활성(설정) → 풀 폰트로 빌드합니다.");
+                }
+
+                return handle;
+            }
+
+            // ── 대상 폰트 결정: 수동 지정(override)이 있으면 그대로, 없으면 자동 탐지 ──
             string[] targets = SplitList(config.fontSubsetTargetPaths);
-
-            // 화이트리스트 이중 안전망: 대상/범위 중 하나라도 비면 동적-텍스트 리스크 때문에 적용하지 않는다.
-            if (targets == null || targets.Length == 0)
+            bool manualTargets = targets != null && targets.Length > 0;
+            if (!manualTargets)
             {
-                Debug.Log("[AIT-FontSubset] 대상 폰트 경로가 비어 있어 건너뜁니다(fontSubsetTargetPaths). 동적 텍스트 안전을 위해 명시적 지정이 필요합니다.");
-                return handle;
+                targets = DetectAutoTargets();
+                if (targets.Length == 0)
+                {
+                    Debug.Log($"[AIT-FontSubset] 자동 탐지된 subset 대상 폰트가 없습니다(≥{AutoTargetMinBytes / 1048576}MB & 빌드 포함 가능 폰트 없음) → no-op.");
+                    return handle;
+                }
+
+                Debug.Log($"[AIT-FontSubset] 자동 탐지: subset 대상 폰트 {targets.Length}개.");
             }
 
-            if (string.IsNullOrEmpty(ranges))
+            // ── 보존 범위 결정: 수동 범위(override)가 있으면 그대로, 없으면 Auto 스캔으로 도출 ──
+            string ranges = (config.fontSubsetUnicodeRanges ?? string.Empty).Trim();
+            bool manualRanges = !string.IsNullOrEmpty(ranges);
+            System.Collections.Generic.List<AITFontUnicodeBlocks.Block> preservedBlocks = null;
+            int detectedCount = 0;
+            int hanPadCount = 0;
+            if (!manualRanges)
             {
-                Debug.LogWarning("[AIT-FontSubset] 보존 유니코드 범위가 비어 있어 건너뜁니다(fontSubsetUnicodeRanges).");
-                return handle;
+                var detected = AITFontUsedCharScanner.ScanProject();
+                detectedCount = detected.Count;
+                var hanPad = AITFontUsedCharScanner.GetKsx1001Han();
+                hanPadCount = hanPad.Count;
+                ranges = AITFontUsedCharScanner.BuildPreservedRanges(detected, hanPad, out preservedBlocks);
+
+                if (string.IsNullOrEmpty(ranges))
+                {
+                    Debug.LogWarning("[AIT-FontSubset] Auto 스캔 결과 보존 범위가 비어 있어 건너뜁니다(풀 폰트로 빌드).");
+                    return handle;
+                }
+            }
+            else
+            {
+                Debug.Log("[AIT-FontSubset] 수동 보존 범위 지정(override) → Auto 스캔 생략.");
             }
 
             string node, runner;
@@ -186,6 +241,7 @@ namespace AppsInToss.Editor
                 }
 
                 Debug.Log($"[AIT-FontSubset] ✓ {n}개 폰트 subset, 소스 {savedBytes / 1048576f:0.0}MB 절감(초기 .data 제거).");
+                LogDropReport(manualTargets, manualRanges, detectedCount, hanPadCount, preservedBlocks);
                 return handle;
             }
             catch (Exception e)
@@ -241,6 +297,186 @@ namespace AppsInToss.Editor
             catch (Exception e)
             {
                 Debug.LogWarning($"[AIT-FontSubset] 안전망 복원 중 예외(무시): {e}");
+            }
+        }
+
+        // ─────────────────────────── 자동 대상 탐지 ───────────────────────────
+
+        /// <summary>
+        /// 빌드에 포함될 가능성이 있는 대형(≥1MB) .ttf/.otf 폰트를 보수적으로 자동 탐지한다.
+        /// 후보 출처:
+        ///   - EditorBuildSettings 활성 씬들의 AssetDatabase.GetDependencies(재귀)
+        ///   - Resources/ 하위(런타임 동적 로드 경로)
+        ///   - TMP_FontAsset 의 소스 폰트(있으면 — 리플렉션으로 TMP 하드 의존 회피)
+        /// 탐지 실패/예외 시 빈 배열을 반환한다(no-op + 로그).
+        /// </summary>
+        private static string[] DetectAutoTargets()
+        {
+            var candidates = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                // 1) 활성 씬 + 의존성(재귀).
+                var scenePaths = new System.Collections.Generic.List<string>();
+                foreach (var scene in EditorBuildSettings.scenes)
+                {
+                    if (scene != null && scene.enabled && !string.IsNullOrEmpty(scene.path))
+                    {
+                        scenePaths.Add(scene.path);
+                    }
+                }
+
+                if (scenePaths.Count > 0)
+                {
+                    foreach (var dep in AssetDatabase.GetDependencies(scenePaths.ToArray(), recursive: true))
+                    {
+                        AddIfFontCandidate(dep, candidates);
+                    }
+                }
+
+                // 2) Resources/ 하위 폰트(런타임 동적 로드 가능 경로).
+                foreach (var guid in AssetDatabase.FindAssets("t:Font"))
+                {
+                    string path = AssetDatabase.GUIDToAssetPath(guid);
+                    if (!string.IsNullOrEmpty(path) && path.Replace('\\', '/').Contains("/Resources/"))
+                    {
+                        AddIfFontCandidate(path, candidates);
+                    }
+                }
+
+                // 3) TMP_FontAsset 소스 폰트(리플렉션 — TMP 미설치 환경에서도 안전).
+                CollectTmpSourceFonts(candidates);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-FontSubset] 자동 대상 탐지 예외(빈 목록으로 계속): {e.Message}");
+                return Array.Empty<string>();
+            }
+
+            var result = new System.Collections.Generic.List<string>();
+            foreach (var path in candidates)
+            {
+                result.Add(path);
+            }
+
+            return result.ToArray();
+        }
+
+        /// <summary>경로가 ≥1MB 인 .ttf/.otf 폰트 에셋이면 후보 집합에 추가한다.</summary>
+        private static void AddIfFontCandidate(string assetPath, System.Collections.Generic.HashSet<string> sink)
+        {
+            if (string.IsNullOrEmpty(assetPath))
+            {
+                return;
+            }
+
+            string norm = assetPath.Replace('\\', '/');
+            if (!norm.StartsWith("Assets/"))
+            {
+                return;
+            }
+
+            string ext = Path.GetExtension(norm).ToLowerInvariant();
+            if (ext != ".ttf" && ext != ".otf")
+            {
+                return;
+            }
+
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string full = Path.Combine(projectRoot, norm);
+                if (File.Exists(full) && new FileInfo(full).Length >= AutoTargetMinBytes)
+                {
+                    sink.Add(norm);
+                }
+            }
+            catch
+            {
+                // 파일 접근 실패는 무시(후보 제외)
+            }
+        }
+
+        /// <summary>
+        /// TMP_FontAsset 의 소스 폰트(sourceFontFile)를 리플렉션으로 수집한다.
+        /// TextMeshPro 미설치/타입 미발견 시 조용히 건너뛴다(하드 의존 회피).
+        /// </summary>
+        private static void CollectTmpSourceFonts(System.Collections.Generic.HashSet<string> sink)
+        {
+            try
+            {
+                foreach (var guid in AssetDatabase.FindAssets("t:TMP_FontAsset"))
+                {
+                    string path = AssetDatabase.GUIDToAssetPath(guid);
+                    if (string.IsNullOrEmpty(path))
+                    {
+                        continue;
+                    }
+
+                    var asset = AssetDatabase.LoadMainAssetAtPath(path);
+                    if (asset == null)
+                    {
+                        continue;
+                    }
+
+                    var prop = asset.GetType().GetProperty("sourceFontFile");
+                    var source = prop?.GetValue(asset) as UnityEngine.Object;
+                    if (source != null)
+                    {
+                        AddIfFontCandidate(AssetDatabase.GetAssetPath(source), sink);
+                    }
+                }
+            }
+            catch
+            {
+                // TMP 미설치 등 — 무시
+            }
+        }
+
+        // ─────────────────────────── 드롭 리포트 ───────────────────────────
+
+        /// <summary>
+        /// 빌드 로그에 subset 드롭 리포트를 출력한다(자동 안전장치 가시화).
+        /// 보존 블록 목록(이름+범위), 감지된 문자체계 요약, 수동 override 안내를 포함한다.
+        /// </summary>
+        private static void LogDropReport(
+            bool manualTargets,
+            bool manualRanges,
+            int detectedCodepoints,
+            int hanPadCount,
+            System.Collections.Generic.List<AITFontUnicodeBlocks.Block> preservedBlocks)
+        {
+            try
+            {
+                string mode = manualRanges ? "수동 범위(override)" : "Auto 스캔";
+                Debug.Log($"[AIT-FontSubset] ── 드롭 리포트 ── (대상: {(manualTargets ? "수동 지정" : "자동 탐지")}, 범위: {mode})");
+
+                if (manualRanges)
+                {
+                    Debug.Log("[AIT-FontSubset]   수동 보존 범위가 적용되었습니다. 동적 텍스트 글자가 누락되지 않도록 범위를 직접 검토하세요.");
+                    return;
+                }
+
+                Debug.Log($"[AIT-FontSubset]   스캔 감지 문자(비ASCII 고유): {detectedCodepoints}개, 한자 패드(KS X 1001): {hanPadCount}자");
+
+                if (preservedBlocks != null && preservedBlocks.Count > 0)
+                {
+                    Debug.Log($"[AIT-FontSubset]   보존 블록(블록 완성 규칙으로 전체 보존) {preservedBlocks.Count}개:");
+                    foreach (var b in preservedBlocks)
+                    {
+                        Debug.Log($"[AIT-FontSubset]     - {b.Name} ({AITFontUnicodeBlocks.FormatCodepoint(b.Start)}-{AITFontUnicodeBlocks.FormatCodepoint(b.End)})");
+                    }
+                }
+                else
+                {
+                    Debug.Log("[AIT-FontSubset]   보존 블록 없음(베이스라인 + 감지 한자만 보존).");
+                }
+
+                Debug.Log("[AIT-FontSubset]   동적 텍스트는 같은 문자체계라면 블록 전체가 보존되어 □ 가 되지 않습니다.");
+                Debug.Log("[AIT-FontSubset]   수동 범위를 쓰려면 fontSubsetUnicodeRanges 를, 수동 대상은 fontSubsetTargetPaths 를 지정하세요.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-FontSubset] 드롭 리포트 출력 예외(무시): {e.Message}");
             }
         }
 

--- a/Editor/AITFontSubsetProcessor.cs
+++ b/Editor/AITFontSubsetProcessor.cs
@@ -1,0 +1,542 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITFontSubsetProcessor.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Font CJK Subset (build-time source subsetter)
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 빌드 직전, 지정한 .ttf/.otf 소스를 "보존할 유니코드 범위"만 남기도록 subset 하여
+// Unity 가 .data 에 굽는 폰트 데이터를 급감시킨다(CJK 전체 폰트는 5~15MB → subset 후 ~0.1MB).
+// 빌드 종료(성공/실패 무관) 후 원본 폰트로 원상 복원한다.
+//
+// 효과: Unity 의 동적 폰트는 소스 .ttf 전체를 빌드에 포함시켜 런타임에 임의 글자를 래스터화한다.
+//   필요한 범위(예: 한글 음절 + ASCII)만 남기면 .data 의 폰트 바이트가 사라져 초기 다운로드/TTI 급감.
+//
+// ⚠ 동적 텍스트 리스크(이 기능만의 고유 위험): subset 에 포함되지 않은 글자(희귀 한자, 이모지,
+//   런타임 동적 텍스트)는 □(누락 글리프)로 렌더된다. 따라서 본 기능은
+//     (1) 대상 폰트 경로(fontSubsetTargetPaths) 를 명시적으로 지정해야만 동작하고(비우면 no-op),
+//     (2) 보존 범위(fontSubsetUnicodeRanges) 도 명시 필요,
+//   두 화이트리스트가 모두 채워졌을 때만 적용된다(프로젝트 전체 폰트 자동 스캔 금지).
+//
+// 도구: harfbuzz(hb-subset, wasm) 를 래핑한 `subset-font`(npm). Google Fonts 와 동일 코덱.
+//   SDK 내장 Node.js(AITNodeJSDownloader)로 실행하며, 최초 1회 ~/.ait-unity-sdk/font-subset/ 에
+//   subset-font 를 설치한다(node 다운로드와 동일한 on-demand 패턴). 네트워크/도구 준비 실패 시
+//   경고만 남기고 subset 을 건너뛴다(빌드는 풀 폰트로 계속 진행 — graceful degradation).
+//
+// 비파괴: 소스 원본은 <src>.aitfontbak 로 백업, 빌드 종료 시 원상 복원한다. 빌드가 비정상
+//   종료되어 복원이 누락돼도 다음 에디터 로드 시 안전망(SafetyNetRestore)이 자동 복원한다.
+//
+// 통합: AITConvertCore.BuildWebGL 가 BuildPipeline.BuildPlayer 직전에 ApplyForBuild,
+//   try/finally 의 finally 에서 RestoreForBuild 를 호출한다(오디오 스트리밍과 동일 패턴).
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 빌드 단계 폰트 CJK subset 처리기. <see cref="AITEditorScriptObject.enableFontSubset"/>
+    /// 설정에 따라 동작한다. 런타임 컴포넌트는 없다(빌드 산출물만 작아질 뿐, 런타임 렌더 경로 동일).
+    /// </summary>
+    [InitializeOnLoad]
+    public static class AITFontSubsetProcessor
+    {
+        /// <summary>치환 전 원본 폰트를 보관하는 백업 접미사.</summary>
+        private const string BackupSuffix = ".aitfontbak";
+
+        /// <summary>SDK 패키지에 동봉된 subset 러너 디렉토리(Unity 미임포트: '~' 접미사).</summary>
+        private const string ToolDirName = "FontSubset~";
+
+        /// <summary>러너 스크립트 파일명.</summary>
+        private const string RunnerName = "subset-font-runner.mjs";
+
+        /// <summary>apply 가 진행 중임을 표시하는 마커(Unity 가 무시하는 '.' 접두 숨김 파일).</summary>
+        private const string MarkerRelative = "Assets/.ait-fontsubset-active";
+
+        /// <summary>한 번의 subset 결과 핸들. finally 에서 정확한 복원에 사용.</summary>
+        public sealed class FontHandle
+        {
+            /// <summary>이번 빌드에서 subset 이 실제로 수행되었는지.</summary>
+            public bool Active;
+
+            /// <summary>subset 된 폰트 개수.</summary>
+            public int Count;
+        }
+
+        static AITFontSubsetProcessor()
+        {
+            EditorApplication.delayCall += SafetyNetRestore;
+        }
+
+        /// <summary>
+        /// 빌드 직전 호출: 설정이 켜져 있고 대상/범위가 지정돼 있으면 대상 폰트를 subset 한다.
+        /// </summary>
+        /// <param name="config">프로젝트 에디터 설정. null·비활성·화이트리스트 미지정 시 no-op.</param>
+        /// <returns>복원에 사용할 핸들(항상 non-null).</returns>
+        public static FontHandle ApplyForBuild(AITEditorScriptObject config)
+        {
+            var handle = new FontHandle();
+            if (config == null || !config.enableFontSubset)
+            {
+                return handle;
+            }
+
+            string ranges = (config.fontSubsetUnicodeRanges ?? string.Empty).Trim();
+            string[] targets = SplitList(config.fontSubsetTargetPaths);
+
+            // 화이트리스트 이중 안전망: 대상/범위 중 하나라도 비면 동적-텍스트 리스크 때문에 적용하지 않는다.
+            if (targets == null || targets.Length == 0)
+            {
+                Debug.Log("[AIT-FontSubset] 대상 폰트 경로가 비어 있어 건너뜁니다(fontSubsetTargetPaths). 동적 텍스트 안전을 위해 명시적 지정이 필요합니다.");
+                return handle;
+            }
+
+            if (string.IsNullOrEmpty(ranges))
+            {
+                Debug.LogWarning("[AIT-FontSubset] 보존 유니코드 범위가 비어 있어 건너뜁니다(fontSubsetUnicodeRanges).");
+                return handle;
+            }
+
+            string node, runner;
+            if (!EnsureTool(out node, out runner))
+            {
+                Debug.LogWarning("[AIT-FontSubset] subset 도구 준비 실패 → subset 을 건너뜁니다(풀 폰트로 빌드 계속).");
+                return handle;
+            }
+
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                CreateMarker();
+
+                int n = 0;
+                long savedBytes = 0;
+                foreach (var rawTarget in targets)
+                {
+                    string assetPath = rawTarget.Trim().Replace('\\', '/');
+                    if (string.IsNullOrEmpty(assetPath))
+                    {
+                        continue;
+                    }
+
+                    if (!assetPath.StartsWith("Assets/"))
+                    {
+                        Debug.LogWarning($"[AIT-FontSubset]   대상 제외(Assets/ 밖): {assetPath}");
+                        continue;
+                    }
+
+                    string ext = Path.GetExtension(assetPath).ToLowerInvariant();
+                    if (ext != ".ttf" && ext != ".otf")
+                    {
+                        Debug.LogWarning($"[AIT-FontSubset]   대상 제외(.ttf/.otf 아님): {assetPath}");
+                        continue;
+                    }
+
+                    string srcFull = Path.Combine(projectRoot, assetPath);
+                    if (!File.Exists(srcFull))
+                    {
+                        Debug.LogWarning($"[AIT-FontSubset]   대상 없음: {assetPath}");
+                        continue;
+                    }
+
+                    long before = new FileInfo(srcFull).Length;
+                    string tmpOut = srcFull + ".subset.tmp";
+
+                    if (!RunSubset(node, runner, srcFull, tmpOut, ranges, out string err))
+                    {
+                        Debug.LogWarning($"[AIT-FontSubset]   subset 실패({Path.GetFileName(assetPath)}): {err} → 이 폰트는 원본 유지");
+                        SafeDelete(tmpOut);
+                        continue;
+                    }
+
+                    if (!File.Exists(tmpOut) || new FileInfo(tmpOut).Length <= 0)
+                    {
+                        Debug.LogWarning($"[AIT-FontSubset]   subset 산출물 비정상 → 원본 유지: {assetPath}");
+                        SafeDelete(tmpOut);
+                        continue;
+                    }
+
+                    // 백업 후 소스 치환 + reimport(폰트 reimport 는 스크립트 컴파일 무유발 → 도메인 리로드 없음).
+                    string bak = srcFull + BackupSuffix;
+                    if (!File.Exists(bak))
+                    {
+                        File.Copy(srcFull, bak, true);
+                    }
+
+                    File.Copy(tmpOut, srcFull, true);
+                    SafeDelete(tmpOut);
+                    AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+
+                    long after = new FileInfo(srcFull).Length;
+                    savedBytes += Math.Max(0, before - after);
+                    n++;
+                    Debug.Log($"[AIT-FontSubset]   subset {Path.GetFileName(assetPath)}: {before / 1024}KB → {after / 1024}KB");
+                }
+
+                AssetDatabase.Refresh();
+                handle.Active = n > 0;
+                handle.Count = n;
+                if (!handle.Active)
+                {
+                    RemoveMarker();
+                }
+
+                Debug.Log($"[AIT-FontSubset] ✓ {n}개 폰트 subset, 소스 {savedBytes / 1048576f:0.0}MB 절감(초기 .data 제거).");
+                return handle;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-FontSubset] 적용 예외 → 복원 후 건너뜀: {e}");
+                RestoreAllBackups();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                return new FontHandle();
+            }
+        }
+
+        /// <summary>빌드 종료 후(성공/실패 무관) 호출: 원본 폰트로 복원한다.</summary>
+        public static void RestoreForBuild(FontHandle handle)
+        {
+            if (handle == null || !handle.Active)
+            {
+                return;
+            }
+
+            try
+            {
+                int restored = RestoreAllBackups();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                Debug.Log($"[AIT-FontSubset] 복원 완료: {restored}개 폰트 원상.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-FontSubset] 복원 예외: {e}");
+            }
+        }
+
+        /// <summary>에디터 로드 시 안전망. 마커가 잔존하면(=이전 빌드가 복원 전 종료) 백업을 자동 복원.</summary>
+        private static void SafetyNetRestore()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                if (!File.Exists(Path.Combine(projectRoot, MarkerRelative)))
+                {
+                    return; // 공통 경로: 잔존물 없음(빠른 반환)
+                }
+
+                int restored = RestoreAllBackups();
+                RemoveMarker();
+                if (restored > 0)
+                {
+                    AssetDatabase.Refresh();
+                    Debug.LogWarning($"[AIT-FontSubset] 안전망: 이전 빌드 잔존 폰트 백업 {restored}개를 복원했습니다.");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-FontSubset] 안전망 복원 중 예외(무시): {e}");
+            }
+        }
+
+        // ─────────────────────────── 도구 준비/실행 ───────────────────────────
+
+        /// <summary>내장 Node.js + subset-font 를 준비한다. node 실행경로와 러너 경로를 반환.</summary>
+        private static bool EnsureTool(out string nodeExe, out string runnerPath)
+        {
+            nodeExe = null;
+            runnerPath = null;
+            try
+            {
+                string npm = AITNodeJSDownloader.FindEmbeddedNpm(autoDownload: true);
+                if (string.IsNullOrEmpty(npm))
+                {
+                    return false;
+                }
+
+                string nodeBin = Path.GetDirectoryName(npm);
+                string node = Path.Combine(nodeBin, AITPlatformHelper.IsWindows ? "node.exe" : "node");
+                if (!File.Exists(node))
+                {
+                    return false;
+                }
+
+                string srcDir = ResolveToolSourceDir();
+                if (string.IsNullOrEmpty(srcDir) || !File.Exists(Path.Combine(srcDir, RunnerName)))
+                {
+                    Debug.LogWarning($"[AIT-FontSubset] 러너 소스 디렉토리를 찾지 못했습니다: '{srcDir}'");
+                    return false;
+                }
+
+                string homeTool = GetHomeToolDir();
+                Directory.CreateDirectory(homeTool);
+
+                // 러너/매니페스트는 항상 최신본으로 동기화(SDK 업데이트 반영).
+                File.Copy(Path.Combine(srcDir, RunnerName), Path.Combine(homeTool, RunnerName), true);
+                File.Copy(Path.Combine(srcDir, "package.json"), Path.Combine(homeTool, "package.json"), true);
+
+                // subset-font 미설치 시 1회 설치(on-demand, node 다운로드와 동일 철학).
+                string installed = Path.Combine(homeTool, "node_modules", "subset-font", "package.json");
+                if (!File.Exists(installed))
+                {
+                    Debug.Log("[AIT-FontSubset] subset-font 최초 설치 중(내장 npm)...");
+                    if (!RunNpmInstall(npm, nodeBin, homeTool) || !File.Exists(installed))
+                    {
+                        Debug.LogWarning("[AIT-FontSubset] subset-font 설치 실패.");
+                        return false;
+                    }
+                }
+
+                nodeExe = node;
+                runnerPath = Path.Combine(homeTool, RunnerName);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-FontSubset] 도구 준비 예외: {e.Message}");
+                return false;
+            }
+        }
+
+        private static bool RunNpmInstall(string npm, string nodeBin, string cwd)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    WorkingDirectory = cwd,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                };
+
+                if (AITPlatformHelper.IsWindows)
+                {
+                    psi.FileName = "cmd.exe";
+                    psi.Arguments = $"/c \"\"{npm}\" install --no-audit --no-fund --loglevel=error\"";
+                }
+                else
+                {
+                    psi.FileName = npm;
+                    psi.Arguments = "install --no-audit --no-fund --loglevel=error";
+                }
+
+                PrependPath(psi, nodeBin);
+                return RunProcess(psi, 180000, out _, out _);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-FontSubset] npm install 예외: {e.Message}");
+                return false;
+            }
+        }
+
+        private static bool RunSubset(string node, string runner, string inAbs, string outAbs, string ranges, out string err)
+        {
+            err = null;
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = node,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                    WorkingDirectory = Path.GetDirectoryName(runner),
+                };
+                psi.ArgumentList.Add(runner);
+                psi.ArgumentList.Add(inAbs);
+                psi.ArgumentList.Add(outAbs);
+                psi.ArgumentList.Add(ranges);
+                PrependPath(psi, Path.GetDirectoryName(node));
+
+                if (!RunProcess(psi, 120000, out string stdout, out string stderr))
+                {
+                    err = string.IsNullOrEmpty(stderr) ? stdout : stderr;
+                    if (string.IsNullOrEmpty(err))
+                    {
+                        err = "러너 비정상 종료";
+                    }
+
+                    return false;
+                }
+
+                // 러너 stdout 마지막 JSON 라인의 ok 판정.
+                return stdout != null && stdout.Contains("\"ok\":true");
+            }
+            catch (Exception e)
+            {
+                err = e.Message;
+                return false;
+            }
+        }
+
+        private static bool RunProcess(ProcessStartInfo psi, int timeoutMs, out string stdout, out string stderr)
+        {
+            stdout = null;
+            stderr = null;
+            using (var p = new Process { StartInfo = psi })
+            {
+                p.Start();
+                stdout = p.StandardOutput.ReadToEnd();
+                stderr = p.StandardError.ReadToEnd();
+                if (!p.WaitForExit(timeoutMs))
+                {
+                    try { p.Kill(); } catch { /* 무시 */ }
+                    return false;
+                }
+
+                return p.ExitCode == 0;
+            }
+        }
+
+        private static void PrependPath(ProcessStartInfo psi, string dir)
+        {
+            if (string.IsNullOrEmpty(dir))
+            {
+                return;
+            }
+
+            string sep = AITPlatformHelper.IsWindows ? ";" : ":";
+            string existing = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            psi.EnvironmentVariables["PATH"] = dir + sep + existing;
+        }
+
+        /// <summary>~/.ait-unity-sdk/font-subset (Windows: %LOCALAPPDATA%\ait-unity-sdk\font-subset).</summary>
+        private static string GetHomeToolDir()
+        {
+            string basePath = AITPlatformHelper.IsWindows
+                ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+                : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return Path.Combine(basePath, ".ait-unity-sdk", "font-subset");
+        }
+
+        /// <summary>SDK 패키지에 동봉된 러너 소스 디렉토리. UPM/embedded 설치 모두 해석.</summary>
+        private static string ResolveToolSourceDir()
+        {
+            try
+            {
+                var pkg = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(AITFontSubsetProcessor).Assembly);
+                if (pkg != null && !string.IsNullOrEmpty(pkg.resolvedPath))
+                {
+                    return Path.Combine(pkg.resolvedPath, "Editor", ToolDirName);
+                }
+            }
+            catch
+            {
+                // PackageInfo 미해석(Assets 내 임베드 개발) → 소스 파일 위치 폴백
+            }
+
+            string here = CallerDir();
+            return string.IsNullOrEmpty(here) ? null : Path.Combine(here, ToolDirName);
+        }
+
+        // ─────────────────────────── 백업/복원 ───────────────────────────
+
+        /// <summary>Assets 트리의 모든 *.aitfontbak 를 원본으로 되돌리고 백업을 삭제한다. 복원 개수 반환.</summary>
+        private static int RestoreAllBackups()
+        {
+            int restored = 0;
+            string assetsPath = Application.dataPath;
+            string projectRoot = Directory.GetParent(assetsPath).FullName;
+            string[] backups;
+            try
+            {
+                backups = Directory.GetFiles(assetsPath, "*" + BackupSuffix, SearchOption.AllDirectories);
+            }
+            catch
+            {
+                return 0;
+            }
+
+            foreach (var bak in backups)
+            {
+                string srcFull = bak.Substring(0, bak.Length - BackupSuffix.Length);
+                try
+                {
+                    File.Copy(bak, srcFull, true);
+                    File.Delete(bak);
+
+                    string rel = AbsoluteToProjectRelative(srcFull, projectRoot);
+                    if (!string.IsNullOrEmpty(rel))
+                    {
+                        AssetDatabase.ImportAsset(rel, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                    }
+
+                    restored++;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-FontSubset] 백업 복원 실패({bak}): {e.Message}");
+                }
+            }
+
+            return restored;
+        }
+
+        private static void CreateMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                File.WriteAllText(Path.Combine(projectRoot, MarkerRelative), "active");
+            }
+            catch
+            {
+                // 마커 생성 실패는 치명적이지 않음(안전망 가속용)
+            }
+        }
+
+        private static void RemoveMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string m = Path.Combine(projectRoot, MarkerRelative);
+                if (File.Exists(m))
+                {
+                    File.Delete(m);
+                }
+            }
+            catch
+            {
+                // 무시
+            }
+        }
+
+        private static void SafeDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch
+            {
+                // 무시
+            }
+        }
+
+        private static string CallerDir([System.Runtime.CompilerServices.CallerFilePath] string thisFile = "")
+            => string.IsNullOrEmpty(thisFile) ? null : Path.GetDirectoryName(thisFile);
+
+        private static string AbsoluteToProjectRelative(string absolute, string projectRoot)
+        {
+            string norm = absolute.Replace('\\', '/');
+            string root = projectRoot.Replace('\\', '/').TrimEnd('/') + "/";
+            return norm.StartsWith(root) ? norm.Substring(root.Length) : null;
+        }
+
+        private static string[] SplitList(string v)
+            => string.IsNullOrEmpty(v) ? null : v.Split(new[] { ',', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+    }
+}

--- a/Editor/AITFontSubsetProcessor.cs.meta
+++ b/Editor/AITFontSubsetProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83f5e694e4f7e4c33809a2422185c6df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AITFontUnicodeBlocks.cs
+++ b/Editor/AITFontUnicodeBlocks.cs
@@ -1,0 +1,273 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITFontUnicodeBlocks.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Font subset 유니코드 블록 테이블 / 블록 완성 규칙
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 폰트 subset Auto 모드의 핵심 불변식을 책임지는 순수 로직 모듈(부수 효과 없음 → 단위 테스트 대상).
+//
+//   ★ 불변식: "게임에 어떤 문자체계가 한 글자라도 있으면 그 문자체계의 유니코드 블록 전체가
+//             폰트에 살아남는다." (동적 텍스트가 같은 문자체계라면 절대 □ 가 되지 않게.)
+//
+// 동작: 스캐너가 수집한 코드포인트 집합을 받아, 각 코드포인트가 속한 유니코드 블록 전체를
+//   보존 범위에 추가한다. 즉 한글 "가" 한 글자만 써도 한글 음절 블록(AC00-D7A3) 전체가 살아남아
+//   런타임 동적 닉네임/채팅의 임의 한글이 □ 가 되지 않는다.
+//
+//   ⚠ Han 예외: CJK Unified Ideographs(U+4E00-9FFF 및 확장 A~)는 2만+자라 블록 전체를
+//     보존하면 subset 의 의미가 사라진다. 따라서 한자만은 블록 완성 규칙에서 제외하고,
+//     [감지된 한자들 자체] + [KS X 1001 한자 4,888자 패드](AITFontUsedCharScanner 가 도출)를
+//     합쳐 보존한다. 한국어 게임의 동적 한자 표시 범위(상용 한자)를 보수적으로 커버한다.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 유니코드 블록 테이블과 "블록 완성" 규칙을 제공하는 순수 정적 헬퍼.
+    /// 부수 효과가 없어 EditMode 단위 테스트에서 직접 검증한다.
+    /// </summary>
+    public static class AITFontUnicodeBlocks
+    {
+        /// <summary>CJK Unified Ideographs 기본 블록(한자) 시작.</summary>
+        public const int HanBlockStart = 0x4E00;
+
+        /// <summary>CJK Unified Ideographs 기본 블록(한자) 끝.</summary>
+        public const int HanBlockEnd = 0x9FFF;
+
+        /// <summary>유니코드 블록 항목(start, end 포함, name).</summary>
+        public readonly struct Block
+        {
+            /// <summary>블록 시작 코드포인트(포함).</summary>
+            public readonly int Start;
+
+            /// <summary>블록 끝 코드포인트(포함).</summary>
+            public readonly int End;
+
+            /// <summary>블록 이름(드롭 리포트 표기용).</summary>
+            public readonly string Name;
+
+            /// <summary>한자 계열(CJK Unified Ideographs)이라 블록 전체 보존 대상에서 제외되는지.</summary>
+            public readonly bool IsHan;
+
+            public Block(int start, int end, string name, bool isHan = false)
+            {
+                Start = start;
+                End = end;
+                Name = name;
+                IsHan = isHan;
+            }
+
+            /// <summary>코드포인트가 이 블록에 속하는지.</summary>
+            public bool Contains(int cp) => cp >= Start && cp <= End;
+        }
+
+        /// <summary>
+        /// 주요 유니코드 블록 테이블(start, end, name). 게임에서 실사용되는 문자체계 위주로
+        /// 내장한다. 여기 없는 코드포인트는 "감지된 글자 자체"만 보존된다(블록 완성 미적용).
+        ///
+        /// Han 예외: CJK Unified Ideographs(및 확장 A)는 IsHan=true 로 표시되어 블록 완성에서
+        ///   제외된다(AITFontUsedCharScanner 가 KS X 1001 패드로 별도 처리).
+        /// </summary>
+        public static readonly Block[] Blocks =
+        {
+            // ── Latin 계열 ──
+            new Block(0x0000, 0x007F, "Basic Latin"),
+            new Block(0x0080, 0x00FF, "Latin-1 Supplement"),
+            new Block(0x0100, 0x017F, "Latin Extended-A"),
+            new Block(0x0180, 0x024F, "Latin Extended-B"),
+            new Block(0x0250, 0x02AF, "IPA Extensions"),
+            new Block(0x02B0, 0x02FF, "Spacing Modifier Letters"),
+            new Block(0x1E00, 0x1EFF, "Latin Extended Additional"),
+
+            // ── 결합 발음 부호 ──
+            new Block(0x0300, 0x036F, "Combining Diacritical Marks"),
+
+            // ── Greek / Cyrillic ──
+            new Block(0x0370, 0x03FF, "Greek and Coptic"),
+            new Block(0x0400, 0x04FF, "Cyrillic"),
+            new Block(0x0500, 0x052F, "Cyrillic Supplement"),
+
+            // ── 기타 표기 체계 ──
+            new Block(0x0530, 0x058F, "Armenian"),
+            new Block(0x0590, 0x05FF, "Hebrew"),
+            new Block(0x0600, 0x06FF, "Arabic"),
+            new Block(0x0E00, 0x0E7F, "Thai"),
+            new Block(0x0900, 0x097F, "Devanagari"),
+
+            // ── 한글 ──
+            new Block(0x1100, 0x11FF, "Hangul Jamo"),
+            new Block(0x3130, 0x318F, "Hangul Compatibility Jamo"),
+            new Block(0xA960, 0xA97F, "Hangul Jamo Extended-A"),
+            new Block(0xAC00, 0xD7A3, "Hangul Syllables"),
+            new Block(0xD7B0, 0xD7FF, "Hangul Jamo Extended-B"),
+
+            // ── 일본어 가나 ──
+            new Block(0x3040, 0x309F, "Hiragana"),
+            new Block(0x30A0, 0x30FF, "Katakana"),
+            new Block(0x31F0, 0x31FF, "Katakana Phonetic Extensions"),
+
+            // ── CJK 기호 / 구두점 / 전각 ──
+            new Block(0x2000, 0x206F, "General Punctuation"),
+            new Block(0x20A0, 0x20CF, "Currency Symbols"),
+            new Block(0x2100, 0x214F, "Letterlike Symbols"),
+            new Block(0x2150, 0x218F, "Number Forms"),
+            new Block(0x2190, 0x21FF, "Arrows"),
+            new Block(0x2200, 0x22FF, "Mathematical Operators"),
+            new Block(0x2460, 0x24FF, "Enclosed Alphanumerics"),
+            new Block(0x2500, 0x257F, "Box Drawing"),
+            new Block(0x25A0, 0x25FF, "Geometric Shapes"),
+            new Block(0x2600, 0x26FF, "Miscellaneous Symbols"),
+            new Block(0x2700, 0x27BF, "Dingbats"),
+            new Block(0x3000, 0x303F, "CJK Symbols and Punctuation"),
+            new Block(0x3200, 0x32FF, "Enclosed CJK Letters and Months"),
+            new Block(0x3300, 0x33FF, "CJK Compatibility"),
+            new Block(0xFE30, 0xFE4F, "CJK Compatibility Forms"),
+            new Block(0xFF00, 0xFFEF, "Halfwidth and Fullwidth Forms"),
+
+            // ── 이모지 관련(BMP 외 일부는 코드포인트 자체만 보존) ──
+            new Block(0x1F300, 0x1F5FF, "Miscellaneous Symbols and Pictographs"),
+            new Block(0x1F600, 0x1F64F, "Emoticons"),
+            new Block(0x1F680, 0x1F6FF, "Transport and Map Symbols"),
+            new Block(0x1F900, 0x1F9FF, "Supplemental Symbols and Pictographs"),
+            new Block(0x2B00, 0x2BFF, "Miscellaneous Symbols and Arrows"),
+
+            // ── 한자(Han 예외: 블록 완성 미적용) ──
+            new Block(HanBlockStart, HanBlockEnd, "CJK Unified Ideographs", isHan: true),
+            new Block(0x3400, 0x4DBF, "CJK Unified Ideographs Extension A", isHan: true),
+            new Block(0xF900, 0xFAFF, "CJK Compatibility Ideographs", isHan: true),
+        };
+
+        /// <summary>
+        /// 코드포인트가 한자 계열(블록 완성에서 제외할 영역)인지 판정한다.
+        /// </summary>
+        public static bool IsHan(int cp)
+        {
+            foreach (var b in Blocks)
+            {
+                if (b.IsHan && b.Contains(cp))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 코드포인트가 속한 블록을 찾는다. 못 찾으면 false.
+        /// </summary>
+        public static bool TryFindBlock(int cp, out Block block)
+        {
+            foreach (var b in Blocks)
+            {
+                if (b.Contains(cp))
+                {
+                    block = b;
+                    return true;
+                }
+            }
+
+            block = default;
+            return false;
+        }
+
+        /// <summary>
+        /// 감지된 코드포인트 집합 → "보존할 블록" 집합으로 확장한다(블록 완성 규칙).
+        ///
+        /// - 한자(IsHan) 블록은 전체 보존하지 않으므로 결과에 포함하지 않는다(호출부가 별도 처리).
+        /// - 테이블에 없는 코드포인트는 블록이 없으므로 무시된다(호출부가 코드포인트 자체를 별도 보존).
+        /// </summary>
+        /// <param name="codepoints">스캔으로 감지한 코드포인트.</param>
+        /// <returns>보존 대상 블록 목록(start 오름차순, 중복 제거).</returns>
+        public static List<Block> ExpandToBlocks(IEnumerable<int> codepoints)
+        {
+            var seen = new HashSet<string>();
+            var result = new List<Block>();
+            foreach (var cp in codepoints)
+            {
+                if (IsHan(cp))
+                {
+                    continue; // Han 예외: 블록 완성 미적용
+                }
+
+                if (TryFindBlock(cp, out var block) && seen.Add($"{block.Start}-{block.End}"))
+                {
+                    result.Add(block);
+                }
+            }
+
+            result.Sort((a, b) => a.Start.CompareTo(b.Start));
+            return result;
+        }
+
+        /// <summary>
+        /// 코드포인트 집합을 fontTools 표기 범위 문자열로 직렬화한다.
+        /// 연속 구간을 "U+XXXX-YYYY", 단일은 "U+XXXX" 로 압축한다.
+        /// 예) {0x41,0x42,0x43,0x61} → "U+0041-0043,U+0061".
+        /// </summary>
+        public static string FormatRanges(IEnumerable<int> codepoints)
+        {
+            var sorted = new List<int>();
+            var dedup = new HashSet<int>();
+            foreach (var cp in codepoints)
+            {
+                if (cp >= 0 && dedup.Add(cp))
+                {
+                    sorted.Add(cp);
+                }
+            }
+
+            sorted.Sort();
+            if (sorted.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder();
+            int runStart = sorted[0];
+            int prev = sorted[0];
+            for (int i = 1; i <= sorted.Count; i++)
+            {
+                bool contiguous = i < sorted.Count && sorted[i] == prev + 1;
+                if (contiguous)
+                {
+                    prev = sorted[i];
+                    continue;
+                }
+
+                if (sb.Length > 0)
+                {
+                    sb.Append(',');
+                }
+
+                if (runStart == prev)
+                {
+                    sb.Append(FormatCodepoint(runStart));
+                }
+                else
+                {
+                    sb.Append(FormatCodepoint(runStart)).Append('-').Append(HexOnly(prev));
+                }
+
+                if (i < sorted.Count)
+                {
+                    runStart = sorted[i];
+                    prev = sorted[i];
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>단일 코드포인트를 "U+XXXX" 표기로(최소 4자리 0패딩).</summary>
+        public static string FormatCodepoint(int cp) => "U+" + HexOnly(cp);
+
+        private static string HexOnly(int cp)
+        {
+            string h = cp.ToString("X");
+            return h.Length < 4 ? h.PadLeft(4, '0') : h;
+        }
+    }
+}

--- a/Editor/AITFontUnicodeBlocks.cs.meta
+++ b/Editor/AITFontUnicodeBlocks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b477d1d376ce44648c1f29612ac818f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AITFontUsedCharScanner.cs
+++ b/Editor/AITFontUsedCharScanner.cs
@@ -1,0 +1,322 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITFontUsedCharScanner.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Font subset Auto 모드 사용 문자 스캐너
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 폰트 subset Auto 모드의 "어떤 문자가 게임에 등장하는가"를 전 프로젝트에서 스캔한다(Editor 전용).
+//
+// 철학(zero-config): 개발자가 보존 범위를 손으로 명시하지 않아도, 프로젝트에 실제로 등장하는
+//   문자체계를 스캔해 그 블록 전체를 보존한다(블록 완성 규칙은 AITFontUnicodeBlocks). 따라서
+//   "가" 한 글자만 써도 한글 음절 전체가 살아남아 동적 닉네임/채팅이 □ 가 되지 않는다.
+//
+// 스캔 대상(보수적 — 누락보다 과보존을 택함):
+//   - 씬/프리팹/ScriptableObject(.unity/.prefab/.asset): YAML 라인에서 비ASCII 문자 전부 + 따옴표 문자열
+//   - C# 소스(.cs, Editor 포함): 문자열/문자 리터럴(단순화: 비ASCII + 따옴표 안 문자)
+//   - StreamingAssets/ 및 Localization 텍스트(.json/.csv/.txt/.xml/.yaml): 비ASCII 문자 전부
+//
+// 비용: 수천 파일에서도 수 초 수준이 되도록 파일을 라인 스트리밍으로 처리한다(전체 read 금지).
+//   파일별 try/catch — 한 파일 실패가 전체 스캔을 막지 않는다.
+//
+// 한자(Han) 처리: 블록이 2만+자라 블록 완성을 적용하지 않는다. 대신 감지된 한자 자체 + KS X 1001
+//   상용 한자 4,888자 패드를 보존한다. KS X 1001 한자는 EUC-KR(Code Page 949)로 한자 영역
+//   (행 0xCA~0xFD)을 디코드해 도출한다(실패 시 감지된 한자만 + 경고).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 전 프로젝트 사용 문자(코드포인트)를 스캔하는 Editor 전용 헬퍼.
+    /// 결과는 <see cref="HashSet{Int32}"/>(코드포인트). 서로게이트 쌍은 UTF-32 로 합쳐 수집한다.
+    /// </summary>
+    public static class AITFontUsedCharScanner
+    {
+        /// <summary>스캔 대상 확장자(소문자, '.' 포함).</summary>
+        private static readonly HashSet<string> ScanExtensions = new HashSet<string>
+        {
+            ".unity", ".prefab", ".asset",          // 씬/프리팹/ScriptableObject(YAML)
+            ".cs",                                   // C# 소스
+            ".json", ".csv", ".txt", ".xml", ".yaml", ".yml", // 로컬라이제이션/StreamingAssets 텍스트
+        };
+
+        private static List<int> _ksx1001HanCache;
+
+        /// <summary>
+        /// 항시 포함 베이스라인 범위(스캔 결과와 무관하게 항상 보존).
+        /// ASCII + Latin-1 + 한글 음절/자모 + CJK 기호 + 전각. 기존 수동 기본값과 동일.
+        /// </summary>
+        public const string BaselineRanges =
+            "U+0020-007E,U+00A0-00FF,U+AC00-D7A3,U+1100-11FF,U+3000-303F,U+FF00-FFEF";
+
+        /// <summary>
+        /// 스캔으로 감지한 코드포인트 + 블록 완성 + Han 패드 + 베이스라인을 합쳐
+        /// 최종 보존 범위 문자열(fontTools 표기)을 만든다. 부수 효과 없음 → 단위 테스트 대상.
+        /// </summary>
+        /// <param name="detected">스캔으로 감지한 코드포인트(비ASCII 위주).</param>
+        /// <param name="hanPad">KS X 1001 등 한자 패드(없으면 빈 목록).</param>
+        /// <param name="preservedBlocks">리포트용: 블록 완성으로 보존된 블록 목록.</param>
+        /// <returns>baseline 을 항상 포함하는 범위 문자열.</returns>
+        public static string BuildPreservedRanges(
+            IEnumerable<int> detected,
+            IEnumerable<int> hanPad,
+            out List<AITFontUnicodeBlocks.Block> preservedBlocks)
+        {
+            var detectedSet = new HashSet<int>();
+            if (detected != null)
+            {
+                foreach (var cp in detected)
+                {
+                    if (cp >= 0)
+                    {
+                        detectedSet.Add(cp);
+                    }
+                }
+            }
+
+            // 1) 비한자 코드포인트 → 속한 블록 전체 보존(블록 완성).
+            preservedBlocks = AITFontUnicodeBlocks.ExpandToBlocks(detectedSet);
+
+            var codepoints = new HashSet<int>();
+
+            // 2) 보존 블록 전체 코드포인트 펼치기.
+            foreach (var block in preservedBlocks)
+            {
+                for (int cp = block.Start; cp <= block.End; cp++)
+                {
+                    codepoints.Add(cp);
+                }
+            }
+
+            // 3) 감지된 한자 자체 보존(블록 완성 제외 대상이지만 글자 자체는 살린다).
+            foreach (var cp in detectedSet)
+            {
+                if (AITFontUnicodeBlocks.IsHan(cp))
+                {
+                    codepoints.Add(cp);
+                }
+            }
+
+            // 4) Han 패드(KS X 1001 상용 한자) 보존.
+            if (hanPad != null)
+            {
+                foreach (var cp in hanPad)
+                {
+                    codepoints.Add(cp);
+                }
+            }
+
+            // 5) 항시 베이스라인 — 스캔 결과와 무관하게 항상 포함.
+            foreach (var cp in EnumerateBaseline())
+            {
+                codepoints.Add(cp);
+            }
+
+            return AITFontUnicodeBlocks.FormatRanges(codepoints);
+        }
+
+        /// <summary>베이스라인 범위 문자열을 코드포인트로 펼친다.</summary>
+        internal static IEnumerable<int> EnumerateBaseline()
+        {
+            foreach (var part in BaselineRanges.Split(','))
+            {
+                string token = part.Trim();
+                if (token.StartsWith("U+", StringComparison.OrdinalIgnoreCase))
+                {
+                    token = token.Substring(2);
+                }
+
+                if (token.Length == 0)
+                {
+                    continue;
+                }
+
+                int dash = token.IndexOf('-');
+                if (dash < 0)
+                {
+                    if (int.TryParse(token, System.Globalization.NumberStyles.HexNumber, null, out int single))
+                    {
+                        yield return single;
+                    }
+
+                    continue;
+                }
+
+                if (int.TryParse(token.Substring(0, dash), System.Globalization.NumberStyles.HexNumber, null, out int lo)
+                    && int.TryParse(token.Substring(dash + 1), System.Globalization.NumberStyles.HexNumber, null, out int hi)
+                    && hi >= lo)
+                {
+                    for (int cp = lo; cp <= hi; cp++)
+                    {
+                        yield return cp;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Assets/ 트리 전체를 스캔해 등장한 코드포인트 집합을 반환한다.
+        /// 실패/예외는 파일 단위로 흡수하며, 치명적 예외 시 지금까지 수집분을 반환한다.
+        /// </summary>
+        public static HashSet<int> ScanProject()
+        {
+            var codepoints = new HashSet<int>();
+            int scannedFiles = 0;
+            try
+            {
+                string assetsPath = Application.dataPath;
+                string[] files;
+                try
+                {
+                    files = Directory.GetFiles(assetsPath, "*.*", SearchOption.AllDirectories);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-FontSubset] 프로젝트 파일 열거 실패 → 스캔 생략: {e.Message}");
+                    return codepoints;
+                }
+
+                foreach (var file in files)
+                {
+                    string ext = Path.GetExtension(file).ToLowerInvariant();
+                    if (!ScanExtensions.Contains(ext))
+                    {
+                        continue;
+                    }
+
+                    if (ScanFile(file, codepoints))
+                    {
+                        scannedFiles++;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-FontSubset] 문자 스캔 중 예외(수집분으로 계속): {e.Message}");
+            }
+
+            Debug.Log($"[AIT-FontSubset] 사용 문자 스캔: {scannedFiles}개 파일에서 고유 코드포인트 {codepoints.Count}개 감지.");
+            return codepoints;
+        }
+
+        /// <summary>
+        /// 파일 하나를 라인 스트리밍으로 읽어 비ASCII 코드포인트(서로게이트 합성)를 수집한다.
+        /// ASCII 영역은 항시 베이스라인에 포함되므로 여기서는 비ASCII만 모아 비용을 줄인다.
+        /// </summary>
+        /// <returns>실제로 읽었으면 true(예외 시 false).</returns>
+        private static bool ScanFile(string path, HashSet<int> sink)
+        {
+            try
+            {
+                using (var reader = new StreamReader(path, Encoding.UTF8, detectEncodingFromByteOrderMarks: true))
+                {
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        CollectNonAscii(line, sink);
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-FontSubset]   파일 스캔 실패(건너뜀): {Path.GetFileName(path)} — {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 문자열에서 비ASCII 코드포인트를 수집한다. 서로게이트 쌍은 <see cref="char.ConvertToUtf32(char, char)"/>
+        /// 로 합쳐 단일 코드포인트로 다룬다(이모지/확장 한자 대응).
+        /// </summary>
+        internal static void CollectNonAscii(string s, HashSet<int> sink)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return;
+            }
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (char.IsHighSurrogate(c) && i + 1 < s.Length && char.IsLowSurrogate(s[i + 1]))
+                {
+                    sink.Add(char.ConvertToUtf32(c, s[i + 1]));
+                    i++;
+                    continue;
+                }
+
+                // ASCII 제어/기본 영역은 베이스라인이 책임지므로 비ASCII(0x80 이상)만 수집.
+                if (c >= 0x80)
+                {
+                    sink.Add(c);
+                }
+            }
+        }
+
+        /// <summary>
+        /// KS X 1001 상용 한자 4,888자의 코드포인트 목록을 반환한다(EUC-KR 디코딩으로 도출, 캐시).
+        /// EUC-KR(Code Page 949)에서 한자 영역은 lead byte 0xCA~0xFD × trail byte 0xA1~0xFE 범위.
+        /// 디코딩 실패(인코딩 미등록 등) 시 빈 목록을 반환하고 경고한다(호출부가 감지된 한자만 사용).
+        /// </summary>
+        public static List<int> GetKsx1001Han()
+        {
+            if (_ksx1001HanCache != null)
+            {
+                return _ksx1001HanCache;
+            }
+
+            var result = new List<int>();
+            try
+            {
+                Encoding eucKr = Encoding.GetEncoding(949);
+                var bytes = new byte[2];
+                for (int lead = 0xCA; lead <= 0xFD; lead++)
+                {
+                    for (int trail = 0xA1; trail <= 0xFE; trail++)
+                    {
+                        bytes[0] = (byte)lead;
+                        bytes[1] = (byte)trail;
+                        string decoded;
+                        try
+                        {
+                            decoded = eucKr.GetString(bytes);
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+
+                        if (string.IsNullOrEmpty(decoded) || decoded.Length != 1)
+                        {
+                            continue;
+                        }
+
+                        int cp = decoded[0];
+                        // 한자 영역(CJK Unified Ideographs)만 채택 — 미매핑/기호 디코드는 제외.
+                        if (AITFontUnicodeBlocks.IsHan(cp))
+                        {
+                            result.Add(cp);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-FontSubset] KS X 1001 한자 도출 실패(감지된 한자만 보존): {e.Message}");
+                result.Clear();
+            }
+
+            _ksx1001HanCache = result;
+            return result;
+        }
+    }
+}

--- a/Editor/AITFontUsedCharScanner.cs.meta
+++ b/Editor/AITFontUsedCharScanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d269259dd4d24c7d97f6efc1cc1fe27f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/FontSubset~/package.json
+++ b/Editor/FontSubset~/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ait-font-subset-runner",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Apps in Toss Unity SDK - build-time CJK font subsetter (harfbuzz/wasm via subset-font). Invoked by AITFontSubsetProcessor through the SDK's embedded Node.js.",
+  "type": "module",
+  "dependencies": {
+    "subset-font": "2.3.0"
+  }
+}

--- a/Editor/FontSubset~/subset-font-runner.mjs
+++ b/Editor/FontSubset~/subset-font-runner.mjs
@@ -1,0 +1,82 @@
+// Apps in Toss Unity SDK — 빌드 단계 폰트 subset 러너 (SDK 내장 Node.js 로 실행).
+//
+// AITFontSubsetProcessor 가 빌드 직전, 대상 .ttf/.otf 소스를 지정한 유니코드 범위만 남기도록
+// subset 하여 Unity 가 .data 에 굽는 폰트 데이터를 급감시킨다. harfbuzz(hb-subset, wasm) 를
+// 래핑한 `subset-font` 패키지를 사용한다(Google Fonts 와 동일 코덱).
+//
+// 사용:
+//   node subset-font-runner.mjs <inputFont> <outputFont> <unicodeRanges>
+//   unicodeRanges: 콤마 구분, fontTools 와 동일 표기. 예) "U+0020-007E,U+AC00-D7A3,U+1100-11FF"
+//
+// 종료코드: 0=성공, 2=잘못된 인자, 3=subset 실패. 결과(JSON 1줄)를 stdout 에 출력한다.
+
+import { readFile, writeFile } from 'node:fs/promises';
+
+function fail(code, msg) {
+  process.stdout.write(JSON.stringify({ ok: false, error: msg }) + '\n');
+  process.exit(code);
+}
+
+const [, , inPath, outPath, rangeSpec] = process.argv;
+if (!inPath || !outPath || !rangeSpec) {
+  fail(2, 'usage: node subset-font-runner.mjs <in> <out> <unicodeRanges>');
+}
+
+// "U+0020-007E,U+AC00-D7A3,..." → 보존할 코드포인트 배열.
+function expandRanges(spec) {
+  const cps = [];
+  for (const raw of spec.split(',')) {
+    const part = raw.trim().replace(/^u\+/i, '');
+    if (!part) continue;
+    if (part.includes('-')) {
+      const [a, b] = part.split('-');
+      const lo = parseInt(a, 16);
+      const hi = parseInt(b, 16);
+      if (Number.isNaN(lo) || Number.isNaN(hi) || hi < lo) continue;
+      for (let c = lo; c <= hi; c++) cps.push(c);
+    } else {
+      const c = parseInt(part, 16);
+      if (!Number.isNaN(c)) cps.push(c);
+    }
+  }
+  return cps;
+}
+
+(async () => {
+  let subsetFont;
+  try {
+    subsetFont = (await import('subset-font')).default;
+  } catch (e) {
+    fail(3, 'subset-font 모듈 로드 실패: ' + (e && e.message ? e.message : String(e)));
+  }
+
+  const cps = expandRanges(rangeSpec);
+  if (cps.length === 0) {
+    fail(2, '유효한 유니코드 범위가 없습니다: ' + rangeSpec);
+  }
+
+  // 코드포인트 → 보존 문자열(subset-font 의 text 인자). 대용량(수만 글자) 대비 청크 join.
+  const parts = [];
+  let buf = [];
+  for (const c of cps) {
+    buf.push(String.fromCodePoint(c));
+    if (buf.length >= 4096) { parts.push(buf.join('')); buf = []; }
+  }
+  if (buf.length) parts.push(buf.join(''));
+  const text = parts.join('');
+
+  try {
+    const input = await readFile(inPath);
+    const out = await subsetFont(input, text, { targetFormat: 'truetype' });
+    await writeFile(outPath, out);
+    process.stdout.write(JSON.stringify({
+      ok: true,
+      codepoints: cps.length,
+      inBytes: input.length,
+      outBytes: out.length,
+    }) + '\n');
+    process.exit(0);
+  } catch (e) {
+    fail(3, 'subset 실패: ' + (e && e.message ? e.message : String(e)));
+  }
+})();

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFontSubsetAutoTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFontSubsetAutoTests.cs
@@ -1,0 +1,236 @@
+// -----------------------------------------------------------------------
+// AITFontSubsetAutoTests.cs - 폰트 subset Auto 모드 순수 로직 검증
+// Level 0: 블록 완성 매핑 / 범위 포맷팅 / 베이스라인 항시 포함 / Han 패드 처리
+//
+// 핵심 불변식 회귀 방지: "어떤 문자체계가 한 글자라도 등장하면 그 블록 전체가 보존된다."
+// (동적 텍스트가 같은 문자체계라면 절대 □ 가 되지 않게.)
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITFontSubsetAutoTests
+{
+    // 범위 문자열 → 코드포인트 집합으로 펼치는 헬퍼(테스트 검증용).
+    private static HashSet<int> Expand(string ranges)
+    {
+        var set = new HashSet<int>();
+        foreach (var part in ranges.Split(','))
+        {
+            string token = part.Trim();
+            if (token.StartsWith("U+") || token.StartsWith("u+"))
+            {
+                token = token.Substring(2);
+            }
+
+            if (token.Length == 0)
+            {
+                continue;
+            }
+
+            int dash = token.IndexOf('-');
+            if (dash < 0)
+            {
+                set.Add(System.Convert.ToInt32(token, 16));
+                continue;
+            }
+
+            int lo = System.Convert.ToInt32(token.Substring(0, dash), 16);
+            int hi = System.Convert.ToInt32(token.Substring(dash + 1), 16);
+            for (int c = lo; c <= hi; c++)
+            {
+                set.Add(c);
+            }
+        }
+
+        return set;
+    }
+
+    // =====================================================
+    // 블록 완성 규칙: 한 글자 → 블록 전체
+    // =====================================================
+
+    [Test]
+    public void Hangul_SingleChar_Preserves_WholeSyllableBlock()
+    {
+        // "가"(U+AC00) 한 글자 → 한글 음절 블록(AC00-D7A3) 전체 보존
+        var blocks = AITFontUnicodeBlocks.ExpandToBlocks(new[] { 0xAC00 });
+
+        var match = blocks.Find(b => b.Start == 0xAC00 && b.End == 0xD7A3);
+        Assert.AreEqual("Hangul Syllables", match.Name,
+            "한글 1자 → 한글 음절 블록 전체가 보존되어야 함(동적 닉네임/채팅 보호)");
+    }
+
+    [Test]
+    public void LatinExtended_SingleChar_Preserves_WholeBlock()
+    {
+        // "ā"(U+0101) 한 글자 → Latin Extended-A(0100-017F) 전체 보존
+        var blocks = AITFontUnicodeBlocks.ExpandToBlocks(new[] { 0x0101 });
+
+        var match = blocks.Find(b => b.Start == 0x0100 && b.End == 0x017F);
+        Assert.AreEqual("Latin Extended-A", match.Name,
+            "라틴 확장 1자 → 해당 블록 전체가 보존되어야 함");
+    }
+
+    [Test]
+    public void Hiragana_SingleChar_Preserves_WholeBlock()
+    {
+        var blocks = AITFontUnicodeBlocks.ExpandToBlocks(new[] { 0x3042 }); // あ
+        var match = blocks.Find(b => b.Start == 0x3040 && b.End == 0x309F);
+        Assert.AreEqual("Hiragana", match.Name);
+    }
+
+    // =====================================================
+    // Han 예외: 한자는 블록 완성 미적용
+    // =====================================================
+
+    [Test]
+    public void Han_SingleChar_DoesNotExpand_ToWholeBlock()
+    {
+        // "韓"(U+97D3) → CJK Unified Ideographs 블록 전체는 보존하지 않음
+        var blocks = AITFontUnicodeBlocks.ExpandToBlocks(new[] { 0x97D3 });
+        Assert.IsFalse(blocks.Exists(b => b.IsHan),
+            "한자는 블록 전체(2만+자)가 아니라 글자 자체 + KS X 1001 패드만 보존되어야 함");
+    }
+
+    [Test]
+    public void IsHan_Identifies_CjkUnifiedIdeographs()
+    {
+        Assert.IsTrue(AITFontUnicodeBlocks.IsHan(0x4E00));
+        Assert.IsTrue(AITFontUnicodeBlocks.IsHan(0x9FFF));
+        Assert.IsFalse(AITFontUnicodeBlocks.IsHan(0xAC00)); // 한글은 한자 아님
+    }
+
+    // =====================================================
+    // 범위 문자열 포맷팅
+    // =====================================================
+
+    [Test]
+    public void FormatRanges_Compresses_ContiguousRuns()
+    {
+        // {0x41,0x42,0x43,0x61} → "U+0041-0043,U+0061"
+        string s = AITFontUnicodeBlocks.FormatRanges(new[] { 0x41, 0x42, 0x43, 0x61 });
+        Assert.AreEqual("U+0041-0043,U+0061", s);
+    }
+
+    [Test]
+    public void FormatRanges_Dedups_And_Sorts()
+    {
+        string s = AITFontUnicodeBlocks.FormatRanges(new[] { 0x61, 0x41, 0x41, 0x42 });
+        Assert.AreEqual("U+0041-0042,U+0061", s);
+    }
+
+    [Test]
+    public void FormatRanges_Empty_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, AITFontUnicodeBlocks.FormatRanges(new int[0]));
+    }
+
+    [Test]
+    public void FormatCodepoint_PadsToFourHexDigits()
+    {
+        Assert.AreEqual("U+0041", AITFontUnicodeBlocks.FormatCodepoint(0x41));
+        Assert.AreEqual("U+AC00", AITFontUnicodeBlocks.FormatCodepoint(0xAC00));
+        Assert.AreEqual("U+1F600", AITFontUnicodeBlocks.FormatCodepoint(0x1F600));
+    }
+
+    // =====================================================
+    // 베이스라인 항시 포함
+    // =====================================================
+
+    [Test]
+    public void BuildPreservedRanges_AlwaysIncludes_Baseline_EvenWithNoDetection()
+    {
+        // 감지 문자가 전혀 없어도 베이스라인(ASCII/한글 음절/CJK 기호/전각)은 항상 포함
+        string ranges = AITFontUsedCharScanner.BuildPreservedRanges(
+            new int[0], new int[0], out _);
+        var cps = Expand(ranges);
+
+        Assert.IsTrue(cps.Contains(0x0041), "ASCII 'A' 는 항상 포함");
+        Assert.IsTrue(cps.Contains(0xAC00), "한글 '가' 는 베이스라인으로 항상 포함");
+        Assert.IsTrue(cps.Contains(0x3000), "CJK 기호 베이스라인 항상 포함");
+        Assert.IsTrue(cps.Contains(0xFF01), "전각 베이스라인 항상 포함");
+    }
+
+    [Test]
+    public void BuildPreservedRanges_DetectedScript_ExpandsToWholeBlock()
+    {
+        // 키릴 한 글자(U+0410) 감지 → 키릴 블록 전체(0400-04FF) 보존
+        string ranges = AITFontUsedCharScanner.BuildPreservedRanges(
+            new[] { 0x0410 }, new int[0], out var blocks);
+        var cps = Expand(ranges);
+
+        Assert.IsTrue(cps.Contains(0x0400), "키릴 1자 감지 → 블록 시작(0400) 보존");
+        Assert.IsTrue(cps.Contains(0x04FF), "키릴 1자 감지 → 블록 끝(04FF) 보존");
+        Assert.IsTrue(blocks.Exists(b => b.Name == "Cyrillic"), "리포트에 Cyrillic 블록 포함");
+    }
+
+    [Test]
+    public void BuildPreservedRanges_IncludesDetectedHan_And_HanPad()
+    {
+        // 감지된 한자 자체 + Han 패드는 보존하되 블록 전체로 펼치지 않음
+        string ranges = AITFontUsedCharScanner.BuildPreservedRanges(
+            new[] { 0x97D3 }, new[] { 0x4E00, 0x4E01 }, out var blocks);
+        var cps = Expand(ranges);
+
+        Assert.IsTrue(cps.Contains(0x97D3), "감지된 한자 자체는 보존");
+        Assert.IsTrue(cps.Contains(0x4E00), "Han 패드 한자 보존");
+        Assert.IsTrue(cps.Contains(0x4E01), "Han 패드 한자 보존");
+        Assert.IsFalse(cps.Contains(0x5000), "패드/감지 외 한자는 보존하지 않음(블록 전체 미적용)");
+        Assert.IsFalse(blocks.Exists(b => b.IsHan), "한자 블록은 리포트에 블록 완성으로 포함되지 않음");
+    }
+
+    // =====================================================
+    // KS X 1001 Han 패드 도출
+    // =====================================================
+
+    [Test]
+    public void Ksx1001Han_WhenAvailable_ContainsCommonHanja()
+    {
+        var han = AITFontUsedCharScanner.GetKsx1001Han();
+
+        // EUC-KR(949) 인코딩이 등록된 환경이면 약 4,888자가 도출됨.
+        // 미등록(.NET 환경 차이)이면 빈 목록으로 graceful degrade — 그 경우는 검증을 건너뛴다.
+        if (han.Count == 0)
+        {
+            Assert.Pass("EUC-KR(949) 미등록 환경 — 감지된 한자만 보존(graceful degrade). 검증 생략.");
+            return;
+        }
+
+        Assert.GreaterOrEqual(han.Count, 4000,
+            "KS X 1001 상용 한자는 약 4,888자여야 함");
+        foreach (var cp in han)
+        {
+            Assert.IsTrue(AITFontUnicodeBlocks.IsHan(cp),
+                $"KS X 1001 패드의 모든 코드포인트는 한자 영역이어야 함: U+{cp:X4}");
+        }
+    }
+
+    // =====================================================
+    // 사용 문자 스캐너: 비ASCII 수집 / 서로게이트 처리
+    // =====================================================
+
+    [Test]
+    public void CollectNonAscii_Collects_OnlyNonAscii()
+    {
+        var sink = new HashSet<int>();
+        AITFontUsedCharScanner.CollectNonAscii("Hello 가나다!", sink);
+
+        Assert.IsFalse(sink.Contains('H'), "ASCII 는 베이스라인이 책임지므로 수집 제외");
+        Assert.IsTrue(sink.Contains(0xAC00), "'가' 수집");
+        Assert.IsTrue(sink.Contains(0xB098), "'나' 수집");
+        Assert.IsTrue(sink.Contains(0xB2E4), "'다' 수집");
+    }
+
+    [Test]
+    public void CollectNonAscii_Handles_SurrogatePairs()
+    {
+        var sink = new HashSet<int>();
+        // U+1F600 (😀) 은 서로게이트 쌍 — UTF-32 단일 코드포인트로 합쳐 수집되어야 함
+        AITFontUsedCharScanner.CollectNonAscii("emoji \U0001F600 here", sink);
+
+        Assert.IsTrue(sink.Contains(0x1F600), "서로게이트 쌍을 합친 코드포인트로 수집");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFontSubsetAutoTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFontSubsetAutoTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9e609aa24f94fb6a1566e06c69ea1c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 개요

크고(≥1MB) 빌드에 포함될 가능성이 있는 `.ttf`/`.otf` 폰트를 **자동 탐지**해, 프로젝트 전체에서 실제 등장하는 문자체계의 유니코드 블록 전체를 보존하도록 subset하는 **zero-config 빌드 프로세서**(`AITFontSubsetProcessor`)입니다(CJK 풀 폰트 5~15MB → ~0.1MB). 빌드 후 원본 폰트로 자동 복원합니다.

> **팀 정책 — zero-config**: 모든 성능 최적화 레버는 개발자의 깊은 이해 없이 자동 적용. **기본 ON + 자동 안전장치**(스캔·블록 완성·보수적 베이스라인·빌드 리포트·opt-out). 안전장치가 정확성을 보존할 수 없는 lossy 레버만 opt-in 예외.

WebGL 로드타임 최적화 레버를 **1기법=1PR**로 분할한 캠페인의 한 갈래입니다(font CJK subset).

## 변경 내용

| 파일 | 역할 |
|------|------|
| `Editor/AITFontSubsetProcessor.cs` (수정) | zero-config Auto 모드: 자동 대상 탐지 + 전 프로젝트 스캔 + 블록 완성 규칙 + 드롭 리포트 |
| `Editor/AITFontUnicodeBlocks.cs` (신규) | 유니코드 블록 테이블 + 블록 완성 규칙(Han 예외 포함) — 순수 로직, 단위 테스트 대상 |
| `Editor/AITFontUsedCharScanner.cs` (신규) | 전 프로젝트 사용 문자 스캐너(씬/프리팹/asset/C#/로컬라이제이션) + KS X 1001 한자 패드 |
| `Editor/FontSubset~/` | 내장 Node.js subset 러너(`package.json`, `subset-font-runner.mjs`) |
| `Editor/AITEditorScriptObject.cs` (수정) | `fontSubset`(int tri-state) + `GetDefaultFontSubset()=>true` + override 필드 |
| `Editor/AITConfigurationWindow.cs` (수정) | Popup(자동/비활성화/수동) + override 필드 + HelpBox |
| `Tests~/…/AITFontSubsetAutoTests.cs` (신규) | EditMode 단위 테스트(블록 완성 규칙·Han 예외·베이스라인 불변식) |

## 기본값 / 활성화 방법

| 레버 | 기본값 | 의미 |
|------|--------|------|
| `fontSubset = -1` | **자동 ON** (기본) | 자동 탐지 + 전 프로젝트 스캔으로 범위 결정 |
| `fontSubset = 0` | 비활성 | 완전 no-op, 원본 폰트 그대로 빌드 |
| `fontSubset = 1` | 자동 ON (명시) | -1과 동일 동작, 명시적으로 켠 것 |

별도 설정 없이 **빌드하면 자동 적용**됩니다. 비활성하려면 Configuration Window → 콘텐츠 최적화 섹션 → 폰트 subset → "비활성화"를 선택하세요.

수동 제어가 필요하면:
- `fontSubsetTargetPaths`: 대상 폰트 에셋 경로(쉼표 구분) — 지정 시 자동 탐지 생략
- `fontSubsetUnicodeRanges`: 보존 유니코드 범위(fontTools 표기) — 지정 시 Auto 스캔 생략

## 자동 안전장치 (정확성 보장)

1. **자동 대상 탐지**: ≥1MB이고 빌드에 포함될 가능성이 있는 폰트만(활성 씬 의존성 + `Resources/` + TMP 소스폰트 리플렉션)
2. **전 프로젝트 스캔** (`AITFontUsedCharScanner`): 씬·프리팹·asset·C#·로컬라이제이션 텍스트, 서로게이트 합성, 파일별 try/catch
3. **★ 블록 완성 규칙** (`AITFontUnicodeBlocks`): 등장한 문자체계의 유니코드 블록 전체 보존 → "가" 한 글자만 써도 한글 음절 전체(AC00–D7A3) 보존 → 동적 닉네임·채팅이 □ 되지 않음
4. **Han 예외**: 한자 블록(2만+자) 전체 보존 대신 [감지 한자 + KS X 1001 상용 한자 4,888자 패드(EUC-KR/CP949 디코드, 실패 시 graceful degrade)]
5. **베이스라인 항시 포함**: ASCII·Latin-1·한글·CJK 기호·전각은 스캔 결과와 무관하게 항상 포함
6. **빌드 드롭 리포트**: 폰트별 원본→subset 크기, 보존 블록, 감지 문자체계 요약(Console 출력)
7. **opt-out**: `fontSubset=0`으로 완전 no-op
8. **비파괴 복원**: 소스 원본 `.aitfontbak` 백업 → 빌드 종료(성공/실패 무관) `try/finally` 복원. 비정상 종료 시 다음 에디터 로드 시 안전망(`SafetyNetRestore`) 자동 복원

## 전 Unity 버전 적용

Unity 2021.3 / 2022.3 / 6000.0 / 6000.2 / 6000.3 모두 동일 동작. SDK 내장 Node.js(`AITNodeJSDownloader`)로 `subset-font`(harfbuzz wasm, Google Fonts 동일 코덱) 실행.

## 측정 Δ (perf CI가 채움)

`perf` 라벨이 부착되면 perf CI가 이 PR 브랜치를 main 위에서 빌드해 **단일 레버 Δ**를 코멘트로 게시합니다.

| Unity | TTFF Δ | on-wire Δ | data Δ |
|-------|--------|-----------|--------|
| 2021.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.0 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |

## 관련

- 측정 하네스: #754
