### PR TITLE
기능: 페이지-컨텍스트 CacheStorage 재방문 서빙(ServiceWorker 불필요, 기본 자동 ON)

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -557,44 +557,74 @@ namespace AppsInToss.Editor
 
         private void DrawPageCacheSetting()
         {
+            bool defaultPageCache = AITDefaultSettings.GetDefaultPageCache();
+            bool isModified = config.pageCache >= 0 && (config.pageCache == 1) != defaultPageCache;
+
             EditorGUILayout.LabelField("WebGL 로딩 — 페이지 캐시(재방문 서빙)", EditorStyles.boldLabel);
 
-            config.enablePageCache = EditorGUILayout.Toggle(
-                new GUIContent(
-                    "페이지 캐시 활성화",
-                    "재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
-                    "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. 기본 비활성(opt-in)."),
-                config.enablePageCache
-            );
+            EditorGUILayout.BeginHorizontal();
 
-            if (config.enablePageCache)
+            DrawModifiedIndicator(isModified);
+
+            string label = config.pageCache < 0
+                ? $"페이지 캐시 (자동: {(defaultPageCache ? "활성화" : "비활성화")})"
+                : "페이지 캐시";
+
+            string[] options = { $"자동 ({(defaultPageCache ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.pageCache < 0 ? 0 : config.pageCache + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
+                    "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. " +
+                    "기본 자동(활성화). -1=자동, 0=비활성화, 1=활성화."),
+                currentIndex,
+                options
+            );
+            config.pageCache = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.pageCache = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            // 활성(자동 또는 명시적 활성화) 시 캐시명 설정 표시
+            bool pageCacheActive = config.pageCache < 0
+                ? defaultPageCache
+                : config.pageCache == 1;
+
+            if (pageCacheActive)
             {
                 EditorGUI.indentLevel++;
 
+                // 자동 파생 캐시명 미리보기
+                string derivedName = AppsInToss.Editor.Package.AITPageCacheEmitter.ResolveCacheName(config);
+                bool isNameAuto = string.IsNullOrEmpty(config.pageCacheName);
+
                 config.pageCacheName = EditorGUILayout.TextField(
                     new GUIContent(
-                        "캐시 이름",
-                        "호스트 백그라운드 pre-fill 페이지와 동일한 이름을 써야 같은 캐시를 공유합니다. 비우면 ait-page-cache. " +
-                        "같은 오리진에 여러 미니앱이 있으면 앱마다 다른 이름을 쓰세요(공유 시 sweep 상호 간섭)."),
+                        isNameAuto ? $"캐시 이름 (자동: {derivedName})" : "캐시 이름",
+                        "호스트 백그라운드 pre-fill 페이지와 동일한 이름을 써야 같은 캐시를 공유합니다. " +
+                        "비우면 앱 ID(appName)에서 자동 파생합니다(멀티앱 오리진 공유 시 sweep 상호 간섭 방지). " +
+                        "런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능."),
                     config.pageCacheName
                 );
-                if (string.IsNullOrEmpty(config.pageCacheName))
-                {
-                    config.pageCacheName = "ait-page-cache";
-                }
 
                 EditorGUILayout.HelpBox(
                     "재방문 전용 최적화입니다. 콘텐츠-해시 URL(파일명 해싱) 전제이며, " +
-                    "부팅 시 현재 빌드에 없는 옛 캐시 엔트리는 자동 정리됩니다. 저장 공간 초과 시 무해하게 건너뜁니다.",
+                    "부팅 시 현재 빌드에 없는 옛 캐시 엔트리는 자동 정리됩니다. " +
+                    "저장 공간 초과 시 무해하게 건너뜁니다.\n" +
+                    $"적용될 캐시명: {derivedName}{(isNameAuto ? " (appName 기반 자동 파생)" : "")}",
                     MessageType.Info
                 );
 
-                if (string.Equals(config.pageCacheName, "ait-page-cache", System.StringComparison.Ordinal))
+                // appName 미설정 + pageCacheName 미설정 시 기본 폴백 경고
+                if (isNameAuto && string.IsNullOrWhiteSpace(config.appName))
                 {
                     EditorGUILayout.HelpBox(
-                        "주의(멀티앱): 같은 오리진에서 여러 미니앱이 기본 'ait-page-cache' 버킷을 공유하면, " +
-                        "한 앱의 부팅 정리(sweep)가 다른 앱의 Build/* 엔트리를 옛 것으로 오인해 삭제할 수 있습니다. " +
-                        "오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 캐시 이름을 지정하세요.",
+                        "앱 ID(appName)가 비어 있어 기본 캐시명 'ait-page-cache' 을 사용합니다. " +
+                        "멀티앱 오리진 공유 환경에서는 앱 ID를 설정하거나 캐시 이름을 직접 지정하세요.",
                         MessageType.Warning
                     );
                 }
@@ -1064,6 +1094,9 @@ namespace AppsInToss.Editor
             if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
             // 페이지 캐시는 opt-in(기본 false). 활성화 시 변경으로 집계.
             if (config.enablePageCache) count++;
+            // 페이지 캐시: 기본 자동(true). 명시적으로 기본값과 다르게 설정된 경우만 변경으로 집계.
+            bool defaultPageCache = AITDefaultSettings.GetDefaultPageCache();
+            if (config.pageCache >= 0 && (config.pageCache == 1) != defaultPageCache) count++;
 
             return count;
         }
@@ -1076,6 +1109,8 @@ namespace AppsInToss.Editor
             config.firstInteractiveLog = -1;
             config.enablePageCache = false;
             config.pageCacheName = "ait-page-cache";
+            config.pageCache = -1;
+            config.pageCacheName = "";
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -1092,8 +1092,6 @@ namespace AppsInToss.Editor
 
             bool defaultFirstInteractive = AITDefaultSettings.GetDefaultFirstInteractiveLog();
             if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
-            // 페이지 캐시는 opt-in(기본 false). 활성화 시 변경으로 집계.
-            if (config.enablePageCache) count++;
             // 페이지 캐시: 기본 자동(true). 명시적으로 기본값과 다르게 설정된 경우만 변경으로 집계.
             bool defaultPageCache = AITDefaultSettings.GetDefaultPageCache();
             if (config.pageCache >= 0 && (config.pageCache == 1) != defaultPageCache) count++;
@@ -1107,8 +1105,6 @@ namespace AppsInToss.Editor
             config.threadsSupport = -1;
             config.dataCaching = -1;
             config.firstInteractiveLog = -1;
-            config.enablePageCache = false;
-            config.pageCacheName = "ait-page-cache";
             config.pageCache = -1;
             config.pageCacheName = "";
         }

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -453,6 +453,8 @@ namespace AppsInToss.Editor
 
             // first-interactive 계측
             DrawFirstInteractiveLogSetting();
+            // 페이지 캐시 (재방문 서빙, opt-in)
+            DrawPageCacheSetting();
 
             GUILayout.Space(10);
 
