### PR TITLE
[auto-resolve] 테스트: ValidateDistOutput 및 GetWebFrameworkMajor 커버리지 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/GraniteBuildRunnerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/GraniteBuildRunnerTests.cs
@@ -1,0 +1,161 @@
+// -----------------------------------------------------------------------
+// GraniteBuildRunnerTests.cs - GraniteBuildRunner 단위 테스트
+// Level 0: GetWebFrameworkMajor 버전 파싱 로직 회귀 방지
+//   (Sentry APPS-IN-TOSS-UNITY-SDK-10X 참조 — .ait 빌드 파이프라인 주변 커버리지 추가)
+//
+// GetWebFrameworkMajor 는 package.json 에서 @apps-in-toss/web-framework 버전의
+// 메이저 번호를 파싱한다. 버전에 따라 빌드 경로가 달라지므로 (2.x: granite build,
+// 3.x: vite→ait build) 파싱 오류는 잘못된 빌드 경로로 이어질 수 있다.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using AppsInToss.Editor.Package;
+
+namespace AppsInToss.Editor.Package.Tests
+{
+    [TestFixture]
+    public class GraniteBuildRunnerTests
+    {
+        private string tempDir;
+
+        [SetUp]
+        public void Setup()
+        {
+            tempDir = Path.Combine(
+                Path.GetTempPath(),
+                "ait-test-granite-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+            Directory.CreateDirectory(tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+
+        private void WritePackageJson(string content)
+        {
+            File.WriteAllText(Path.Combine(tempDir, "package.json"), content);
+        }
+
+        // =====================================================
+        // 파일 없음/파싱 불가 시 기본값 2 반환 (보수적 폴백)
+        // =====================================================
+
+        [Test]
+        public void GetWebFrameworkMajor_NoPackageJson_Returns2()
+        {
+            // package.json 이 없으면 2.x(granite) 경로로 폴백해야 한다
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(2, major,
+                "package.json 부재 시 보수적 기본값 2 를 반환해야 한다");
+        }
+
+        [Test]
+        public void GetWebFrameworkMajor_NoDependenciesKey_Returns2()
+        {
+            WritePackageJson(@"{""name"": ""test-app"", ""version"": ""1.0.0""}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(2, major);
+        }
+
+        [Test]
+        public void GetWebFrameworkMajor_NoWebFrameworkDep_Returns2()
+        {
+            WritePackageJson(@"{""dependencies"": {""some-other-package"": ""^1.0.0""}}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(2, major);
+        }
+
+        [Test]
+        public void GetWebFrameworkMajor_EmptyVersionString_Returns2()
+        {
+            WritePackageJson(
+                @"{""dependencies"": {""@apps-in-toss/web-framework"": """"}}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(2, major);
+        }
+
+        [Test]
+        public void GetWebFrameworkMajor_InvalidJson_Returns2()
+        {
+            WritePackageJson("not valid json {{{");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(2, major,
+                "JSON 파싱 실패 시 보수적 기본값 2 를 반환해야 한다");
+        }
+
+        // =====================================================
+        // 2.x 버전
+        // =====================================================
+
+        [Test]
+        public void GetWebFrameworkMajor_Version2_WithCaret_Returns2()
+        {
+            WritePackageJson(
+                @"{""dependencies"": {""@apps-in-toss/web-framework"": ""^2.6.1""}}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(2, major);
+        }
+
+        [Test]
+        public void GetWebFrameworkMajor_Version2_ExactVersion_Returns2()
+        {
+            WritePackageJson(
+                @"{""dependencies"": {""@apps-in-toss/web-framework"": ""2.0.0""}}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(2, major);
+        }
+
+        // =====================================================
+        // 3.x 버전 — vite→ait build 경로로 전환되는 기준
+        // =====================================================
+
+        [Test]
+        public void GetWebFrameworkMajor_Version3_WithCaret_Returns3()
+        {
+            WritePackageJson(
+                @"{""dependencies"": {""@apps-in-toss/web-framework"": ""^3.0.0""}}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(3, major,
+                "3.x 버전은 vite build → ait build (2단계) 경로로 전환되므로 3 을 반환해야 한다");
+        }
+
+        [Test]
+        public void GetWebFrameworkMajor_Version3_BetaPrerelease_Returns3()
+        {
+            // 프리릴리즈 버전: "3.0.0-beta.9d42c0b" → 메이저 3 추출
+            WritePackageJson(
+                @"{""dependencies"": {""@apps-in-toss/web-framework"": ""3.0.0-beta.9d42c0b""}}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(3, major,
+                "프리릴리즈 버전에서도 메이저 번호를 올바르게 추출해야 한다");
+        }
+
+        [Test]
+        public void GetWebFrameworkMajor_Version3_WithTildeAndMinor_Returns3()
+        {
+            WritePackageJson(
+                @"{""dependencies"": {""@apps-in-toss/web-framework"": ""~3.1.2""}}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(3, major);
+        }
+
+        // =====================================================
+        // 4+ 버전도 3.x 경로(major >= 3) 를 따름
+        // =====================================================
+
+        [Test]
+        public void GetWebFrameworkMajor_Version4_Returns4()
+        {
+            WritePackageJson(
+                @"{""dependencies"": {""@apps-in-toss/web-framework"": ""^4.0.0""}}");
+            int major = GraniteBuildRunner.GetWebFrameworkMajor(tempDir);
+            Assert.AreEqual(4, major,
+                "4.x 이상도 major >= 3 조건으로 3.x 빌드 경로를 따라야 한다");
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/GraniteBuildRunnerTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/GraniteBuildRunnerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2517c32ccb7e4ac18cb1581f9c169398
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs
@@ -1,0 +1,139 @@
+// -----------------------------------------------------------------------
+// ValidateDistOutputTests.cs - ValidateDistOutput 커버리지 테스트
+// Level 0: .ait 파일 존재 여부에 따른 ValidateDistOutput 동작 고정
+//   (Sentry APPS-IN-TOSS-UNITY-SDK-10X 참조 — 원 증상 미해결, 커버리지 추가 목적)
+//
+// 원 증상: ait build 가 exit 0 으로 완료되었으나 .ait 파일이 dist/ 에 생성되지
+//          않아 "[AIT] ✗ .ait 파일이 생성되지 않았습니다!" 에러 발생.
+//          bundle.ios.js 는 dist/ 에 존재하나 .ait 패키징 단계가 실패한 시나리오.
+//          → ait build CLI 동작이므로 EditMode 재현 불가.
+//            ValidateDistOutput 자체의 판별 로직을 회귀 테스트로 고정.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using AppsInToss.Editor;
+using AppsInToss;
+
+[TestFixture]
+public class ValidateDistOutputTests
+{
+    private string tempDir;
+
+    [SetUp]
+    public void Setup()
+    {
+        tempDir = Path.Combine(
+            Path.GetTempPath(),
+            "ait-test-validate-dist-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+        Directory.CreateDirectory(tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, true);
+    }
+
+    // =====================================================
+    // .ait 파일 없음 → AIT_FILE_MISSING
+    // 원 이슈 시나리오: dist/ 에 bundle.ios.js 만 있고 .ait 파일이 없는 경우
+    // =====================================================
+
+    [Test]
+    public void ValidateDistOutput_NoAitFile_NoDistFolder_ReturnsAitFileMissing()
+    {
+        // buildProjectPath 에 아무 파일도 없는 경우
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.AIT_FILE_MISSING, result);
+    }
+
+    [Test]
+    public void ValidateDistOutput_DistFolderExists_ButOnlyNonAitFiles_ReturnsAitFileMissing()
+    {
+        // 원 이슈 시나리오: dist/ 에 bundle.ios.js 는 있으나 .ait 파일이 없음
+        string distPath = Path.Combine(tempDir, "dist");
+        Directory.CreateDirectory(distPath);
+        File.WriteAllText(Path.Combine(distPath, "bundle.ios.js"), "// js bundle");
+        File.WriteAllText(Path.Combine(distPath, "bundle.android.js"), "// js bundle");
+
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.AIT_FILE_MISSING, result,
+            "dist/ 에 .ait 파일이 없으면 AIT_FILE_MISSING 을 반환해야 한다");
+    }
+
+    [Test]
+    public void ValidateDistOutput_EmptyDistFolder_ReturnsAitFileMissing()
+    {
+        string distPath = Path.Combine(tempDir, "dist");
+        Directory.CreateDirectory(distPath);
+
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.AIT_FILE_MISSING, result);
+    }
+
+    // =====================================================
+    // .ait 파일이 빌드 루트에 있음 → SUCCEED
+    // =====================================================
+
+    [Test]
+    public void ValidateDistOutput_AitFileInBuildRoot_ReturnsSucceed()
+    {
+        // ait build CLI 버전에 따라 빌드 루트에 .ait 파일이 생성될 수 있음
+        File.WriteAllText(Path.Combine(tempDir, "app.ait"), "ait-content");
+
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result,
+            "빌드 루트에 .ait 파일이 있으면 SUCCEED 를 반환해야 한다");
+    }
+
+    // =====================================================
+    // .ait 파일이 dist/ 에 있음 → SUCCEED
+    // =====================================================
+
+    [Test]
+    public void ValidateDistOutput_AitFileInDistFolder_ReturnsSucceed()
+    {
+        // 일반 케이스: dist/ 에 .ait 파일이 생성된 경우
+        string distPath = Path.Combine(tempDir, "dist");
+        Directory.CreateDirectory(distPath);
+        File.WriteAllText(Path.Combine(distPath, "app.ait"), "ait-content");
+
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result,
+            "dist/ 에 .ait 파일이 있으면 SUCCEED 를 반환해야 한다");
+    }
+
+    [Test]
+    public void ValidateDistOutput_AitFileInDistFolder_WithOtherFiles_ReturnsSucceed()
+    {
+        // dist/ 에 .ait 파일과 다른 파일들이 함께 있는 경우
+        string distPath = Path.Combine(tempDir, "dist");
+        Directory.CreateDirectory(distPath);
+        File.WriteAllText(Path.Combine(distPath, "app.ait"), "ait-content");
+        File.WriteAllText(Path.Combine(distPath, "bundle.ios.js"), "// js");
+
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result);
+    }
+
+    // =====================================================
+    // 빌드 루트 .ait 파일이 dist/ 탐색보다 우선됨
+    // =====================================================
+
+    [Test]
+    public void ValidateDistOutput_AitFileInRoot_DistFolderAlsoExists_ReturnsSucceed()
+    {
+        // 빌드 루트에 .ait 파일이 있고 dist/ 도 존재하는 경우
+        File.WriteAllText(Path.Combine(tempDir, "app.ait"), "ait-content");
+        string distPath = Path.Combine(tempDir, "dist");
+        Directory.CreateDirectory(distPath);
+        // dist/ 에는 .ait 파일 없음
+
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result,
+            "빌드 루트에 .ait 파일이 있으면 dist/ 탐색 없이 SUCCEED 를 반환해야 한다");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d7fc233af5b47099ea10c379b2bb23e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
**범위**: 원 이슈 \`APPS-IN-TOSS-UNITY-SDK-10X\`의 실제 증상은 미해결 — 참조만. 별도 조사 필요.

원 증상(\`ait build\` exit 0 이후 \`.ait\` 파일 미생성)은 외부 CLI 동작이므로 EditMode에서 재현 불가.
인접 커버리지 갭을 발견해 테스트를 추가합니다.

---

## 묶음 항목

| # | 이슈 | 제목 | 처리 |
|---|------|------|------|
| 1 | APPS-IN-TOSS-UNITY-SDK-10X | "UnityError: [AIT] ✗ .ait 파일이 생성되지 않았습니다!" | 재현 실패 — 커버리지 추가 (tangential) |

## 재현 시도 결과

- **시도한 방법**: EditMode 단위 테스트로 `ValidateDistOutput` 직접 호출
- **재현 결과**: 재현 불가
- **이유**: 원 증상은 `ait build` CLI가 exit 0으로 완료되었음에도 `.ait` 파일을 생성하지 않는 시나리오. CLI 동작은 Unity EditMode 환경 내에서 제어 불가. bundle.ios.js가 `dist/`에 존재한다는 점에서 패키징 단계 자체의 버그로 보이나, 재현에 필요한 실제 ait build 환경 접근 불가.

## 발견된 커버리지 갭 및 추가 내용

### 1. `ValidateDistOutputTests` (신규)

`AITBuildValidator.ValidateDistOutput` — `.ait` 파일 존재 여부를 검증하는 함수 — 에 기존 테스트가 전혀 없었음. 다음 케이스를 추가:

- `dist/`에 `bundle.ios.js`만 있고 `.ait` 없음 → `AIT_FILE_MISSING` (원 이슈 시나리오 고정)
- 빌드 루트에 `.ait` 파일 있음 → `SUCCEED`
- `dist/`에 `.ait` 파일 있음 → `SUCCEED`
- `dist/` 자체가 없음 → `AIT_FILE_MISSING`
- 빈 `dist/` 폴더 → `AIT_FILE_MISSING`

### 2. `GraniteBuildRunnerTests` (신규)

`GraniteBuildRunner.GetWebFrameworkMajor` — 버전에 따라 빌드 경로가 달라지는 핵심 분기 — 에 기존 테스트가 없었음. 다음 케이스를 추가:

- `package.json` 없음 / 파싱 불가 → 보수적 기본값 `2` 반환
- `^2.6.1` → `2`
- `^3.0.0` → `3` (vite→ait build 경로 전환 기준)
- `3.0.0-beta.9d42c0b` → `3` (프리릴리즈 지원)
- `^4.0.0` → `4`

## 변경 파일

- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs` (신규)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/GraniteBuildRunnerTests.cs` (신규)