### PR TITLE
기능: 대형 텍스처 스트리밍 + 런타임 재수화

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -221,6 +221,10 @@ namespace AppsInToss.Editor
                 ? editorConfig.firstInteractiveLog == 1
                 : AITDefaultSettings.GetDefaultFirstInteractiveLog();
             Debug.Log($"[AIT]   - first-interactive 계측: {firstInteractiveEnabled}{(editorConfig.firstInteractiveLog < 0 ? " (자동)" : "")}");
+            // 텍스처 스트리밍은 ExternalizeForBuild 에서 별도 리포트를 출력하므로 활성 여부만 기록.
+            bool texStreamEnabled = editorConfig.textureStreaming == 1
+                || (editorConfig.textureStreaming < 0 && AITDefaultSettings.GetDefaultTextureStreaming());
+            Debug.Log($"[AIT]   - 텍스처 스트리밍: {(texStreamEnabled ? "활성화" : "비활성화")}{(editorConfig.textureStreaming < 0 ? " (자동)" : "")}");
         }
 
         /// <summary>

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -18,6 +18,7 @@ namespace AppsInToss.Editor
         private bool showBuildProfiles = true;
         private bool showDevServerProfile = false;
         private bool showProductionProfile = false;
+        private bool showTextureStreamingSettings = true;
 
         // 하이라이트 색상
         private static readonly Color ModifiedColor = new Color(1f, 0.6f, 0f); // 주황색
@@ -62,6 +63,8 @@ namespace AppsInToss.Editor
             DrawBuildSettings();
             GUILayout.Space(10);
             DrawWebGLOptimizationSettings();
+            GUILayout.Space(10);
+            DrawTextureStreamingSettings();
             GUILayout.Space(10);
             DrawPermissionSettings();
             GUILayout.Space(10);