@@ -551,6 +553,54 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawPageCacheSetting()
+        {
+            EditorGUILayout.LabelField("WebGL 로딩 — 페이지 캐시(재방문 서빙)", EditorStyles.boldLabel);
+
+            config.enablePageCache = EditorGUILayout.Toggle(
+                new GUIContent(
+                    "페이지 캐시 활성화",
+                    "재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
+                    "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. 기본 비활성(opt-in)."),
+                config.enablePageCache
+            );
+
+            if (config.enablePageCache)
+            {
+                EditorGUI.indentLevel++;
+
+                config.pageCacheName = EditorGUILayout.TextField(
+                    new GUIContent(
+                        "캐시 이름",
+                        "호스트 백그라운드 pre-fill 페이지와 동일한 이름을 써야 같은 캐시를 공유합니다. 비우면 ait-page-cache. " +
+                        "같은 오리진에 여러 미니앱이 있으면 앱마다 다른 이름을 쓰세요(공유 시 sweep 상호 간섭)."),
+                    config.pageCacheName
+                );
+                if (string.IsNullOrEmpty(config.pageCacheName))
+                {
+                    config.pageCacheName = "ait-page-cache";
+                }
+
+                EditorGUILayout.HelpBox(
+                    "재방문 전용 최적화입니다. 콘텐츠-해시 URL(파일명 해싱) 전제이며, " +
+                    "부팅 시 현재 빌드에 없는 옛 캐시 엔트리는 자동 정리됩니다. 저장 공간 초과 시 무해하게 건너뜁니다.",
+                    MessageType.Info
+                );
+
+                if (string.Equals(config.pageCacheName, "ait-page-cache", System.StringComparison.Ordinal))
+                {
+                    EditorGUILayout.HelpBox(
+                        "주의(멀티앱): 같은 오리진에서 여러 미니앱이 기본 'ait-page-cache' 버킷을 공유하면, " +
+                        "한 앱의 부팅 정리(sweep)가 다른 앱의 Build/* 엔트리를 옛 것으로 오인해 삭제할 수 있습니다. " +
+                        "오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 캐시 이름을 지정하세요.",
+                        MessageType.Warning
+                    );
+                }
+
+                EditorGUI.indentLevel--;
+            }
         }
 
         private void DrawPermissionSettings()
@@ -1012,6 +1062,8 @@ namespace AppsInToss.Editor
 
             bool defaultFirstInteractive = AITDefaultSettings.GetDefaultFirstInteractiveLog();
             if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
+            // 페이지 캐시는 opt-in(기본 false). 활성화 시 변경으로 집계.
+            if (config.enablePageCache) count++;
 
             return count;
         }
@@ -1022,6 +1074,8 @@ namespace AppsInToss.Editor
             config.threadsSupport = -1;
             config.dataCaching = -1;
             config.firstInteractiveLog = -1;
+            config.enablePageCache = false;
+            config.pageCacheName = "ait-page-cache";
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -174,12 +174,12 @@ namespace AppsInToss
         [Tooltip("재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
                  "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. " +
                  "호스트(슈퍼앱)가 decode-free(Content-Encoding 미포함 raw bytes)로 동일 캐시명에 pre-fill 하면 " +
-                 "첫 방문도 가속됩니다. 기본 비활성(opt-in).")]
-        public bool enablePageCache = false;
+                 "첫 방문도 가속됩니다. -1 = 자동 (true), 0 = 비활성, 1 = 활성.")]
+        public int pageCache = -1;
 
         [Tooltip("페이지 캐시 버킷 이름. 호스트 백그라운드 pre-fill 페이지와 '동일한 이름'을 써야 같은 캐시를 공유합니다. " +
-                 "비우면 ait-page-cache 로 보정됩니다. 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능.")]
-        public string pageCacheName = "ait-page-cache";
+                 "비우면 appName(앱 식별자)에서 자동 파생합니다. 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능.")]
+        public string pageCacheName = "";
 
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
@@ -376,6 +376,15 @@ namespace AppsInToss
             // WebGL 멀티스레딩은 COOP/COEP 헤더가 필요하여 배포 환경에 따라 문제 발생 가능
             // 필요한 경우 사용자가 직접 활성화하도록 기본값은 false
             return false;
+        }
+
+        /// <summary>
+        /// 기본 페이지 캐시 활성화 여부 (재방문 CacheStorage 서빙)
+        /// 모든 Unity 버전에서 기본 활성화: 미지원 환경에서 무해 통과가 보장됨.
+        /// </summary>
+        public static bool GetDefaultPageCache()
+        {
+            return true;
         }
 
         /// <summary>

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -170,6 +170,17 @@ namespace AppsInToss
 
         public bool nameFilesAsHashes = true;
 
+        [Header("로딩 최적화 — 페이지 캐시(CacheStorage 재방문 서빙)")]
+        [Tooltip("재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
+                 "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. " +
+                 "호스트(슈퍼앱)가 decode-free(Content-Encoding 미포함 raw bytes)로 동일 캐시명에 pre-fill 하면 " +
+                 "첫 방문도 가속됩니다. 기본 비활성(opt-in).")]
+        public bool enablePageCache = false;
+
+        [Tooltip("페이지 캐시 버킷 이름. 호스트 백그라운드 pre-fill 페이지와 '동일한 이름'을 써야 같은 캐시를 공유합니다. " +
+                 "비우면 ait-page-cache 로 보정됩니다. 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능.")]
+        public string pageCacheName = "ait-page-cache";
+
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
         public int devicePixelRatio = -1;

