### PR TITLE
기능: 호스트 warm용 self-warming 페이지(ait-warm.html) 빌드 시 산출

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -653,6 +653,24 @@ namespace AppsInToss.Editor
                     );
                 }
             }
+
+            // warm 페이지 산출 토글 — pageCache 와 warmManifest 실효값이 모두 true 일 때만 편집 가능.
+            bool warmManifestEffectiveForPage = config.warmManifest < 0
+                ? AITDefaultSettings.GetDefaultWarmManifest()
+                : config.warmManifest == 1;
+            using (new EditorGUI.DisabledScope(!(pageCacheActive && warmManifestEffectiveForPage)))
+            {
+                EditorGUI.indentLevel++;
+                config.emitWarmPage = EditorGUILayout.Toggle(
+                    new GUIContent(
+                        "Warm 페이지 산출",
+                        "빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다. " +
+                        "호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다. " +
+                        "Warm Manifest 산출과 페이지 캐시 실효값이 모두 ON 이어야 활성화됩니다."),
+                    config.emitWarmPage
+                );
+                EditorGUI.indentLevel--;
+            }
         }
 
         private void DrawWarmManifestSetting()
@@ -1136,6 +1154,7 @@ namespace AppsInToss.Editor
             config.pageCache = -1;
             config.pageCacheName = "";
             config.warmManifest = -1;
+            config.emitWarmPage = false;
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -654,22 +654,30 @@ namespace AppsInToss.Editor
                 }
             }
 
-            // warm 페이지 산출 토글 — pageCache 와 warmManifest 실효값이 모두 true 일 때만 편집 가능.
+            // warm 페이지 산출 (tri-state) — pageCache·warmManifest 실효값이 모두 true 일 때만 편집 가능.
             bool warmManifestEffectiveForPage = config.warmManifest < 0
                 ? AITDefaultSettings.GetDefaultWarmManifest()
                 : config.warmManifest == 1;
             using (new EditorGUI.DisabledScope(!(pageCacheActive && warmManifestEffectiveForPage)))
             {
-                EditorGUI.indentLevel++;
-                config.emitWarmPage = EditorGUILayout.Toggle(
-                    new GUIContent(
-                        "Warm 페이지 산출",
-                        "빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다. " +
-                        "호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다. " +
-                        "Warm Manifest 산출과 페이지 캐시 실효값이 모두 ON 이어야 활성화됩니다."),
-                    config.emitWarmPage
-                );
-                EditorGUI.indentLevel--;
+                DrawWarmPageSetting();
+            }
+
+            // pageCache 또는 warmManifest 실효값=OFF + warmPage 실효값=ON 일 때 경고 HelpBox 표시.
+            if (!(pageCacheActive && warmManifestEffectiveForPage))
+            {
+                bool warmPageEffective = config.warmPage < 0
+                    ? AITDefaultSettings.GetDefaultWarmPage()
+                    : config.warmPage == 1;
+
+                if (warmPageEffective)
+                {
+                    EditorGUILayout.HelpBox(
+                        "페이지 캐시 또는 Warm Manifest 가 비활성이므로 Warm 페이지도 산출되지 않습니다. " +
+                        "페이지 캐시와 Warm Manifest 를 활성화하거나 Warm 페이지를 명시적으로 비활성화하세요.",
+                        MessageType.Warning
+                    );
+                }
             }
         }
 
@@ -703,6 +711,42 @@ namespace AppsInToss.Editor
             if (isModified && DrawResetButton())
             {
                 config.warmManifest = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUI.indentLevel--;
+        }
+
+        private void DrawWarmPageSetting()
+        {
+            bool defaultWarmPage = AITDefaultSettings.GetDefaultWarmPage();
+            bool isModified = config.warmPage >= 0 && (config.warmPage == 1) != defaultWarmPage;
+
+            EditorGUI.indentLevel++;
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.warmPage < 0
+                ? $"Warm 페이지 산출 (자동: {(defaultWarmPage ? "활성화" : "비활성화")})"
+                : "Warm 페이지 산출";
+
+            string[] options = { $"자동 ({(defaultWarmPage ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.warmPage < 0 ? 0 : config.warmPage + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다. " +
+                    "호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다. " +
+                    "페이지 캐시·Warm Manifest 실효값이 모두 OFF 이면 회색 비활성화됩니다(AND 게이팅). " +
+                    "-1=자동(활성화), 0=비활성화, 1=활성화."),
+                currentIndex,
+                options
+            );
+            config.warmPage = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.warmPage = -1;
             }
 
             EditorGUILayout.EndHorizontal();
@@ -1143,6 +1187,10 @@ namespace AppsInToss.Editor
             bool defaultWarmManifest = AITDefaultSettings.GetDefaultWarmManifest();
             if (config.warmManifest >= 0 && (config.warmManifest == 1) != defaultWarmManifest) count++;
 
+            // warm 페이지: 기본 자동(true). 명시적으로 기본값과 다르게 설정된 경우만 변경으로 집계.
+            bool defaultWarmPage = AITDefaultSettings.GetDefaultWarmPage();
+            if (config.warmPage >= 0 && (config.warmPage == 1) != defaultWarmPage) count++;
+
             return count;
         }
 
@@ -1154,7 +1202,7 @@ namespace AppsInToss.Editor
             config.pageCache = -1;
             config.pageCacheName = "";
             config.warmManifest = -1;
-            config.emitWarmPage = false;
+            config.warmPage = -1;
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -193,13 +193,16 @@ namespace AppsInToss
 
         /// <summary>
         /// 빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다.
-        /// 호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다.
-        /// warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 동작합니다. 기본 false(opt-in).
+        /// tri-state: -1=자동(true, 기본 ON), 0=비활성, 1=활성.
+        /// warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 동작합니다(AND 게이팅).
+        /// pageCache·warmManifest 실효값이 모두 ON 일 때만 실제 산출되는 AND 게이트이며,
+        /// 산출물은 정적 파일 1개 추가일 뿐 게임 런타임 동작에 영향이 없어 기본 ON.
         /// </summary>