@@ -548,6 +551,83 @@ namespace AppsInToss.Editor
             if (isModified && DrawResetButton())
             {
                 config.dataCaching = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawTextureStreamingSettings()
+        {
+            showTextureStreamingSettings = EditorGUILayout.Foldout(showTextureStreamingSettings, "콘텐츠 최적화 — 텍스처 스트리밍", true);
+
+            if (!showTextureStreamingSettings) return;
+
+            EditorGUILayout.BeginVertical("box");
+
+            // tri-state 드롭다운
+            DrawTextureStreamingSetting();
+
+            GUILayout.Space(5);
+
+            // 스텁 노출 구간 설명 HelpBox
+            EditorGUILayout.HelpBox(
+                "스텁 노출 구간: 첫 프레임 직후 ~ 비동기 로드 완료 사이에 단색 스텁이 잠깐 보일 수 있습니다.\n" +
+                "항상 원본 텍스처가 보여야 하는 경로는 '제외 폴더'에 지정하세요.\n\n" +
+                "외부화 대상: 부팅 씬에 의존하지 않는 대형(기본 512KB 이상) Texture2D.\n" +
+                "자동 제외: 부팅 씬 의존 / Resources / SpriteAtlas 패킹 대상 / 동명·동차원 충돌 / linear / NormalMap.",
+                MessageType.Info
+            );
+
+            GUILayout.Space(5);
+
+            // 최소 바이트 설정
+            config.textureStreamingMinBytes = EditorGUILayout.IntField(
+                new GUIContent("외부화 최소 크기 (바이트)", "이 크기보다 큰 텍스처 소스만 외부화합니다 (기본 524288 = 512KB)."),
+                config.textureStreamingMinBytes
+            );
+
+            // 대상 폴더
+            config.textureStreamingDirs = EditorGUILayout.TextField(
+                new GUIContent("대상 폴더 (쉼표 구분)", "비우면 프로젝트 전체. 예) Assets/Art/BG,Assets/Textures"),
+                config.textureStreamingDirs
+            );
+
+            // 제외 폴더
+            config.textureStreamingExcludeDirs = EditorGUILayout.TextField(
+                new GUIContent("제외 폴더 (쉼표 구분)", "항상 원본 텍스처를 사용해야 하는 경로. 예) Assets/UI/Always"),
+                config.textureStreamingExcludeDirs
+            );
+
+            // 최대 동시 스트리밍
+            config.textureStreamingMaxConcurrent = EditorGUILayout.IntSlider(
+                new GUIContent("최대 동시 스트리밍", "런타임 동시 다운로드/디코드 상한 (기본 3). VRAM/메인스레드 hitch 제한."),
+                config.textureStreamingMaxConcurrent, 1, 8
+            );
+
+            EditorGUILayout.EndVertical();
+        }
+
+        private void DrawTextureStreamingSetting()
+        {
+            bool defaultEnabled = AITDefaultSettings.GetDefaultTextureStreaming();
+            bool isModified = config.textureStreaming >= 0 && (config.textureStreaming == 1) != defaultEnabled;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.textureStreaming < 0
+                ? $"텍스처 스트리밍 (자동: {(defaultEnabled ? "활성화" : "비활성화")})"
+                : "텍스처 스트리밍";
+
+            string[] options = { $"자동 ({(defaultEnabled ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.textureStreaming < 0 ? 0 : config.textureStreaming + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.textureStreaming = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.textureStreaming = -1;
             }
 
             EditorGUILayout.EndHorizontal();

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -993,6 +993,9 @@ namespace AppsInToss
             // .cs 파일 수정과 달리 .json은 스크립트 컴파일을 유발하지 않으므로 도메인 리로드 없음
             bool versionInfoWritten = WriteVersionInfoJson(out bool createdResourcesDir);
 
+            // 콘텐츠 최적화 — 대형 텍스처 외부화 (초기 .data 에서 분리, 빌드 후 임포터/소스 원복)
+            var textureStreamHandle = Editor.AITLargeTextureExternalizer.ExternalizeForBuild(config);
+
             UnityEditor.Build.Reporting.BuildReport result;
             try
             {
@@ -1000,6 +1003,9 @@ namespace AppsInToss
             }
             finally
             {
+                // 콘텐츠 최적화 — 대형 텍스처 외부화 원복(소스/임포터 복원) (빌드 성공/실패 무관)
+                Editor.AITLargeTextureExternalizer.RestoreForBuild(textureStreamHandle);
+
                 // 빌드 완료 후 (성공/실패 무관) 생성한 JSON 제거 — 사용자 프로젝트에 산출물 남기지 않음
                 if (versionInfoWritten)
                 {

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -494,6 +494,11 @@ namespace AppsInToss
         /// 픽셀 불변·세션당 1회 단일 이벤트·호스트 로딩 지표 표준화에 해당하므로 기본 ON.
         /// </summary>
         public static bool GetDefaultFirstInteractiveLog()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// 기본 텍스처 스트리밍 활성 여부.
         /// 비-부팅 대형 텍스처를 자동으로 외부화해 초기 다운로드/TTFF 를 줄인다(zero-config).
         /// </summary>

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -209,6 +209,25 @@ namespace AppsInToss
         [Header("계측 설정")]
         [Tooltip("first-interactive 계측: -1 = 자동 (활성), 0 = 비활성, 1 = 활성")]
         public int firstInteractiveLog = -1;
+        [Header("콘텐츠 최적화 — 대형 텍스처 스트리밍")]
+        [Tooltip("비-부팅 대형 Texture2D 를 초기 .data 에서 분리해 StreamingAssets 로 외부화하고, 소스를 '동일 차원 단색 스텁'으로 치환합니다. " +
+                 "런타임(AITStreamingTexture)이 first-frame 이후 실 텍스처를 비동기 스트리밍 로드하여 동일 Texture2D 객체에 픽셀을 제자리 복원하므로 " +
+                 "이를 참조하는 Sprite/Material 이 참조 재할당 없이 갱신됩니다. 초기 다운로드/TTFF 를 크게 줄입니다. " +
+                 "빌드 후 원본/임포터 설정을 원상 복원하므로 명시적 opt-in 으로 기본 비활성입니다.")]
+        public bool enableTextureStreaming = false;
+
+        [Tooltip("이 바이트 수보다 큰 텍스처 소스만 외부화 대상입니다 (기본 512KB). 소형 아이콘은 동적 Resources.Load 로 부팅에 끌려올 수 있어 보호합니다.")]
+        public int textureStreamingMinBytes = 524288;
+
+        [Tooltip("외부화 대상 폴더(쉼표 구분, Assets/ 기준 경로). 비우면 프로젝트 전체의 큰 텍스처가 대상입니다. 예) Assets/Art/BG,Assets/Textures")]
+        public string textureStreamingDirs = "";
+
+        [Tooltip("외부화에서 제외할 폴더(쉼표 구분, Assets/ 기준). 부팅에 필요한 텍스처를 사용자가 명시 보호하는 escape hatch. 예) Assets/UI/Always")]
+        public string textureStreamingExcludeDirs = "";
+
+        [Range(1, 8)]
+        [Tooltip("런타임 동시 스트리밍 다운로드/디코드 상한(기본 3). LoadImage 가 RGBA32 로 강제하므로 VRAM/메인스레드 hitch 를 이 값으로 제한합니다.")]
+        public int textureStreamingMaxConcurrent = 3;
 
         [Header("권한 설정")]
         public AITPermissionConfig permissionConfig = new AITPermissionConfig();

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -213,8 +213,8 @@ namespace AppsInToss
         [Tooltip("비-부팅 대형 Texture2D 를 초기 .data 에서 분리해 StreamingAssets 로 외부화하고, 소스를 '동일 차원 단색 스텁'으로 치환합니다. " +
                  "런타임(AITStreamingTexture)이 first-frame 이후 실 텍스처를 비동기 스트리밍 로드하여 동일 Texture2D 객체에 픽셀을 제자리 복원하므로 " +
                  "이를 참조하는 Sprite/Material 이 참조 재할당 없이 갱신됩니다. 초기 다운로드/TTFF 를 크게 줄입니다. " +
-                 "빌드 후 원본/임포터 설정을 원상 복원하므로 명시적 opt-in 으로 기본 비활성입니다.")]
-        public bool enableTextureStreaming = false;
+                 "빌드 후 원본/임포터 설정을 원상 복원합니다. -1 = 자동 (활성화), 0 = 비활성화, 1 = 활성화.")]
+        public int textureStreaming = -1;
 
         [Tooltip("이 바이트 수보다 큰 텍스처 소스만 외부화 대상입니다 (기본 512KB). 소형 아이콘은 동적 Resources.Load 로 부팅에 끌려올 수 있어 보호합니다.")]
         public int textureStreamingMinBytes = 524288;
@@ -494,6 +494,10 @@ namespace AppsInToss
         /// 픽셀 불변·세션당 1회 단일 이벤트·호스트 로딩 지표 표준화에 해당하므로 기본 ON.
         /// </summary>
         public static bool GetDefaultFirstInteractiveLog()
+        /// 기본 텍스처 스트리밍 활성 여부.
+        /// 비-부팅 대형 텍스처를 자동으로 외부화해 초기 다운로드/TTFF 를 줄인다(zero-config).
+        /// </summary>
+        public static bool GetDefaultTextureStreaming()
         {
             return true;
         }

--- a/Editor/AITLargeTextureExternalizer.cs
+++ b/Editor/AITLargeTextureExternalizer.cs
@@ -1,0 +1,642 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITLargeTextureExternalizer.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Large Texture Streaming (build-time externalizer)
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 빌드 직전, 비-부팅 대형 Texture2D 를 초기 .data 밖(StreamingAssets)으로 빼내고
+// 프로젝트 내 소스는 "동일 차원 단색 스텁"으로 치환한다. 런타임(AITStreamingTexture)이
+// 매니페스트를 보고 first-frame 이후 실 텍스처를 스트리밍 로드하여 동일 Texture2D 객체에
+// 픽셀을 제자리(in-place) 복원한다 — 이를 참조하는 모든 Sprite/Material 이 참조 재할당 없이 갱신.
+//
+// 메커니즘(M2, 차원 보존 스텁 + in-place 복원): 오디오 스트리밍 패턴의 텍스처 버전.
+//   오디오는 AudioSource.clip(단일 가변 프로퍼티) 재할당으로 핫스왑하지만,
+//   텍스처는 Sprite.texture 가 read-only 라 참조 재할당이 불가하다. 대신 스텁을 "원본과
+//   동일 차원"으로 만들어 Sprite rect/pivot/border 가 동일하게 bake 되게 하고, 런타임에
+//   공유 Texture2D 객체의 픽셀만 교체하면(LoadImage+Apply) 모든 참조가 자동으로 새 픽셀을 렌더한다.
+//
+// 효과: 동일 차원 단색 스텁은 crunch+brotli 에서 차원과 무관하게 ~0 으로 수렴하므로,
+//   .data 에서 비-부팅 텍스처 바이트가 사라져 초기 다운로드/TTFF 가 감소한다. 원본은
+//   StreamingAssets/ait-stream-texture/<guid>.<ext> 로 동봉(온디맨드).
+//
+// 적대검증(4-에이전트)으로 확정된 빌드타임 필수 완화:
+//   ① 런타임 LoadImage 는 crunch/non-readable 텍스처에 실패 → 스텁만 isReadable=true +
+//      crunchedCompression=false + Uncompressed 로 reimport (스텁은 단색이라 그래도 brotli ~0).
+//   ② NormalMap / linear(sRGB=false) 는 LoadImage 가 sRGB 로 덮어써 깨짐 → 하드 제외.
+//   ③ 부팅 씬 의존(GetDependencies scene0) + /Resources/ + Splash + 사용자 제외목록 → frame-1 보호.
+//   ④ <minBytes(기본 512KB) 소형 텍스처 제외 (동적 Resources.Load 로 부팅에 끌려올 수 있는 작은 아이콘 보호).
+//   ⑤ SpriteAtlas 패킹 대상 제외(GROUND TRUTH §3-P): 아틀라스는 빌드 시 소스 PNG 를 페이지(sactx-*)로
+//      굽고 소스 자체는 .data 에 안 넣는다 → 소스 스텁은 (a) 아틀라스에 스텁을 패킹해 영구 투명,
+//      (b) .data 의 페이지가 잔존해 on-wire 이득 0. 페이지 단위 defer 는 소스-PNG 스텁이 닿지 못하는
+//      별도 메커니즘 영역이므로 여기서는 하드 제외(BuildSpriteAtlasPackedSet, 폴더 패킹 포함).
+//
+// 비파괴: 소스 원본은 <src>.aittexstreambak, .meta 는 <meta>.aittexstreammetabak 로 백업,
+//   빌드 종료(성공/실패 무관) 시 둘 다 원상 복원한다. 비정상 종료 시 다음 에디터 로드의
+//   안전망(SafetyNetRestore, 마커 게이트)이 잔존 백업을 자동 복원한다.
+//
+// 통합: AITConvertCore.BuildWebGL 가 빌드 직전 ExternalizeForBuild 를 호출하고,
+//   finally 에서 RestoreForBuild 로 원상 복원한다.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 빌드 단계 대형 텍스처 외부화/복원 처리기. <see cref="AITEditorScriptObject.enableTextureStreaming"/>
+    /// 설정에 따라 동작하며, 런타임 컴포넌트 <c>AppsInToss.AITStreamingTexture</c> 와 짝을 이룬다.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class AITLargeTextureExternalizer
+    {
+        /// <summary>외부화된 텍스처/매니페스트가 놓이는 프로젝트 상대 경로.</summary>
+        private const string StreamRootAssets = "Assets/StreamingAssets/ait-stream-texture";
+
+        /// <summary>치환 전 원본 소스(png/jpg 등)를 보관하는 백업 접미사.</summary>
+        private const string SrcBackupSuffix = ".aittexstreambak";
+
+        /// <summary>치환 전 원본 .meta 를 보관하는 백업 접미사(스텁 임포터 override 복원용).</summary>
+        private const string MetaBackupSuffix = ".aittexstreammetabak";
+
+        /// <summary>apply 진행 중임을 표시하는 마커(Unity 가 무시하는 '.' 접두 숨김 파일).</summary>
+        private const string MarkerRelative = "Assets/.ait-texstream-active";
+
+        /// <summary>외부화 기본 최소 소스 크기(512KB). 동적 Resources.Load 로 부팅에 끌려올 수 있는 소형 아이콘 보호.</summary>
+        private const long DefaultMinBytes = 524288;
+
+        /// <summary>한 번의 외부화 결과 핸들. finally 에서 정확한 복원에 사용.</summary>
+        public sealed class TextureStreamHandle
+        {
+            /// <summary>이번 빌드에서 외부화가 실제로 수행되었는지.</summary>
+            public bool Active;
+
+            /// <summary>외부화된 텍스처 개수.</summary>
+            public int Count;
+        }
+
+        static AITLargeTextureExternalizer()
+        {
+            // 에디터 로드 시 안전망: 이전 빌드가 비정상 종료되어 복원이 누락된 경우(마커 잔존) 자동 복원.
+            EditorApplication.delayCall += SafetyNetRestore;
+        }
+
+        /// <summary>
+        /// 빌드 직전 호출: 설정이 켜져 있으면 비-부팅 대형 텍스처를 외부화하고 소스를 동일 차원 스텁으로 치환한다.
+        /// </summary>
+        /// <param name="config">프로젝트 에디터 설정. null 이거나 기능이 꺼져 있으면 no-op.</param>
+        /// <returns>복원에 사용할 핸들(항상 non-null).</returns>
+        public static TextureStreamHandle ExternalizeForBuild(AITEditorScriptObject config)
+        {
+            var handle = new TextureStreamHandle();
+            if (config == null || !config.enableTextureStreaming)
+            {
+                return handle;
+            }
+
+            try
+            {
+                long minBytes = config.textureStreamingMinBytes > 0 ? config.textureStreamingMinBytes : DefaultMinBytes;
+                string[] dirs = SplitDirs(config.textureStreamingDirs);              // null = 전체 Assets
+                string[] excludeDirs = SplitDirs(config.textureStreamingExcludeDirs); // 사용자 escape hatch
+
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                var bootSet = BuildBootDependencySet();
+                var (atlasPaths, atlasFolders) = BuildSpriteAtlasPackedSet();
+
+                CreateMarker();
+                Directory.CreateDirectory(Path.Combine(projectRoot, StreamRootAssets));
+
+                var entries = new List<string>();
+                int n = 0;
+                long stubbedBytes = 0;
+                var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets" });
+                foreach (var g in guids)
+                {
+                    string path = AssetDatabase.GUIDToAssetPath(g);
+                    if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/"))
+                    {
+                        continue;
+                    }
+
+                    if (path.StartsWith(StreamRootAssets))
+                    {
+                        continue; // 자기 사본 제외
+                    }
+
+                    if (dirs != null && !UnderAny(path, dirs))
+                    {
+                        continue;
+                    }
+
+                    if (!PassesExclusionGates(path, bootSet, atlasPaths, atlasFolders, excludeDirs, out var ti))
+                    {
+                        continue;
+                    }
+
+                    string srcFull = Path.Combine(projectRoot, path);
+                    if (!File.Exists(srcFull))
+                    {
+                        continue;
+                    }
+
+                    long size = new FileInfo(srcFull).Length;
+                    if (size < minBytes)
+                    {
+                        continue;
+                    }
+
+                    // 스텁 차원 = "임포트된" 텍스처 차원(crunch 의 maxTextureSize 캡 반영 후). 이래야
+                    // 스텁 reimport 시 Sprite rect/pivot/border 가 crunch 가 만든 것과 동일하게 bake 된다.
+                    var imported = AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+                    int w = imported != null ? imported.width : 0;
+                    int h = imported != null ? imported.height : 0;
+                    if (w <= 0 || h <= 0)
+                    {
+                        Debug.LogWarning($"[AIT-StreamingTexture] 차원 산출 실패(skip): {path}");
+                        continue;
+                    }
+
+                    string ext = Path.GetExtension(path).ToLowerInvariant(); // ".png" 등(점 포함)
+                    string texName = Path.GetFileNameWithoutExtension(path);
+
+                    // 1) 원본 소스 → StreamingAssets/<guid><ext> (온디맨드 스트리밍 소스).
+                    //    png/jpg 만 런타임 LoadImage 가능 — 그 외 확장자는 매니페스트에 기록은 하되
+                    //    런타임이 처리 못하면 조용히 스킵(측정/대형 텍스처는 전부 png).
+                    string streamFile = g + ext;
+                    File.Copy(srcFull, Path.Combine(projectRoot, StreamRootAssets, streamFile), true);
+
+                    // 2) 소스 + .meta 백업(둘 다 — 스텁이 소스 바이트와 임포터 설정 모두 바꾸므로).
+                    string metaFull = srcFull + ".meta";
+                    string srcBak = srcFull + SrcBackupSuffix;
+                    string metaBak = metaFull + MetaBackupSuffix;
+                    if (!File.Exists(srcBak))
+                    {
+                        File.Copy(srcFull, srcBak, true);
+                    }
+
+                    if (File.Exists(metaFull) && !File.Exists(metaBak))
+                    {
+                        File.Copy(metaFull, metaBak, true);
+                    }
+
+                    // 3) 동일 차원 단색 스텁 PNG 를 소스에 덮어쓴다(leak-safe: temp Texture2D 는 finally 에서 파괴).
+                    if (!WriteStubPng(srcFull, w, h))
+                    {
+                        // 스텁 생성 실패 → 이 텍스처는 백업 되돌리고 건너뜀.
+                        RevertSingle(srcFull, metaFull, srcBak, metaBak, projectRoot);
+                        continue;
+                    }
+
+                    // 4) 스텁 서브셋만 런타임 writable 로 reimport: isReadable + non-crunch + Uncompressed.
+                    //    sprite mode/spritesheet/pivot/border/sRGB 등은 건드리지 않아 Sprite rect 동일 유지.
+                    AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                    var ti2 = AssetImporter.GetAtPath(path) as TextureImporter;
+                    if (ti2 != null)
+                    {
+                        ti2.isReadable = true;
+                        ti2.crunchedCompression = false;
+                        ti2.textureCompression = TextureImporterCompression.Uncompressed;
+                        ti2.SaveAndReimport();
+                    }
+
+                    entries.Add("{\"guid\":\"" + g + "\",\"name\":" + JsonStr(texName)
+                                + ",\"file\":" + JsonStr(streamFile)
+                                + ",\"width\":" + w + ",\"height\":" + h + "}");
+                    n++;
+                    stubbedBytes += size;
+                    Debug.Log($"[AIT-StreamingTexture]   외부화 {texName} ({w}x{h}, src {size / 1048576f:0.00}MB) → {streamFile}");
+                }
+
+                // 5) 매니페스트 동봉(런타임 AITStreamingTexture 가 읽는 계약: maxConcurrent + entries).
+                int maxConcurrent = config.textureStreamingMaxConcurrent > 0 ? config.textureStreamingMaxConcurrent : 3;
+                var sb = new StringBuilder();
+                sb.Append("{\"maxConcurrent\":").Append(maxConcurrent)
+                  .Append(",\"entries\":[").Append(string.Join(",", entries)).Append("]}");
+                File.WriteAllText(Path.Combine(projectRoot, StreamRootAssets, "manifest.json"), sb.ToString());
+                AssetDatabase.Refresh();
+
+                handle.Active = n > 0;
+                handle.Count = n;
+                if (!handle.Active)
+                {
+                    RemoveStreamRoot();
+                    RemoveMarker();
+                }
+
+                Debug.Log($"[AIT-StreamingTexture] ✓ {n}개 텍스처 외부화, 소스 {stubbedBytes / 1048576f:0.0}MB 스텁(초기 .data 제거).");
+                return handle;
+            }
+            catch (Exception e)
+            {
+                // 외부화 실패가 빌드 전체를 막지 않도록: 부분 변경을 즉시 복원하고 비활성 핸들 반환.
+                Debug.LogError($"[AIT-StreamingTexture] 외부화 예외 → 복원 후 건너뜀: {e}");
+                RestoreAllBackups();
+                RemoveStreamRoot();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                return new TextureStreamHandle();
+            }
+        }
+
+        /// <summary>
+        /// 빌드 종료 후(성공/실패 무관) 호출: 스텁/임포터 override 를 원본으로 복원하고 StreamingAssets 사본을 제거한다.
+        /// </summary>
+        public static void RestoreForBuild(TextureStreamHandle handle)
+        {
+            if (handle == null || !handle.Active)
+            {
+                return;
+            }
+
+            try
+            {
+                int restored = RestoreAllBackups();
+                RemoveStreamRoot();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                Debug.Log($"[AIT-StreamingTexture] 복원 완료: {restored}개 소스/임포터 원상, StreamingAssets 사본 제거");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-StreamingTexture] 복원 예외: {e}");
+            }
+        }
+
+        // ─────────────────────────── 제외 게이트 ───────────────────────────
+
+        /// <summary>부팅 씬(0번)이 의존하는 에셋 경로 집합. 여기 포함된 텍스처는 절대 스텁하지 않는다(frame-1 보호).</summary>
+        private static HashSet<string> BuildBootDependencySet()
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                var scenes = EditorBuildSettings.scenes;
+                if (scenes != null && scenes.Length > 0 && !string.IsNullOrEmpty(scenes[0].path))
+                {
+                    // AssetDatabase.GetDependencies(path, recursive) — 부팅 씬이 끌어오는 모든 에셋 경로(재귀).
+                    foreach (var dep in AssetDatabase.GetDependencies(scenes[0].path, true))
+                    {
+                        set.Add(dep);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-StreamingTexture] 부팅 의존성 산출 경고(보수적으로 모두 보호): {e.Message}");
+            }
+
+            return set;
+        }
+
+        /// <summary>
+        /// 어느 SpriteAtlas 에든 패킹되는 텍스처/스프라이트의 소스 경로 집합 + 폴더 프리픽스.
+        /// 아틀라스 패킹 대상은 빌드 시 아틀라스 페이지(<c>sactx-*</c>)로 구워져 .data 에 들어가고
+        /// 소스 PNG 자체는 .data 에 포함되지 않는다. 따라서 소스를 단색 스텁으로 치환하면
+        ///   ① 아틀라스가 그 스텁을 패킹해 영구 투명 스프라이트가 되고(시각 파손),
+        ///   ② 정작 .data 의 아틀라스 페이지는 그대로 남아 on-wire 이득이 0 이다.
+        /// → 소스-PNG 스텁 경로에서는 하드 제외한다(페이지 단위 defer 는 별도 메커니즘 영역).
+        /// </summary>
+        private static (HashSet<string> paths, string[] folders) BuildSpriteAtlasPackedSet()
+        {
+            var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var folders = new List<string>();
+            try
+            {
+                foreach (var g in AssetDatabase.FindAssets("t:SpriteAtlas"))
+                {
+                    string atlasPath = AssetDatabase.GUIDToAssetPath(g);
+                    var atlas = AssetDatabase.LoadAssetAtPath<UnityEngine.U2D.SpriteAtlas>(atlasPath);
+                    if (atlas == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var packable in UnityEditor.U2D.SpriteAtlasExtensions.GetPackables(atlas))
+                    {
+                        if (packable == null)
+                        {
+                            continue;
+                        }
+
+                        string p = AssetDatabase.GetAssetPath(packable);
+                        if (string.IsNullOrEmpty(p))
+                        {
+                            continue;
+                        }
+
+                        // 폴더 패킹 → 폴더 하위 모든 스프라이트가 아틀라스에 들어감.
+                        if (AssetDatabase.IsValidFolder(p))
+                        {
+                            folders.Add(p);
+                        }
+                        else
+                        {
+                            paths.Add(p);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                // 산출 실패 시 부분 적용(이미 수집된 항목만). 게이트가 비어도 다른 가드(sRGB/NormalMap 등)는 유지.
+                Debug.LogWarning($"[AIT-StreamingTexture] SpriteAtlas 패킹 집합 산출 경고(아틀라스 제외 게이트 부분 적용): {e.Message}");
+            }
+
+            return (paths, folders.ToArray());
+        }
+
+        /// <summary>
+        /// 적대검증으로 확정된 제외 필터를 모두 통과하는지 판정. 통과 시 <paramref name="ti"/> 에 임포터를 채운다.
+        /// </summary>
+        private static bool PassesExclusionGates(string path, HashSet<string> bootSet, HashSet<string> atlasPaths, string[] atlasFolders, string[] excludeDirs, out TextureImporter ti)
+        {
+            ti = null;
+
+            // ③ 부팅 씬 의존 → frame-1 에 보임 → 절대 스텁 금지.
+            if (bootSet.Contains(path))
+            {
+                return false;
+            }
+
+            // ① SpriteAtlas 패킹 대상 → 소스 스텁이 시각 파손 + on-wire 이득 0(아틀라스 페이지가 .data 에 잔존) → 하드 제외.
+            if (atlasPaths.Contains(path) || (atlasFolders.Length > 0 && UnderAny(path, atlasFolders)))
+            {
+                return false;
+            }
+
+            // ③ Resources/ → 런타임 문자열 경로 Resources.Load 로 언제든 끌려옴(GetDependencies 가 추적 못함) → 보호.
+            if (path.IndexOf("/Resources/", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return false;
+            }
+
+            // ③ 스플래시/로고 휴리스틱 → 보호.
+            if (path.IndexOf("Splash", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return false;
+            }
+
+            // ③ 사용자 escape hatch.
+            if (excludeDirs != null && UnderAny(path, excludeDirs))
+            {
+                return false;
+            }
+
+            ti = AssetImporter.GetAtPath(path) as TextureImporter;
+            if (ti == null)
+            {
+                return false;
+            }
+
+            // ② NormalMap → 단색 스텁이 degenerate normal, 런타임 LoadImage 가 sRGB 로 덮어써 라이팅 깨짐 → 제외.
+            if (ti.textureType == TextureImporterType.NormalMap)
+            {
+                return false;
+            }
+
+            // ② linear(sRGB=false) → LoadImage 는 항상 sRGB 로 기록, colorSpace 플래그는 객체 생성 시 고정 → 제외.
+            if (!ti.sRGBTexture)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        // ─────────────────────────── 스텁 생성 ───────────────────────────
+
+        /// <summary>동일 차원 단색(투명) RGBA32 스텁 PNG 를 <paramref name="dstFull"/> 에 쓴다. temp 텍스처는 즉시 파괴(leak 방지).</summary>
+        private static bool WriteStubPng(string dstFull, int w, int h)
+        {
+            Texture2D tex = null;
+            try
+            {
+                tex = new Texture2D(w, h, TextureFormat.RGBA32, false);
+                var fill = new Color32[w * h]; // 기본값 = (0,0,0,0) 투명 — 균일 → crunch+brotli ~0.
+                tex.SetPixels32(fill);
+                tex.Apply(false, false);
+                File.WriteAllBytes(dstFull, tex.EncodeToPNG());
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-StreamingTexture] 스텁 생성 실패({dstFull}): {e.Message}");
+                return false;
+            }
+            finally
+            {
+                if (tex != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(tex);
+                }
+            }
+        }
+
+        // ─────────────────────────── 백업/복원 ───────────────────────────
+
+        /// <summary>단일 텍스처의 부분 변경(스텁/백업)을 즉시 되돌린다(스텁 생성 실패 경로).</summary>
+        private static void RevertSingle(string srcFull, string metaFull, string srcBak, string metaBak, string projectRoot)
+        {
+            try
+            {
+                if (File.Exists(srcBak))
+                {
+                    File.Copy(srcBak, srcFull, true);
+                    File.Delete(srcBak);
+                }
+
+                if (File.Exists(metaBak))
+                {
+                    File.Copy(metaBak, metaFull, true);
+                    File.Delete(metaBak);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-StreamingTexture] 부분 복원 실패({srcFull}): {e.Message}");
+            }
+        }
+
+        /// <summary>Assets 트리의 모든 *.aittexstreambak / *.aittexstreammetabak 를 원본으로 되돌리고 백업을 삭제한다. 복원 개수 반환.</summary>
+        private static int RestoreAllBackups()
+        {
+            int restored = 0;
+            string assetsPath = Application.dataPath;
+            string projectRoot = Directory.GetParent(assetsPath).FullName;
+
+            // .meta 백업 먼저 복원(임포터 설정), 그다음 소스 복원 — 순서 무관하나 한 번에 reimport 하도록 경로 수집.
+            var reimport = new HashSet<string>();
+
+            restored += RestoreBySuffix(assetsPath, projectRoot, MetaBackupSuffix, true, reimport);
+            restored += RestoreBySuffix(assetsPath, projectRoot, SrcBackupSuffix, false, reimport);
+
+            foreach (var rel in reimport)
+            {
+                try
+                {
+                    AssetDatabase.ImportAsset(rel, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-StreamingTexture] reimport 실패({rel}): {e.Message}");
+                }
+            }
+
+            return restored;
+        }
+
+        /// <summary>주어진 접미사 백업을 복원하고, 복원 대상 에셋의 프로젝트 상대 경로를 <paramref name="reimport"/> 에 모은다.</summary>
+        private static int RestoreBySuffix(string assetsPath, string projectRoot, string suffix, bool isMeta, HashSet<string> reimport)
+        {
+            int restored = 0;
+            string[] backups;
+            try
+            {
+                backups = Directory.GetFiles(assetsPath, "*" + suffix, SearchOption.AllDirectories);
+            }
+            catch
+            {
+                return 0;
+            }
+
+            foreach (var bak in backups)
+            {
+                string original = bak.Substring(0, bak.Length - suffix.Length); // meta: "<src>.meta", src: "<src>"
+                try
+                {
+                    File.Copy(bak, original, true);
+                    File.Delete(bak);
+
+                    string assetFull = isMeta && original.EndsWith(".meta")
+                        ? original.Substring(0, original.Length - ".meta".Length)
+                        : original;
+                    string rel = AbsoluteToProjectRelative(assetFull, projectRoot);
+                    if (!string.IsNullOrEmpty(rel))
+                    {
+                        reimport.Add(rel);
+                    }
+
+                    restored++;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-StreamingTexture] 백업 복원 실패({bak}): {e.Message}");
+                }
+            }
+
+            return restored;
+        }
+
+        /// <summary>에디터 로드 시 안전망. 마커가 잔존하면(=이전 빌드가 복원 전에 종료) 백업을 자동 복원.</summary>
+        private static void SafetyNetRestore()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string markerFull = Path.Combine(projectRoot, MarkerRelative);
+                if (!File.Exists(markerFull))
+                {
+                    return; // 공통 경로: 잔존물 없음(빠른 반환)
+                }
+
+                int restored = RestoreAllBackups();
+                RemoveStreamRoot();
+                RemoveMarker();
+                if (restored > 0)
+                {
+                    AssetDatabase.Refresh();
+                    Debug.LogWarning($"[AIT-StreamingTexture] 안전망: 이전 빌드 잔존 백업 {restored}개를 복원했습니다.");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-StreamingTexture] 안전망 복원 중 예외(무시): {e}");
+            }
+        }
+
+        private static void RemoveStreamRoot()
+        {
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+            string streamRootFull = Path.Combine(projectRoot, StreamRootAssets);
+            try
+            {
+                if (Directory.Exists(streamRootFull))
+                {
+                    Directory.Delete(streamRootFull, true);
+                }
+
+                string meta = streamRootFull + ".meta";
+                if (File.Exists(meta))
+                {
+                    File.Delete(meta);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-StreamingTexture] StreamingAssets 사본 제거 실패: {e.Message}");
+            }
+        }
+
+        private static void CreateMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                File.WriteAllText(Path.Combine(projectRoot, MarkerRelative), "active");
+            }
+            catch
+            {
+                // 마커 생성 실패는 치명적이지 않음(안전망 가속용일 뿐).
+            }
+        }
+
+        private static void RemoveMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string m = Path.Combine(projectRoot, MarkerRelative);
+                if (File.Exists(m))
+                {
+                    File.Delete(m);
+                }
+            }
+            catch
+            {
+                // 무시
+            }
+        }
+
+        private static string AbsoluteToProjectRelative(string absolute, string projectRoot)
+        {
+            string norm = absolute.Replace('\\', '/');
+            string root = projectRoot.Replace('\\', '/').TrimEnd('/') + "/";
+            return norm.StartsWith(root) ? norm.Substring(root.Length) : null;
+        }
+
+        private static string[] SplitDirs(string v)
+            => string.IsNullOrEmpty(v) ? null : v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+        private static bool UnderAny(string path, string[] dirs)
+        {
+            foreach (var d in dirs)
+            {
+                var t = d.Trim().TrimEnd('/');
+                if (path.StartsWith(t + "/") || path == t)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string JsonStr(string s)
+            => "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+    }
+}

--- a/Editor/AITLargeTextureExternalizer.cs
+++ b/Editor/AITLargeTextureExternalizer.cs
@@ -48,7 +48,7 @@ using UnityEngine;
 namespace AppsInToss.Editor
 {
     /// <summary>
-    /// 빌드 단계 대형 텍스처 외부화/복원 처리기. <see cref="AITEditorScriptObject.enableTextureStreaming"/>
+    /// 빌드 단계 대형 텍스처 외부화/복원 처리기. <see cref="AITEditorScriptObject.textureStreaming"/>
     /// 설정에 따라 동작하며, 런타임 컴포넌트 <c>AppsInToss.AITStreamingTexture</c> 와 짝을 이룬다.
     /// </summary>
     [InitializeOnLoad]
@@ -77,6 +77,24 @@ namespace AppsInToss.Editor
 
             /// <summary>외부화된 텍스처 개수.</summary>
             public int Count;
+
+            /// <summary>외부화된 총 바이트(소스 파일 크기 합계).</summary>
+            public long TotalBytes;
+
+            /// <summary>부팅 씬 의존으로 제외된 개수.</summary>
+            public int ExcludedBoot;
+
+            /// <summary>/Resources/ 경로로 제외된 개수.</summary>
+            public int ExcludedResources;
+
+            /// <summary>SpriteAtlas 패킹 대상으로 제외된 개수.</summary>
+            public int ExcludedAtlas;
+
+            /// <summary>동명·동차원 충돌로 제외된 개수(매칭 모호).</summary>
+            public int ExcludedDuplicate;
+
+            /// <summary>linear(sRGB=false) 또는 NormalMap 으로 제외된 개수.</summary>
+            public int ExcludedColorSpace;
         }
 
         static AITLargeTextureExternalizer()
@@ -93,7 +111,10 @@ namespace AppsInToss.Editor
         public static TextureStreamHandle ExternalizeForBuild(AITEditorScriptObject config)
         {
             var handle = new TextureStreamHandle();
-            if (config == null || !config.enableTextureStreaming)
+            // tri-state: -1 = 자동(기본 활성), 0 = 비활성, 1 = 강제 활성.
+            bool enabled = config != null && (config.textureStreaming == 1
+                || (config.textureStreaming < 0 && AITDefaultSettings.GetDefaultTextureStreaming()));
+            if (config == null || !enabled)
             {
                 return handle;
             }
@@ -106,15 +127,33 @@ namespace AppsInToss.Editor
 
                 string projectRoot = Directory.GetParent(Application.dataPath).FullName;
                 var bootSet = BuildBootDependencySet();
-                var (atlasPaths, atlasFolders) = BuildSpriteAtlasPackedSet();
+
+                // SpriteAtlas 패킹 집합: 예외 발생 시 전체 외부화 no-op(부분 적용 → 영구 투명 스프라이트 리스크 차단).
+                HashSet<string> atlasPaths;
+                string[] atlasFolders;
+                try
+                {
+                    (atlasPaths, atlasFolders) = BuildSpriteAtlasPackedSet();
+                }
+                catch (Exception atlasEx)
+                {
+                    Debug.LogWarning($"[AIT-StreamingTexture] SpriteAtlas 패킹 집합 산출 실패 → 외부화 전체 skip(영구 투명 스프라이트 리스크 차단): {atlasEx.Message}");
+                    return handle; // no-op: 비활성 핸들 반환
+                }
 
                 CreateMarker();
                 Directory.CreateDirectory(Path.Combine(projectRoot, StreamRootAssets));
 
-                var entries = new List<string>();
-                int n = 0;
-                long stubbedBytes = 0;
+                // 제외 사유별 카운터(빌드 리포트용).
+                int cntBoot = 0, cntResources = 0, cntAtlas = 0, cntDuplicate = 0, cntColorSpace = 0;
+
+                // ─── 1단계: 후보 수집 + 차원 산출 ─────────────────────────────────
+                // (동명·동차원 충돌 검사를 위해 전체 목록을 먼저 모은다.)
                 var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets" });
+
+                // 경로 → (guid, w, h) 후보 목록(제외 게이트 통과 + minBytes 충족).
+                var candidates = new List<(string guid, string path, int w, int h, long size)>();
+
                 foreach (var g in guids)
                 {
                     string path = AssetDatabase.GUIDToAssetPath(g);
@@ -133,7 +172,9 @@ namespace AppsInToss.Editor
                         continue;
                     }
 
-                    if (!PassesExclusionGates(path, bootSet, atlasPaths, atlasFolders, excludeDirs, out var ti))
+                    // 제외 게이트: 사유별 카운터 갱신.
+                    if (!PassesExclusionGatesWithCount(path, bootSet, atlasPaths, atlasFolders, excludeDirs,
+                            ref cntBoot, ref cntResources, ref cntAtlas, ref cntColorSpace, out _))
                     {
                         continue;
                     }
@@ -161,6 +202,61 @@ namespace AppsInToss.Editor
                         continue;
                     }
 
+                    candidates.Add((g, path, w, h, size));
+                }
+
+                // ─── 2단계: 동명·동차원 충돌 검사 ────────────────────────────────
+                // (name, w, h) 키가 동일한 Texture2D 가 2개 이상이면 런타임 매칭이 모호 → 그룹 전체 제외.
+                var nameKey = new Dictionary<string, List<int>>(); // key → candidate 인덱스 목록
+                for (int i = 0; i < candidates.Count; i++)
+                {
+                    var (_, cpath, cw, ch, _) = candidates[i];
+                    string name = Path.GetFileNameWithoutExtension(cpath);
+                    string key = name + "\0" + cw + "\0" + ch;
+                    if (!nameKey.TryGetValue(key, out var idxList))
+                    {
+                        nameKey[key] = idxList = new List<int>();
+                    }
+
+                    idxList.Add(i);
+                }
+
+                var duplicateIndices = new HashSet<int>();
+                foreach (var kv in nameKey)
+                {
+                    if (kv.Value.Count >= 2)
+                    {
+                        var parts = kv.Key.Split('\0');
+                        string dupName = parts[0];
+                        string dupW = parts.Length > 1 ? parts[1] : "?";
+                        string dupH = parts.Length > 2 ? parts[2] : "?";
+                        var paths = new List<string>();
+                        foreach (var idx in kv.Value)
+                        {
+                            duplicateIndices.Add(idx);
+                            paths.Add(candidates[idx].path);
+                        }
+
+                        Debug.LogWarning($"[AIT-StreamingTexture] 동명·동차원 텍스처 {kv.Value.Count}건 — 매칭 모호로 외부화에서 제외: {dupName} ({dupW}x{dupH})\n  {string.Join("\n  ", paths)}");
+                        cntDuplicate += kv.Value.Count;
+                    }
+                }
+
+                // ─── 3단계: 외부화 실행 ─────────────────────────────────────────
+                var entries = new List<string>();
+                int n = 0;
+                long stubbedBytes = 0;
+                var detailLines = new List<string>();
+
+                for (int i = 0; i < candidates.Count; i++)
+                {
+                    if (duplicateIndices.Contains(i))
+                    {
+                        continue; // 동명·동차원 충돌 → 제외
+                    }
+
+                    var (g, path, w, h, size) = candidates[i];
+                    string srcFull = Path.Combine(projectRoot, path);
                     string ext = Path.GetExtension(path).ToLowerInvariant(); // ".png" 등(점 포함)
                     string texName = Path.GetFileNameWithoutExtension(path);
 
@@ -209,10 +305,11 @@ namespace AppsInToss.Editor
                                 + ",\"width\":" + w + ",\"height\":" + h + "}");
                     n++;
                     stubbedBytes += size;