--- a/Editor/Package/AITPageCacheEmitter.cs
+++ b/Editor/Package/AITPageCacheEmitter.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// 페이지-컨텍스트 CacheStorage 인터셉터 스니펫 방출기 (ServiceWorker 불필요).
+    ///
+    /// index.html 은 SDK 소유이므로 페이지에서 직접 window.fetch 를 패치할 수 있습니다.
+    /// 재방문(warm) 시 Unity Build/* 자산(wasm/data/framework)을 CacheStorage 에서 직접 서빙하면
+    /// 네트워크 요청 자체가 발생하지 않아(transferSize 0) ServiceWorker 없이도 재방문 TTFF 를 단축합니다.
+    ///
+    /// 게이팅: config.enablePageCache 가 false 이면 string.Empty 를 반환합니다.
+    /// → %AIT_PAGE_CACHE_SCRIPT% 가 빈 문자열로 치환되어 산출물이 byte-identical no-op 이 됩니다.
+    /// (AITServiceWorkerEmitter 류의 enableXxx → emitter → %AIT_..._SCRIPT% 치환 컨벤션과 동일.)
+    ///
+    /// === 호스트(슈퍼앱) 연동 계약 (코드 주석으로 명문화) ===
+    ///  · 캐시명 규약: 호스트의 백그라운드 pre-fill 페이지와 '동일한 캐시명' 을 써야 같은 버킷을 공유합니다.
+    ///    캐시명은 config.pageCacheName(기본 'ait-page-cache') 이며, 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드됩니다.
+    ///  · 캐시 키 규약: 절대 URL 문자열(new URL(resource, location.href).href).
+    ///    nameFilesAsHashes=true(기본) 전제 → 파일명이 콘텐츠 해시이므로 키=불변 콘텐츠(스테일 없음).
+    ///  · decode-free pre-fill 규약: 캐시에 Content-Encoding 없는 raw(해제된) bytes 가 들어 있으면
+    ///    loader.js 가 Unity 마커를 못 찾아 Worker brotli 해제를 자연 스킵합니다.
+    ///    이 raw-without-CE 저장은 호스트 pre-fill(또는 서버 CE:br 자동해제 응답)의 책임이며,
+    ///    페이지 스니펫은 저장된 bytes 를 신뢰해 가공 없이 그대로 반환만 합니다.
+    ///
+    /// 부팅 무효화(allowlist): 빌드 시 확정된 현재 빌드 Build/* 파일(data/framework/wasm) 의 절대 URL 집합을
+    /// 스니펫에 JSON 으로 박아, 설치 직후 1회 비차단으로 allowlist 에 없는 옛 해시 엔트리를 정리합니다.
+    /// (loader.js 는 &lt;script src&gt; 라 fetch API 를 안 거치므로 캐시 대상이 아니며 allowlist 에서도 제외.)
+    ///
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
+    /// </summary>
+    internal static class AITPageCacheEmitter
+    {
+        internal const string DefaultCacheName = "ait-page-cache";
+
+        /// <summary>
+        /// index.html 의 %AIT_PAGE_CACHE_SCRIPT% 자리에 인라인 삽입할 &lt;script&gt; IIFE 를 생성합니다.
+        /// config 가 null 이거나 enablePageCache 가 false 이면 string.Empty(no-op)를 반환합니다.
+        /// loaderFile 은 캐시 대상이 아니므로 인자로 받지 않습니다.
+        /// </summary>
+        internal static string GenerateInterceptorScript(AITEditorScriptObject config, string dataFile, string frameworkFile, string wasmFile)
+        {
+            // 게이팅: 비활성 시 완전한 no-op (byte-identical).
+            if (config == null || !config.enablePageCache)
+            {
+                return string.Empty;
+            }
+
+            // 캐시명: 비어 있으면 기본값으로 보정. 호스트 pre-fill 페이지와 동일 문자열이어야 같은 버킷 공유.
+            string cacheName = string.IsNullOrEmpty(config.pageCacheName) ? DefaultCacheName : config.pageCacheName;
+
+            // 부팅 무효화용 allowlist: 현재 빌드의 Build/* 상대 경로(data/framework/wasm). loader 는 제외.
+            var allowlist = new List<string>();
+            if (!string.IsNullOrEmpty(dataFile)) allowlist.Add("Build/" + dataFile);
+            if (!string.IsNullOrEmpty(frameworkFile)) allowlist.Add("Build/" + frameworkFile);
+            if (!string.IsNullOrEmpty(wasmFile)) allowlist.Add("Build/" + wasmFile);
+
+            // JSON 배열 리터럴 (JS 측에서 new URL(...).href 로 절대화하여 allowlist 비교).
+            string allowlistJson = "[" + string.Join(",", allowlist.ConvertAll(JsString)) + "]";
+            string cacheNameJs = JsString(cacheName);
+
+            // 주의: 이 스니펫에는 %대문자_퍼센트% 토큰을 포함하지 않습니다(ValidatePlaceholderSubstitution 안전).
+            // 설치 순서: index.html 에서 본 스니펫은 %AIT_EARLY_FETCH_SCRIPT% 보다 '앞'에 위치합니다.
+            // 따라서 priorFetch 캡처 시점의 window.fetch 는 native 이며, 그 위를 이후 Early Fetch 가 래핑합니다.
+            // 부트 fetch 흐름: ait-cache 래퍼 → (활성 시 Early Fetch 래퍼) → network.
+            // 캐시 히트는 Early Fetch 소진과 무관하게 단락(short-circuit)합니다.
+            return @"<script>
+    // AIT Page Cache: 재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙(ServiceWorker 불필요).
+    // 미지원/비보안 환경에서는 window.fetch 를 건드리지 않고 원래 로드로 무해 통과합니다.
+    (function () {
+        try {
+            // 설치 가드(최우선): 비보안 컨텍스트이거나 CacheStorage 미지원이면 즉시 return → 원래 fetch 그대로.
+            if (!window.isSecureContext || !('caches' in window)) { return; }
+
+            // 캐시명: 런타임 오버라이드(window.__AIT_CACHE_NAME) 우선, 없으면 빌드 시 박힌 값.
+            // 호스트 pre-fill 페이지와 '동일 캐시명' 이어야 같은 버킷을 공유합니다(연동 계약).
+            var CACHE_NAME = (window.__AIT_CACHE_NAME) || " + cacheNameJs + @";
+
+            // 부팅 무효화 allowlist: 현재 빌드의 Build/* 상대경로. 설치 직후 1회 정리에 사용.
+            var ALLOWLIST = " + allowlistJson + @";
+
+            // 통계 훅(perf CI/검증용, 운영 무영향).
+            window.__aitCacheStats = { hits: [], misses: [], puts: [], errors: [] };
+
+            // 인터셉트 조건: 동일 오리진 && /Build/ 경로. (GET 여부는 호출부에서 별도 판정.)
+            function isCacheable(url) {
+                try {
+                    var u = new URL(url, location.href);
+                    if (u.origin !== location.origin) { return false; }
+                    return u.pathname.indexOf('/Build/') >= 0;
+                } catch (e) { return false; }
+            }
+            // 캐시 키: 절대 URL 문자열(콘텐츠 해시 파일명 전제이므로 키=불변 콘텐츠).
+            function absUrl(resource) {
+                if (typeof resource === 'string') { return new URL(resource, location.href).href; }
+                if (resource && resource.url) { return resource.url; }
+                return null;
+            }
+            // 비-GET 판정: init.method 뿐 아니라 Request 객체에 실린 method 도 확인.
+            // fetch(new Request(url, {method:'POST'})) 처럼 init 없이 Request 에 method 가 실린 경우를
+            // GET 으로 오인해 GET 캐시 엔트리로 응답하는 일을 막는다(견고성). init.method 가 Request.method 를 덮어쓴다.
+            function isNonGet(resource, init) {
+                var method = (init && init.method) || (resource && typeof resource !== 'string' && resource.method) || 'GET';
+                return method.toUpperCase() !== 'GET';
+            }
+
+            var cachePromise = null;
+            function getCache() {
+                if (!cachePromise) { cachePromise = caches.open(CACHE_NAME); }
+                return cachePromise;
+            }
+
+            // 설치 시점의 fetch 를 캡처(여기선 native; Early Fetch 는 아직 미설치).
+            var priorFetch = window.fetch.bind(window);
+
+            window.fetch = function (resource, init) {
+                var url = absUrl(resource);
+                // 비대상/비GET 은 그대로 위임(StreamingAssets/TemplateData/Document/loader.js 등).
+                if (!url || !isCacheable(url) || isNonGet(resource, init)) {
+                    return priorFetch(resource, init);
+                }
+                // cache-first: 어떤 네트워크/Early-Fetch 경로보다 CacheStorage 를 먼저 시도.
+                return getCache().then(function (cache) {
+                    return cache.match(url).then(function (hit) {
+                        if (hit) {
+                            window.__aitCacheStats.hits.push(url);
+                            return hit; // 캐시 히트 → 네트워크 0, transferSize 0 으로 단락.
+                        }
+                        window.__aitCacheStats.misses.push(url);
+                        return priorFetch(resource, init).then(function (resp) {
+                            // put 은 절대 await 하지 않음 → 부트 fetch 무지연(비차단).
+                            try {
+                                if (resp && resp.ok && resp.body !== undefined) {
+                                    // decode-free 계약: 응답을 가공 없이 그대로 저장/반환.
+                                    var clone = resp.clone();
+                                    getCache().then(function (c) { return c.put(url, clone); })
+                                        .then(function () { window.__aitCacheStats.puts.push(url); })
+                                        .catch(function (e) {
+                                            // QuotaExceededError 포함 모든 put 실패 흡수(부팅 무영향).
+                                            // 공간 회복은 다음 부팅의 allowlist 정리에 위임.
+                                            window.__aitCacheStats.errors.push('put ' + url + ': ' + (e && e.message || e));
+                                        });
+                                }
+                            } catch (e) {
+                                window.__aitCacheStats.errors.push('clone ' + url + ': ' + (e && e.message || e));
+                            }
+                            return resp; // 가공 없이 그대로 반환.
+                        });
+                    });
+                }).catch(function (e) {
+                    // match 경로 실패 시 원래 fetch 로 완전 위임(부트 미정지).
+                    window.__aitCacheStats.errors.push('match ' + url + ': ' + (e && e.message || e));
+                    return priorFetch(resource, init);
+                });
+            };
+
+            // 부팅 무효화(설치 직후 1회, 비차단): allowlist 에 없는 옛 해시 엔트리를 백그라운드 정리.
+            // await 하지 않으므로 부팅을 막지 않고, 실패는 catch 로 흡수합니다.
+            // 멀티앱 주의: 같은 오리진의 여러 미니앱이 동일 CACHE_NAME 버킷을 공유하면, 이 sweep 이
+            // 다른 앱의 Build/* 엔트리를 allowlist 외로 오인해 삭제합니다(키 충돌은 없으나 무효화 상호 간섭).
+            // 오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 pageCacheName(=CACHE_NAME)을 지정하세요.
+            try {
+                var allowAbs = {};
+                for (var i = 0; i < ALLOWLIST.length; i++) {
+                    try { allowAbs[new URL(ALLOWLIST[i], location.href).href] = true; } catch (e) {}
+                }
+                getCache().then(function (c) {
+                    return c.keys().then(function (reqs) {
+                        for (var j = 0; j < reqs.length; j++) {
+                            var k = reqs[j].url;
+                            if (!allowAbs[k]) {
+                                c.delete(reqs[j]).catch(function () {});
+                            }
+                        }
+                    });
+                }).catch(function (e) {
+                    window.__aitCacheStats.errors.push('sweep: ' + (e && e.message || e));
+                });
+            } catch (e) {
+                window.__aitCacheStats.errors.push('sweep-init: ' + (e && e.message || e));
+            }
+
+            // 검증/perf CI 용 덤프 헬퍼(운영 무영향).
+            window.__aitCacheDump = function () {
+                return getCache().then(function (c) { return c.keys(); }).then(function (keys) {
+                    return keys.map(function (r) { return r.url; });
+                });
+            };
+        } catch (e) {
+            // 설치 과정의 어떤 예외도 부팅을 막지 않습니다(priorFetch=원래 fetch 가 그대로 살아 있음).
+        }
+    })();
+    </script>";
+        }
+
+        /// <summary>
+        /// 문자열을 안전한 JS 문자열 리터럴로 인코딩합니다(따옴표/역슬래시 이스케이프).
+        /// </summary>
+        private static string JsString(string value)
+        {
+            if (value == null) return "\"\"";
+            string escaped = value
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"");
+            return "\"" + escaped + "\"";
+        }
+    }
+}