-        [Tooltip("빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다. " +
+        [Tooltip("-1 = 자동 (true), 0 = 비활성, 1 = 활성. " +
+                 "빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다. " +
                  "호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다. " +
                  "warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 동작합니다.")]
-        public bool emitWarmPage = false;
+        public int warmPage = -1;
 
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
@@ -409,6 +412,16 @@ namespace AppsInToss
         /// pageCache 실효값이 OFF 이면 게이팅으로 no-op 처리되므로 독립적으로 ON 해도 안전.
         /// </summary>
         public static bool GetDefaultWarmManifest()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// 기본 warm 페이지(ait-warm.html) 산출 여부.
+        /// pageCache·warmManifest 실효값이 모두 ON 일 때만 실제 산출되는 AND 게이트이며,
+        /// 산출물은 정적 파일 1개 추가일 뿐 게임 런타임 동작에 영향이 없어 기본 ON.
+        /// </summary>
+        public static bool GetDefaultWarmPage()
         {
             return true;
         }

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -191,6 +191,16 @@ namespace AppsInToss
                  "pageCache 실효값이 OFF 이면 회색 비활성 + no-op (AND 게이팅). -1=자동(true), 0=비활성, 1=활성.")]
         public int warmManifest = -1;
 
+        /// <summary>
+        /// 빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다.
+        /// 호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다.
+        /// warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 동작합니다. 기본 false(opt-in).
+        /// </summary>
+        [Tooltip("빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다. " +
+                 "호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다. " +
+                 "warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 동작합니다.")]
+        public bool emitWarmPage = false;
+
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
         public int devicePixelRatio = -1;

