### PR TITLE
기능: 호스트 warm용 ait-warm-manifest.json 빌드 시 산출

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -599,6 +599,22 @@ namespace AppsInToss.Editor
 
                 EditorGUI.indentLevel--;
             }
+
+            // warm manifest 산출 토글 — enablePageCache=false 이면 회색 비활성, true 이면 편집 가능.
+            // if (config.enablePageCache) 블록 바깥에 배치해 항상 렌더링(숨김 없음).
+            using (new EditorGUI.DisabledScope(!config.enablePageCache))
+            {
+                EditorGUI.indentLevel++;
+                config.emitWarmManifest = EditorGUILayout.Toggle(
+                    new GUIContent(
+                        "Warm Manifest 산출",
+                        "빌드 시 ait-warm-manifest.json 을 web 루트에 산출합니다. " +
+                        "호스트(슈퍼앱)가 선다운로드(warm) diff 기준으로 사용합니다. " +
+                        "페이지 캐시(enablePageCache)가 비활성이면 회색 비활성화됩니다."),
+                    config.emitWarmManifest
+                );
+                EditorGUI.indentLevel--;
+            }
         }
 
         private void DrawPermissionSettings()
@@ -1040,6 +1056,7 @@ namespace AppsInToss.Editor
             config.dataCaching = -1;
             config.enablePageCache = false;
             config.pageCacheName = "ait-page-cache";
+            config.emitWarmManifest = false;
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -555,44 +555,74 @@ namespace AppsInToss.Editor
 
         private void DrawPageCacheSetting()
         {
+            bool defaultPageCache = AITDefaultSettings.GetDefaultPageCache();
+            bool isModified = config.pageCache >= 0 && (config.pageCache == 1) != defaultPageCache;
+
             EditorGUILayout.LabelField("WebGL 로딩 — 페이지 캐시(재방문 서빙)", EditorStyles.boldLabel);
 
-            config.enablePageCache = EditorGUILayout.Toggle(
-                new GUIContent(
-                    "페이지 캐시 활성화",
-                    "재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
-                    "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. 기본 비활성(opt-in)."),
-                config.enablePageCache
-            );
+            EditorGUILayout.BeginHorizontal();
 
-            if (config.enablePageCache)
+            DrawModifiedIndicator(isModified);
+
+            string label = config.pageCache < 0
+                ? $"페이지 캐시 (자동: {(defaultPageCache ? "활성화" : "비활성화")})"
+                : "페이지 캐시";
+
+            string[] options = { $"자동 ({(defaultPageCache ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.pageCache < 0 ? 0 : config.pageCache + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
+                    "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. " +
+                    "기본 자동(활성화). -1=자동, 0=비활성화, 1=활성화."),
+                currentIndex,
+                options
+            );
+            config.pageCache = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.pageCache = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            // 활성(자동 또는 명시적 활성화) 시 캐시명 설정 표시
+            bool pageCacheActive = config.pageCache < 0
+                ? defaultPageCache
+                : config.pageCache == 1;
+
+            if (pageCacheActive)
             {
                 EditorGUI.indentLevel++;
 
+                // 자동 파생 캐시명 미리보기
+                string derivedName = AppsInToss.Editor.Package.AITPageCacheEmitter.ResolveCacheName(config);
+                bool isNameAuto = string.IsNullOrEmpty(config.pageCacheName);
+
                 config.pageCacheName = EditorGUILayout.TextField(
                     new GUIContent(
-                        "캐시 이름",
-                        "호스트 백그라운드 pre-fill 페이지와 동일한 이름을 써야 같은 캐시를 공유합니다. 비우면 ait-page-cache. " +
-                        "같은 오리진에 여러 미니앱이 있으면 앱마다 다른 이름을 쓰세요(공유 시 sweep 상호 간섭)."),
+                        isNameAuto ? $"캐시 이름 (자동: {derivedName})" : "캐시 이름",
+                        "호스트 백그라운드 pre-fill 페이지와 동일한 이름을 써야 같은 캐시를 공유합니다. " +
+                        "비우면 앱 ID(appName)에서 자동 파생합니다(멀티앱 오리진 공유 시 sweep 상호 간섭 방지). " +
+                        "런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능."),
                     config.pageCacheName
                 );
-                if (string.IsNullOrEmpty(config.pageCacheName))
-                {
-                    config.pageCacheName = "ait-page-cache";
-                }
 
                 EditorGUILayout.HelpBox(
                     "재방문 전용 최적화입니다. 콘텐츠-해시 URL(파일명 해싱) 전제이며, " +
-                    "부팅 시 현재 빌드에 없는 옛 캐시 엔트리는 자동 정리됩니다. 저장 공간 초과 시 무해하게 건너뜁니다.",
+                    "부팅 시 현재 빌드에 없는 옛 캐시 엔트리는 자동 정리됩니다. " +
+                    "저장 공간 초과 시 무해하게 건너뜁니다.\n" +
+                    $"적용될 캐시명: {derivedName}{(isNameAuto ? " (appName 기반 자동 파생)" : "")}",
                     MessageType.Info
                 );
 
-                if (string.Equals(config.pageCacheName, "ait-page-cache", System.StringComparison.Ordinal))
+                // appName 미설정 + pageCacheName 미설정 시 기본 폴백 경고
+                if (isNameAuto && string.IsNullOrWhiteSpace(config.appName))
                 {
                     EditorGUILayout.HelpBox(
-                        "주의(멀티앱): 같은 오리진에서 여러 미니앱이 기본 'ait-page-cache' 버킷을 공유하면, " +
-                        "한 앱의 부팅 정리(sweep)가 다른 앱의 Build/* 엔트리를 옛 것으로 오인해 삭제할 수 있습니다. " +
-                        "오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 캐시 이름을 지정하세요.",
+                        "앱 ID(appName)가 비어 있어 기본 캐시명 'ait-page-cache' 을 사용합니다. " +
+                        "멀티앱 오리진 공유 환경에서는 앱 ID를 설정하거나 캐시 이름을 직접 지정하세요.",
                         MessageType.Warning
                     );
                 }
@@ -1027,8 +1057,9 @@ namespace AppsInToss.Editor
             bool defaultCaching = AITDefaultSettings.GetDefaultDataCaching();
             if (config.dataCaching >= 0 && (config.dataCaching == 1) != defaultCaching) count++;
 
-            // 페이지 캐시는 opt-in(기본 false). 활성화 시 변경으로 집계.
-            if (config.enablePageCache) count++;
+            // 페이지 캐시: 기본 자동(true). 명시적으로 기본값과 다르게 설정된 경우만 변경으로 집계.
+            bool defaultPageCache = AITDefaultSettings.GetDefaultPageCache();
+            if (config.pageCache >= 0 && (config.pageCache == 1) != defaultPageCache) count++;
 
             return count;
         }
@@ -1038,8 +1069,8 @@ namespace AppsInToss.Editor
             config.memorySize = -1;
             config.threadsSupport = -1;
             config.dataCaching = -1;
-            config.enablePageCache = false;
-            config.pageCacheName = "ait-page-cache";
+            config.pageCache = -1;
+            config.pageCacheName = "";
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -451,6 +451,11 @@ namespace AppsInToss.Editor
 
             GUILayout.Space(10);
 
+            // 페이지 캐시 (재방문 서빙, opt-in)
+            DrawPageCacheSetting();
+
+            GUILayout.Space(10);
+
             // 변경된 설정 개수 표시
             int modifiedCount = CountModifiedWebGLSettings();
             if (modifiedCount > 0)
@@ -546,6 +551,54 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawPageCacheSetting()
+        {
+            EditorGUILayout.LabelField("WebGL 로딩 — 페이지 캐시(재방문 서빙)", EditorStyles.boldLabel);
+
+            config.enablePageCache = EditorGUILayout.Toggle(
+                new GUIContent(
+                    "페이지 캐시 활성화",
+                    "재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
+                    "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. 기본 비활성(opt-in)."),
+                config.enablePageCache
+            );
+
+            if (config.enablePageCache)
+            {
+                EditorGUI.indentLevel++;
+
+                config.pageCacheName = EditorGUILayout.TextField(
+                    new GUIContent(
+                        "캐시 이름",
+                        "호스트 백그라운드 pre-fill 페이지와 동일한 이름을 써야 같은 캐시를 공유합니다. 비우면 ait-page-cache. " +
+                        "같은 오리진에 여러 미니앱이 있으면 앱마다 다른 이름을 쓰세요(공유 시 sweep 상호 간섭)."),
+                    config.pageCacheName
+                );
+                if (string.IsNullOrEmpty(config.pageCacheName))
+                {
+                    config.pageCacheName = "ait-page-cache";
+                }
+
+                EditorGUILayout.HelpBox(
+                    "재방문 전용 최적화입니다. 콘텐츠-해시 URL(파일명 해싱) 전제이며, " +
+                    "부팅 시 현재 빌드에 없는 옛 캐시 엔트리는 자동 정리됩니다. 저장 공간 초과 시 무해하게 건너뜁니다.",
+                    MessageType.Info
+                );
+
+                if (string.Equals(config.pageCacheName, "ait-page-cache", System.StringComparison.Ordinal))
+                {
+                    EditorGUILayout.HelpBox(
+                        "주의(멀티앱): 같은 오리진에서 여러 미니앱이 기본 'ait-page-cache' 버킷을 공유하면, " +
+                        "한 앱의 부팅 정리(sweep)가 다른 앱의 Build/* 엔트리를 옛 것으로 오인해 삭제할 수 있습니다. " +
+                        "오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 캐시 이름을 지정하세요.",
+                        MessageType.Warning
+                    );
+                }
+
+                EditorGUI.indentLevel--;
+            }
         }
 
         private void DrawPermissionSettings()
@@ -974,6 +1027,9 @@ namespace AppsInToss.Editor
             bool defaultCaching = AITDefaultSettings.GetDefaultDataCaching();
             if (config.dataCaching >= 0 && (config.dataCaching == 1) != defaultCaching) count++;
 
+            // 페이지 캐시는 opt-in(기본 false). 활성화 시 변경으로 집계.
+            if (config.enablePageCache) count++;
+
             return count;
         }
 
@@ -982,6 +1038,8 @@ namespace AppsInToss.Editor
             config.memorySize = -1;
             config.threadsSupport = -1;
             config.dataCaching = -1;
+            config.enablePageCache = false;
+            config.pageCacheName = "ait-page-cache";
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -183,12 +183,13 @@ namespace AppsInToss
 
         /// <summary>
         /// 빌드 시 ait-warm-manifest.json 산출 여부 (호스트 warm 연동용).
-        /// 기본 false(opt-in). enablePageCache 와 AND 게이팅되어 있으며,
-        /// enablePageCache=false 이면 manifest 를 내보내지 않습니다.
+        /// tri-state: -1=자동(true, 기본 ON), 0=비활성, 1=활성.
+        /// pageCache 실효값이 OFF 이면 warmManifest 도 no-op (AND 게이팅).
+        /// pageCache 실효값이 OFF 이면서 warmManifest 실효값이 ON 이면 경고 로그를 출력합니다.
         /// </summary>
         [Tooltip("빌드 시 ait-warm-manifest.json 을 산출합니다. 호스트(슈퍼앱)가 선다운로드(warm) diff 기준으로 사용합니다. " +
-                 "enablePageCache 와 AND 게이팅: enablePageCache=false 이면 미산출. 기본 비활성(opt-in).")]
-        public bool emitWarmManifest = false;
+                 "pageCache 실효값이 OFF 이면 회색 비활성 + no-op (AND 게이팅). -1=자동(true), 0=비활성, 1=활성.")]
+        public int warmManifest = -1;
 
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
@@ -388,6 +389,16 @@ namespace AppsInToss
         /// 모든 Unity 버전에서 기본 활성화: 미지원 환경에서 무해 통과가 보장됨.
         /// </summary>
         public static bool GetDefaultPageCache()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// 기본 warm manifest 산출 여부.
+        /// pageCache 와 쌍으로 기본 ON: 호스트 warm 연동 zero-config 제공.
+        /// pageCache 실효값이 OFF 이면 게이팅으로 no-op 처리되므로 독립적으로 ON 해도 안전.
+        /// </summary>
+        public static bool GetDefaultWarmManifest()
         {
             return true;
         }

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -181,6 +181,15 @@ namespace AppsInToss
                  "비우면 ait-page-cache 로 보정됩니다. 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능.")]
         public string pageCacheName = "ait-page-cache";
 