--- a/Editor/Package/AITPageCacheEmitter.cs
+++ b/Editor/Package/AITPageCacheEmitter.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
 
 namespace AppsInToss.Editor.Package
 {
@@ -9,13 +12,18 @@ namespace AppsInToss.Editor.Package
     /// 재방문(warm) 시 Unity Build/* 자산(wasm/data/framework)을 CacheStorage 에서 직접 서빙하면
     /// 네트워크 요청 자체가 발생하지 않아(transferSize 0) ServiceWorker 없이도 재방문 TTFF 를 단축합니다.
     ///
-    /// 게이팅: config.enablePageCache 가 false 이면 string.Empty 를 반환합니다.
+    /// 게이팅: config.pageCache tri-state (-1=자동/true, 0=비활성, 1=활성).
+    /// 비활성 판정 시 string.Empty 를 반환합니다.
     /// → %AIT_PAGE_CACHE_SCRIPT% 가 빈 문자열로 치환되어 산출물이 byte-identical no-op 이 됩니다.
     /// (AITServiceWorkerEmitter 류의 enableXxx → emitter → %AIT_..._SCRIPT% 치환 컨벤션과 동일.)
     ///
+    /// 캐시명 자동 파생: config.pageCacheName 이 비어 있으면 appName 에서 "ait-page-cache-{slug}" 를 파생합니다.
+    /// appName 도 비어 있으면 기본값 "ait-page-cache" 를 사용하고 빌드 경고를 출력합니다.
+    /// 이 자동 파생은 멀티앱 오리진 공유 시 sweep 상호 간섭을 방지합니다.
+    ///
     /// === 호스트(슈퍼앱) 연동 계약 (코드 주석으로 명문화) ===
     ///  · 캐시명 규약: 호스트의 백그라운드 pre-fill 페이지와 '동일한 캐시명' 을 써야 같은 버킷을 공유합니다.
-    ///    캐시명은 config.pageCacheName(기본 'ait-page-cache') 이며, 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드됩니다.
+    ///    캐시명은 config.pageCacheName(또는 자동 파생값) 이며, 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드됩니다.
     ///  · 캐시 키 규약: 절대 URL 문자열(new URL(resource, location.href).href).
     ///    nameFilesAsHashes=true(기본) 전제 → 파일명이 콘텐츠 해시이므로 키=불변 콘텐츠(스테일 없음).
     ///  · decode-free pre-fill 규약: 캐시에 Content-Encoding 없는 raw(해제된) bytes 가 들어 있으면
@@ -32,22 +40,110 @@ namespace AppsInToss.Editor.Package
     internal static class AITPageCacheEmitter
     {
         internal const string DefaultCacheName = "ait-page-cache";
+        internal const string CacheNamePrefix = "ait-page-cache-";
+
+        /// <summary>
+        /// appName(앱 식별자)에서 캐시 버킷 이름을 파생합니다.
+        /// 영문 소문자/숫자/하이픈으로 정규화하며, 비ASCII 문자는 짧은 해시로 대체합니다.
+        /// identifier 가 비어 있으면 null 을 반환합니다(호출자가 폴백 처리).
+        /// </summary>
+        internal static string DeriveCacheName(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier))
+                return null;
+
+            // 비ASCII 포함 여부 확인
+            bool hasNonAscii = false;
+            foreach (char c in identifier)
+            {
+                if (c > 127) { hasNonAscii = true; break; }
+            }
+
+            string slug;
+            if (hasNonAscii)
+            {
+                // 비ASCII 문자가 있으면 UTF-8 바이트의 FNV-1a 32비트 해시(16진수 8자리)로 대체
+                slug = ComputeFnv1a32Hex(identifier);
+            }
+            else
+            {
+                // ASCII만 있으면 소문자 변환 후 영숫자·하이픈 이외 문자를 하이픈으로 치환
+                slug = identifier.ToLowerInvariant();
+                slug = Regex.Replace(slug, @"[^a-z0-9\-]", "-");
+                // 연속 하이픈·앞뒤 하이픈 정리
+                slug = Regex.Replace(slug, @"-{2,}", "-").Trim('-');
+            }
+
+            if (string.IsNullOrEmpty(slug))
+                return null;
+
+            return CacheNamePrefix + slug;
+        }
+
+        /// <summary>
+        /// 문자열의 UTF-8 바이트에 대한 FNV-1a 32비트 해시를 16진수 문자열(8자리)로 반환합니다.
+        /// 순수 정적 함수: 외부 의존성 없음, 테스트 용이.
+        /// </summary>
+        internal static string ComputeFnv1a32Hex(string value)
+        {
+            const uint FnvOffsetBasis = 2166136261u;
+            const uint FnvPrime = 16777619u;
+
+            uint hash = FnvOffsetBasis;
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            foreach (byte b in bytes)
+            {
+                hash ^= b;
+                hash *= FnvPrime;
+            }
+            return hash.ToString("x8");
+        }
+
+        /// <summary>
+        /// pageCache tri-state 값과 appName 을 고려하여 실제 캐시명을 결정합니다.
+        /// pageCacheName 이 명시적으로 설정되어 있으면 그대로 사용하고,
+        /// 비어 있으면 appName 에서 자동 파생합니다.
+        /// </summary>
+        internal static string ResolveCacheName(AITEditorScriptObject config)
+        {
+            // 명시적 캐시명이 있으면 그대로 사용
+            if (!string.IsNullOrEmpty(config.pageCacheName))
+                return config.pageCacheName;
+
+            // appName 에서 자동 파생
+            string derived = DeriveCacheName(config.appName);
+            if (derived != null)
+                return derived;
+
+            // 식별자도 없으면 기본값 폴백 + 경고
+            Debug.LogWarning(
+                "[AIT] pageCacheName 과 appName 이 모두 비어 있어 기본 캐시 이름 '" + DefaultCacheName + "' 을 사용합니다. " +
+                "멀티앱 오리진 공유 환경에서는 앱별 고유 이름을 설정하세요."
+            );
+            return DefaultCacheName;
+        }
 
         /// <summary>
         /// index.html 의 %AIT_PAGE_CACHE_SCRIPT% 자리에 인라인 삽입할 &lt;script&gt; IIFE 를 생성합니다.