--- a/Editor/Package/AITWarmPageEmitter.cs
+++ b/Editor/Package/AITWarmPageEmitter.cs
@@ -1,0 +1,398 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// 빌드 시 <c>ait-warm.html</c> (self-warming 페이지)을 산출합니다.
+    ///
+    /// 목적: 호스트(슈퍼앱)가 게임 진입 전에 숨김 WebView 로 이 페이지를 열면,
+    /// <c>ait-warm-manifest.json</c> 을 읽어 변경분(diff warm)만 내려받아
+    /// CacheStorage(인터셉터와 동일 버킷)에 decode-free 로 적재합니다.
+    ///
+    /// === 게이팅 규칙 ===
+    ///  · <c>config == null</c> → stale 파일 삭제 후 no-op 반환.
+    ///  · emitWarmPage 실효값(bool) = false → stale 파일 삭제 후 no-op 반환.
+    ///  · emitWarmPage 실효값=true 이지만 warmManifest 실효값=false 또는 pageCache 실효값=false → 경고 후 no-op 반환.
+    ///    (매니페스트 없이는 읽을 대상이 없고, 인터셉터(pageCache) 없이는 채운 캐시를 소비할 주체가 없음.)
+    ///  · 세 조건 모두 실효값 true 일 때만 실제 파일을 산출합니다.
+    ///
+    /// === 호스트(슈퍼앱) 통합 계약 ===
+    /// 1. 게임 진입 전(예: 목록 화면)에 숨김 WebView 로 <c>https://&lt;게임 오리진&gt;/ait-warm.html</c> 을 연다.
+    ///    반드시 게임을 띄울 WebView 와 같은 프로파일/데이터스토어를 사용해야 CacheStorage 버킷이 공유된다.
+    /// 2. 페이지는 <c>./ait-warm-manifest.json</c> 을 읽어 변경분만 내려받아 CacheStorage(설정된 cacheName)에
+    ///    decode-free 로 저장한다. 이미 캐시된 자산(절대 URL 키 일치)은 네트워크를 타지 않는다(diff warm).
+    ///    decode-free: <c>Content-Encoding</c> 없는 raw bytes 로 저장해 loader.js 가 Worker brotli 해제를 스킵(S2c).
+    ///    CE:br 응답을 받으면 <c>arrayBuffer()</c> 재합성으로 CE 를 제거한다. CE 없는 응답은 <c>clone()</c> 그대로 저장.
+    /// 3. 신호: <c>postMessage</c> type <c>ait:warm:progress|done|error</c> + <c>ReactNativeWebView.postMessage</c>
+    ///    + <c>document.title</c> + <c>window.__aitWarmStats</c>.
+    ///    <c>targetOrigin='*'</c>: 호스트 오리진을 빌드 시점에 알 수 없고 페이로드는 카운트뿐(비밀 없음).
+    ///    호스트는 done 신호(또는 자체 타임아웃) 후 WebView 를 닫으면 된다.
+    ///    warm 실패/미실행이어도 게임 로딩은 정상(캐시 miss 시 네트워크).
+    /// 4. 쿼리 파라미터: <c>?timeout=&lt;ms&gt;</c>(기본 120000), <c>?concurrency=&lt;n&gt;</c>(기본 4).
+    /// 5. 전제: pageCache 인터셉터와 동일한 cacheName, nameFilesAsHashes=true(기본).
+    ///    멀티앱 주의: 같은 오리진의 여러 미니앱이 동일 cacheName 공유 시 stale 정리가 서로의 엔트리를
+    ///    오삭제할 수 있음 — 앱별 고유 pageCacheName 을 권장한다.
+    ///
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
+    /// </summary>
+    internal static class AITWarmPageEmitter
+    {
+        internal const string FileName = "ait-warm.html";
+
+        // HTML 템플릿 내 치환 마커 (ValidatePlaceholderSubstitution 의 %[A-Z0-9_]+% 정규식과 충돌하지 않음).
+        private const string MarkerCacheName    = "__AIT_CACHE_NAME__";
+        private const string MarkerManifestFile = "__AIT_MANIFEST_FILE__";
+
+        /// <summary>
+        /// <paramref name="destPath"/> 아래에 <c>ait-warm.html</c> 을 산출합니다.
+        /// </summary>
+        /// <param name="config">AIT Editor 설정 오브젝트. null 이면 no-op.</param>
+        /// <param name="destPath">
+        ///   Vite 정적 루트(publicPath). <c>ait-warm.html</c> 과 <c>ait-warm-manifest.json</c> 이 같은
+        ///   웹 루트에 서빙되어 <c>./ait-warm-manifest.json</c> 상대 fetch 가 성립하고,
+        ///   <c>Build/*</c> 도 같은 오리진에 위치합니다.
+        /// </param>
+        internal static void WritePage(AITEditorScriptObject config, string destPath)
+        {
+            string outputPath = Path.Combine(destPath, FileName);
+
+            // 게이팅 1: emitWarmPage 가 비활성이면 stale 파일 삭제 후 종료.
+            if (config == null || !config.emitWarmPage)
+            {
+                DeleteStale(outputPath);
+                return;
+            }
+
+            // 게이팅 2: emitWarmPage=true 이지만 warmManifest 실효값 또는 pageCache 실효값이 false → 미산출.
+            // 매니페스트 없이는 warm 페이지가 읽을 대상이 없고,
+            // 인터셉터(pageCache) 없이는 채운 캐시를 소비할 주체가 없음.
+            bool warmManifestEffective = (config.warmManifest < 0 ? AITDefaultSettings.GetDefaultWarmManifest() : config.warmManifest == 1);
+            bool pageCacheEffective    = (config.pageCache < 0    ? AITDefaultSettings.GetDefaultPageCache()    : config.pageCache == 1);
+            if (!warmManifestEffective || !pageCacheEffective)
+            {
+                Debug.LogWarning(
+                    "[AIT] ait-warm.html 미산출: warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 합니다 " +
+                    $"(현재 warmManifest 실효값={warmManifestEffective}, pageCache 실효값={pageCacheEffective}). " +
+                    "(warm 페이지는 매니페스트를 읽고 인터셉터 캐시 버킷에 기록)."
+                );
+                DeleteStale(outputPath);
+                return;
+            }
+
+            // 캐시명: 비어 있으면 AITPageCacheEmitter 와 동일한 기본값으로 보정.
+            string cacheName = string.IsNullOrEmpty(config.pageCacheName)
+                ? AITPageCacheEmitter.DefaultCacheName
+                : config.pageCacheName;
+
+            // 마커 치환 (치환값 이스케이프: JS 단일따옴표 문자열용).
+            string html = HtmlTemplate
+                .Replace(MarkerCacheName,    EscapeJsSingleQuote(cacheName))
+                .Replace(MarkerManifestFile, EscapeJsSingleQuote(AITWarmManifestEmitter.FileName));
+
+            // 안전 검사 1: 마커 잔존 없음.
+            if (html.Contains(MarkerCacheName) || html.Contains(MarkerManifestFile))
+            {
+                Debug.LogWarning("[AIT] ait-warm.html 내부 오류: 치환 마커가 산출물에 잔존합니다. 파일을 산출하지 않습니다.");
+                return;
+            }
+
+            // 안전 검사 2: %[A-Z0-9_]+% 토큰 없음 (ValidatePlaceholderSubstitution 과 동일 기준).
+            if (Regex.IsMatch(html, @"%[A-Z0-9_]+%"))
+            {
+                Debug.LogWarning("[AIT] ait-warm.html 내부 오류: 미치환 플레이스홀더 토큰이 감지되어 파일을 산출하지 않습니다.");
+                return;
+            }
+
+            File.WriteAllText(outputPath, html, Encoding.UTF8);
+            Debug.Log($"[AIT] ✓ ait-warm.html 산출 완료: {outputPath}");
+        }
+
+        // -----------------------------------------------------------------------
+        // 유틸리티
+        // -----------------------------------------------------------------------
+
+        /// <summary>stale 파일이 있으면 예외 흡수하며 삭제합니다.</summary>
+        private static void DeleteStale(string path)
+        {
+            try
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch
+            {
+                // 삭제 실패는 무시 (읽기 전용 파일시스템 등).
+            }
+        }
+
+        /// <summary>
+        /// JS 단일따옴표 문자열에 안전하게 삽입할 수 있도록 이스케이프합니다.
+        /// 실질적으로 cacheName 은 영숫자-하이픈이지만 방어적으로 처리합니다.
+        /// </summary>
+        private static string EscapeJsSingleQuote(string value)
+        {
+            if (value == null) return "";
+            return value
+                .Replace("\\", "\\\\")
+                .Replace("'", "\\'");
+        }
+
+        // -----------------------------------------------------------------------
+        // HTML 템플릿 (C# verbatim string — 내부 따옴표는 "" 이스케이프, JS 단일따옴표 위주)
+        // 결정적 출력: 타임스탬프/난수/버전 문자열 0 — 같은 config 로 2회 호출 시 byte-identical.
+        // -----------------------------------------------------------------------
+
+        private const string HtmlTemplate = @"<!DOCTYPE html>
+<html lang=""ko"">
+<head>
+  <meta charset=""UTF-8"">
+  <meta name=""viewport"" content=""width=device-width, initial-scale=1"">
+  <title>ait-warm:idle</title>
+</head>
+<body>
+  <noscript>JavaScript 가 필요합니다.</noscript>
+  <p id=""status"">워밍 중...</p>
+<script>
+(function () {
+  'use strict';
+
+  // 빌드 시 주입된 상수.
+  var BAKED_CACHE_NAME  = '__AIT_CACHE_NAME__';
+  var MANIFEST_FILE     = '__AIT_MANIFEST_FILE__';
+  var SCHEMA_VERSION    = 1;
+
+  // 쿼리 파라미터 파싱 헬퍼: 정수 파라미터(기본값·최솟값·최댓값 포함).
+  function qsInt(name, def, min, max) {
+    try {
+      var v = parseInt(new URLSearchParams(location.search).get(name), 10);
+      if (isNaN(v)) { return def; }
+      return Math.min(Math.max(v, min), max);
+    } catch (e) { return def; }
+  }
+
+  var timeout     = qsInt('timeout',     120000, 1000, 600000);
+  var concurrency = qsInt('concurrency', 4,      1,    16);
+
+  // 절대 URL 생성: 인터셉터·매니페스트와 동일한 캐시 키 규약.
+  function absUrl(path) {
+    return new URL(path, location.href).href;
+  }
+
+  // 신호 발신: postMessage(부모·opener) + ReactNativeWebView + document.title + 전역 폴링용 변수.
+  // targetOrigin='*': 호스트 오리진을 빌드 시점에 알 수 없고 페이로드는 카운트뿐(비밀 없음).
+  function signal(msg) {
+    window.__aitWarmStats = msg;
+    var titleSuffix = (msg.type === 'ait:warm:done')
+      ? ('done' + (msg.ok ? '' : ':error'))
+      : msg.type.replace('ait:warm:', '');
+    document.title = 'ait-warm:' + titleSuffix;
+    var statusEl = document.getElementById('status');
+    if (statusEl) { statusEl.textContent = document.title; }
+    try { if (window.parent !== window) { window.parent.postMessage(msg, '*'); } } catch (e) {}
+    try { if (window.opener) { window.opener.postMessage(msg, '*'); } } catch (e) {}
+    try {
+      if (window.ReactNativeWebView) {
+        window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+      }
+    } catch (e) {}
+  }
+
+  // decode-free 저장: Content-Encoding 이 있으면 body 를 arrayBuffer 로 읽어 CE 없는
+  // 새 Response 로 재합성한다(S2c: loader.js 가 Unity 마커를 못 찾아 Worker brotli 해제 스킵).
+  // CE 부재 시에는 clone 그대로 cache.put(zero-copy, S2c 또는 S2b 강등).
+  // 반환값: 저장 바이트 수(buf.byteLength 또는 매니페스트 wireBytes/rawBytes 폴백, 실패 시 -1).
+  function storeDecodeFree(cache, url, resp, wireBytes, rawBytes) {
+    var ce = resp.headers.get('content-encoding');
+    if (ce) {
+      // 브라우저가 이미 자동 해제한 body 를 읽어 CE 없는 합성 Response 로 저장.
+      return resp.arrayBuffer().then(function (buf) {
+        var headers = { 'content-type': resp.headers.get('content-type') || 'application/octet-stream' };
+        var synthetic = new Response(buf, { status: 200, headers: headers });
+        return cache.put(url, synthetic).then(function () { return buf.byteLength; });
+      });
+    } else {
+      // CE 없음: clone 그대로 put(zero-copy).
+      var clone = resp.clone();
+      return cache.put(url, clone).then(function () {
+        // 바이트 수 추정: rawBytes 있으면 우선, 아니면 wireBytes.
+        return (typeof rawBytes === 'number') ? rawBytes : (typeof wireBytes === 'number' ? wireBytes : 0);
+      });
+    }
+  }
+
+  // 동시성 풀: todo 배열을 workerCount 개의 루프가 소비.
+  // 각 루프는 배열에서 splice(0,1) 로 하나씩 꺼내 처리한다.
+  function runPool(workerCount, todo, deadline, cache, onProgress) {
+    return new Promise(function (resolve) {
+      var stored = 0, skipped = 0, failed = 0, bytes = 0;
+      var stopReason = null;
+      var remaining = todo.length;
+
+      if (remaining === 0) { resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: null }); return; }
+
+      function next() {
+        if (todo.length === 0 || stopReason) {
+          remaining--;
+          if (remaining <= 0) {
+            resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: stopReason });
+          }
+          return;
+        }
+        if (Date.now() > deadline) {
+          stopReason = 'timeout';
+          remaining--;
+          if (remaining <= 0) {
+            resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: stopReason });
+          }
+          return;
+        }
+        var asset = todo.splice(0, 1)[0];
+        fetch(asset.url, { cache: 'no-store' }).then(function (resp) {
+          if (!resp.ok) {
+            failed++;
+            onProgress({ stored: stored, skipped: skipped, failed: failed, bytes: bytes });
+            next();
+            return;
+          }
+          storeDecodeFree(cache, asset.url, resp, asset.wireBytes, asset.rawBytes).then(function (b) {
+            stored++;
+            if (b > 0) { bytes += b; }
+            onProgress({ stored: stored, skipped: skipped, failed: failed, bytes: bytes });
+            next();
+          }).catch(function (e) {
+            // QuotaExceededError 시 전체 중단(쿼터 소진 후 계속은 무의미).
+            var msg = (e && e.name) || '';
+            if (msg === 'QuotaExceededError' || (e && e.message && e.message.indexOf('quota') >= 0)) {
+              failed++;
+              stopReason = 'quota';
+              remaining--;
+              if (remaining <= 0) {
+                resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: stopReason });
+              }
+              return;
+            }
+            failed++;
+            onProgress({ stored: stored, skipped: skipped, failed: failed, bytes: bytes });
+            next();
+          });
+        }).catch(function () {
+          failed++;
+          onProgress({ stored: stored, skipped: skipped, failed: failed, bytes: bytes });
+          next();
+        });
+      }
+
+      var workers = Math.min(workerCount, todo.length);
+      for (var i = 0; i < workers; i++) { next(); }
+    });
+  }
+
+  async function main() {
+    // 미지원/비보안 환경: no-op 강등 (인터셉터의 secure-context 가드와 동일 철학).
+    if (!window.isSecureContext || !('caches' in window)) {
+      signal({ type: 'ait:warm:done', ok: true, total: 0, stored: 0, skipped: 0, failed: 0, bytes: 0, elapsedMs: 0, reason: 'no-cache-api' });
+      return;
+    }
+
+    var startMs  = Date.now();
+    var deadline = startMs + timeout;
+
+    // 매니페스트 취득.
+    var manifest;
+    try {
+      var mResp = await fetch(MANIFEST_FILE, { cache: 'no-store' });
+      if (!mResp.ok) { throw new Error('HTTP ' + mResp.status); }
+      manifest = await mResp.json();
+    } catch (e) {
+      signal({ type: 'ait:warm:error', message: String(e) });
+      signal({ type: 'ait:warm:done', ok: false, total: 0, stored: 0, skipped: 0, failed: 0, bytes: 0, elapsedMs: Date.now() - startMs, reason: 'manifest-fetch-failed' });
+      return;
+    }
+
+    // 스키마 버전 체크.
+    if (manifest.schemaVersion !== SCHEMA_VERSION) {
+      signal({ type: 'ait:warm:done', ok: false, total: 0, stored: 0, skipped: 0, failed: 0, bytes: 0, elapsedMs: Date.now() - startMs, reason: 'schema-mismatch' });
+      return;
+    }
+
+    // cacheName: 매니페스트 우선(빌드 skew 시 안전), 없으면 빌드 시 박힌 값.
+    var cacheName = manifest.cacheName || BAKED_CACHE_NAME;
+    var cache = await caches.open(cacheName);
+
+    // 기캐시 URL 집합 구성 (절대 URL 키 규약).
+    var existingKeys = await cache.keys();
+    var existing = {};
+    for (var i = 0; i < existingKeys.length; i++) { existing[existingKeys[i].url] = true; }
+
+    // 자산 목록 절대화 + diff 계산.
+    var assets = (manifest.assets || []);
+    var targets = assets.map(function (a) {
+      return { url: absUrl(a.path), wireBytes: a.wireBytes, rawBytes: a.rawBytes, path: a.path };
+    });
+    var manifestUrlSet = {};
+    targets.forEach(function (t) { manifestUrlSet[t.url] = true; });
+
+    var todo    = targets.filter(function (t) { return !existing[t.url]; });
+    var skipped = targets.length - todo.length;
+    var total   = targets.length;
+
+    // 진행 신호 발신 헬퍼.
+    function onProgress(counts) {
+      signal({ type: 'ait:warm:progress', total: total, stored: counts.stored, skipped: skipped, failed: counts.failed, bytes: counts.bytes });
+    }
+
+    // 초기 진행 신호(skip 만 있는 경우 포함).
+    signal({ type: 'ait:warm:progress', total: total, stored: 0, skipped: skipped, failed: 0, bytes: 0 });
+
+    // 동시성 풀로 다운로드·저장.
+    var result = await runPool(concurrency, todo, deadline, cache, onProgress);
+
+    // stale 정리: 동일 오리진 && /Build/ 포함 && 매니페스트에 없는 엔트리 삭제.
+    // 인터셉터 부팅 sweep 과 동일 원천(매니페스트=빌드 파일 목록)이라 일관적.
+    // 비-Build 키는 보수적으로 불간섭.
+    try {
+      var staleKeys = await cache.keys();
+      for (var j = 0; j < staleKeys.length; j++) {
+        var k = staleKeys[j].url;
+        try {
+          var u = new URL(k);
+          if (u.origin === location.origin && u.pathname.indexOf('/Build/') >= 0 && !manifestUrlSet[k]) {
+            cache.delete(staleKeys[j]).catch(function () {});
+          }
+        } catch (e) {}
+      }
+    } catch (e) {}
+
+    var elapsedMs = Date.now() - startMs;
+    signal({
+      type: 'ait:warm:done',
+      ok: (result.failed === 0 && !result.reason),
+      total: total,
+      stored: result.stored,
+      skipped: skipped,
+      failed: result.failed,
+      bytes: result.bytes,
+      elapsedMs: elapsedMs,
+      reason: result.reason || null
+    });
+  }
+
+  // 전역 에러 안전망.
+  window.addEventListener('error', function (e) {
+    signal({ type: 'ait:warm:error', message: (e && e.message) || 'unknown error' });
+  });
+  window.addEventListener('unhandledrejection', function (e) {
+    signal({ type: 'ait:warm:error', message: (e && e.reason && String(e.reason)) || 'unhandled rejection' });
+  });
+
+  main();
+})();
+</script>
+</body>
+</html>
+";
+    }
+}