-                    Debug.Log($"[AIT-StreamingTexture]   외부화 {texName} ({w}x{h}, src {size / 1048576f:0.00}MB) → {streamFile}");
+                    detailLines.Add($"  {texName} ({w}x{h}, {size / 1048576f:0.00}MB) → {streamFile}");
                 }
 
-                // 5) 매니페스트 동봉(런타임 AITStreamingTexture 가 읽는 계약: maxConcurrent + entries).
+                // ─── 4단계: 매니페스트 동봉 ─────────────────────────────────────
+                // 런타임 AITStreamingTexture 가 읽는 계약: maxConcurrent + entries.
                 int maxConcurrent = config.textureStreamingMaxConcurrent > 0 ? config.textureStreamingMaxConcurrent : 3;
                 var sb = new StringBuilder();
                 sb.Append("{\"maxConcurrent\":").Append(maxConcurrent)
@@ -222,13 +319,40 @@ namespace AppsInToss.Editor
 
                 handle.Active = n > 0;
                 handle.Count = n;
+                handle.TotalBytes = stubbedBytes;
+                handle.ExcludedBoot = cntBoot;
+                handle.ExcludedResources = cntResources;
+                handle.ExcludedAtlas = cntAtlas;
+                handle.ExcludedDuplicate = cntDuplicate;
+                handle.ExcludedColorSpace = cntColorSpace;
+
                 if (!handle.Active)
                 {
                     RemoveStreamRoot();
                     RemoveMarker();
                 }
 