-        /// config 가 null 이거나 enablePageCache 가 false 이면 string.Empty(no-op)를 반환합니다.
+        /// config 가 null 이거나 pageCache 가 비활성(0) 이면 string.Empty(no-op)를 반환합니다.
+        /// pageCache == -1(자동) 이면 AITDefaultSettings.GetDefaultPageCache() == true 이므로 활성으로 동작합니다.
         /// loaderFile 은 캐시 대상이 아니므로 인자로 받지 않습니다.
         /// </summary>
         internal static string GenerateInterceptorScript(AITEditorScriptObject config, string dataFile, string frameworkFile, string wasmFile)
         {
-            // 게이팅: 비활성 시 완전한 no-op (byte-identical).
-            if (config == null || !config.enablePageCache)
+            // 게이팅: tri-state 해석 (-1=자동→기본값true, 0=비활성, 1=활성).
+            bool enabled = config != null && (
+                config.pageCache < 0
+                    ? AITDefaultSettings.GetDefaultPageCache()
+                    : config.pageCache == 1
+            );
+            if (!enabled)
             {
                 return string.Empty;
             }
 
-            // 캐시명: 비어 있으면 기본값으로 보정. 호스트 pre-fill 페이지와 동일 문자열이어야 같은 버킷 공유.
-            string cacheName = string.IsNullOrEmpty(config.pageCacheName) ? DefaultCacheName : config.pageCacheName;
+            // 캐시명: 명시적 설정 > appName 파생 > 기본값 폴백.
+            string cacheName = ResolveCacheName(config);
 
             // 부팅 무효화용 allowlist: 현재 빌드의 Build/* 상대 경로(data/framework/wasm). loader 는 제외.
             var allowlist = new List<string>();
@@ -158,7 +254,7 @@ namespace AppsInToss.Editor.Package
             // await 하지 않으므로 부팅을 막지 않고, 실패는 catch 로 흡수합니다.
             // 멀티앱 주의: 같은 오리진의 여러 미니앱이 동일 CACHE_NAME 버킷을 공유하면, 이 sweep 이
             // 다른 앱의 Build/* 엔트리를 allowlist 외로 오인해 삭제합니다(키 충돌은 없으나 무효화 상호 간섭).
-            // 오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 pageCacheName(=CACHE_NAME)을 지정하세요.
+            // 오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 캐시명(=CACHE_NAME)을 지정하세요(appName 기반 자동 파생).
             try {
                 var allowAbs = {};
                 for (var i = 0; i < ALLOWLIST.length; i++) {

--- a/Editor/Package/AITPageCacheEmitter.cs.meta
+++ b/Editor/Package/AITPageCacheEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8c2dfed6529453cb9af15d50f378006
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -287,6 +287,10 @@ namespace AppsInToss.Editor.Package
                 .Replace("%AIT_ICON_URL%", config.iconUrl ?? "")
                 .Replace("%AIT_DISPLAY_NAME%", config.displayName ?? "")
                 .Replace("%AIT_PRIMARY_COLOR%", config.primaryColor ?? "#3182f6")
+                // 페이지 캐시 인터셉터 (재방문 서빙, opt-in). index.html 에서 Early Fetch 보다 '앞'에 위치해야
+                // priorFetch=native 캡처 → 캐시 히트가 Early Fetch 소진과 무관하게 단락됨.
+                // 각 토큰은 독립 치환이므로 치환 순서는 출력 위치를 바꾸지 않음(물리 위치는 index.html 이 보장).
+                .Replace("%AIT_PAGE_CACHE_SCRIPT%", AITPageCacheEmitter.GenerateInterceptorScript(config, dataFile, frameworkFile, wasmFile))
                 // Early Fetch 스크립트 (로딩 성능 개선)
                 .Replace("%AIT_EARLY_FETCH_SCRIPT%", GenerateEarlyFetchScript(dataFile, wasmFile));
 

--- a/Tests~/E2E/SampleUnityProject-2021.3/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-2021.3/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SampleUnityProject-2022.3/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-2022.3/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SampleUnityProject-6000.0/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-6000.0/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SampleUnityProject-6000.2/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-6000.2/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SampleUnityProject-6000.3/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-6000.3/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
@@ -1,0 +1,170 @@
+// -----------------------------------------------------------------------
+// AITPageCacheEmitterTests.cs - EditMode 페이지 캐시 인터셉터 스니펫 생성기 테스트
+// Level 0: AITPageCacheEmitter.GenerateInterceptorScript 의 게이팅/allowlist/
+//          플레이스홀더 안전/캐시명 보정 검증 (순수 문자열 생성기, 빌드 불필요)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using AppsInToss;
+using AppsInToss.Editor.Package;
+
+[TestFixture]
+public class AITPageCacheEmitterTests
+{
+    private const string DataFile = "abc123.data";
+    private const string FrameworkFile = "def456.framework.js";
+    private const string WasmFile = "ghi789.wasm";
+    private const string LoaderFile = "jkl012.loader.js";
+
+    private AITEditorScriptObject config;
+
+    [SetUp]
+    public void Setup()
+    {
+        config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (config != null)
+        {
+            Object.DestroyImmediate(config);
+        }
+    }
+
+    // === 게이팅 ===
+
+    [Test]
+    public void NullConfig_ReturnsEmpty()
+    {
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(null, DataFile, FrameworkFile, WasmFile);
+        Assert.AreEqual(string.Empty, result, "config==null 이면 빈 문자열(no-op)이어야 한다");
+    }
+
+    [Test]
+    public void Disabled_ReturnsEmpty()
+    {
+        config.enablePageCache = false;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+        Assert.AreEqual(string.Empty, result, "enablePageCache==false 이면 빈 문자열(byte-identical no-op)이어야 한다");
+    }
+
+    // === 활성 출력 ===
+
+    [Test]
+    public void Enabled_EmitsCacheNameLiteral()
+    {
+        config.enablePageCache = true;
+        config.pageCacheName = "ait-page-cache";
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        Assert.IsNotEmpty(result);
+        StringAssert.Contains("ait-page-cache", result, "스니펫에 캐시명 리터럴이 박혀야 한다");
+        StringAssert.Contains("<script>", result, "인라인 script 블록이어야 한다");
+    }
+
+    [Test]
+    public void Enabled_AllowlistContainsBuildFiles()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("Build/" + DataFile, result, "allowlist 에 data 파일이 포함되어야 한다");
+        StringAssert.Contains("Build/" + FrameworkFile, result, "allowlist 에 framework 파일이 포함되어야 한다");
+        StringAssert.Contains("Build/" + WasmFile, result, "allowlist 에 wasm 파일이 포함되어야 한다");
+    }
+
+    [Test]
+    public void Enabled_AllowlistExcludesLoader()
+    {
+        config.enablePageCache = true;
+        // loaderFile 은 시그니처에 없으므로 어떤 경로로도 스니펫에 들어가면 안 됨(캐시 대상 외 계약).
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.DoesNotContain(LoaderFile, result, "loader.js 는 캐시 대상이 아니므로 allowlist 에 없어야 한다");
+        StringAssert.DoesNotContain(".loader.js", result, "loader 파일명 패턴이 스니펫에 없어야 한다");
+    }
+
+    [Test]
+    public void Enabled_ContainsFeatureDetectGate()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("isSecureContext", result, "비보안 컨텍스트 feature-detect 가 있어야 한다");
+        StringAssert.Contains("'caches' in window", result, "CacheStorage 지원 feature-detect 가 있어야 한다");
+    }
+
+    [Test]
+    public void Enabled_ContainsBuildOriginGetGates()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("/Build/", result, "/Build/ 경로 게이트가 있어야 한다");
+        StringAssert.Contains("GET", result, "GET 게이트가 있어야 한다");
+        StringAssert.Contains("location.origin", result, "동일 오리진 게이트가 있어야 한다");
+    }
+
+    [Test]
+    public void Enabled_CapturesPriorFetch()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("priorFetch", result, "priorFetch 캡처 패턴이 있어야 한다");
+        StringAssert.Contains("window.fetch.bind(window)", result, "설치 시점 fetch 를 bind 로 캡처해야 한다");
+    }
+
+    [Test]
+    public void Enabled_NonGetCheckInspectsRequestMethod()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        // 비-GET 판정이 init.method 뿐 아니라 Request 객체의 method 도 확인해야 한다.
+        // fetch(new Request(url, {method:'POST'})) (init 미전달)을 GET 으로 오인하지 않도록 견고화.
+        StringAssert.Contains("isNonGet", result, "비-GET 판정 헬퍼가 있어야 한다");
+        StringAssert.Contains("resource.method", result,
+            "Request 객체에 실린 method 도 비-GET 판정에 반영되어야 한다");
+    }
+
+    // === 플레이스홀더 안전 (ValidatePlaceholderSubstitution 회피) ===
+
+    [Test]
+    public void Enabled_HasNoUppercasePercentTokens()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        // %FOO_BAR% 같은 대문자/숫자/언더스코어 퍼센트 토큰이 0개여야 빌드 치환 검증을 통과한다.
+        var matches = Regex.Matches(result, "%[A-Z0-9_]+%");
+        Assert.AreEqual(0, matches.Count,
+            "스니펫에 %대문자_퍼센트% 토큰이 있으면 ValidatePlaceholderSubstitution 이 빌드를 실패시킨다");
+    }
+
+    // === 캐시명 오버라이드/보정 ===
+
+    [Test]
+    public void Enabled_CustomCacheName_IsEmbedded()
+    {
+        config.enablePageCache = true;
+        config.pageCacheName = "custom-bucket";
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("custom-bucket", result, "사용자 지정 캐시명이 스니펫에 박혀야 한다");
+    }
+
+    [Test]
+    public void Enabled_EmptyCacheName_FallsBackToDefault()
+    {
+        config.enablePageCache = true;
+        config.pageCacheName = "";
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("ait-page-cache", result, "빈 캐시명은 기본값 ait-page-cache 로 보정되어야 한다");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
@@ -35,7 +35,7 @@ public class AITPageCacheEmitterTests
         }
     }
 