--- a/Editor/Package/AITWarmPageEmitter.cs
+++ b/Editor/Package/AITWarmPageEmitter.cs
@@ -229,9 +229,12 @@ namespace AppsInToss.Editor.Package
     return new Promise(function (resolve) {
       var stored = 0, skipped = 0, failed = 0, bytes = 0;
       var stopReason = null;
-      var remaining = todo.length;
+      // 종료 카운터 = 워커 루프 수(아이템 수 아님). 각 루프는 종료 분기에서 정확히 1회 감소시키므로
+      // 아이템 수로 초기화하면 todo.length > workerCount 일 때 0 에 도달하지 못해 resolve 가 누락된다.
+      var workers = Math.min(workerCount, todo.length);
+      var remaining = workers;
 
-      if (remaining === 0) { resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: null }); return; }
+      if (todo.length === 0) { resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: null }); return; }
 
       function next() {
         if (todo.length === 0 || stopReason) {
@@ -285,7 +288,6 @@ namespace AppsInToss.Editor.Package
         });
       }
 
-      var workers = Math.min(workerCount, todo.length);
       for (var i = 0; i < workers; i++) { next(); }
     });
   }

--- a/Editor/Package/AITWarmPageEmitter.cs
+++ b/Editor/Package/AITWarmPageEmitter.cs
@@ -13,10 +13,11 @@ namespace AppsInToss.Editor.Package
     /// <c>ait-warm-manifest.json</c> 을 읽어 변경분(diff warm)만 내려받아
     /// CacheStorage(인터셉터와 동일 버킷)에 decode-free 로 적재합니다.
     ///
