### PR TITLE
수정: framework.js 누락 회귀 테스트의 unhandled-log 결정적 실패 해소

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -154,9 +154,21 @@ public class BuildFileSelectionTests
         File.WriteAllText(Path.Combine(tempDir, "build.wasm"), "wasm");
         // framework.js 의도적으로 생성 안 함
 
+        // AITLog.Error → Debug.LogError 다단 진단 블록(검색 경로·Build 폴더 파일 목록 등
+        // 가변 개수)을 의도적으로 발화시키므로, UTF의 unhandled-log 실패를 스코프 한정으로
+        // 무시한다. 핵심 에러의 실제 방출 여부는 아래 CollectLogs 기반 양성 검증이 보장한다.
         string result = null;
-        var logs = CollectLogs(() =>
-            result = AITBuildValidator.FindFileInBuild(tempDir, "*.framework.js*", isRequired: true));
+        List<LogEntry> logs;
+        LogAssert.ignoreFailingMessages = true;
+        try
+        {
+            logs = CollectLogs(() =>
+                result = AITBuildValidator.FindFileInBuild(tempDir, "*.framework.js*", isRequired: true));
+        }
+        finally
+        {
+            LogAssert.ignoreFailingMessages = false;
+        }
 
         // 빈 문자열 반환 → missingFiles.Add("*.framework.js") 로 이어짐 (WebGLBuildCopier.cs)
         Assert.AreEqual("", result,


### PR DESCRIPTION
## 문제

#740 이 추가한 `BuildFileSelectionTests.FindFileInBuild_MissingFrameworkJs_EmitsRequiredErrorLog` 가 **모든 환경에서 결정적으로 실패**합니다.

```
Unhandled log message: '[Error] [AIT] ✗ 필수 파일을 찾을 수 없습니다: *.framework.js*'.
Use UnityEngine.TestTools.LogAssert.Expect
```

### 원인

- 테스트가 `AITBuildValidator.FindFileInBuild(..., isRequired: true)` 를 호출해 `AITLog.Error`(→`Debug.LogError`) **다단 진단 블록**(헤더 + 검색 경로 + 안내 + Build 폴더 파일 목록 = 7줄, 가변 개수)을 의도적으로 발화시킴
- 그런데 로그 검증을 수동 `Application.logMessageReceived` 리스너(`CollectLogs`)로만 하고 **`LogAssert` 처리를 누락** → Unity Test Framework 기본 동작이 unhandled Error 로그를 테스트 실패로 처리
- 같은 코드베이스의 다른 테스트들은 규약 준수 중 (`PathValidatorTests.cs:81` 주석: "AITLog.Error → Debug.LogError 를 호출하므로 LogAssert.Expect 필요")

## 수정

진단 블록이 **가변 개수**(Build 폴더 파일 목록 포함)라 `LogAssert.Expect` 7줄 나열은 구현 변경에 부서지기 쉬워, **스코프 한정 `LogAssert.ignoreFailingMessages`**(try-finally 복원)로 처리했습니다. 핵심 에러가 실제로 방출되는지는 기존 `CollectLogs` 기반 양성 검증이 계속 보장합니다 (회귀 가드 기능 유지).

## 검증

로컬 Unity 2022.3.62f2, `SampleUnityProject-2022.3` EditMode:

| 시점 | 결과 |
|---|---|
| 수정 전 | `BuildFileSelectionTests` fixture — 대상 테스트 **Failed** (unhandled log) |
| 수정 후 | fixture 41개 중 **40 Passed / 0 Failed** / 1 Inconclusive(`…_Windows` — macOS에서 의도된 skip) |

수정은 테스트 파일 1개 단일 헌크이며 프로덕션 코드 변경 없음.