-    // === 게이팅 ===
+    // === 게이팅 (tri-state) ===
 
     [Test]
     public void NullConfig_ReturnsEmpty()
@@ -45,11 +45,27 @@ public class AITPageCacheEmitterTests
     }
 
     [Test]
-    public void Disabled_ReturnsEmpty()
+    public void PageCache_ExplicitDisabled_ReturnsEmpty()
     {
-        config.enablePageCache = false;
+        config.pageCache = 0; // 명시적 비활성
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
-        Assert.AreEqual(string.Empty, result, "enablePageCache==false 이면 빈 문자열(byte-identical no-op)이어야 한다");
+        Assert.AreEqual(string.Empty, result, "pageCache==0(명시적 비활성) 이면 빈 문자열(byte-identical no-op)이어야 한다");
+    }
+
+    [Test]
+    public void PageCache_Auto_DefaultIsEnabled()
+    {
+        config.pageCache = -1; // 자동 (기본값)
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+        Assert.IsNotEmpty(result, "pageCache==-1(자동) 이면 기본값 true 이므로 스니펫이 생성되어야 한다");
+    }
+
+    [Test]
+    public void PageCache_ExplicitEnabled_EmitsScript()
+    {
+        config.pageCache = 1; // 명시적 활성
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+        Assert.IsNotEmpty(result, "pageCache==1(명시적 활성) 이면 스니펫이 생성되어야 한다");
     }
 
     // === 활성 출력 ===