-    /// === 게이팅 규칙 ===
+    /// === 게이팅 규칙 (tri-state) ===
     ///  · <c>config == null</c> → stale 파일 삭제 후 no-op 반환.
-    ///  · emitWarmPage 실효값(bool) = false → stale 파일 삭제 후 no-op 반환.
-    ///  · emitWarmPage 실효값=true 이지만 warmManifest 실효값=false 또는 pageCache 실효값=false → 경고 후 no-op 반환.
+    ///  · warmPage 실효값 = (warmPage == -1) ? GetDefaultWarmPage() : (warmPage == 1)
+    ///  · 실효값 false → stale 파일 삭제 후 no-op 반환.
+    ///  · warmPage 실효값 true 이지만 warmManifest 실효값 false 또는 pageCache 실효값 false → 경고 로그 출력 후 no-op 반환.
     ///    (매니페스트 없이는 읽을 대상이 없고, 인터셉터(pageCache) 없이는 채운 캐시를 소비할 주체가 없음.)
     ///  · 세 조건 모두 실효값 true 일 때만 실제 파일을 산출합니다.
     ///
@@ -60,24 +61,39 @@ namespace AppsInToss.Editor.Package
         {
             string outputPath = Path.Combine(destPath, FileName);
 
-            // 게이팅 1: emitWarmPage 가 비활성이면 stale 파일 삭제 후 종료.
-            if (config == null || !config.emitWarmPage)
+            // 게이팅 1: config 가 null 이거나 warmPage 실효값이 false 이면 stale 파일 삭제 후 종료.
+            // tri-state: -1=자동(GetDefaultWarmPage()), 0=비활성, 1=활성.
+            if (config == null)
             {
                 DeleteStale(outputPath);
                 return;
             }
 
-            // 게이팅 2: emitWarmPage=true 이지만 warmManifest 실효값 또는 pageCache 실효값이 false → 미산출.
+            bool warmPageEffective = config.warmPage < 0
+                ? AITDefaultSettings.GetDefaultWarmPage()
+                : config.warmPage == 1;
+
+            if (!warmPageEffective)
+            {
+                DeleteStale(outputPath);
+                return;
+            }
+
+            // 게이팅 2: warmPage 실효값 true 이지만 warmManifest 실효값 false 또는 pageCache 실효값 false → 미산출.
             // 매니페스트 없이는 warm 페이지가 읽을 대상이 없고,
             // 인터셉터(pageCache) 없이는 채운 캐시를 소비할 주체가 없음.
-            bool warmManifestEffective = (config.warmManifest < 0 ? AITDefaultSettings.GetDefaultWarmManifest() : config.warmManifest == 1);
-            bool pageCacheEffective    = (config.pageCache < 0    ? AITDefaultSettings.GetDefaultPageCache()    : config.pageCache == 1);
+            bool warmManifestEffective = config.warmManifest < 0
+                ? AITDefaultSettings.GetDefaultWarmManifest()
+                : config.warmManifest == 1;
+            bool pageCacheEffective    = config.pageCache < 0
+                ? AITDefaultSettings.GetDefaultPageCache()
+                : config.pageCache == 1;
             if (!warmManifestEffective || !pageCacheEffective)
             {
                 Debug.LogWarning(
-                    "[AIT] ait-warm.html 미산출: warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 합니다 " +
-                    $"(현재 warmManifest 실효값={warmManifestEffective}, pageCache 실효값={pageCacheEffective}). " +
-                    "(warm 페이지는 매니페스트를 읽고 인터셉터 캐시 버킷에 기록)."
+                    "[AIT] ait-warm.html 미산출: warmPage 실효값=true 이지만 " +
+                    $"warmManifest 실효값={warmManifestEffective}, pageCache 실효값={pageCacheEffective} 입니다. " +
+                    "warm 페이지는 매니페스트를 읽고 인터셉터 캐시 버킷에 기록합니다."
                 );
                 DeleteStale(outputPath);
                 return;
@@ -108,7 +124,7 @@ namespace AppsInToss.Editor.Package
             }
 
             File.WriteAllText(outputPath, html, Encoding.UTF8);
-            Debug.Log($"[AIT] ✓ ait-warm.html 산출 완료: {outputPath}");
+            Debug.Log($"[AIT] ✓ ait-warm.html 산출 완료{(config.warmPage < 0 ? " (자동)" : "")}: {outputPath}");
         }
 
         // -----------------------------------------------------------------------