+        /// <summary>
+        /// 빌드 시 ait-warm-manifest.json 산출 여부 (호스트 warm 연동용).
+        /// 기본 false(opt-in). enablePageCache 와 AND 게이팅되어 있으며,
+        /// enablePageCache=false 이면 manifest 를 내보내지 않습니다.
+        /// </summary>
+        [Tooltip("빌드 시 ait-warm-manifest.json 을 산출합니다. 호스트(슈퍼앱)가 선다운로드(warm) diff 기준으로 사용합니다. " +
+                 "enablePageCache 와 AND 게이팅: enablePageCache=false 이면 미산출. 기본 비활성(opt-in).")]
+        public bool emitWarmManifest = false;
+
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
         public int devicePixelRatio = -1;

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -174,12 +174,12 @@ namespace AppsInToss
         [Tooltip("재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
                  "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. " +
                  "호스트(슈퍼앱)가 decode-free(Content-Encoding 미포함 raw bytes)로 동일 캐시명에 pre-fill 하면 " +
-                 "첫 방문도 가속됩니다. 기본 비활성(opt-in).")]
-        public bool enablePageCache = false;
+                 "첫 방문도 가속됩니다. -1 = 자동 (true), 0 = 비활성, 1 = 활성.")]
+        public int pageCache = -1;
 
         [Tooltip("페이지 캐시 버킷 이름. 호스트 백그라운드 pre-fill 페이지와 '동일한 이름'을 써야 같은 캐시를 공유합니다. " +
-                 "비우면 ait-page-cache 로 보정됩니다. 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능.")]
-        public string pageCacheName = "ait-page-cache";
+                 "비우면 appName(앱 식별자)에서 자동 파생합니다. 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능.")]
+        public string pageCacheName = "";
 
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
@@ -372,6 +372,15 @@ namespace AppsInToss
             // WebGL 멀티스레딩은 COOP/COEP 헤더가 필요하여 배포 환경에 따라 문제 발생 가능
             // 필요한 경우 사용자가 직접 활성화하도록 기본값은 false
             return false;
+        }
+
+        /// <summary>
+        /// 기본 페이지 캐시 활성화 여부 (재방문 CacheStorage 서빙)
+        /// 모든 Unity 버전에서 기본 활성화: 미지원 환경에서 무해 통과가 보장됨.
+        /// </summary>
+        public static bool GetDefaultPageCache()
+        {
+            return true;
         }
 
         /// <summary>

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -170,6 +170,17 @@ namespace AppsInToss
 
         public bool nameFilesAsHashes = true;
 
+        [Header("로딩 최적화 — 페이지 캐시(CacheStorage 재방문 서빙)")]
+        [Tooltip("재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙합니다(ServiceWorker 불필요). " +
+                 "첫 방문(콜드)에는 효과가 없고, 미지원/비보안 환경에서는 자동으로 원래 로드로 무해 통과합니다. " +
+                 "호스트(슈퍼앱)가 decode-free(Content-Encoding 미포함 raw bytes)로 동일 캐시명에 pre-fill 하면 " +
+                 "첫 방문도 가속됩니다. 기본 비활성(opt-in).")]
+        public bool enablePageCache = false;
+
+        [Tooltip("페이지 캐시 버킷 이름. 호스트 백그라운드 pre-fill 페이지와 '동일한 이름'을 써야 같은 캐시를 공유합니다. " +
+                 "비우면 ait-page-cache 로 보정됩니다. 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능.")]
+        public string pageCacheName = "ait-page-cache";
+
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
         public int devicePixelRatio = -1;

--- a/Editor/Package/AITPageCacheEmitter.cs
+++ b/Editor/Package/AITPageCacheEmitter.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// 페이지-컨텍스트 CacheStorage 인터셉터 스니펫 방출기 (ServiceWorker 불필요).
+    ///
+    /// index.html 은 SDK 소유이므로 페이지에서 직접 window.fetch 를 패치할 수 있습니다.
+    /// 재방문(warm) 시 Unity Build/* 자산(wasm/data/framework)을 CacheStorage 에서 직접 서빙하면
+    /// 네트워크 요청 자체가 발생하지 않아(transferSize 0) ServiceWorker 없이도 재방문 TTFF 를 단축합니다.
+    ///
+    /// 게이팅: config.enablePageCache 가 false 이면 string.Empty 를 반환합니다.
+    /// → %AIT_PAGE_CACHE_SCRIPT% 가 빈 문자열로 치환되어 산출물이 byte-identical no-op 이 됩니다.
+    /// (AITServiceWorkerEmitter 류의 enableXxx → emitter → %AIT_..._SCRIPT% 치환 컨벤션과 동일.)
+    ///
+    /// === 호스트(슈퍼앱) 연동 계약 (코드 주석으로 명문화) ===
+    ///  · 캐시명 규약: 호스트의 백그라운드 pre-fill 페이지와 '동일한 캐시명' 을 써야 같은 버킷을 공유합니다.
+    ///    캐시명은 config.pageCacheName(기본 'ait-page-cache') 이며, 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드됩니다.
+    ///  · 캐시 키 규약: 절대 URL 문자열(new URL(resource, location.href).href).
+    ///    nameFilesAsHashes=true(기본) 전제 → 파일명이 콘텐츠 해시이므로 키=불변 콘텐츠(스테일 없음).
+    ///  · decode-free pre-fill 규약: 캐시에 Content-Encoding 없는 raw(해제된) bytes 가 들어 있으면
+    ///    loader.js 가 Unity 마커를 못 찾아 Worker brotli 해제를 자연 스킵합니다.
+    ///    이 raw-without-CE 저장은 호스트 pre-fill(또는 서버 CE:br 자동해제 응답)의 책임이며,
+    ///    페이지 스니펫은 저장된 bytes 를 신뢰해 가공 없이 그대로 반환만 합니다.
+    ///
+    /// 부팅 무효화(allowlist): 빌드 시 확정된 현재 빌드 Build/* 파일(data/framework/wasm) 의 절대 URL 집합을
+    /// 스니펫에 JSON 으로 박아, 설치 직후 1회 비차단으로 allowlist 에 없는 옛 해시 엔트리를 정리합니다.
+    /// (loader.js 는 &lt;script src&gt; 라 fetch API 를 안 거치므로 캐시 대상이 아니며 allowlist 에서도 제외.)
+    ///
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
+    /// </summary>
+    internal static class AITPageCacheEmitter
+    {
+        internal const string DefaultCacheName = "ait-page-cache";
+
+        /// <summary>
+        /// index.html 의 %AIT_PAGE_CACHE_SCRIPT% 자리에 인라인 삽입할 &lt;script&gt; IIFE 를 생성합니다.
+        /// config 가 null 이거나 enablePageCache 가 false 이면 string.Empty(no-op)를 반환합니다.
+        /// loaderFile 은 캐시 대상이 아니므로 인자로 받지 않습니다.
+        /// </summary>
+        internal static string GenerateInterceptorScript(AITEditorScriptObject config, string dataFile, string frameworkFile, string wasmFile)
+        {
+            // 게이팅: 비활성 시 완전한 no-op (byte-identical).
+            if (config == null || !config.enablePageCache)
+            {
+                return string.Empty;
+            }
+
+            // 캐시명: 비어 있으면 기본값으로 보정. 호스트 pre-fill 페이지와 동일 문자열이어야 같은 버킷 공유.
+            string cacheName = string.IsNullOrEmpty(config.pageCacheName) ? DefaultCacheName : config.pageCacheName;
+
+            // 부팅 무효화용 allowlist: 현재 빌드의 Build/* 상대 경로(data/framework/wasm). loader 는 제외.
+            var allowlist = new List<string>();
+            if (!string.IsNullOrEmpty(dataFile)) allowlist.Add("Build/" + dataFile);
+            if (!string.IsNullOrEmpty(frameworkFile)) allowlist.Add("Build/" + frameworkFile);
+            if (!string.IsNullOrEmpty(wasmFile)) allowlist.Add("Build/" + wasmFile);
+
+            // JSON 배열 리터럴 (JS 측에서 new URL(...).href 로 절대화하여 allowlist 비교).
+            string allowlistJson = "[" + string.Join(",", allowlist.ConvertAll(JsString)) + "]";
+            string cacheNameJs = JsString(cacheName);
+
+            // 주의: 이 스니펫에는 %대문자_퍼센트% 토큰을 포함하지 않습니다(ValidatePlaceholderSubstitution 안전).
+            // 설치 순서: index.html 에서 본 스니펫은 %AIT_EARLY_FETCH_SCRIPT% 보다 '앞'에 위치합니다.
+            // 따라서 priorFetch 캡처 시점의 window.fetch 는 native 이며, 그 위를 이후 Early Fetch 가 래핑합니다.
+            // 부트 fetch 흐름: ait-cache 래퍼 → (활성 시 Early Fetch 래퍼) → network.
+            // 캐시 히트는 Early Fetch 소진과 무관하게 단락(short-circuit)합니다.
+            return @"<script>
+    // AIT Page Cache: 재방문 시 Build/* 자산을 CacheStorage 에서 직접 서빙(ServiceWorker 불필요).
+    // 미지원/비보안 환경에서는 window.fetch 를 건드리지 않고 원래 로드로 무해 통과합니다.
+    (function () {
+        try {
+            // 설치 가드(최우선): 비보안 컨텍스트이거나 CacheStorage 미지원이면 즉시 return → 원래 fetch 그대로.
+            if (!window.isSecureContext || !('caches' in window)) { return; }
+
+            // 캐시명: 런타임 오버라이드(window.__AIT_CACHE_NAME) 우선, 없으면 빌드 시 박힌 값.
+            // 호스트 pre-fill 페이지와 '동일 캐시명' 이어야 같은 버킷을 공유합니다(연동 계약).
+            var CACHE_NAME = (window.__AIT_CACHE_NAME) || " + cacheNameJs + @";
+
+            // 부팅 무효화 allowlist: 현재 빌드의 Build/* 상대경로. 설치 직후 1회 정리에 사용.
+            var ALLOWLIST = " + allowlistJson + @";
+
+            // 통계 훅(perf CI/검증용, 운영 무영향).
+            window.__aitCacheStats = { hits: [], misses: [], puts: [], errors: [] };
+
+            // 인터셉트 조건: 동일 오리진 && /Build/ 경로. (GET 여부는 호출부에서 별도 판정.)
+            function isCacheable(url) {
+                try {
+                    var u = new URL(url, location.href);
+                    if (u.origin !== location.origin) { return false; }
+                    return u.pathname.indexOf('/Build/') >= 0;
+                } catch (e) { return false; }
+            }
+            // 캐시 키: 절대 URL 문자열(콘텐츠 해시 파일명 전제이므로 키=불변 콘텐츠).
+            function absUrl(resource) {
+                if (typeof resource === 'string') { return new URL(resource, location.href).href; }
+                if (resource && resource.url) { return resource.url; }
+                return null;
+            }
+            // 비-GET 판정: init.method 뿐 아니라 Request 객체에 실린 method 도 확인.
+            // fetch(new Request(url, {method:'POST'})) 처럼 init 없이 Request 에 method 가 실린 경우를
+            // GET 으로 오인해 GET 캐시 엔트리로 응답하는 일을 막는다(견고성). init.method 가 Request.method 를 덮어쓴다.
+            function isNonGet(resource, init) {
+                var method = (init && init.method) || (resource && typeof resource !== 'string' && resource.method) || 'GET';
+                return method.toUpperCase() !== 'GET';
+            }
+
+            var cachePromise = null;
+            function getCache() {
+                if (!cachePromise) { cachePromise = caches.open(CACHE_NAME); }
+                return cachePromise;
+            }
+
+            // 설치 시점의 fetch 를 캡처(여기선 native; Early Fetch 는 아직 미설치).
+            var priorFetch = window.fetch.bind(window);
+
+            window.fetch = function (resource, init) {
+                var url = absUrl(resource);
+                // 비대상/비GET 은 그대로 위임(StreamingAssets/TemplateData/Document/loader.js 등).
+                if (!url || !isCacheable(url) || isNonGet(resource, init)) {
+                    return priorFetch(resource, init);
+                }
+                // cache-first: 어떤 네트워크/Early-Fetch 경로보다 CacheStorage 를 먼저 시도.
+                return getCache().then(function (cache) {
+                    return cache.match(url).then(function (hit) {
+                        if (hit) {
+                            window.__aitCacheStats.hits.push(url);
+                            return hit; // 캐시 히트 → 네트워크 0, transferSize 0 으로 단락.
+                        }
+                        window.__aitCacheStats.misses.push(url);
+                        return priorFetch(resource, init).then(function (resp) {
+                            // put 은 절대 await 하지 않음 → 부트 fetch 무지연(비차단).
+                            try {
+                                if (resp && resp.ok && resp.body !== undefined) {
+                                    // decode-free 계약: 응답을 가공 없이 그대로 저장/반환.
+                                    var clone = resp.clone();
+                                    getCache().then(function (c) { return c.put(url, clone); })
+                                        .then(function () { window.__aitCacheStats.puts.push(url); })
+                                        .catch(function (e) {
+                                            // QuotaExceededError 포함 모든 put 실패 흡수(부팅 무영향).
+                                            // 공간 회복은 다음 부팅의 allowlist 정리에 위임.
+                                            window.__aitCacheStats.errors.push('put ' + url + ': ' + (e && e.message || e));
+                                        });
+                                }
+                            } catch (e) {
+                                window.__aitCacheStats.errors.push('clone ' + url + ': ' + (e && e.message || e));
+                            }
+                            return resp; // 가공 없이 그대로 반환.
+                        });
+                    });
+                }).catch(function (e) {
+                    // match 경로 실패 시 원래 fetch 로 완전 위임(부트 미정지).
+                    window.__aitCacheStats.errors.push('match ' + url + ': ' + (e && e.message || e));
+                    return priorFetch(resource, init);
+                });
+            };
+
+            // 부팅 무효화(설치 직후 1회, 비차단): allowlist 에 없는 옛 해시 엔트리를 백그라운드 정리.
+            // await 하지 않으므로 부팅을 막지 않고, 실패는 catch 로 흡수합니다.
+            // 멀티앱 주의: 같은 오리진의 여러 미니앱이 동일 CACHE_NAME 버킷을 공유하면, 이 sweep 이
+            // 다른 앱의 Build/* 엔트리를 allowlist 외로 오인해 삭제합니다(키 충돌은 없으나 무효화 상호 간섭).
+            // 오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 pageCacheName(=CACHE_NAME)을 지정하세요.
+            try {
+                var allowAbs = {};
+                for (var i = 0; i < ALLOWLIST.length; i++) {
+                    try { allowAbs[new URL(ALLOWLIST[i], location.href).href] = true; } catch (e) {}
+                }
+                getCache().then(function (c) {
+                    return c.keys().then(function (reqs) {
+                        for (var j = 0; j < reqs.length; j++) {
+                            var k = reqs[j].url;
+                            if (!allowAbs[k]) {
+                                c.delete(reqs[j]).catch(function () {});
+                            }
+                        }
+                    });
+                }).catch(function (e) {
+                    window.__aitCacheStats.errors.push('sweep: ' + (e && e.message || e));
+                });
+            } catch (e) {
+                window.__aitCacheStats.errors.push('sweep-init: ' + (e && e.message || e));
+            }
+
+            // 검증/perf CI 용 덤프 헬퍼(운영 무영향).
+            window.__aitCacheDump = function () {
+                return getCache().then(function (c) { return c.keys(); }).then(function (keys) {
+                    return keys.map(function (r) { return r.url; });
+                });
+            };
+        } catch (e) {
+            // 설치 과정의 어떤 예외도 부팅을 막지 않습니다(priorFetch=원래 fetch 가 그대로 살아 있음).
+        }
+    })();
+    </script>";
+        }
+
+        /// <summary>
+        /// 문자열을 안전한 JS 문자열 리터럴로 인코딩합니다(따옴표/역슬래시 이스케이프).
+        /// </summary>
+        private static string JsString(string value)
+        {
+            if (value == null) return "\"\"";
+            string escaped = value
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"");
+            return "\"" + escaped + "\"";
+        }
+    }
+}