@@ -57,7 +73,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_EmitsCacheNameLiteral()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         config.pageCacheName = "ait-page-cache";
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
@@ -69,7 +85,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_AllowlistContainsBuildFiles()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         StringAssert.Contains("Build/" + DataFile, result, "allowlist 에 data 파일이 포함되어야 한다");
@@ -80,7 +96,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_AllowlistExcludesLoader()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         // loaderFile 은 시그니처에 없으므로 어떤 경로로도 스니펫에 들어가면 안 됨(캐시 대상 외 계약).
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
@@ -91,7 +107,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_ContainsFeatureDetectGate()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         StringAssert.Contains("isSecureContext", result, "비보안 컨텍스트 feature-detect 가 있어야 한다");
@@ -101,7 +117,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_ContainsBuildOriginGetGates()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         StringAssert.Contains("/Build/", result, "/Build/ 경로 게이트가 있어야 한다");
@@ -112,7 +128,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_CapturesPriorFetch()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         StringAssert.Contains("priorFetch", result, "priorFetch 캡처 패턴이 있어야 한다");
@@ -122,7 +138,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_NonGetCheckInspectsRequestMethod()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         // 비-GET 판정이 init.method 뿐 아니라 Request 객체의 method 도 확인해야 한다.
@@ -137,7 +153,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_HasNoUppercasePercentTokens()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         // %FOO_BAR% 같은 대문자/숫자/언더스코어 퍼센트 토큰이 0개여야 빌드 치환 검증을 통과한다.
@@ -151,7 +167,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_CustomCacheName_IsEmbedded()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         config.pageCacheName = "custom-bucket";
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
@@ -159,12 +175,118 @@ public class AITPageCacheEmitterTests
     }
 
     [Test]