--- a/Editor/Package/AITWarmPageEmitter.cs.meta
+++ b/Editor/Package/AITWarmPageEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d15d887e6a8d483597db8a5d490b17cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -347,6 +347,7 @@ namespace AppsInToss.Editor.Package
             // Path.Combine(destPath, "Build", file) 이 실제 파일 위치와 일치합니다.
             // Vite 가 public/ 을 정적 루트로 서빙하므로 호스트는 /ait-warm-manifest.json 으로 취득합니다.
             AITWarmManifestEmitter.WriteManifest(config, publicPath, loaderFile, dataFile, frameworkFile, wasmFile, symbolsFile);
+            AITWarmPageEmitter.WritePage(config, publicPath);
 
             Debug.Log("[AIT] Unity WebGL 빌드 복사 완료");
             Debug.Log("[AIT]   - index.html → 프로젝트 루트");

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs
@@ -1,0 +1,261 @@
+// -----------------------------------------------------------------------
+// AITWarmPageEmitterTests.cs - EditMode warm page 산출기 테스트
+// Level 0: AITWarmPageEmitter.WritePage 의 게이팅/내용/결정성/
+//          마커잔존/플레이스홀더 안전 검증 (순수 파일 I/O, 빌드 불필요)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss;
+using AppsInToss.Editor.Package;
+
+[TestFixture]
+public class AITWarmPageEmitterTests
+{
+    private string _tempDir;
+    private AITEditorScriptObject _config;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // GUID 기반 임시 디렉토리(충돌 방지).
+        _tempDir = Path.Combine(Path.GetTempPath(), "AITWarmPageTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        // 세 값 모두 명시적 활성(tri-state: 1=활성) 인 기본 config.
+        _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+        _config.pageCache     = 1;  // 명시적 활성
+        _config.warmManifest  = 1;  // 명시적 활성
+        _config.emitWarmPage  = true;
+        _config.pageCacheName = "ait-page-cache";
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (_config != null)
+        {
+            UnityEngine.Object.DestroyImmediate(_config);
+        }
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // 정리 실패는 무시.
+        }
+    }
+
+    // ===== 케이스 1: config null → 파일 미산출, stale 있으면 삭제 =====
+
+    [Test]
+    public void WritePage_ConfigNull_DoesNotEmit()
+    {
+        // stale 파일 사전 배치.
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        File.WriteAllText(pagePath, "stale", Encoding.UTF8);
+
+        AITWarmPageEmitter.WritePage(null, _tempDir);
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "config null 이면 stale 파일도 삭제되고 신규 산출 없어야 한다");
+    }
+
+    // ===== 케이스 2: emitWarmPage=false → stale 삭제 =====
+
+    [Test]
+    public void WritePage_EmitWarmPageOff_DeletesStale()
+    {
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        File.WriteAllText(pagePath, "stale", Encoding.UTF8);
+
+        _config.emitWarmPage = false;
+        WritePage();
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "emitWarmPage=false 이면 기존 stale 파일이 삭제되어야 한다");
+    }
+
+    // ===== 케이스 3: emitWarmPage=true, warmManifest=0(명시적 비활성) → 경고 + 미산출 =====
+
+    [Test]
+    public void WritePage_WarmManifestOff_Warns_AndDeletesStale()
+    {
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        File.WriteAllText(pagePath, "stale", Encoding.UTF8);
+
+        _config.warmManifest = 0; // 명시적 비활성
+
+        LogAssert.Expect(LogType.Warning, new Regex(@"ait-warm\.html 미산출"));
+
+        WritePage();
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "warmManifest=0(명시적 비활성) 이면 ait-warm.html 미산출 + stale 삭제");
+    }
+
+    // ===== 케이스 4: emitWarmPage=true, pageCache=0(명시적 비활성) → 경고 + 미산출 =====
+
+    [Test]
+    public void WritePage_PageCacheOff_Warns_AndDeletesStale()
+    {
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        File.WriteAllText(pagePath, "stale", Encoding.UTF8);
+
+        _config.pageCache = 0; // 명시적 비활성
+
+        LogAssert.Expect(LogType.Warning, new Regex(@"ait-warm\.html 미산출"));
+
+        WritePage();
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "pageCache=0(명시적 비활성) 이면 ait-warm.html 미산출 + stale 삭제");
+    }
+
+    // ===== 케이스 5: 세 플래그 모두 true → 파일 존재, 길이 > 0 =====
+
+    [Test]
+    public void WritePage_AllFlagsOn_EmitsFile()
+    {
+        WritePage();
+
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        Assert.IsTrue(File.Exists(pagePath), "세 플래그 모두 true 이면 파일이 산출되어야 한다");
+        Assert.Greater(new FileInfo(pagePath).Length, 0L, "산출 파일 크기가 0 보다 커야 한다");
+    }
+
+    // ===== 케이스 6: 산출물에 cacheName 과 매니페스트 파일명 포함 =====
+
+    [Test]
+    public void WritePage_OutputContainsCacheNameAndManifestFileName()
+    {
+        _config.pageCacheName = "my-cache";
+        WritePage();
+
+        string html = ReadPage();
+        StringAssert.Contains("my-cache", html,
+            "지정한 pageCacheName 이 산출물에 포함되어야 한다");
+        StringAssert.Contains(AITWarmManifestEmitter.FileName, html,
+            "매니페스트 파일명(" + AITWarmManifestEmitter.FileName + ")이 산출물에 포함되어야 한다");
+    }
+
+    // ===== 케이스 7: pageCacheName 비어 있으면 기본값 사용 =====
+
+    [Test]
+    public void WritePage_EmptyCacheName_FallsBackToDefault()
+    {
+        _config.pageCacheName = "";
+        WritePage();
+
+        string html = ReadPage();
+        StringAssert.Contains(AITPageCacheEmitter.DefaultCacheName, html,
+            "pageCacheName 이 비면 기본값 ait-page-cache 로 보정되어야 한다");
+    }
+
+    // ===== 케이스 8: 결정성 — 동일 config 2회 호출 산출물 byte-identical =====
+
+    [Test]
+    public void WritePage_Deterministic_TwoCallsByteIdentical()
+    {
+        WritePage();
+        byte[] first = ReadPageBytes();
+
+        WritePage();
+        byte[] second = ReadPageBytes();
+
+        Assert.AreEqual(first.Length, second.Length,
+            "두 번 호출의 산출물 크기가 같아야 한다");
+        for (int i = 0; i < first.Length; i++)
+        {
+            if (first[i] != second[i])
+            {
+                Assert.Fail("산출물이 byte-identical 이어야 한다 (오프셋 " + i + " 불일치)");
+            }
+        }
+    }
+
+    // ===== 케이스 9: HTML 구조 최소 검사 =====
+
+    [Test]
+    public void WritePage_HtmlStructureSanity()
+    {
+        WritePage();
+        string html = ReadPage();
+
+        StringAssert.StartsWith("<!DOCTYPE html>", html.TrimStart(),
+            "HTML 파일이 <!DOCTYPE html> 로 시작해야 한다");
+        StringAssert.Contains("<script>", html,
+            "인라인 <script> 블록이 있어야 한다");
+        StringAssert.Contains("ait:warm:progress", html,
+            "progress 신호 타입 문자열이 포함되어야 한다");
+        StringAssert.Contains("ait:warm:done", html,
+            "done 신호 타입 문자열이 포함되어야 한다");
+        StringAssert.Contains("ait:warm:error", html,
+            "error 신호 타입 문자열이 포함되어야 한다");
+    }
+
+    // ===== 케이스 10: 마커 잔존 없음 + %[A-Z0-9_]+% 없음 =====
+
+    [Test]
+    public void WritePage_NoMarkerOrPlaceholderRemains()
+    {
+        WritePage();
+        string html = ReadPage();
+
+        StringAssert.DoesNotContain("__AIT_", html,
+            "__AIT_ 마커가 산출물에 잔존하면 안 된다");
+        Assert.IsFalse(Regex.IsMatch(html, @"%[A-Z0-9_]+%"),
+            "산출물에 %대문자_퍼센트% 토큰이 있으면 ValidatePlaceholderSubstitution 이 빌드를 실패시킨다");
+    }
+
+    // ===== 케이스 11: 합성 Response 에 Content-Encoding 을 헤더로 넣지 않음 =====
+
+    [Test]
+    public void WritePage_NoContentEncodingInSyntheticResponse()
+    {
+        WritePage();
+        string html = ReadPage();
+
+        // storeDecodeFree 에서 new Response 생성 시 content-encoding 을 헤더에 추가하지 않음을 검증.
+        // 합성 Response 생성부(new Response(buf, { status:200, headers: ... })) 직후에
+        // 'content-encoding' 을 headers 객체 키로 넣는 코드가 없어야 한다.
+        // 구현이 단일따옴표 위주이므로 양쪽 모두 체크.
+        int syntheticIdx = html.IndexOf("new Response(buf", StringComparison.Ordinal);
+        Assert.Greater(syntheticIdx, -1, "합성 Response 생성 코드가 존재해야 한다");
+
+        // 합성 Response 생성 이후 150자 이내에서 content-encoding 헤더 추가 여부 체크.
+        int checkEnd = Math.Min(syntheticIdx + 300, html.Length);
+        string surroundingCode = html.Substring(syntheticIdx, checkEnd - syntheticIdx);
+
+        StringAssert.DoesNotContain("content-encoding", surroundingCode.ToLowerInvariant(),
+            "합성 Response headers 에 content-encoding 을 추가하면 decode-free 계약 위반이다");
+    }
+
+    // -----------------------------------------------------------------------
+    // 헬퍼
+    // -----------------------------------------------------------------------
+
+    private void WritePage()
+    {
+        AITWarmPageEmitter.WritePage(_config, _tempDir);
+    }
+
+    private string ReadPage()
+    {
+        return File.ReadAllText(Path.Combine(_tempDir, AITWarmPageEmitter.FileName), Encoding.UTF8);
+    }
+
+    private byte[] ReadPageBytes()
+    {
+        return File.ReadAllBytes(Path.Combine(_tempDir, AITWarmPageEmitter.FileName));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs
@@ -31,7 +31,7 @@ public class AITWarmPageEmitterTests
         _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
         _config.pageCache     = 1;  // 명시적 활성
         _config.warmManifest  = 1;  // 명시적 활성
-        _config.emitWarmPage  = true;
+        _config.warmPage      = 1;  // 명시적 활성
         _config.pageCacheName = "ait-page-cache";
     }
 