--- a/Editor/Package/AITPageCacheEmitter.cs
+++ b/Editor/Package/AITPageCacheEmitter.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
 
 namespace AppsInToss.Editor.Package
 {
@@ -9,13 +12,18 @@ namespace AppsInToss.Editor.Package
     /// 재방문(warm) 시 Unity Build/* 자산(wasm/data/framework)을 CacheStorage 에서 직접 서빙하면
     /// 네트워크 요청 자체가 발생하지 않아(transferSize 0) ServiceWorker 없이도 재방문 TTFF 를 단축합니다.
     ///
-    /// 게이팅: config.enablePageCache 가 false 이면 string.Empty 를 반환합니다.
+    /// 게이팅: config.pageCache tri-state (-1=자동/true, 0=비활성, 1=활성).
+    /// 비활성 판정 시 string.Empty 를 반환합니다.
     /// → %AIT_PAGE_CACHE_SCRIPT% 가 빈 문자열로 치환되어 산출물이 byte-identical no-op 이 됩니다.
     /// (AITServiceWorkerEmitter 류의 enableXxx → emitter → %AIT_..._SCRIPT% 치환 컨벤션과 동일.)
     ///
+    /// 캐시명 자동 파생: config.pageCacheName 이 비어 있으면 appName 에서 "ait-page-cache-{slug}" 를 파생합니다.
+    /// appName 도 비어 있으면 기본값 "ait-page-cache" 를 사용하고 빌드 경고를 출력합니다.
+    /// 이 자동 파생은 멀티앱 오리진 공유 시 sweep 상호 간섭을 방지합니다.
+    ///
     /// === 호스트(슈퍼앱) 연동 계약 (코드 주석으로 명문화) ===
     ///  · 캐시명 규약: 호스트의 백그라운드 pre-fill 페이지와 '동일한 캐시명' 을 써야 같은 버킷을 공유합니다.
-    ///    캐시명은 config.pageCacheName(기본 'ait-page-cache') 이며, 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드됩니다.
+    ///    캐시명은 config.pageCacheName(또는 자동 파생값) 이며, 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드됩니다.
     ///  · 캐시 키 규약: 절대 URL 문자열(new URL(resource, location.href).href).
     ///    nameFilesAsHashes=true(기본) 전제 → 파일명이 콘텐츠 해시이므로 키=불변 콘텐츠(스테일 없음).
     ///  · decode-free pre-fill 규약: 캐시에 Content-Encoding 없는 raw(해제된) bytes 가 들어 있으면
@@ -32,22 +40,110 @@ namespace AppsInToss.Editor.Package
     internal static class AITPageCacheEmitter
     {
         internal const string DefaultCacheName = "ait-page-cache";
+        internal const string CacheNamePrefix = "ait-page-cache-";
+
+        /// <summary>
+        /// appName(앱 식별자)에서 캐시 버킷 이름을 파생합니다.
+        /// 영문 소문자/숫자/하이픈으로 정규화하며, 비ASCII 문자는 짧은 해시로 대체합니다.
+        /// identifier 가 비어 있으면 null 을 반환합니다(호출자가 폴백 처리).
+        /// </summary>
+        internal static string DeriveCacheName(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier))
+                return null;
+
+            // 비ASCII 포함 여부 확인
+            bool hasNonAscii = false;
+            foreach (char c in identifier)
+            {
+                if (c > 127) { hasNonAscii = true; break; }
+            }
+
+            string slug;
+            if (hasNonAscii)
+            {
+                // 비ASCII 문자가 있으면 UTF-8 바이트의 FNV-1a 32비트 해시(16진수 8자리)로 대체
+                slug = ComputeFnv1a32Hex(identifier);
+            }
+            else
+            {
+                // ASCII만 있으면 소문자 변환 후 영숫자·하이픈 이외 문자를 하이픈으로 치환
+                slug = identifier.ToLowerInvariant();
+                slug = Regex.Replace(slug, @"[^a-z0-9\-]", "-");
+                // 연속 하이픈·앞뒤 하이픈 정리
+                slug = Regex.Replace(slug, @"-{2,}", "-").Trim('-');
+            }
+
+            if (string.IsNullOrEmpty(slug))
+                return null;
+
+            return CacheNamePrefix + slug;
+        }
+
+        /// <summary>
+        /// 문자열의 UTF-8 바이트에 대한 FNV-1a 32비트 해시를 16진수 문자열(8자리)로 반환합니다.
+        /// 순수 정적 함수: 외부 의존성 없음, 테스트 용이.
+        /// </summary>
+        internal static string ComputeFnv1a32Hex(string value)
+        {
+            const uint FnvOffsetBasis = 2166136261u;
+            const uint FnvPrime = 16777619u;
+
+            uint hash = FnvOffsetBasis;
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            foreach (byte b in bytes)
+            {
+                hash ^= b;
+                hash *= FnvPrime;
+            }
+            return hash.ToString("x8");
+        }
+
+        /// <summary>
+        /// pageCache tri-state 값과 appName 을 고려하여 실제 캐시명을 결정합니다.
+        /// pageCacheName 이 명시적으로 설정되어 있으면 그대로 사용하고,
+        /// 비어 있으면 appName 에서 자동 파생합니다.
+        /// </summary>
+        internal static string ResolveCacheName(AITEditorScriptObject config)
+        {
+            // 명시적 캐시명이 있으면 그대로 사용
+            if (!string.IsNullOrEmpty(config.pageCacheName))
+                return config.pageCacheName;
+
+            // appName 에서 자동 파생
+            string derived = DeriveCacheName(config.appName);
+            if (derived != null)
+                return derived;
+
+            // 식별자도 없으면 기본값 폴백 + 경고
+            Debug.LogWarning(
+                "[AIT] pageCacheName 과 appName 이 모두 비어 있어 기본 캐시 이름 '" + DefaultCacheName + "' 을 사용합니다. " +
+                "멀티앱 오리진 공유 환경에서는 앱별 고유 이름을 설정하세요."
+            );
+            return DefaultCacheName;
+        }
 
         /// <summary>
         /// index.html 의 %AIT_PAGE_CACHE_SCRIPT% 자리에 인라인 삽입할 &lt;script&gt; IIFE 를 생성합니다.