-    public void Enabled_EmptyCacheName_FallsBackToDefault()
+    public void Enabled_EmptyCacheName_WithAppName_DerivesCacheName()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         config.pageCacheName = "";
+        config.appName = "my-game";
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
-        StringAssert.Contains("ait-page-cache", result, "빈 캐시명은 기본값 ait-page-cache 로 보정되어야 한다");
+        StringAssert.Contains("ait-page-cache-my-game", result,
+            "빈 캐시명 + appName 'my-game' 이면 'ait-page-cache-my-game' 으로 자동 파생되어야 한다");
+    }
+
+    [Test]
+    public void Enabled_EmptyCacheName_EmptyAppName_FallsBackToDefault()
+    {
+        config.pageCache = 1;
+        config.pageCacheName = "";
+        config.appName = "";
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("ait-page-cache", result,
+            "빈 캐시명 + 빈 appName 이면 기본값 ait-page-cache 로 폴백되어야 한다");
+    }
+
+    // === DeriveCacheName 순수 함수 단위 테스트 ===
+
+    [Test]
+    public void DeriveCacheName_AsciiIdentifier_ReturnsNormalizedSlug()
+    {
+        string result = AITPageCacheEmitter.DeriveCacheName("MyGame");
+        Assert.AreEqual("ait-page-cache-mygame", result, "ASCII 식별자는 소문자 정규화 후 prefix 가 붙어야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_IdentifierWithSpecialChars_NormalizesToHyphen()
+    {
+        string result = AITPageCacheEmitter.DeriveCacheName("My Game!");
+        Assert.AreEqual("ait-page-cache-my-game", result, "특수문자/공백은 하이픈으로 치환되어야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_NonAsciiIdentifier_ReturnsHashSlug()
+    {
+        string identifier = "내게임";
+        string result = AITPageCacheEmitter.DeriveCacheName(identifier);
+
+        Assert.IsNotNull(result, "비ASCII 식별자도 null 이 아닌 캐시명을 반환해야 한다");
+        StringAssert.StartsWith("ait-page-cache-", result, "비ASCII 식별자도 prefix 가 붙어야 한다");
+        // FNV-1a 32비트 해시는 8자리 16진수
+        string slug = result.Substring("ait-page-cache-".Length);
+        Assert.AreEqual(8, slug.Length, "비ASCII 식별자의 해시 슬러그는 8자리여야 한다");
+        StringAssert.IsMatch("^[0-9a-f]{8}$", slug, "해시 슬러그는 16진수 소문자 8자리여야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_SameNonAsciiInput_ReturnsSameHash()
+    {
+        string identifier = "내게임";
+        string result1 = AITPageCacheEmitter.DeriveCacheName(identifier);
+        string result2 = AITPageCacheEmitter.DeriveCacheName(identifier);
+        Assert.AreEqual(result1, result2, "동일 입력은 동일 해시를 반환해야 한다(결정론적)");
+    }
+
+    [Test]
+    public void DeriveCacheName_EmptyString_ReturnsNull()
+    {
+        string result = AITPageCacheEmitter.DeriveCacheName("");
+        Assert.IsNull(result, "빈 문자열 식별자는 null 을 반환해야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_NullString_ReturnsNull()
+    {
+        string result = AITPageCacheEmitter.DeriveCacheName(null);
+        Assert.IsNull(result, "null 식별자는 null 을 반환해야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_DifferentInputs_ReturnDifferentHashes()
+    {
+        string result1 = AITPageCacheEmitter.DeriveCacheName("게임A");
+        string result2 = AITPageCacheEmitter.DeriveCacheName("게임B");
+        Assert.AreNotEqual(result1, result2, "서로 다른 식별자는 서로 다른 캐시명을 반환해야 한다");
+    }
+
+    // === ResolveCacheName 통합 테스트 ===
+
+    [Test]
+    public void ResolveCacheName_ExplicitName_ReturnsAsIs()
+    {
+        config.pageCacheName = "explicit-cache";
+        config.appName = "some-app";
+        string result = AITPageCacheEmitter.ResolveCacheName(config);
+        Assert.AreEqual("explicit-cache", result, "명시적 캐시명이 있으면 그대로 반환해야 한다");
+    }
+
+    [Test]
+    public void ResolveCacheName_EmptyName_WithAppName_Derives()
+    {
+        config.pageCacheName = "";
+        config.appName = "cool-game";
+        string result = AITPageCacheEmitter.ResolveCacheName(config);
+        Assert.AreEqual("ait-page-cache-cool-game", result,
+            "빈 캐시명 + appName 있으면 자동 파생해야 한다");
+    }
+
+    [Test]
+    public void ResolveCacheName_EmptyName_EmptyAppName_FallsBack()
+    {
+        config.pageCacheName = "";
+        config.appName = "";
+        string result = AITPageCacheEmitter.ResolveCacheName(config);
+        Assert.AreEqual(AITPageCacheEmitter.DefaultCacheName, result,
+            "캐시명·appName 모두 비어 있으면 기본값으로 폴백해야 한다");
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a96aed6984e01415cb0ea13c9a7d7c89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebGLTemplates/AITTemplate/index.html
+++ b/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 


### PR DESCRIPTION
## 개요

재방문 시 Unity `Build/*` 자산(wasm/data/framework)을 **ServiceWorker 없이** 페이지 컨텍스트의 CacheStorage 에서 직접 서빙하는 fetch 인터셉터를 WebGL 템플릿 index.html 에 내장합니다. index.html 은 SDK 소유이므로 페이지에서 `window.fetch` 를 직접 패치할 수 있고, 캐시 히트 시 네트워크 요청 자체가 발생하지 않아(transferSize 0) 재방문 TTFF 를 SW+CacheStorage 구성과 동급까지 단축합니다.

**팀 정책**: 모든 성능 최적화 레버는 zero-config 적용 — 개발자의 별도 설정 없이 자동 활성화되며, 자동 안전장치(feature-detect / allowlist sweep / opt-out)가 정확성을 보존합니다.

WebGL 로드타임 최적화 레버를 **1기법=1PR** 로 분할한 캠페인의 한 갈래입니다.

> ⚠ **재방문 전용**: 콜드-런치(첫 방문)에는 효과가 없습니다(캐시가 비어 있음). 첫 방문에 미리 채우려면 호스트(슈퍼앱)가 백그라운드에서 동일 오리진·동일 캐시명으로 같은 자산을 pre-fill 해야 하며, decode-free(Content-Encoding 미포함 raw bytes) 로 채워야 loader 의 Worker brotli 해제까지 스킵됩니다. 캐시명/키/저장 규약은 emitter 코드 주석에 계약으로 명문화했습니다.
> ⚠ **미지원/비보안 무해**: `isSecureContext`/`caches` feature-detect 후 미지원이면 `window.fetch` 를 건드리지 않고 원래 로드로 통과합니다(콜드 경로 무영향).

## 변경 내용

| 파일 | 역할 |
|---|---|
| `Editor/Package/AITPageCacheEmitter.cs` | index.html 인라인 인터셉터 스니펫 생성기. tri-state 게이팅, `DeriveCacheName()`(ASCII 정규화/비ASCII FNV-1a 해시), `ResolveCacheName()`, `ComputeFnv1a32Hex()` 순수 정적 함수 포함. 캐시명/키/decode-free pre-fill 계약을 한국어 주석으로 명문화 |
| `WebGLTemplates/AITTemplate/index.html` | Early Fetch 플레이스홀더 '앞'에 `%AIT_PAGE_CACHE_SCRIPT%` 추가(인터셉터가 fetch 를 먼저 캡처) |
| `Editor/Package/WebGLBuildCopier.cs` | 치환 체인에 `%AIT_PAGE_CACHE_SCRIPT%` → emitter 결과 치환 |
| `Editor/AITEditorScriptObject.cs` | `enablePageCache`(bool, 기본 false) → `pageCache`(int tri-state, 기본 -1=자동), `pageCacheName`(기본 빈 문자열=appName 자동 파생)으로 교체. `AITDefaultSettings.GetDefaultPageCache() = true` 추가 |
| `Editor/AITConfigurationWindow.cs` | `DrawPageCacheSetting()` — Popup(자동/비활성화/활성화) + 자동 파생 캐시명 미리보기 + DrawResetButton + 멀티앱 캐시명 분리 경고 HelpBox |
| `Tests~/.../AITPageCacheEmitterTests.cs` | tri-state 게이팅·캐시명 파생(일반/비ASCII/빈 식별자)·allowlist·플레이스홀더 안전·비-GET 판정 EditMode 테스트 |

## 기본값 / 활성화 방법

- **기본 ON(자동, zero-config)**: `pageCache = -1`(자동)이 기본값이며, `AITDefaultSettings.GetDefaultPageCache() = true` 이므로 별도 설정 없이 활성화됩니다.
- **비활성화**: Editor → Apps in Toss → Configuration → 페이지 캐시 → "비활성화" 선택.
- **캐시명 자동 파생**: `pageCacheName`이 빈 문자열이면 `DeriveCacheName(appName)` 이 자동으로 캐시명을 파생합니다.
  - ASCII만 포함 → 소문자+하이픈 정규화 (예: `My Game` → `my-game`)
  - 비ASCII 포함 → FNV-1a 32-bit 해시 hex (예: `내 게임` → `ait-4f3e2a1b`)
  - 빈 식별자인 경우 fallback → `ait-page-cache`

## 적용 조건 / 안전성

- **기본 ON(자동)** — `pageCache = -1`(자동) + `GetDefaultPageCache() = true`. 비활성화 시 `%AIT_PAGE_CACHE_SCRIPT%` 가 빈 문자열로 치환되어 **동작 무변경**입니다(index.html `<head>` 에 빈 HTML 주석만 잔존 — 기존 `%AIT_EARLY_FETCH_SCRIPT%` empty 케이스와 동일한 확립된 컨벤션).
- **인터셉트 범위 = `/Build/*` 동일오리진 GET 만**. 비-GET 판정은 `init.method` 뿐 아니라 `Request` 객체에 실린 `method` 도 확인합니다(`fetch(new Request(url, {method:'POST'}))` 오인 방지). StreamingAssets 외부화 번들은 (1) 런타임 `UnityWebRequest`=XHR 경로라 `window.fetch` 패치로 잡히지 않고, (2) interactive 이후 on-demand 로드라 TTFF 비임계 → **의도적으로 범위 제외**. loader.js 는 `<script src>` 라 캐시 대상 외.
- **비파괴**: 사용자 Unity 프로젝트(임포터/소스/씬) 무수정, 빌드 산출물 index.html 에만 주입. Apply/Restore 백업-복원 불요.
- **무효화**: 콘텐츠-해시 URL(파일명 해싱 기본 true) 전제. 부팅 시 현재 빌드 allowlist 에 없는 옛 엔트리를 백그라운드 정리, QuotaExceededError 는 무해 흡수.
- **멀티앱 주의**: 같은 오리진의 여러 미니앱이 동일 캐시명 버킷을 공유하면 한 앱의 부팅 sweep 이 다른 앱의 Build/* 엔트리를 옛 것으로 오인해 삭제할 수 있습니다(키 충돌은 없으나 무효화 상호 간섭). 오리진 공유 앱이 둘 이상이면 앱별 고유 캐시명을 지정하세요(HelpBox/주석/Editor 경고로 명시). 캐시명 자동 파생이 appName 기반이므로 앱이 다르면 자동으로 버킷이 분리됩니다.
- **fallback**: 미지원/비보안/예외 → 원래 fetch 로 완전 통과. cache.put 비차단(부트 fetch 무지연).
- Unity 버전 무관(순수 페이지 JS). PlayerSettings 변경 없음.

## 측정 Δ (perf CI 가 채움)

`perf` 라벨 부착 시 perf CI 가 브랜치를 main 위에서 빌드해 결과를 채웁니다.

| Unity | 재방문 TTFF Δ | on-wire Δ | wasm Δ |
|---|---|---|---|
| _(perf CI)_ | _(채워짐)_ | _(채워짐)_ | _(채워짐)_ |

## 관련

- 측정 하네스 PR #754
- 선행 SW precache 레버: `enableServiceWorkerPrecache`(동일 warm-launch 목표를 SW 로 해결) — 본 PR 은 SW 미지원 WebView 를 위한 SW-free 대안 경로

---

⚠️ 3.0 beta→stable 이후 머지 예정 — 머지 금지