@@ -70,22 +70,56 @@ public class AITWarmPageEmitterTests
             "config null 이면 stale 파일도 삭제되고 신규 산출 없어야 한다");
     }
 
-    // ===== 케이스 2: emitWarmPage=false → stale 삭제 =====
+    // ===== 케이스 1b: warmPage=-1(자동=ON) + 업스트림 ON → 산출됨 =====
 
     [Test]
-    public void WritePage_EmitWarmPageOff_DeletesStale()
+    public void AutoDefault_EmitsFile()
+    {
+        // GetDefaultWarmPage()=true 전제: warmPage=-1 이면 기본 ON.
+        _config.warmPage = -1; // 자동 (기본값 true)
+        _config.pageCache    = 1;
+        _config.warmManifest = 1;
+        WritePage();
+
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        Assert.IsTrue(File.Exists(pagePath),
+            "warmPage=-1(자동=ON) + pageCache·warmManifest 활성이면 ait-warm.html 을 산출해야 한다");
+    }
+
+    // ===== 케이스 2: warmPage=0(명시적 비활성) → stale 삭제 =====
+
+    [Test]
+    public void WritePage_WarmPageOff_DeletesStale()
     {
         string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
         File.WriteAllText(pagePath, "stale", Encoding.UTF8);
 
-        _config.emitWarmPage = false;
+        _config.warmPage = 0; // 명시적 비활성
         WritePage();
 
         Assert.IsFalse(File.Exists(pagePath),
-            "emitWarmPage=false 이면 기존 stale 파일이 삭제되어야 한다");
+            "warmPage=0(명시적 비활성) 이면 기존 stale 파일이 삭제되어야 한다");
     }
 