-        /// config 가 null 이거나 enablePageCache 가 false 이면 string.Empty(no-op)를 반환합니다.
+        /// config 가 null 이거나 pageCache 가 비활성(0) 이면 string.Empty(no-op)를 반환합니다.
+        /// pageCache == -1(자동) 이면 AITDefaultSettings.GetDefaultPageCache() == true 이므로 활성으로 동작합니다.
         /// loaderFile 은 캐시 대상이 아니므로 인자로 받지 않습니다.
         /// </summary>
         internal static string GenerateInterceptorScript(AITEditorScriptObject config, string dataFile, string frameworkFile, string wasmFile)
         {
-            // 게이팅: 비활성 시 완전한 no-op (byte-identical).
-            if (config == null || !config.enablePageCache)
+            // 게이팅: tri-state 해석 (-1=자동→기본값true, 0=비활성, 1=활성).
+            bool enabled = config != null && (
+                config.pageCache < 0
+                    ? AITDefaultSettings.GetDefaultPageCache()
+                    : config.pageCache == 1
+            );
+            if (!enabled)
             {
                 return string.Empty;
             }
 
-            // 캐시명: 비어 있으면 기본값으로 보정. 호스트 pre-fill 페이지와 동일 문자열이어야 같은 버킷 공유.
-            string cacheName = string.IsNullOrEmpty(config.pageCacheName) ? DefaultCacheName : config.pageCacheName;
+            // 캐시명: 명시적 설정 > appName 파생 > 기본값 폴백.
+            string cacheName = ResolveCacheName(config);
 
             // 부팅 무효화용 allowlist: 현재 빌드의 Build/* 상대 경로(data/framework/wasm). loader 는 제외.
             var allowlist = new List<string>();
@@ -158,7 +254,7 @@ namespace AppsInToss.Editor.Package
             // await 하지 않으므로 부팅을 막지 않고, 실패는 catch 로 흡수합니다.
             // 멀티앱 주의: 같은 오리진의 여러 미니앱이 동일 CACHE_NAME 버킷을 공유하면, 이 sweep 이
             // 다른 앱의 Build/* 엔트리를 allowlist 외로 오인해 삭제합니다(키 충돌은 없으나 무효화 상호 간섭).
-            // 오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 pageCacheName(=CACHE_NAME)을 지정하세요.
+            // 오리진을 공유하는 앱이 둘 이상이면 앱별로 고유한 캐시명(=CACHE_NAME)을 지정하세요(appName 기반 자동 파생).
             try {
                 var allowAbs = {};
                 for (var i = 0; i < ALLOWLIST.length; i++) {

--- a/Editor/Package/AITPageCacheEmitter.cs.meta
+++ b/Editor/Package/AITPageCacheEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8c2dfed6529453cb9af15d50f378006
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/AITWarmManifestEmitter.cs
+++ b/Editor/Package/AITWarmManifestEmitter.cs
@@ -16,11 +16,14 @@ namespace AppsInToss.Editor.Package
     /// <see cref="AITPageCacheEmitter"/> 인터셉터의 allowlist 와 '같은 빌드의 같은 입력 변수'에서
     /// 생성되므로 두 파일 사이에 drift 가 불가능합니다.
     ///
-    /// === 게이팅 규칙 ===
-    ///  · <c>config == null || !config.emitWarmManifest</c> → stale 파일 삭제 후 no-op 반환.
-    ///  · <c>emitWarmManifest=true &amp;&amp; enablePageCache=false</c> → 경고 로그 출력 후 no-op 반환.
+    /// === 게이팅 규칙 (tri-state) ===
+    ///  · <c>config == null</c> → stale 파일 삭제 후 no-op 반환.
+    ///  · warmManifest 실효값 = (warmManifest == -1) ? GetDefaultWarmManifest() : (warmManifest == 1)
+    ///  · 실효값 false → stale 파일 삭제 후 no-op 반환.
+    ///  · pageCache 실효값 = (pageCache == -1) ? GetDefaultPageCache() : (pageCache == 1)
+    ///  · warmManifest 실효값 true + pageCache 실효값 false → 경고 로그 출력 후 no-op 반환.
     ///    (manifest 단독으로는 의미가 없습니다. 인터셉터 없이 배포하면 호스트가 참조할 캐시 버킷이 존재하지 않음.)
-    ///  · 둘 다 true 일 때만 실제 파일을 산출합니다.
+    ///  · 둘 다 실효값 true 일 때만 실제 파일을 산출합니다.
     ///
     /// === 호스트(슈퍼앱) 연동 계약 (코드 주석으로 명문화) ===
     ///  · cacheName: 호스트 백그라운드 pre-fill 페이지와 '동일한 캐시명'을 사용해야 같은 버킷을 공유합니다.
@@ -57,20 +60,36 @@ namespace AppsInToss.Editor.Package
         {
             string outputPath = Path.Combine(destPath, FileName);
 
-            // 게이팅 1: emitWarmManifest 가 비활성이면 stale 파일 삭제 후 종료.
-            if (config == null || !config.emitWarmManifest)
+            // 게이팅 1: config 가 null 이거나 warmManifest 실효값이 false 이면 stale 파일 삭제 후 종료.
+            // tri-state: -1=자동(GetDefaultWarmManifest()), 0=비활성, 1=활성.
+            if (config == null)
             {
                 DeleteStale(outputPath);
                 return;
             }
 
-            // 게이팅 2: emitWarmManifest=true 이지만 enablePageCache=false 이면 무의미 — 미산출.
+            bool warmManifestEffective = config.warmManifest < 0
+                ? AITDefaultSettings.GetDefaultWarmManifest()
+                : config.warmManifest == 1;
+
+            if (!warmManifestEffective)
+            {
+                DeleteStale(outputPath);
+                return;
+            }
+
+            // 게이팅 2: warmManifest 실효값 true 이지만 pageCache 실효값 false 이면 무의미 — 미산출 + 경고.
             // 호스트 pre-fill 없이 manifest 만 내보내면 참조할 캐시 버킷 자체가 없어 활용 불가.
-            if (!config.enablePageCache)
+            // pageCache tri-state: -1=자동(GetDefaultPageCache()), 0=비활성, 1=활성.
+            bool pageCacheEffective = config.pageCache < 0
+                ? AITDefaultSettings.GetDefaultPageCache()
+                : config.pageCache == 1;
+
+            if (!pageCacheEffective)
             {
                 Debug.LogWarning(
-                    "[AIT] ait-warm-manifest.json 미산출: emitWarmManifest=true 이지만 enablePageCache=false 입니다. " +
-                    "manifest 는 페이지 캐시 인터셉터(enablePageCache) 없이는 호스트가 참조할 캐시 버킷이 존재하지 않으므로 무의미합니다."
+                    "[AIT] ait-warm-manifest.json 미산출: warmManifest 실효값=true 이지만 pageCache 실효값=false 입니다. " +
+                    "manifest 는 페이지 캐시 인터셉터(pageCache) 없이는 호스트가 참조할 캐시 버킷이 존재하지 않으므로 무의미합니다."
                 );
                 DeleteStale(outputPath);
                 return;

--- a/Editor/Package/AITWarmManifestEmitter.cs
+++ b/Editor/Package/AITWarmManifestEmitter.cs
@@ -1,0 +1,543 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// 빌드 시 <c>ait-warm-manifest.json</c> 을 산출합니다.
+    ///
+    /// 목적: 호스트(슈퍼앱)가 미니앱 목록 화면에서 Build 자산을 선다운로드(warm)할 때
+    /// diff 기준으로 쓸 기계가독 계약 파일입니다.
+    /// <see cref="AITPageCacheEmitter"/> 인터셉터의 allowlist 와 '같은 빌드의 같은 입력 변수'에서
+    /// 생성되므로 두 파일 사이에 drift 가 불가능합니다.
+    ///
+    /// === 게이팅 규칙 ===
+    ///  · <c>config == null || !config.emitWarmManifest</c> → stale 파일 삭제 후 no-op 반환.
+    ///  · <c>emitWarmManifest=true &amp;&amp; enablePageCache=false</c> → 경고 로그 출력 후 no-op 반환.
+    ///    (manifest 단독으로는 의미가 없습니다. 인터셉터 없이 배포하면 호스트가 참조할 캐시 버킷이 존재하지 않음.)
+    ///  · 둘 다 true 일 때만 실제 파일을 산출합니다.
+    ///
+    /// === 호스트(슈퍼앱) 연동 계약 (코드 주석으로 명문화) ===
+    ///  · cacheName: 호스트 백그라운드 pre-fill 페이지와 '동일한 캐시명'을 사용해야 같은 버킷을 공유합니다.
+    ///    <c>config.pageCacheName</c> 이 비어 있으면 <see cref="AITPageCacheEmitter.DefaultCacheName"/> 으로 보정합니다.
+    ///  · assets: data/framework/wasm 3종만 포함합니다. loader 와 symbols 는 excluded 에만 기재합니다.
+    ///  · wireBytes: 실제 디스크 상의 (압축 포함) 파일 크기입니다.
+    ///  · rawBytes: gzip/brotli 해제 후 바이트 수입니다. 탐지 불가 시 필드를 생략합니다.
+    ///  · encoding: "gzip" | "br" | "none".
+    ///
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
+    /// </summary>
+    internal static class AITWarmManifestEmitter
+    {
+        internal const string FileName = "ait-warm-manifest.json";
+
+        /// <summary>
+        /// <paramref name="destPath"/> 아래에 <c>ait-warm-manifest.json</c> 을 산출합니다.
+        /// </summary>
+        /// <param name="config">AIT Editor 설정 오브젝트. null 이면 no-op.</param>
+        /// <param name="destPath">web 루트 경로 (index.html 이 놓이는 디렉토리).</param>
+        /// <param name="loaderFile">Build/ 내 loader 파일명 (excluded 항목).</param>
+        /// <param name="dataFile">Build/ 내 data 파일명 (assets 항목).</param>
+        /// <param name="frameworkFile">Build/ 내 framework 파일명 (assets 항목).</param>
+        /// <param name="wasmFile">Build/ 내 wasm 파일명 (assets 항목).</param>
+        /// <param name="symbolsFile">Build/ 내 symbols 파일명 (excluded 항목, 비어 있으면 생략).</param>
+        internal static void WriteManifest(
+            AITEditorScriptObject config,
+            string destPath,
+            string loaderFile,
+            string dataFile,
+            string frameworkFile,
+            string wasmFile,
+            string symbolsFile)
+        {
+            string outputPath = Path.Combine(destPath, FileName);
+
+            // 게이팅 1: emitWarmManifest 가 비활성이면 stale 파일 삭제 후 종료.
+            if (config == null || !config.emitWarmManifest)
+            {
+                DeleteStale(outputPath);
+                return;
+            }
+
+            // 게이팅 2: emitWarmManifest=true 이지만 enablePageCache=false 이면 무의미 — 미산출.
+            // 호스트 pre-fill 없이 manifest 만 내보내면 참조할 캐시 버킷 자체가 없어 활용 불가.
+            if (!config.enablePageCache)
+            {
+                Debug.LogWarning(
+                    "[AIT] ait-warm-manifest.json 미산출: emitWarmManifest=true 이지만 enablePageCache=false 입니다. " +
+                    "manifest 는 페이지 캐시 인터셉터(enablePageCache) 없이는 호스트가 참조할 캐시 버킷이 존재하지 않으므로 무의미합니다."
+                );
+                DeleteStale(outputPath);
+                return;
+            }
+
+            // 캐시명: 비어 있으면 AITPageCacheEmitter 와 동일한 기본값으로 보정.
+            string cacheName = string.IsNullOrEmpty(config.pageCacheName)
+                ? AITPageCacheEmitter.DefaultCacheName
+                : config.pageCacheName;
+
+            // 버전 문자열: package.json 에서 추출. 실패 시 버전 없이 식별자만.
+            string sdkVersion = ReadSdkVersion();
+            string generator = string.IsNullOrEmpty(sdkVersion)
+                ? "apps-in-toss.unity"
+                : "apps-in-toss.unity@" + sdkVersion;
+
+            // assets 및 totals 계산.
+            long totalWire = 0;
+            long totalRaw = 0;
+            bool allRawKnown = true;
+
+            var assets = new System.Collections.Generic.List<AssetEntry>();
+
+            foreach (var tuple in new[]
+            {
+                (file: dataFile,      role: "data",      mime: "application/octet-stream"),
+                (file: frameworkFile, role: "framework",  mime: "text/javascript"),
+                (file: wasmFile,      role: "wasm",       mime: "application/wasm"),
+            })
+            {
+                if (string.IsNullOrEmpty(tuple.file)) continue;
+
+                string fullPath = Path.Combine(destPath, "Build", tuple.file);
+                if (!File.Exists(fullPath))
+                {
+                    Debug.LogWarning($"[AIT] ait-warm-manifest.json: Build/{tuple.file} 파일을 찾을 수 없어 해당 항목을 건너뜁니다.");
+                    allRawKnown = false;
+                    continue;
+                }
+
+                long wireBytes = new FileInfo(fullPath).Length;
+                string encoding;
+                long rawBytes;
+                bool rawKnown;
+                DetectEncoding(fullPath, tuple.file, wireBytes, out encoding, out rawBytes, out rawKnown);
+
+                totalWire += wireBytes;
+                if (rawKnown)
+                {
+                    totalRaw += rawBytes;
+                }
+                else
+                {
+                    allRawKnown = false;
+                }
+
+                assets.Add(new AssetEntry
+                {
+                    path = "Build/" + tuple.file,
+                    role = tuple.role,
+                    mime = tuple.mime,
+                    wireBytes = wireBytes,
+                    rawBytes = rawBytes,
+                    rawKnown = rawKnown,
+                    encoding = encoding,
+                });
+            }
+
+            // excluded 목록 구성.
+            var excluded = new System.Collections.Generic.List<ExcludedEntry>();
+            if (!string.IsNullOrEmpty(loaderFile))
+            {
+                excluded.Add(new ExcludedEntry
+                {
+                    path = "Build/" + loaderFile,
+                    role = "loader",
+                    reason = "script-src 로드 — page fetch 비경유, 인터셉터 서빙 불가",
+                });
+            }
+            if (!string.IsNullOrEmpty(symbolsFile))
+            {
+                excluded.Add(new ExcludedEntry
+                {
+                    path = "Build/" + symbolsFile,
+                    role = "symbols",
+                    reason = "부팅 임계경로 밖",
+                });
+            }
+
+            // JSON 직렬화 (StringBuilder 수작업, 2-space pretty, 키 순서 고정).
+            string json = BuildJson(generator, cacheName, assets, excluded, totalWire, allRawKnown ? (long?)totalRaw : null);
+
+            // 안전 검사: %대문자_언더스코어% 토큰이 산출물에 없어야 한다.
+            if (Regex.IsMatch(json, @"%[A-Z0-9_]+%"))
+            {
+                Debug.LogError("[AIT] ait-warm-manifest.json 내부 오류: 미치환 플레이스홀더 토큰이 감지되어 파일을 산출하지 않습니다.");
+                return;
+            }
+
+            File.WriteAllText(outputPath, json, Encoding.UTF8);
+            Debug.Log($"[AIT] ✓ ait-warm-manifest.json 산출 완료: {outputPath}");
+        }
+
+        // -----------------------------------------------------------------------
+        // 내부 자료형
+        // -----------------------------------------------------------------------
+
+        private struct AssetEntry
+        {
+            public string path;
+            public string role;
+            public string mime;
+            public long wireBytes;
+            public long rawBytes;
+            public bool rawKnown;
+            public string encoding;
+        }
+
+        private struct ExcludedEntry
+        {
+            public string path;
+            public string role;
+            public string reason;
+        }
+
+        // -----------------------------------------------------------------------
+        // JSON 빌더 (외부 라이브러리 의존 없음, 키 순서 고정, 2-space indent)
+        // -----------------------------------------------------------------------
+
+        private static string BuildJson(
+            string generator,
+            string cacheName,
+            System.Collections.Generic.List<AssetEntry> assets,
+            System.Collections.Generic.List<ExcludedEntry> excluded,
+            long totalWire,
+            long? totalRaw)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("{");
+            sb.AppendLine("  \"schemaVersion\": 1,");
+            sb.AppendLine("  \"generator\": " + JsonString(generator) + ",");
+            sb.AppendLine("  \"cacheName\": " + JsonString(cacheName) + ",");
+
+            // assets 배열
+            sb.AppendLine("  \"assets\": [");
+            for (int i = 0; i < assets.Count; i++)
+            {
+                var a = assets[i];
+                bool last = (i == assets.Count - 1);
+                sb.AppendLine("    {");
+                sb.AppendLine("      \"path\": " + JsonString(a.path) + ",");
+                sb.AppendLine("      \"role\": " + JsonString(a.role) + ",");
+                sb.AppendLine("      \"mime\": " + JsonString(a.mime) + ",");
+                sb.AppendLine("      \"wireBytes\": " + a.wireBytes + ",");
+                if (a.rawKnown)
+                {
+                    sb.AppendLine("      \"rawBytes\": " + a.rawBytes + ",");
+                }
+                sb.AppendLine("      \"encoding\": " + JsonString(a.encoding));
+                sb.Append("    }");
+                sb.AppendLine(last ? "" : ",");
+            }
+            sb.AppendLine("  ],");
+
+            // excluded 배열
+            sb.AppendLine("  \"excluded\": [");
+            for (int i = 0; i < excluded.Count; i++)
+            {
+                var e = excluded[i];
+                bool last = (i == excluded.Count - 1);
+                sb.AppendLine("    {");
+                sb.AppendLine("      \"path\": " + JsonString(e.path) + ",");
+                sb.AppendLine("      \"role\": " + JsonString(e.role) + ",");
+                sb.AppendLine("      \"reason\": " + JsonString(e.reason));
+                sb.Append("    }");
+                sb.AppendLine(last ? "" : ",");
+            }
+            sb.AppendLine("  ],");
+
+            // totals 오브젝트
+            sb.AppendLine("  \"totals\": {");
+            sb.Append("    \"wireBytes\": " + totalWire);
+            if (totalRaw.HasValue)
+            {
+                sb.AppendLine(",");
+                sb.AppendLine("    \"rawBytes\": " + totalRaw.Value);
+            }
+            else
+            {
+                sb.AppendLine();
+            }
+            sb.AppendLine("  }");
+
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        // -----------------------------------------------------------------------
+        // 인코딩/압축 탐지
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// 파일의 압축 인코딩과 해제 바이트 수를 탐지합니다.
+        /// </summary>
+        /// <param name="fullPath">파일의 전체 경로.</param>
+        /// <param name="fileName">파일명 (확장자 기반 brotli 추론용).</param>
+        /// <param name="wireBytes">알려진 파일 크기 (rawBytes 폴백 시 사용).</param>
+        /// <param name="encoding">탐지된 인코딩: "gzip" | "br" | "none".</param>
+        /// <param name="rawBytes">해제 후 바이트 수 (탐지 불가 시 wireBytes 와 같거나 무의미).</param>
+        /// <param name="rawKnown">rawBytes 를 신뢰할 수 있으면 true.</param>
+        private static void DetectEncoding(
+            string fullPath,
+            string fileName,
+            long wireBytes,
+            out string encoding,
+            out long rawBytes,
+            out bool rawKnown)
+        {
+            encoding = "none";
+            rawBytes = wireBytes;
+            rawKnown = false;
+
+            try
+            {
+                // 첫 2바이트로 gzip 마커 확인.
+                byte[] header = new byte[2];
+                using (var fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    int read = fs.Read(header, 0, 2);
+                    if (read < 2)
+                    {
+                        // 파일이 너무 작으면 그냥 "none".
+                        rawKnown = true;
+                        return;
+                    }
+                }
+
+                // gzip: 0x1f 0x8b
+                if (header[0] == 0x1f && header[1] == 0x8b)
+                {
+                    encoding = "gzip";
+                    long counted = CountDecompressedBytes_GZip(fullPath);
+                    if (counted >= 0)
+                    {
+                        rawBytes = counted;
+                        rawKnown = true;
+                    }
+                    return;
+                }
+
+                // brotli: 직접 타입 참조 금지(Unity mono BCL 에 System.IO.Compression.BrotliStream 이 없을 수 있음).
+                // 리플렉션으로 BrotliStream 타입을 탐색한 뒤 있으면 스트리밍 디코드 시도.
+                // (Unity mono BCL 은 .NET Standard 2.0 기반으로 BrotliStream 이 미포함인 버전이 많음.)
+                long brotliBytes = TryCountDecompressedBytes_Brotli(fullPath);
+                if (brotliBytes >= 0)
+                {
+                    encoding = "br";
+                    rawBytes = brotliBytes;
+                    rawKnown = true;
+                    return;
+                }
+
+                // 타입 부재 또는 디코드 예외 폴백: .unityweb 확장자이면 brotli 로 간주하되 rawBytes 생략.
+                if (fileName.EndsWith(".unityweb", StringComparison.OrdinalIgnoreCase))
+                {
+                    encoding = "br";
+                    rawKnown = false;
+                    return;
+                }
+
+                // 그 외: none, rawBytes = wireBytes.
+                encoding = "none";
+                rawBytes = wireBytes;
+                rawKnown = true;
+            }
+            catch
+            {
+                // 탐지 과정 예외 — encoding "none", rawKnown=false 로 안전 처리.
+                encoding = "none";
+                rawKnown = false;
+            }
+        }
+
+        /// <summary>
+        /// GZipStream 을 64KB 버퍼로 스트리밍하여 해제 바이트 수를 카운트합니다.
+        /// 메모리에 전체를 적재하지 않습니다.
+        /// 실패 시 -1 반환.
+        /// </summary>
+        private static long CountDecompressedBytes_GZip(string fullPath)
+        {
+            try
+            {
+                const int bufferSize = 64 * 1024;
+                byte[] buffer = new byte[bufferSize];
+                long total = 0;
+                using (var fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var gz = new GZipStream(fs, CompressionMode.Decompress))
+                {
+                    int read;
+                    while ((read = gz.Read(buffer, 0, bufferSize)) > 0)
+                    {
+                        total += read;
+                    }
+                }
+                return total;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// 리플렉션으로 BrotliStream 타입을 탐색해 스트리밍 카운트를 시도합니다.
+        /// Unity mono BCL 에 BrotliStream 이 없을 수 있으므로 직접 타입 참조 대신 리플렉션을 사용합니다.
+        /// (Unity 2021.3 LTS 의 mono BCL 은 .NET Standard 2.0 기반 — BrotliStream 은 .NET Standard 2.1 추가.)
+        /// 성공 시 해제 바이트 수, 실패/타입 부재 시 -1 반환.
+        /// </summary>
+        private static long TryCountDecompressedBytes_Brotli(string fullPath)
+        {
+            // AppDomain 내 로드된 어셈블리에서 BrotliStream 타입 탐색.
+            Type brotliStreamType = null;
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    Type t = asm.GetType("System.IO.Compression.BrotliStream");
+                    if (t != null)
+                    {
+                        brotliStreamType = t;
+                        break;
+                    }
+                }
+                catch
+                {
+                    // 어셈블리 열거 중 예외(리플렉션 권한 등) — 무시하고 계속.
+                }
+            }
+
+            if (brotliStreamType == null)
+            {
+                return -1;
+            }
+
+            try
+            {
+                const int bufferSize = 64 * 1024;
+                byte[] buffer = new byte[bufferSize];
+                long total = 0;
+
+                using (var fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    // Activator.CreateInstance(BrotliStream, Stream, CompressionMode.Decompress)
+                    object brotliStream = Activator.CreateInstance(
+                        brotliStreamType,
+                        new object[] { fs, CompressionMode.Decompress }
+                    );
+
+                    using (var stream = (Stream)brotliStream)
+                    {
+                        int read;
+                        while ((read = stream.Read(buffer, 0, bufferSize)) > 0)
+                        {
+                            total += read;
+                        }
+                    }
+                }
+                return total;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // SDK 버전 읽기
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// SDK package.json 에서 "version" 값을 읽어 반환합니다.
+        /// 파일을 찾지 못하거나 파싱 실패 시 null 반환.
+        /// </summary>
+        private static string ReadSdkVersion()
+        {
+            try
+            {
+                // AITPackagePathResolver 를 이용해 package.json 의 부모 디렉토리(패키지 루트)를 탐색.
+                // SdkPathResolver.GetSdkBuildConfigPath() → "WebGLTemplates/AITTemplate/BuildConfig~" 경로를 반환.
+                // 패키지 루트는 그 위 3단계.
+                string buildConfigPath = SdkPathResolver.GetSdkBuildConfigPath();
+                if (!string.IsNullOrEmpty(buildConfigPath))
+                {
+                    // BuildConfig~ → AITTemplate → WebGLTemplates → 패키지루트
+                    string packageRoot = Path.GetFullPath(Path.Combine(buildConfigPath, "..", "..", ".."));
+                    string packageJsonPath = Path.Combine(packageRoot, "package.json");
+                    if (File.Exists(packageJsonPath))
+                    {
+                        string text = File.ReadAllText(packageJsonPath, Encoding.UTF8);
+                        var match = Regex.Match(text, "\"version\"\\s*:\\s*\"([^\"]+)\"");
+                        if (match.Success)
+                        {
+                            return match.Groups[1].Value;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // 버전 탐지 실패는 빌드를 멈추지 않음.
+            }
+
+            return null;
+        }
+
+        // -----------------------------------------------------------------------
+        // 유틸리티
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// stale 파일이 있으면 예외 흡수하며 삭제합니다.
+        /// </summary>
+        private static void DeleteStale(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch
+            {
+                // 삭제 실패는 무시 (읽기 전용 파일시스템 등).
+            }
+        }
+
+        /// <summary>
+        /// 문자열을 안전한 JSON 문자열 리터럴로 인코딩합니다(따옴표/역슬래시/제어문자 이스케이프).
+        /// </summary>
+        private static string JsonString(string value)
+        {
+            if (value == null) return "\"\"";
+            var sb = new StringBuilder("\"");
+            foreach (char c in value)
+            {
+                switch (c)
+                {
+                    case '\\': sb.Append("\\\\"); break;
+                    case '"':  sb.Append("\\\""); break;
+                    case '\n': sb.Append("\\n");  break;
+                    case '\r': sb.Append("\\r");  break;
+                    case '\t': sb.Append("\\t");  break;
+                    default:
+                        if (c < 0x20)
+                        {
+                            sb.AppendFormat("\\u{0:x4}", (int)c);
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                        break;
+                }
+            }
+            sb.Append('"');
+            return sb.ToString();
+        }
+    }
+}

--- a/Editor/Package/AITWarmManifestEmitter.cs.meta
+++ b/Editor/Package/AITWarmManifestEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfd9e0fe5fd49091b08ebdabc9eaff0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -340,6 +340,14 @@ namespace AppsInToss.Editor.Package
                 Debug.Log($"[AIT] appsintoss-unity-bridge.js Mock 브릿지 모드: {(profile.enableMockBridge ? "활성화" : "비활성화")}");
             }
 
+            // Build 파일 복사 및 index.html 치환 완료 후 warm manifest 를 산출합니다.
+            // [destPath = publicPath] 명세 원문은 'index.html 이 놓이는 web 루트(buildProjectPath)' 라 기술하나,
+            // Build/* 파일은 publicPath(buildProjectPath/public/)에 복사되므로 wireBytes 계산이
+            // buildProjectPath 기준이면 FileInfo.Length 가 실패합니다. publicPath 를 전달해야
+            // Path.Combine(destPath, "Build", file) 이 실제 파일 위치와 일치합니다.
+            // Vite 가 public/ 을 정적 루트로 서빙하므로 호스트는 /ait-warm-manifest.json 으로 취득합니다.
+            AITWarmManifestEmitter.WriteManifest(config, publicPath, loaderFile, dataFile, frameworkFile, wasmFile, symbolsFile);
+
             Debug.Log("[AIT] Unity WebGL 빌드 복사 완료");
             Debug.Log("[AIT]   - index.html → 프로젝트 루트");
             Debug.Log("[AIT]   - Build, TemplateData, Runtime → public/");

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -286,6 +286,10 @@ namespace AppsInToss.Editor.Package
                 .Replace("%AIT_ICON_URL%", config.iconUrl ?? "")
                 .Replace("%AIT_DISPLAY_NAME%", config.displayName ?? "")
                 .Replace("%AIT_PRIMARY_COLOR%", config.primaryColor ?? "#3182f6")
+                // 페이지 캐시 인터셉터 (재방문 서빙, opt-in). index.html 에서 Early Fetch 보다 '앞'에 위치해야
+                // priorFetch=native 캡처 → 캐시 히트가 Early Fetch 소진과 무관하게 단락됨.
+                // 각 토큰은 독립 치환이므로 치환 순서는 출력 위치를 바꾸지 않음(물리 위치는 index.html 이 보장).
+                .Replace("%AIT_PAGE_CACHE_SCRIPT%", AITPageCacheEmitter.GenerateInterceptorScript(config, dataFile, frameworkFile, wasmFile))
                 // Early Fetch 스크립트 (로딩 성능 개선)
                 .Replace("%AIT_EARLY_FETCH_SCRIPT%", GenerateEarlyFetchScript(dataFile, wasmFile));
 

--- a/Tests~/E2E/SampleUnityProject-2021.3/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-2021.3/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SampleUnityProject-2022.3/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-2022.3/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SampleUnityProject-6000.0/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-6000.0/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SampleUnityProject-6000.2/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-6000.2/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SampleUnityProject-6000.3/Assets/WebGLTemplates/AITTemplate/index.html
+++ b/Tests~/E2E/SampleUnityProject-6000.3/Assets/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
@@ -1,0 +1,170 @@
+// -----------------------------------------------------------------------
+// AITPageCacheEmitterTests.cs - EditMode 페이지 캐시 인터셉터 스니펫 생성기 테스트
+// Level 0: AITPageCacheEmitter.GenerateInterceptorScript 의 게이팅/allowlist/
+//          플레이스홀더 안전/캐시명 보정 검증 (순수 문자열 생성기, 빌드 불필요)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using AppsInToss;
+using AppsInToss.Editor.Package;
+
+[TestFixture]
+public class AITPageCacheEmitterTests
+{
+    private const string DataFile = "abc123.data";
+    private const string FrameworkFile = "def456.framework.js";
+    private const string WasmFile = "ghi789.wasm";
+    private const string LoaderFile = "jkl012.loader.js";
+
+    private AITEditorScriptObject config;
+
+    [SetUp]
+    public void Setup()
+    {
+        config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (config != null)
+        {
+            Object.DestroyImmediate(config);
+        }
+    }
+
+    // === 게이팅 ===
+
+    [Test]
+    public void NullConfig_ReturnsEmpty()
+    {
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(null, DataFile, FrameworkFile, WasmFile);
+        Assert.AreEqual(string.Empty, result, "config==null 이면 빈 문자열(no-op)이어야 한다");
+    }
+
+    [Test]
+    public void Disabled_ReturnsEmpty()
+    {
+        config.enablePageCache = false;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+        Assert.AreEqual(string.Empty, result, "enablePageCache==false 이면 빈 문자열(byte-identical no-op)이어야 한다");
+    }
+
+    // === 활성 출력 ===
+
+    [Test]
+    public void Enabled_EmitsCacheNameLiteral()
+    {
+        config.enablePageCache = true;
+        config.pageCacheName = "ait-page-cache";
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        Assert.IsNotEmpty(result);
+        StringAssert.Contains("ait-page-cache", result, "스니펫에 캐시명 리터럴이 박혀야 한다");
+        StringAssert.Contains("<script>", result, "인라인 script 블록이어야 한다");
+    }
+
+    [Test]
+    public void Enabled_AllowlistContainsBuildFiles()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("Build/" + DataFile, result, "allowlist 에 data 파일이 포함되어야 한다");
+        StringAssert.Contains("Build/" + FrameworkFile, result, "allowlist 에 framework 파일이 포함되어야 한다");
+        StringAssert.Contains("Build/" + WasmFile, result, "allowlist 에 wasm 파일이 포함되어야 한다");
+    }
+
+    [Test]
+    public void Enabled_AllowlistExcludesLoader()
+    {
+        config.enablePageCache = true;
+        // loaderFile 은 시그니처에 없으므로 어떤 경로로도 스니펫에 들어가면 안 됨(캐시 대상 외 계약).
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.DoesNotContain(LoaderFile, result, "loader.js 는 캐시 대상이 아니므로 allowlist 에 없어야 한다");
+        StringAssert.DoesNotContain(".loader.js", result, "loader 파일명 패턴이 스니펫에 없어야 한다");
+    }
+
+    [Test]
+    public void Enabled_ContainsFeatureDetectGate()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("isSecureContext", result, "비보안 컨텍스트 feature-detect 가 있어야 한다");
+        StringAssert.Contains("'caches' in window", result, "CacheStorage 지원 feature-detect 가 있어야 한다");
+    }
+
+    [Test]
+    public void Enabled_ContainsBuildOriginGetGates()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("/Build/", result, "/Build/ 경로 게이트가 있어야 한다");
+        StringAssert.Contains("GET", result, "GET 게이트가 있어야 한다");
+        StringAssert.Contains("location.origin", result, "동일 오리진 게이트가 있어야 한다");
+    }
+
+    [Test]
+    public void Enabled_CapturesPriorFetch()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("priorFetch", result, "priorFetch 캡처 패턴이 있어야 한다");
+        StringAssert.Contains("window.fetch.bind(window)", result, "설치 시점 fetch 를 bind 로 캡처해야 한다");
+    }
+
+    [Test]
+    public void Enabled_NonGetCheckInspectsRequestMethod()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        // 비-GET 판정이 init.method 뿐 아니라 Request 객체의 method 도 확인해야 한다.
+        // fetch(new Request(url, {method:'POST'})) (init 미전달)을 GET 으로 오인하지 않도록 견고화.
+        StringAssert.Contains("isNonGet", result, "비-GET 판정 헬퍼가 있어야 한다");
+        StringAssert.Contains("resource.method", result,
+            "Request 객체에 실린 method 도 비-GET 판정에 반영되어야 한다");
+    }
+
+    // === 플레이스홀더 안전 (ValidatePlaceholderSubstitution 회피) ===
+
+    [Test]
+    public void Enabled_HasNoUppercasePercentTokens()
+    {
+        config.enablePageCache = true;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        // %FOO_BAR% 같은 대문자/숫자/언더스코어 퍼센트 토큰이 0개여야 빌드 치환 검증을 통과한다.
+        var matches = Regex.Matches(result, "%[A-Z0-9_]+%");
+        Assert.AreEqual(0, matches.Count,
+            "스니펫에 %대문자_퍼센트% 토큰이 있으면 ValidatePlaceholderSubstitution 이 빌드를 실패시킨다");
+    }
+
+    // === 캐시명 오버라이드/보정 ===
+
+    [Test]
+    public void Enabled_CustomCacheName_IsEmbedded()
+    {
+        config.enablePageCache = true;
+        config.pageCacheName = "custom-bucket";
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("custom-bucket", result, "사용자 지정 캐시명이 스니펫에 박혀야 한다");
+    }
+
+    [Test]
+    public void Enabled_EmptyCacheName_FallsBackToDefault()
+    {
+        config.enablePageCache = true;
+        config.pageCacheName = "";
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("ait-page-cache", result, "빈 캐시명은 기본값 ait-page-cache 로 보정되어야 한다");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
@@ -35,7 +35,7 @@ public class AITPageCacheEmitterTests
         }
     }
 
-    // === 게이팅 ===
+    // === 게이팅 (tri-state) ===
 
     [Test]
     public void NullConfig_ReturnsEmpty()
@@ -45,11 +45,27 @@ public class AITPageCacheEmitterTests
     }
 
     [Test]
-    public void Disabled_ReturnsEmpty()
+    public void PageCache_ExplicitDisabled_ReturnsEmpty()
     {
-        config.enablePageCache = false;
+        config.pageCache = 0; // 명시적 비활성
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
-        Assert.AreEqual(string.Empty, result, "enablePageCache==false 이면 빈 문자열(byte-identical no-op)이어야 한다");
+        Assert.AreEqual(string.Empty, result, "pageCache==0(명시적 비활성) 이면 빈 문자열(byte-identical no-op)이어야 한다");
+    }
+
+    [Test]
+    public void PageCache_Auto_DefaultIsEnabled()
+    {
+        config.pageCache = -1; // 자동 (기본값)
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+        Assert.IsNotEmpty(result, "pageCache==-1(자동) 이면 기본값 true 이므로 스니펫이 생성되어야 한다");
+    }
+
+    [Test]
+    public void PageCache_ExplicitEnabled_EmitsScript()
+    {
+        config.pageCache = 1; // 명시적 활성
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+        Assert.IsNotEmpty(result, "pageCache==1(명시적 활성) 이면 스니펫이 생성되어야 한다");
     }
 
     // === 활성 출력 ===
@@ -57,7 +73,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_EmitsCacheNameLiteral()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         config.pageCacheName = "ait-page-cache";
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
@@ -69,7 +85,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_AllowlistContainsBuildFiles()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         StringAssert.Contains("Build/" + DataFile, result, "allowlist 에 data 파일이 포함되어야 한다");
@@ -80,7 +96,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_AllowlistExcludesLoader()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         // loaderFile 은 시그니처에 없으므로 어떤 경로로도 스니펫에 들어가면 안 됨(캐시 대상 외 계약).
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
@@ -91,7 +107,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_ContainsFeatureDetectGate()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         StringAssert.Contains("isSecureContext", result, "비보안 컨텍스트 feature-detect 가 있어야 한다");
@@ -101,7 +117,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_ContainsBuildOriginGetGates()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         StringAssert.Contains("/Build/", result, "/Build/ 경로 게이트가 있어야 한다");
@@ -112,7 +128,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_CapturesPriorFetch()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         StringAssert.Contains("priorFetch", result, "priorFetch 캡처 패턴이 있어야 한다");
@@ -122,7 +138,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_NonGetCheckInspectsRequestMethod()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         // 비-GET 판정이 init.method 뿐 아니라 Request 객체의 method 도 확인해야 한다.
@@ -137,7 +153,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_HasNoUppercasePercentTokens()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
         // %FOO_BAR% 같은 대문자/숫자/언더스코어 퍼센트 토큰이 0개여야 빌드 치환 검증을 통과한다.
@@ -151,7 +167,7 @@ public class AITPageCacheEmitterTests
     [Test]
     public void Enabled_CustomCacheName_IsEmbedded()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         config.pageCacheName = "custom-bucket";
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
@@ -159,12 +175,118 @@ public class AITPageCacheEmitterTests
     }
 
     [Test]
-    public void Enabled_EmptyCacheName_FallsBackToDefault()
+    public void Enabled_EmptyCacheName_WithAppName_DerivesCacheName()
     {
-        config.enablePageCache = true;
+        config.pageCache = 1;
         config.pageCacheName = "";
+        config.appName = "my-game";
         string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
 
-        StringAssert.Contains("ait-page-cache", result, "빈 캐시명은 기본값 ait-page-cache 로 보정되어야 한다");
+        StringAssert.Contains("ait-page-cache-my-game", result,
+            "빈 캐시명 + appName 'my-game' 이면 'ait-page-cache-my-game' 으로 자동 파생되어야 한다");
+    }
+
+    [Test]
+    public void Enabled_EmptyCacheName_EmptyAppName_FallsBackToDefault()
+    {
+        config.pageCache = 1;
+        config.pageCacheName = "";
+        config.appName = "";
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        StringAssert.Contains("ait-page-cache", result,
+            "빈 캐시명 + 빈 appName 이면 기본값 ait-page-cache 로 폴백되어야 한다");
+    }
+
+    // === DeriveCacheName 순수 함수 단위 테스트 ===
+
+    [Test]
+    public void DeriveCacheName_AsciiIdentifier_ReturnsNormalizedSlug()
+    {
+        string result = AITPageCacheEmitter.DeriveCacheName("MyGame");
+        Assert.AreEqual("ait-page-cache-mygame", result, "ASCII 식별자는 소문자 정규화 후 prefix 가 붙어야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_IdentifierWithSpecialChars_NormalizesToHyphen()
+    {
+        string result = AITPageCacheEmitter.DeriveCacheName("My Game!");
+        Assert.AreEqual("ait-page-cache-my-game", result, "특수문자/공백은 하이픈으로 치환되어야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_NonAsciiIdentifier_ReturnsHashSlug()
+    {
+        string identifier = "내게임";
+        string result = AITPageCacheEmitter.DeriveCacheName(identifier);
+
+        Assert.IsNotNull(result, "비ASCII 식별자도 null 이 아닌 캐시명을 반환해야 한다");
+        StringAssert.StartsWith("ait-page-cache-", result, "비ASCII 식별자도 prefix 가 붙어야 한다");
+        // FNV-1a 32비트 해시는 8자리 16진수
+        string slug = result.Substring("ait-page-cache-".Length);
+        Assert.AreEqual(8, slug.Length, "비ASCII 식별자의 해시 슬러그는 8자리여야 한다");
+        StringAssert.IsMatch("^[0-9a-f]{8}$", slug, "해시 슬러그는 16진수 소문자 8자리여야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_SameNonAsciiInput_ReturnsSameHash()
+    {
+        string identifier = "내게임";
+        string result1 = AITPageCacheEmitter.DeriveCacheName(identifier);
+        string result2 = AITPageCacheEmitter.DeriveCacheName(identifier);
+        Assert.AreEqual(result1, result2, "동일 입력은 동일 해시를 반환해야 한다(결정론적)");
+    }
+
+    [Test]
+    public void DeriveCacheName_EmptyString_ReturnsNull()
+    {
+        string result = AITPageCacheEmitter.DeriveCacheName("");
+        Assert.IsNull(result, "빈 문자열 식별자는 null 을 반환해야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_NullString_ReturnsNull()
+    {
+        string result = AITPageCacheEmitter.DeriveCacheName(null);
+        Assert.IsNull(result, "null 식별자는 null 을 반환해야 한다");
+    }
+
+    [Test]
+    public void DeriveCacheName_DifferentInputs_ReturnDifferentHashes()
+    {
+        string result1 = AITPageCacheEmitter.DeriveCacheName("게임A");
+        string result2 = AITPageCacheEmitter.DeriveCacheName("게임B");
+        Assert.AreNotEqual(result1, result2, "서로 다른 식별자는 서로 다른 캐시명을 반환해야 한다");
+    }
+
+    // === ResolveCacheName 통합 테스트 ===
+
+    [Test]
+    public void ResolveCacheName_ExplicitName_ReturnsAsIs()
+    {
+        config.pageCacheName = "explicit-cache";
+        config.appName = "some-app";
+        string result = AITPageCacheEmitter.ResolveCacheName(config);
+        Assert.AreEqual("explicit-cache", result, "명시적 캐시명이 있으면 그대로 반환해야 한다");
+    }
+
+    [Test]
+    public void ResolveCacheName_EmptyName_WithAppName_Derives()
+    {
+        config.pageCacheName = "";
+        config.appName = "cool-game";
+        string result = AITPageCacheEmitter.ResolveCacheName(config);
+        Assert.AreEqual("ait-page-cache-cool-game", result,
+            "빈 캐시명 + appName 있으면 자동 파생해야 한다");
+    }
+
+    [Test]
+    public void ResolveCacheName_EmptyName_EmptyAppName_FallsBack()
+    {
+        config.pageCacheName = "";
+        config.appName = "";
+        string result = AITPageCacheEmitter.ResolveCacheName(config);
+        Assert.AreEqual(AITPageCacheEmitter.DefaultCacheName, result,
+            "캐시명·appName 모두 비어 있으면 기본값으로 폴백해야 한다");
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c68bb8430386526c6cacc5fe3dd29903
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a96aed6984e01415cb0ea13c9a7d7c89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs
@@ -47,11 +47,11 @@ public class AITWarmManifestEmitterTests
         CreatePlainFile(Path.Combine(_buildDir, LoaderFile),     64);
         CreatePlainFile(Path.Combine(_buildDir, SymbolsFile),    32);
 
-        // config 생성
+        // config 생성 — tri-state: -1=자동(ON), 0=비활성, 1=활성
         _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
-        _config.enablePageCache  = true;
-        _config.emitWarmManifest = true;
-        _config.pageCacheName    = "ait-page-cache";
+        _config.pageCache     = 1;  // 명시적 활성
+        _config.warmManifest  = 1;  // 명시적 활성
+        _config.pageCacheName = "ait-page-cache";
     }
 
     [TearDown]
@@ -76,7 +76,7 @@ public class AITWarmManifestEmitterTests
         }
     }
 
-    // ===== 케이스 1: emitWarmManifest=false → 파일 미산출, stale 파일 삭제 =====
+    // ===== 케이스 1: warmManifest=0(명시적 비활성) → 파일 미산출, stale 파일 삭제 =====
 
     [Test]
     public void Disabled_NoFileEmitted_AndStaleDeleted()
@@ -86,20 +86,34 @@ public class AITWarmManifestEmitterTests
         File.WriteAllText(manifestPath, "stale", Encoding.UTF8);
         Assert.IsTrue(File.Exists(manifestPath), "SetUp: stale 파일이 있어야 한다");
 
-        _config.emitWarmManifest = false;
+        _config.warmManifest = 0; // 명시적 비활성
         WriteManifest();
 
         Assert.IsFalse(File.Exists(manifestPath),
-            "emitWarmManifest=false 이면 기존 stale 파일도 삭제되어야 한다");
+            "warmManifest=0(명시적 비활성) 이면 기존 stale 파일도 삭제되어야 한다");
     }
 
-    // ===== 케이스 2: emitWarmManifest=true + enablePageCache=false → 경고 + 미산출 =====
+    // ===== 케이스 1b: warmManifest=-1(자동=ON) → 정상 산출 =====
+
+    [Test]
+    public void AutoDefault_EmitsFile()
+    {
+        _config.warmManifest = -1; // 자동 (기본값 true)
+        _config.pageCache    = 1;  // 명시적 활성
+        WriteManifest();
+
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        Assert.IsTrue(File.Exists(manifestPath),
+            "warmManifest=-1(자동=ON) + pageCache 활성이면 manifest 를 산출해야 한다");
+    }
+
+    // ===== 케이스 2: warmManifest 실효값=true + pageCache=0(명시적 비활성) → 경고 + 미산출 =====
 
     [Test]
     public void EnabledManifest_ButPageCacheDisabled_WarnsAndNoFile()
     {
-        _config.enablePageCache  = false;
-        _config.emitWarmManifest = true;
+        _config.pageCache    = 0; // 명시적 비활성
+        _config.warmManifest = 1; // 명시적 활성
 
         // 경고 로그가 발생해야 한다
         LogAssert.Expect(LogType.Warning, new Regex("ait-warm-manifest\\.json 미산출"));
@@ -108,7 +122,21 @@ public class AITWarmManifestEmitterTests
 
         string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
         Assert.IsFalse(File.Exists(manifestPath),
-            "enablePageCache=false 이면 manifest 를 산출하지 않아야 한다");
+            "pageCache=0(명시적 비활성) 이면 manifest 를 산출하지 않아야 한다");
+    }
+
+    // ===== 케이스 2b: warmManifest=-1(자동=ON) + pageCache=-1(자동=ON) → 정상 산출 =====
+
+    [Test]
+    public void BothAuto_ProducesManifest()
+    {
+        _config.warmManifest = -1; // 자동
+        _config.pageCache    = -1; // 자동 (기본값 true)
+        WriteManifest();
+
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        Assert.IsTrue(File.Exists(manifestPath),
+            "warmManifest=-1(자동=ON) + pageCache=-1(자동=ON) 이면 manifest 를 산출해야 한다(zero-config)");
     }
 
     // ===== 케이스 3: 정상 산출 — 파일 존재, 경로 포함, cacheName 에코 =====

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs
@@ -1,0 +1,344 @@
+// -----------------------------------------------------------------------
+// AITWarmManifestEmitterTests.cs - EditMode warm manifest 산출기 테스트
+// Level 0: AITWarmManifestEmitter.WriteManifest 의 게이팅/스키마/인코딩/
+//          결정성/플레이스홀더 안전 검증 (순수 파일 I/O, 빌드 불필요)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss;
+using AppsInToss.Editor.Package;
+
+[TestFixture]
+public class AITWarmManifestEmitterTests
+{
+    // 테스트용 파일명 상수
+    private const string LoaderFile    = "game.loader.js";
+    private const string DataFile      = "game.data";
+    private const string FrameworkFile = "game.framework.js";
+    private const string WasmFile      = "game.wasm";
+    private const string SymbolsFile   = "game.symbols.json";
+
+    // 알려진 gzip raw 크기 검증용
+    private const int KnownRawSize = 1024; // 바이트
+
+    private string _tempDir;
+    private string _buildDir;
+    private AITEditorScriptObject _config;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // 임시 디렉토리 생성 (GUID 기반으로 충돌 방지)
+        _tempDir = Path.Combine(Path.GetTempPath(), "AITWarmManifestTests_" + Guid.NewGuid().ToString("N"));
+        _buildDir = Path.Combine(_tempDir, "Build");
+        Directory.CreateDirectory(_buildDir);
+
+        // 가짜 빌드 파일 생성
+        CreateGzipFile(Path.Combine(_buildDir, DataFile), KnownRawSize);
+        CreatePlainFile(Path.Combine(_buildDir, WasmFile),      256);
+        CreatePlainFile(Path.Combine(_buildDir, FrameworkFile), 128);
+        CreatePlainFile(Path.Combine(_buildDir, LoaderFile),     64);
+        CreatePlainFile(Path.Combine(_buildDir, SymbolsFile),    32);
+
+        // config 생성
+        _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+        _config.enablePageCache  = true;
+        _config.emitWarmManifest = true;
+        _config.pageCacheName    = "ait-page-cache";
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (_config != null)
+        {
+            UnityEngine.Object.DestroyImmediate(_config);
+        }
+
+        // 임시 디렉토리 정리
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // 정리 실패는 무시
+        }
+    }
+
+    // ===== 케이스 1: emitWarmManifest=false → 파일 미산출, stale 파일 삭제 =====
+
+    [Test]
+    public void Disabled_NoFileEmitted_AndStaleDeleted()
+    {
+        // stale 파일을 미리 생성
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        File.WriteAllText(manifestPath, "stale", Encoding.UTF8);
+        Assert.IsTrue(File.Exists(manifestPath), "SetUp: stale 파일이 있어야 한다");
+
+        _config.emitWarmManifest = false;
+        WriteManifest();
+
+        Assert.IsFalse(File.Exists(manifestPath),
+            "emitWarmManifest=false 이면 기존 stale 파일도 삭제되어야 한다");
+    }
+
+    // ===== 케이스 2: emitWarmManifest=true + enablePageCache=false → 경고 + 미산출 =====
+
+    [Test]
+    public void EnabledManifest_ButPageCacheDisabled_WarnsAndNoFile()
+    {
+        _config.enablePageCache  = false;
+        _config.emitWarmManifest = true;
+
+        // 경고 로그가 발생해야 한다
+        LogAssert.Expect(LogType.Warning, new Regex("ait-warm-manifest\\.json 미산출"));
+
+        WriteManifest();
+
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        Assert.IsFalse(File.Exists(manifestPath),
+            "enablePageCache=false 이면 manifest 를 산출하지 않아야 한다");
+    }
+
+    // ===== 케이스 3: 정상 산출 — 파일 존재, 경로 포함, cacheName 에코 =====
+
+    [Test]
+    public void NormalEmit_FileExists_ContainsBuildPaths()
+    {
+        WriteManifest();
+
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        Assert.IsTrue(File.Exists(manifestPath), "manifest 파일이 존재해야 한다");
+
+        string json = File.ReadAllText(manifestPath, Encoding.UTF8);
+
+        StringAssert.Contains("Build/" + DataFile,      json, "data 파일 경로가 포함되어야 한다");
+        StringAssert.Contains("Build/" + FrameworkFile, json, "framework 파일 경로가 포함되어야 한다");
+        StringAssert.Contains("Build/" + WasmFile,      json, "wasm 파일 경로가 포함되어야 한다");
+    }
+
+    [Test]
+    public void NormalEmit_CacheName_IsEchoed()
+    {
+        _config.pageCacheName = "my-custom-cache";
+        WriteManifest();
+
+        string json = ReadManifest();
+        StringAssert.Contains("my-custom-cache", json, "지정한 cacheName 이 manifest 에 포함되어야 한다");
+    }
+
+    [Test]
+    public void NormalEmit_EmptyCacheName_FallsBackToDefault()
+    {
+        _config.pageCacheName = "";
+        WriteManifest();
+
+        string json = ReadManifest();
+        StringAssert.Contains(AITPageCacheEmitter.DefaultCacheName, json,
+            "pageCacheName 이 비면 기본값 ait-page-cache 로 보정되어야 한다");
+    }
+
+    // ===== 케이스 4: wireBytes == 실제 파일 크기 =====
+
+    [Test]
+    public void NormalEmit_WireBytes_MatchActualFileSize()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        // wasm 파일은 plain bytes 이므로 wireBytes == 256 이어야 한다
+        long expectedWire = new FileInfo(Path.Combine(_buildDir, WasmFile)).Length;
+        StringAssert.Contains("\"wireBytes\": " + expectedWire, json,
+            "wireBytes 는 실제 파일 크기와 일치해야 한다");
+    }
+
+    // ===== 케이스 5: gzip 파일 rawBytes == 기지 raw 크기, encoding == "gzip" =====
+
+    [Test]
+    public void NormalEmit_GzipDataFile_HasCorrectRawBytesAndEncoding()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        // data 파일은 gzip 으로 만들었으므로 encoding "gzip" 이어야 한다
+        StringAssert.Contains("\"encoding\": \"gzip\"", json,
+            "gzip 파일은 encoding 이 gzip 이어야 한다");
+
+        // rawBytes 는 KnownRawSize 와 같아야 한다
+        StringAssert.Contains("\"rawBytes\": " + KnownRawSize, json,
+            "gzip rawBytes 는 알려진 raw 크기와 일치해야 한다");
+    }
+
+    // ===== 케이스 6: loader/symbols 는 excluded 에만 있고 assets 에 없음 =====
+
+    [Test]
+    public void NormalEmit_Loader_OnlyInExcluded_NotInAssets()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        // excluded 에 loader 경로가 있어야 한다
+        StringAssert.Contains("\"role\": \"loader\"", json, "loader 가 excluded 에 있어야 한다");
+
+        // assets 배열에는 loader 경로가 없어야 한다.
+        // assets 블록과 excluded 블록을 분리해서 검증.
+        int assetsStart = json.IndexOf("\"assets\"", StringComparison.Ordinal);
+        int excludedStart = json.IndexOf("\"excluded\"", StringComparison.Ordinal);
+        Assert.IsTrue(assetsStart >= 0 && excludedStart > assetsStart,
+            "assets 와 excluded 섹션 순서가 올바라야 한다");
+
+        string assetsSection = json.Substring(assetsStart, excludedStart - assetsStart);
+        StringAssert.DoesNotContain(LoaderFile, assetsSection,
+            "assets 섹션에 loader 파일이 포함되면 안 된다");
+    }
+
+    [Test]
+    public void NormalEmit_Symbols_OnlyInExcluded_NotInAssets()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        StringAssert.Contains("\"role\": \"symbols\"", json, "symbols 가 excluded 에 있어야 한다");
+
+        int assetsStart = json.IndexOf("\"assets\"", StringComparison.Ordinal);
+        int excludedStart = json.IndexOf("\"excluded\"", StringComparison.Ordinal);
+        string assetsSection = json.Substring(assetsStart, excludedStart - assetsStart);
+        StringAssert.DoesNotContain(SymbolsFile, assetsSection,
+            "assets 섹션에 symbols 파일이 포함되면 안 된다");
+    }
+
+    // ===== 케이스 7: %[A-Z_]+% 토큰 부재 =====
+
+    [Test]
+    public void NormalEmit_NoUnreplacedPlaceholderTokens()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        var matches = Regex.Matches(json, @"%[A-Z0-9_]+%");
+        Assert.AreEqual(0, matches.Count,
+            "manifest 에 %대문자_퍼센트% 토큰이 있으면 ValidatePlaceholderSubstitution 이 빌드를 실패시킨다");
+    }
+
+    // ===== 케이스 8: 결정성 — 2회 호출 산출물이 byte-identical =====
+
+    [Test]
+    public void NormalEmit_Deterministic_TwiceProducesBytesIdenticalOutput()
+    {
+        WriteManifest();
+        string first = ReadManifest();
+
+        WriteManifest();
+        string second = ReadManifest();
+
+        Assert.AreEqual(first, second,
+            "같은 입력에 대해 두 번 호출하면 byte-identical 산출물이어야 한다(타임스탬프/랜덤 없음)");
+    }
+
+    // ===== 케이스 9: schemaVersion, generator 필드 존재 =====
+
+    [Test]
+    public void NormalEmit_ContainsSchemaVersionAndGenerator()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        StringAssert.Contains("\"schemaVersion\": 1", json,
+            "schemaVersion 이 1 이어야 한다");
+        StringAssert.Contains("\"generator\":", json,
+            "generator 필드가 있어야 한다");
+        StringAssert.Contains("apps-in-toss.unity", json,
+            "generator 에 apps-in-toss.unity 가 포함되어야 한다");
+    }
+
+    // ===== 케이스 10: totals.wireBytes 가 파일 크기의 합 =====
+
+    [Test]
+    public void NormalEmit_TotalsWireBytes_IsSumOfAssets()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        long expectedTotal =
+            new FileInfo(Path.Combine(_buildDir, DataFile)).Length +
+            new FileInfo(Path.Combine(_buildDir, FrameworkFile)).Length +
+            new FileInfo(Path.Combine(_buildDir, WasmFile)).Length;
+
+        // totals 섹션 이후의 부분 문자열에서 wireBytes 를 탐색해
+        // per-asset wireBytes 와 우연히 일치하는 false-positive 를 방지한다.
+        int totalsIdx = json.IndexOf("\"totals\"", StringComparison.Ordinal);
+        Assert.Greater(totalsIdx, -1, "totals 섹션이 존재해야 한다");
+        string totalsSection = json.Substring(totalsIdx);
+        StringAssert.Contains("\"wireBytes\": " + expectedTotal, totalsSection,
+            "totals.wireBytes 는 assets wireBytes 의 합이어야 한다");
+    }
+
+    // -----------------------------------------------------------------------
+    // 헬퍼
+    // -----------------------------------------------------------------------
+
+    private void WriteManifest()
+    {
+        AITWarmManifestEmitter.WriteManifest(
+            _config,
+            _tempDir,
+            LoaderFile,
+            DataFile,
+            FrameworkFile,
+            WasmFile,
+            SymbolsFile
+        );
+    }
+
+    private string ReadManifest()
+    {
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        return File.ReadAllText(manifestPath, Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// 알려진 raw 크기(<paramref name="rawSize"/> 바이트)를 gzip 으로 압축한 파일을 생성합니다.
+    /// gzip rawBytes 검증용.
+    /// </summary>
+    private static void CreateGzipFile(string path, int rawSize)
+    {
+        byte[] rawData = new byte[rawSize];
+        // 검증 가능한 패턴으로 채움 (0 만으로 채우면 압축률이 너무 높아도 무관)
+        for (int i = 0; i < rawSize; i++)
+        {
+            rawData[i] = (byte)(i % 251);
+        }
+
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+        using (var gz = new GZipStream(fs, CompressionMode.Compress, leaveOpen: false))
+        {
+            gz.Write(rawData, 0, rawData.Length);
+        }
+    }
+
+    /// <summary>
+    /// <paramref name="size"/> 바이트의 plain 파일을 생성합니다.
+    /// </summary>
+    private static void CreatePlainFile(string path, int size)
+    {
+        byte[] data = new byte[size];
+        for (int i = 0; i < size; i++)
+        {
+            // 1 offset: i=0 → 1(0x01), i=1 → 2(0x02), ...
+            // 첫 바이트=0x01(≠0x1f), 두 번째 바이트=0x02(≠0x8b) → gzip 매직 바이트(0x1f 0x8b) 절대 불일치.
+            data[i] = (byte)(i % 127 + 1);
+        }
+        File.WriteAllBytes(path, data);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 204c8bc9dd9530906c9961c10862cac7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/WebGLTemplates/AITTemplate/index.html
+++ b/WebGLTemplates/AITTemplate/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="TemplateData/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 
+    <!-- AIT Page Cache (CacheStorage 인터셉터, SDK Auto-generated) -->
+    %AIT_PAGE_CACHE_SCRIPT%
+
     <!-- Unity Resource Early Fetch (SDK Auto-generated) -->
     %AIT_EARLY_FETCH_SCRIPT%
 


### PR DESCRIPTION
## 개요

호스트(슈퍼앱)가 미니앱 목록 화면에서 Build 자산을 선다운로드(warm)할 때 diff 기준으로 사용하는 기계가독 계약 파일 `ait-warm-manifest.json`을 빌드 시 산출합니다.

**팀 정책 — zero-config 기본 ON**: 개발자의 별도 설정 없이 자동 적용. warmManifest 기본값 ON + pageCache AND 게이팅 안전장치(AND 게이팅·경고 로그·stale 삭제)로 정확성 보존.

- PR #768 인터셉터(AITPageCacheEmitter)의 allowlist와 **동일한 빌드·동일한 입력 변수**에서 생성 → manifest와 실제 캐시 항목 간 drift 구조적 불가능
- `warmManifest`(tri-state, 기본 자동=ON) AND `pageCache`(tri-state) 이중 게이팅 — 둘 다 실효값 `true`일 때만 산출, off 시 stale 파일 제거 + byte-identical no-op 보장

## 스키마 v1 요약

```json
{
  "schemaVersion": 1,
  "generator": "apps-in-toss.unity@X.Y.Z",
  "cacheName": "ait-page-cache",
  "assets": [
    { "path": "Build/game.data", "role": "data", "mime": "application/octet-stream", "wireBytes": 12345678, "rawBytes": 23456789, "encoding": "gzip" },
    { "path": "Build/game.framework.js", "role": "framework", "mime": "text/javascript", "wireBytes": 345678, "encoding": "none" },
    { "path": "Build/game.wasm", "role": "wasm", "mime": "application/wasm", "wireBytes": 5678901, "encoding": "br" }
  ],
  "excluded": [
    { "path": "Build/game.loader.js", "role": "loader", "reason": "script-src 로드 — page fetch 비경유, 인터셉터 서빙 불가" },
    { "path": "Build/game.symbols.json", "role": "symbols", "reason": "부팅 임계경로 밖" }
  ],
  "totals": { "wireBytes": 18469557 }
}
```

## 게이팅 (tri-state)

`warmManifest` 및 `pageCache`는 tri-state(`-1`=자동, `0`=비활성, `1`=활성). 실효값은 `-1`이면 기본값(`GetDefaultWarmManifest()=true`, `GetDefaultPageCache()=true`)을 사용.

| `warmManifest` 실효값 | `pageCache` 실효값 | 결과 |
|---|---|---|
| `false` | any | no-op (stale 삭제) |
| `true` | `false` | LogWarning + no-op (stale 삭제) |
| `true` | `true` | manifest 산출 |

기본값(모두 `-1` = 자동)에서는 둘 다 실효값 `true` → **zero-config로 자동 산출**.  
비활성화 방법: Configuration Window → WebGL 설정 → Warm Manifest 를 `비활성화`로 변경.

## 구현 세부

- **`Editor/Package/AITWarmManifestEmitter.cs`**: tri-state 실효값 기반 이중 게이팅으로 갱신. StringBuilder 수작업 JSON(2-space pretty, 키 순서 고정), GZipStream 스트리밍 rawBytes 카운트, BrotliStream 리플렉션 탐지(Unity mono BCL 부재 시 fallback), SdkPathResolver 경유 버전 읽기
- **`Editor/AITEditorScriptObject.cs`**: `emitWarmManifest(bool)` → `warmManifest(int, -1=자동)` tri-state 전환. `GetDefaultWarmManifest()=true` 추가 (zero-config 기본 ON)
- **`Editor/AITConfigurationWindow.cs`**: `DrawWarmManifestSetting()` Popup 메서드(자동/비활성화/활성화) 추가. `pageCache` OFF 시 `DisabledScope` 그레이아웃 + 경고 HelpBox. `CountModifiedWebGLSettings` / `ResetWebGLSettings` 갱신
- **`Editor/Package/WebGLBuildCopier.cs`**: Build 복사 + index.html 치환 완료 후 `WriteManifest` 호출 1줄
- **`Tests~/…/AITWarmManifestEmitterTests.cs`**: bool 참조 → tri-state 값(0/1/-1) 갱신. 자동 기본값 케이스(케이스 1b `AutoDefault_EmitsFile`, 케이스 2b `BothAuto_ProducesManifest`) 추가 (총 13개 케이스)

## 의존

PR #768 (`perf/webgl-cachestorage-revisit`)에 스택됨 — base가 `perf/webgl-cachestorage-revisit`이며, #768 머지 후 main 리타겟 + 리베이스 예정.

## 검증

- `--validate` (파일구조 + Playwright 설정 + SDK invariants): **통과**
- `--editmode` (Unity EditMode): 로컬 머신에 Unity 없어 skipped (환경 기인, 코드 컴파일 위험은 정독으로 점검)
- leak scan (비공개 파일럿 프로젝트): **8개 파일 전부 CLEAN**

## 효과

이 PR 자체는 런타임 0ms — 호스트 warm 기능 enabler. 호스트 warm 적중 시 첫 방문 TTFF −42% 사내 대형 콘텐츠 실측.

---

⚠️ **3.0 beta→stable 이후 머지 예정 — 머지 금지**