-                Debug.Log($"[AIT-StreamingTexture] ✓ {n}개 텍스처 외부화, 소스 {stubbedBytes / 1048576f:0.0}MB 스텁(초기 .data 제거).");
+                // ─── 5단계: 빌드 리포트 ──────────────────────────────────────────
+                if (n == 0)
+                {
+                    Debug.Log("[AIT-StreamingTexture] 텍스처 스트리밍: 외부화 대상 없음.");
+                }
+                else
+                {
+                    // 요약 1줄 (제외 사유별 카운트 포함)
+                    var excParts = new List<string>();
+                    if (cntBoot > 0) excParts.Add($"부팅 의존 {cntBoot}");
+                    if (cntResources > 0) excParts.Add($"Resources {cntResources}");
+                    if (cntAtlas > 0) excParts.Add($"아틀라스 {cntAtlas}");
+                    if (cntDuplicate > 0) excParts.Add($"동명 충돌 {cntDuplicate}");
+                    if (cntColorSpace > 0) excParts.Add($"linear/NormalMap {cntColorSpace}");
+                    string excSummary = excParts.Count > 0 ? $" | 제외: {string.Join(", ", excParts)}" : "";
+                    Debug.Log($"[AIT-StreamingTexture] ✓ 외부화 {n}개 / {stubbedBytes / 1048576f:0.0}MB 절감{excSummary}");
+
+                    // 상세 목록
+                    Debug.Log($"[AIT-StreamingTexture] 외부화 상세 목록:\n{string.Join("\n", detailLines)}");
+                }
+
                 return handle;
             }
             catch (Exception e)