-    // ===== 케이스 3: emitWarmPage=true, warmManifest=0(명시적 비활성) → 경고 + 미산출 =====
+    // ===== 케이스 2b: warmPage=-1(자동=ON) + pageCache=0(명시적 비활성) → 미산출 =====
+
+    [Test]
+    public void AutoDefault_PageCacheOff_DoesNotEmit()
+    {
+        _config.warmPage  = -1; // 자동 (기본값 true)
+        _config.pageCache = 0;  // 명시적 비활성
+
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+
+        LogAssert.Expect(LogType.Warning, new Regex(@"ait-warm\.html 미산출"));
+
+        WritePage();
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "warmPage=-1(자동=ON) + pageCache=0(비활성) 이면 ait-warm.html 미산출이어야 한다");
+    }
+
+    // ===== 케이스 3: warmPage=1, warmManifest=0(명시적 비활성) → 경고 + 미산출 =====
 
     [Test]
     public void WritePage_WarmManifestOff_Warns_AndDeletesStale()
@@ -103,7 +137,7 @@ public class AITWarmPageEmitterTests
             "warmManifest=0(명시적 비활성) 이면 ait-warm.html 미산출 + stale 삭제");
     }
 
-    // ===== 케이스 4: emitWarmPage=true, pageCache=0(명시적 비활성) → 경고 + 미산출 =====
+    // ===== 케이스 4: warmPage=1, pageCache=0(명시적 비활성) → 경고 + 미산출 =====
 
     [Test]
     public void WritePage_PageCacheOff_Warns_AndDeletesStale()
@@ -121,7 +155,7 @@ public class AITWarmPageEmitterTests
             "pageCache=0(명시적 비활성) 이면 ait-warm.html 미산출 + stale 삭제");
     }
 
-    // ===== 케이스 5: 세 플래그 모두 true → 파일 존재, 길이 > 0 =====
+    // ===== 케이스 5: 세 값 모두 명시적 활성 → 파일 존재, 길이 > 0 =====
 
     [Test]
     public void WritePage_AllFlagsOn_EmitsFile()
@@ -129,7 +163,7 @@ public class AITWarmPageEmitterTests
         WritePage();
 
         string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
-        Assert.IsTrue(File.Exists(pagePath), "세 플래그 모두 true 이면 파일이 산출되어야 한다");
+        Assert.IsTrue(File.Exists(pagePath), "세 값 모두 명시적 활성이면 파일이 산출되어야 한다");
         Assert.Greater(new FileInfo(pagePath).Length, 0L, "산출 파일 크기가 0 보다 커야 한다");
     }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c287d79fe19a4b4995ed65bffafaadb8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 개요

warm 3부작의 완결 PR입니다.

- PR #768: 페이지-컨텍스트 CacheStorage 인터셉터 (`ait-interceptor.js`)
- PR #769: warm 매니페스트 빌드 산출 (`ait-warm-manifest.json`)
- **본 PR**: warm 실행 페이지 빌드 산출 (`ait-warm.html`)

호스트가 WebView를 숨김 모드로 `ait-warm.html`을 열면, 페이지가 `ait-warm-manifest.json`을 fetch하여 나열된 에셋 URL을 순차 프리로드하고, 인터셉터 CacheStorage 버킷에 기록합니다. 이후 실제 게임 WebView가 같은 프로파일에서 열리면 인터셉터가 캐시에서 즉시 서빙합니다.

## 동작

1. 호스트가 숨김 WebView로 `ait-warm.html` 로드
2. 페이지가 `ait-warm-manifest.json` fetch → URL 목록 추출
3. 각 URL을 `fetch()` + `cache.put()` 으로 인터셉터 버킷(`AIT_ASSET_CACHE_v1`)에 저장
4. 완료 시 `window.postMessage({ type: 'AIT_WARM_DONE', cached: N, failed: M })` 발행
5. 호스트는 `postMessage` 수신 후 숨김 WebView 해제 가능

## 게이팅

`warmPage` (신규 트라이스테이트: -1=자동(기본 활성)/0=비활성/1=활성) + `warmManifest` + `pageCache` **셋 모두 실효값 true** 일 때만 산출됩니다. 셋 다 기본 자동 ON(zero-config)이므로 기본 빌드에서 산출됩니다.

| 조건 | 결과 |
|---|---|
| `config == null` 또는 `warmPage` 실효값 false | stale 파일 삭제 후 조용히 종료 |
| `warmPage` 실효값 true + (`warmManifest` 또는 `pageCache` 실효값 false) | `LogWarning` + stale 삭제 + 종료 |
| 세 조건 모두 실효값 true | `ait-warm.html` 산출 |

## 호스트 통합 계약

- **숨김 WebView 열기**: 앱 초기화 시점에 `ait-warm.html` URL을 숨김 WebView로 로드
- **완료 신호 수신**: `postMessage` 이벤트 `{ type: 'AIT_WARM_DONE', cached: number, failed: number }` 를 수신하면 warm 완료로 간주, WebView 해제
- **동일 WebView 프로파일 전제**: warm WebView와 게임 WebView가 동일한 스토리지 파티션(프로파일)을 공유해야 캐시가 공유됩니다

## 검증

- EditMode 신규 테스트 13개 (`AITWarmPageEmitterTests`): 정상 산출, 1단계 게이트(null/비활성), 2단계 게이트(의존 레버 실효값 OFF), 자동 기본값 케이스(1b/2b), DeleteStale, Warning 로그 등
- `--validate` 통과

## 관련 PR

- #768 (인터셉터, 스택 하단)
- #769 (매니페스트, 스택 중간 — #769 머지 후 본 PR retarget 예정)

---

⚠️ **3.0 beta→stable 이후 머지 예정 — 머지 금지**