@@ -341,49 +465,61 @@ namespace AppsInToss.Editor
                     }
                 }
             }
-            catch (Exception e)
-            {
-                // 산출 실패 시 부분 적용(이미 수집된 항목만). 게이트가 비어도 다른 가드(sRGB/NormalMap 등)는 유지.
-                Debug.LogWarning($"[AIT-StreamingTexture] SpriteAtlas 패킹 집합 산출 경고(아틀라스 제외 게이트 부분 적용): {e.Message}");
-            }
-
+            // 예외는 잡지 않는다: 호출자(ExternalizeForBuild)가 전체 외부화 no-op 으로 처리.
+            // (부분 적용 후 영구 투명 스프라이트 리스크를 원천 차단)
             return (paths, folders.ToArray());
         }
 
         /// <summary>
         /// 적대검증으로 확정된 제외 필터를 모두 통과하는지 판정. 통과 시 <paramref name="ti"/> 에 임포터를 채운다.
+        /// 제외 사유별 카운터(<paramref name="cntBoot"/> 등)를 갱신한다(빌드 리포트용).
         /// </summary>
-        private static bool PassesExclusionGates(string path, HashSet<string> bootSet, HashSet<string> atlasPaths, string[] atlasFolders, string[] excludeDirs, out TextureImporter ti)
+        private static bool PassesExclusionGatesWithCount(
+            string path,
+            HashSet<string> bootSet,
+            HashSet<string> atlasPaths,
+            string[] atlasFolders,
+            string[] excludeDirs,
+            ref int cntBoot,
+            ref int cntResources,
+            ref int cntAtlas,
+            ref int cntColorSpace,
+            out TextureImporter ti)
         {
             ti = null;
 
             // ③ 부팅 씬 의존 → frame-1 에 보임 → 절대 스텁 금지.
             if (bootSet.Contains(path))
             {
+                cntBoot++;
                 return false;
             }
 
             // ① SpriteAtlas 패킹 대상 → 소스 스텁이 시각 파손 + on-wire 이득 0(아틀라스 페이지가 .data 에 잔존) → 하드 제외.
             if (atlasPaths.Contains(path) || (atlasFolders.Length > 0 && UnderAny(path, atlasFolders)))
             {
+                cntAtlas++;
                 return false;
             }
 
             // ③ Resources/ → 런타임 문자열 경로 Resources.Load 로 언제든 끌려옴(GetDependencies 가 추적 못함) → 보호.
             if (path.IndexOf("/Resources/", StringComparison.OrdinalIgnoreCase) >= 0)
             {
+                cntResources++;
                 return false;
             }
 
             // ③ 스플래시/로고 휴리스틱 → 보호.
             if (path.IndexOf("Splash", StringComparison.OrdinalIgnoreCase) >= 0)
             {
+                cntBoot++; // 부팅 계열로 집계
                 return false;
             }
 
             // ③ 사용자 escape hatch.
             if (excludeDirs != null && UnderAny(path, excludeDirs))
             {
+                cntBoot++; // 사용자 제외는 부팅 보호와 동일 목적(사용자가 지정한 보호 경로)
                 return false;
             }
 
@@ -396,12 +532,14 @@ namespace AppsInToss.Editor
             // ② NormalMap → 단색 스텁이 degenerate normal, 런타임 LoadImage 가 sRGB 로 덮어써 라이팅 깨짐 → 제외.
             if (ti.textureType == TextureImporterType.NormalMap)
             {
+                cntColorSpace++;
                 return false;
             }
 
             // ② linear(sRGB=false) → LoadImage 는 항상 sRGB 로 기록, colorSpace 플래그는 객체 생성 시 고정 → 제외.
             if (!ti.sRGBTexture)
             {
+                cntColorSpace++;
                 return false;
             }
 

--- a/Editor/AITLargeTextureExternalizer.cs
+++ b/Editor/AITLargeTextureExternalizer.cs
@@ -429,44 +429,42 @@ namespace AppsInToss.Editor
         {
             var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var folders = new List<string>();
-            try
+            // 예외는 잡지 않는다: 호출자(ExternalizeForBuild)가 전체 외부화 no-op 으로 처리.
+            // (부분 적용 후 영구 투명 스프라이트 리스크를 원천 차단)
+            foreach (var g in AssetDatabase.FindAssets("t:SpriteAtlas"))
             {
-                foreach (var g in AssetDatabase.FindAssets("t:SpriteAtlas"))
+                string atlasPath = AssetDatabase.GUIDToAssetPath(g);
+                var atlas = AssetDatabase.LoadAssetAtPath<UnityEngine.U2D.SpriteAtlas>(atlasPath);
+                if (atlas == null)
                 {
-                    string atlasPath = AssetDatabase.GUIDToAssetPath(g);
-                    var atlas = AssetDatabase.LoadAssetAtPath<UnityEngine.U2D.SpriteAtlas>(atlasPath);
-                    if (atlas == null)
+                    continue;
+                }
+
+                foreach (var packable in UnityEditor.U2D.SpriteAtlasExtensions.GetPackables(atlas))
+                {
+                    if (packable == null)
                     {
                         continue;
                     }
 
-                    foreach (var packable in UnityEditor.U2D.SpriteAtlasExtensions.GetPackables(atlas))
+                    string p = AssetDatabase.GetAssetPath(packable);
+                    if (string.IsNullOrEmpty(p))
                     {
-                        if (packable == null)
-                        {
-                            continue;
-                        }
+                        continue;
+                    }
 
-                        string p = AssetDatabase.GetAssetPath(packable);
-                        if (string.IsNullOrEmpty(p))
-                        {
-                            continue;
-                        }
-
-                        // 폴더 패킹 → 폴더 하위 모든 스프라이트가 아틀라스에 들어감.
-                        if (AssetDatabase.IsValidFolder(p))
-                        {
-                            folders.Add(p);
-                        }
-                        else
-                        {
-                            paths.Add(p);
-                        }
+                    // 폴더 패킹 → 폴더 하위 모든 스프라이트가 아틀라스에 들어감.
+                    if (AssetDatabase.IsValidFolder(p))
+                    {
+                        folders.Add(p);
+                    }
+                    else
+                    {
+                        paths.Add(p);
                     }
                 }
             }
-            // 예외는 잡지 않는다: 호출자(ExternalizeForBuild)가 전체 외부화 no-op 으로 처리.
-            // (부분 적용 후 영구 투명 스프라이트 리스크를 원천 차단)
+
             return (paths, folders.ToArray());
         }
 

--- a/Editor/AITLargeTextureExternalizer.cs.meta
+++ b/Editor/AITLargeTextureExternalizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f14035b764204649a71ae4a63d14921d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Helpers/AIT.StreamingTexture.cs
+++ b/Runtime/Helpers/AIT.StreamingTexture.cs
@@ -1,0 +1,297 @@
+// -----------------------------------------------------------------------
+// <copyright file="AIT.StreamingTexture.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Streaming Texture (runtime rehydrator)
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 빌드 단계에서 초기 .data 밖(StreamingAssets)으로 외부화된 비-부팅 대형 Texture2D를,
+// 게임이 interactive 된(=첫 프레임 그려진) 이후 비동기로 스트리밍 로드하여 원래 픽셀을 복원한다.
+// 오디오 스트리밍의 텍스처 버전이다.
+//
+// 오디오는 AudioSource.clip(가변 프로퍼티) 재할당으로 핫스왑하지만, 텍스처는 Sprite.texture 가
+// read-only 라 참조 재할당이 불가하다. 대신 빌드 단계가 스텁을 "원본과 동일 차원"으로 만들어
+// 두므로(Sprite rect/pivot/border 동일 bake), 런타임은 살아있는 공유 Texture2D 객체의 픽셀만
+// LoadImage 로 제자리(in-place) 교체한다 — 이를 참조하는 모든 Sprite/Material 이 참조 재할당
+// 없이 새 픽셀을 렌더한다.
+//
+// 동작:
+//   1) [RuntimeInitializeOnLoadMethod(AfterSceneLoad)] 로 자동 부팅 (게임 코드 수정 불필요).
+//   2) StreamingAssets/ait-stream-texture/manifest.json 로드 → 외부화 엔트리 목록.
+//   3) 주기적으로(throttle) 로드된 Texture2D 를 스캔. manifest 엔트리와 name+차원이 일치하는
+//      "스텁" 텍스처를 찾으면 실 텍스처 바이트를 UnityWebRequest 로 async 로드 →
+//      LoadImage 로 동일 객체에 in-place 복원. (maxConcurrent 로 동시 다운로드/디코드 제한.)
+//   4) 모든 엔트리 복원 완료 시 워처를 종료(자원 회수). 매니페스트가 없는 빌드(기능 미사용)에서는
+//      조용히 no-op 후 자체 종료한다.
+//
+// TTFF 영향: 복원은 interactive(=TTFF 측정 시점) 이후에 일어나므로 TTFF에 영향 없음.
+// 초기 .data 에서 비-부팅 텍스처 바이트가 빠진 만큼 초기 다운로드/TTFF가 줄어드는 것이 본질 효과.
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.Scripting;
+
+namespace AppsInToss
+{
+    /// <summary>
+    /// 외부화된 텍스처를 런타임에 스트리밍으로 복원하는 SDK 컴포넌트.
+    /// 빌드 단계(<c>AITLargeTextureExternalizer</c>)가 매니페스트와 StreamingAssets 사본을 만들어 두면,
+    /// 이 컴포넌트가 자동 부팅되어 동일 차원 단색 스텁 텍스처의 픽셀을 실 텍스처로 in-place 복원한다.
+    /// 매니페스트가 없는 빌드(기능 미사용)에서는 조용히 no-op 후 자체 종료한다.
+    /// </summary>
+    [DefaultExecutionOrder(-10000)]
+    public sealed class AITStreamingTexture : MonoBehaviour
+    {
+        /// <summary>스캔 주기(초). 너무 잦으면 FindObjectsOfTypeAll 비용, 너무 느리면 텍스처 복원 지연.</summary>
+        private const float ScanIntervalSeconds = 0.25f;
+
+        /// <summary>동시 스트리밍 다운로드/디코드 기본 상한(매니페스트에 값이 없을 때). LoadImage 가 메인스레드 디코드라 hitch 제한용.</summary>
+        private const int DefaultMaxConcurrent = 3;
+
+        private const string ManifestRelativePath = "ait-stream-texture/manifest.json";
+        private const string StreamDirRelativePath = "ait-stream-texture/";
+
+        [System.Serializable]
+        private struct Entry
+        {
+            public string guid;
+            public string name;
+            public string file;
+            public int width;
+            public int height;
+        }
+
+        [System.Serializable]
+        private struct Manifest
+        {
+            public int maxConcurrent;
+            public Entry[] entries;
+        }
+
+        /// <summary>아직 복원되지 않은 엔트리(복원 성공 시 제거).</summary>
+        private readonly List<Entry> pending = new List<Entry>();
+
+        /// <summary>현재 다운로드/디코드 진행 중인 엔트리 guid (중복 로드 방지).</summary>
+        private readonly HashSet<string> inflight = new HashSet<string>();
+
+        /// <summary>이미 복원한 Texture2D 인스턴스 ID (동일 name+차원 중복 텍스처를 각기 다른 인스턴스에 매핑).</summary>
+        private readonly HashSet<int> restoredInstanceIds = new HashSet<int>();
+
+        private int maxConcurrent = DefaultMaxConcurrent;
+        private int loadingCount;
+        private bool ready;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        [Preserve]
+        private static void Bootstrap()
+        {
+            // SDK가 텍스처 외부화를 수행한 빌드에서만 매니페스트가 존재한다.
+            // 부팅 후 매니페스트가 없으면 Run() 코루틴이 스스로 종료한다.
+            var go = new GameObject("[AIT] StreamingTexture");
+            Object.DontDestroyOnLoad(go);
+            go.hideFlags = HideFlags.HideAndDontSave;
+            go.AddComponent<AITStreamingTexture>();
+        }
+
+        private void Start() => StartCoroutine(Run());
+
+        private IEnumerator Run()
+        {
+            yield return LoadManifest();
+            if (!ready || pending.Count == 0)
+            {
+                // 외부화된 텍스처가 없는 빌드 → 워처 종료(자원 회수).
+                Destroy(gameObject);
+                yield break;
+            }
+
+            var wait = new WaitForSeconds(ScanIntervalSeconds);
+            while (pending.Count > 0)
+            {
+                ScanAndRestore();
+                yield return wait;
+            }
+
+            // 모든 외부화 텍스처 복원 완료 → 더 스캔할 것이 없으므로 종료.
+            Destroy(gameObject);
+        }
+
+        private IEnumerator LoadManifest()
+        {
+            string url = ResolveStreamingUrl(ManifestRelativePath);
+            using (var req = UnityWebRequest.Get(url))
+            {
+                yield return req.SendWebRequest();
+                if (!IsSuccess(req))
+                {
+                    // 매니페스트 없음 = 이 빌드는 텍스처 외부화를 안 함. 정상 경로(no-op).
+                    yield break;
+                }
+
+                try
+                {
+                    var m = JsonUtility.FromJson<Manifest>(req.downloadHandler.text);
+                    if (m.maxConcurrent > 0)
+                    {
+                        maxConcurrent = m.maxConcurrent;
+                    }
+
+                    if (m.entries != null)
+                    {
+                        foreach (var e in m.entries)
+                        {
+                            if (!string.IsNullOrEmpty(e.name) && !string.IsNullOrEmpty(e.file) && e.width > 0 && e.height > 0)
+                            {
+                                pending.Add(e);
+                            }
+                        }
+                    }
+
+                    ready = true;
+                    Debug.Log($"[AIT-StreamingTexture] 매니페스트 로드: {pending.Count}개 외부화 텍스처 (동시 {maxConcurrent})");
+                }
+                catch (System.Exception ex)
+                {
+                    Debug.LogWarning($"[AIT-StreamingTexture] 매니페스트 파싱 실패: {ex.Message}");
+                }
+            }
+        }
+
+        private void ScanAndRestore()
+        {
+            if (loadingCount >= maxConcurrent)
+            {
+                return; // 동시 상한 — 다음 스캔에서 재시도
+            }
+
+            // 로드된 모든 Texture2D(에셋 포함). 스텁은 씬 컴포넌트가 아니므로 FindObjectsOfTypeAll 필요.
+            var all = Resources.FindObjectsOfTypeAll<Texture2D>();
+            foreach (var e in pending)
+            {
+                if (loadingCount >= maxConcurrent)
+                {
+                    break;
+                }
+
+                if (inflight.Contains(e.guid))
+                {
+                    continue;
+                }
+
+                var tex = FindStub(all, e);
+                if (tex == null)
+                {
+                    continue; // 아직 로드 안 됨(해당 씬/프리팹 미로드) → 다음 스캔
+                }
+
+                inflight.Add(e.guid);
+                restoredInstanceIds.Add(tex.GetInstanceID());
+                loadingCount++;
+                StartCoroutine(LoadAndApply(e, tex));
+            }
+        }
+
+        /// <summary>manifest 엔트리와 name+차원이 일치하고 아직 복원하지 않은 Texture2D 인스턴스를 찾는다.</summary>
+        private Texture2D FindStub(Texture2D[] all, Entry e)
+        {
+            foreach (var t in all)
+            {
+                if (t == null || t.width != e.width || t.height != e.height)
+                {
+                    continue;
+                }
+
+                if (t.name != e.name)
+                {
+                    continue;
+                }
+
+                if (restoredInstanceIds.Contains(t.GetInstanceID()))
+                {
+                    continue; // 동일 name+차원 중복 텍스처 — 이미 다른 엔트리가 이 인스턴스 복원
+                }
+
+                return t;
+            }
+
+            return null;
+        }
+
+        private IEnumerator LoadAndApply(Entry e, Texture2D tex)
+        {
+            string url = ResolveStreamingUrl(StreamDirRelativePath + e.file);
+            using (var req = UnityWebRequest.Get(url))
+            {
+                yield return req.SendWebRequest();
+                loadingCount--;
+                inflight.Remove(e.guid);
+
+                if (!IsSuccess(req))
+                {
+                    // 실패 → 인스턴스 예약 해제 후 다음 스캔에서 재시도(다른 인스턴스 포함).
+                    restoredInstanceIds.Remove(tex != null ? tex.GetInstanceID() : 0);
+                    Debug.LogWarning($"[AIT-StreamingTexture] 로드 실패 {e.file}: {req.error}");
+                    yield break;
+                }
+
+                if (tex == null)
+                {
+                    // 대상 텍스처가 그 사이 언로드됨 — 복원 불필요로 간주하고 pending 에서 제거.
+                    pending.RemoveAll(x => x.guid == e.guid);
+                    yield break;
+                }
+
+                bool applied = false;
+                try
+                {
+                    // 동일 차원 스텁(readable+uncompressed)에 실 픽셀을 in-place 업로드.
+                    // LoadImage 는 PNG/JPG 디코드 후 GPU 업로드까지 수행 → 참조하는 Sprite/Material 자동 갱신.
+                    applied = tex.LoadImage(req.downloadHandler.data, false);
+                    if (applied && (tex.width != e.width || tex.height != e.height))
+                    {
+                        // 스텁 차원과 원본 차원 불일치(예: crunch maxTextureSize 캡 + D1 동시 사용).
+                        // Sprite rect 가 스텁 차원으로 bake 됐다면 UV 가 어긋날 수 있음 — 경고만(복원은 유지).
+                        Debug.LogWarning($"[AIT-StreamingTexture] 차원 불일치 {e.name}: 스텁 {e.width}x{e.height} → 원본 {tex.width}x{tex.height}");
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    Debug.LogWarning($"[AIT-StreamingTexture] 복원 예외 {e.name}: {ex.Message}");
+                }
+
+                if (applied)
+                {
+                    pending.RemoveAll(x => x.guid == e.guid);
+                }
+                else
+                {
+                    // 적용 실패 → 인스턴스 예약 해제(다음 스캔 재시도).
+                    restoredInstanceIds.Remove(tex.GetInstanceID());
+                }
+            }
+        }
+
+        private static bool IsSuccess(UnityWebRequest req)
+        {
+#if UNITY_2020_2_OR_NEWER
+            return req.result == UnityWebRequest.Result.Success;
+#else
+            return !req.isHttpError && !req.isNetworkError;
+#endif
+        }
+
+        // WebGL: streamingAssetsPath는 상대/절대 URL. UnityWebRequest는 file:// 또는 http(s):// 모두 처리.
+        private static string ResolveStreamingUrl(string rel)
+        {
+            return JoinUrl(Application.streamingAssetsPath, rel);
+        }
+
+        /// <summary>basePath와 상대 경로를 슬래시 중복 없이 결합. (테스트 가능한 순수 함수)</summary>
+        internal static string JoinUrl(string basePath, string rel)
+        {
+            return basePath.EndsWith("/") ? basePath + rel : basePath + "/" + rel;
+        }
+    }
+}

--- a/Runtime/Helpers/AIT.StreamingTexture.cs.meta
+++ b/Runtime/Helpers/AIT.StreamingTexture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 719289b2bad04a73b6cb9b9fab68e5e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 개요

비-부팅 **대형 Texture2D**를 빌드 시 초기 `.data`에서 분리해 `StreamingAssets`로 외부화하고, 소스를 **동일 차원 단색 스텁**으로 치환하는 **빌드 프로세서**(`AITLargeTextureExternalizer`)와, **런타임 재수화**(`AITStreamingTexture`)를 추가합니다. 런타임은 첫 프레임 이후 실 텍스처를 비동기 스트리밍 로드하여 **동일 Texture2D 객체에 픽셀을 제자리(in-place) 복원**하므로, 이를 참조하는 모든 Sprite/Material이 **참조 재할당 없이** 갱신됩니다. 초기 다운로드/TTFF를 크게 줄입니다.

**팀 정책 — zero-config 기본 ON + 자동 안전장치**: 개발자의 별도 설정 없이 즉시 적용되며, 정확성을 보장할 수 없는 텍스처(부팅 씬 의존/Resources/SpriteAtlas/동명 충돌/linear·NormalMap)는 자동으로 제외됩니다.

WebGL 로드타임 최적화 레버를 **1기법=1PR**로 분할한 캠페인의 한 갈래입니다(texture streaming).

## 변경 내용

| 파일 | 역할 |
|------|------|
| `Editor/AITLargeTextureExternalizer.cs` (신규) | 빌드 시 대형 텍스처 외부화 + 동일 차원 스텁 bake + 빌드 후 원복(`TextureStreamHandle`) |
| `Runtime/Helpers/AIT.StreamingTexture.cs` (신규) | 런타임 in-place 재수화 컴포넌트(`AITStreamingTexture`) |
| `Editor/AITEditorScriptObject.cs` | `int textureStreaming = -1` (tri-state: -1=자동/활성, 0=비활성, 1=강제활성) + `AITDefaultSettings.GetDefaultTextureStreaming() → true` |
| `Editor/AITConfigurationWindow.cs` | Popup(자동/비활성화/활성화) + HelpBox(스텁 노출 구간 설명) + 파라미터 필드 |
| `Editor/AITBuildInitializer.cs` | 빌드 로그에 텍스처 스트리밍 활성 여부 + (자동) 표기 출력 |
| `Editor/AITConvertCore.cs` | 빌드 직전 `ExternalizeForBuild` / `finally`에서 `RestoreForBuild` 한 쌍 |

## 기본값 / 활성화 방법

**기본 ON** (별도 설정 불필요). `int textureStreaming = -1`(자동)이 기본값이며, `AITDefaultSettings.GetDefaultTextureStreaming() → true`이므로 자동 = 활성입니다.

- **비활성화**: AIT Configuration 윈도우 → "콘텐츠 최적화 — 텍스처 스트리밍" → Popup에서 **"비활성화"** 선택
- **강제 활성화**: Popup에서 **"활성화"** 선택 (기본값과 동일 동작, 명시적 고정)

## 안전장치 (자동)

| 안전장치 | 설명 |
|----------|------|
| 부팅 씬 의존 제외 | `AssetDatabase.GetDependencies(scene0, recursive)`로 감지 → 스텁 금지 |
| Resources/ 제외 | 동적 `Resources.Load` 경로 보호 |
| SpriteAtlas 패킹 대상 제외 | 스텁 → 영구 투명 스프라이트 방지; `BuildSpriteAtlasPackedSet` 예외 시 외부화 전체 no-op |
| 동명·동차원 충돌 제외 | `(name, w, h)` 키 충돌 그룹 전체 자동 제외 + `LogWarning` |
| linear / NormalMap 제외 | `LoadImage` sRGB 덮어쓰기로 깨지는 텍스처 보호 |
| 비파괴 원복 | 소스/임포터를 try/finally로 항상 원복, 비정상 종료 시 에디터 로드 안전망(`SafetyNetRestore`) |
| escape hatch | `textureStreamingExcludeDirs`로 특정 폴더 수동 보호 가능 |

## 빌드 리포트

외부화 실행 시 Unity 콘솔에 출력:
- 요약 1줄: `[AIT-StreamingTexture] ✓ 외부화 N개 / X.X MB 절감 | 제외: 부팅 의존 N, Resources N, 아틀라스 N, 동명 충돌 N, linear/NormalMap N`
- 상세 목록: `Debug.Log`로 각 텍스처 경로/차원/크기 출력

## 스텁 노출 구간

첫 프레임 직후 ~ 비동기 로드 완료 사이에 단색 스텁이 잠깐 보일 수 있습니다. 항상 원본 텍스처가 보여야 하는 경로는 "제외 폴더"에 지정하세요.

## 측정 Δ (perf CI가 채움)

`perf` 라벨이 부착되면 perf CI가 이 PR 브랜치를 main 위에서 빌드해 **단일 레버 Δ**를 코멘트로 게시합니다.

| Unity | TTFF Δ | on-wire Δ | data Δ |
|-------|--------|-----------|--------|
| 2021.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.0 | _측정 대기_ | _측정 대기_ | _측정 대기_ |
| 6000.3 | _측정 대기_ | _측정 대기_ | _측정 대기_ |

## 관련

- 측정 하네스: #754
- 머지 순서: **텍스처 crunch(L9) 머지 후** 본 PR(L11) 머지 권장.
