### PR TITLE
기능: ASTC 블록 에스컬레이션(빌드 시 lossy 블록↑ + maxTextureSize 캡, ASTC 서브타겟 전용)

### DIFF
--- a/Editor/AITAstcBlockProcessor.cs
+++ b/Editor/AITAstcBlockProcessor.cs
@@ -1,0 +1,725 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITAstcBlockProcessor.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - ASTC 블록 에스컬레이션 (build-time importer override)
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 빌드 직전, 대상 Texture2D / SpriteAtlas 의 임포터 설정을 일시적으로
+//   WebGL 플랫폼 오버라이드 format=ASTC_NxN + maxTextureSize 캡
+// 으로 바꿔 reimport 하여, Unity 가 더 작은 ASTC 텍스처를 .data 에 굽도록 한다.
+// 빌드 종료(성공/실패 무관) 후 원본 임포트 설정으로 원상 복원한다.
+//
+// 효과: ASTC_12x12 는 ASTC_4x4(8bpp) 대비 ~2.25×(0.89bpp) 압축률. .data on-wire 크기 감소.
+//   WebGL 플랫폼 오버라이드(overridden=true/format/maxTextureSize)를 직접 기록하여
+//   빌드 시 해당 포맷이 그대로 사용된다. Texture2D 의 비압축(Uncompressed) 에셋은
+//   RGBA32 팽창 위험이 있으므로 skip.
+//   SpriteAtlas 는 WebGL 플랫폼 설정(GetPlatformSettings("WebGL"))에 동일 적용 후 repack.
+//   폰트/SDF/TextMeshPro 에셋은 텍스트 품질 보호를 위해 내장 휴리스틱으로 항상 제외.
+//
+// 비파괴: 각 에셋의 원본 .meta(텍스처) / .spriteatlasv2(아틀라스) 를 <path>.aitastcbak 로 백업,
+//   빌드 후 원본을 그대로 복원한다. 빌드가 비정상 종료되어 복원이 누락돼도, 다음 에디터 로드 시
+//   안전망(SafetyNetRestore)이 잔존 백업을 자동 복원한다.
+//   (crunch 기능의 .aittexbak / .ait-texcrunch-active 와 상호 간섭 없음)
+//
+// 통합: AITConvertCore.BuildWebGL 가 BuildPipeline.BuildPlayer 직전에 ApplyForBuild,
+//   try/finally 의 finally 에서 RestoreForBuild 를 호출한다.
+//
+// ⚠ 비용: ASTC reimport 는 무겁다(에셋 수에 비례). 빌드 시 apply + 복원으로 2회 reimport 가
+//   발생하므로, 명시적 opt-in 으로 기본 비활성이다. 대용량 ASTC 텍스처가 많은 프로젝트의
+//   다운로드 최적화용이다. ASTC 서브타겟 전용 — DXT 서브타겟 프로젝트에서는 crunch 를 사용할 것.
+
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEditor.U2D;
+using UnityEngine;
+using UnityEngine.U2D;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 빌드 단계 ASTC 블록 에스컬레이션 처리기. <see cref="AITEditorScriptObject.enableAstcBlockEscalation"/>
+    /// 설정에 따라 동작한다. 런타임 컴포넌트는 없다(빌드 산출물만 작아질 뿐, 런타임 동작 동일).
+    /// ASTC 서브타겟 전용 — DXT 서브타겟이면 skip.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class AITAstcBlockProcessor
+    {
+        /// <summary>원본 .meta / .spriteatlasv2 를 보관하는 백업 접미사.</summary>
+        private const string BackupSuffix = ".aitastcbak";
+
+        /// <summary>apply 가 진행 중임을 표시하는 마커(Unity 가 무시하는 '.' 접두 숨김 파일).</summary>
+        private const string MarkerRelative = "Assets/.ait-astcblock-active";
+
+        /// <summary>후보 스캔 상한. 이 수를 넘으면 스캔을 중단하고 "N+개" 로 표기한다.</summary>
+        private const int CandidateScanLimit = 2000;
+
+        /// <summary>한 번의 ASTC 블록 적용 결과 핸들. finally 에서 정확한 복원에 사용.</summary>
+        public sealed class AstcBlockHandle
+        {
+            /// <summary>이번 빌드에서 ASTC 블록 에스컬레이션이 실제로 수행되었는지.</summary>
+            public bool Active;
+
+            /// <summary>처리된 텍스처 개수.</summary>
+            public int TextureCount;
+
+            /// <summary>처리된 SpriteAtlas 개수.</summary>
+            public int AtlasCount;
+        }
+
+        static AITAstcBlockProcessor()
+        {
+            EditorApplication.delayCall += SafetyNetRestore;
+        }
+
+        /// <summary>
+        /// 빌드 직전 호출: 설정이 켜져 있으면 대상 텍스처/아틀라스를 ASTC_NxN 으로 reimport 한다.
+        /// 설정이 꺼져 있으면 ASTC 서브타겟일 때만 후보 스캔 후 절감 가능 여부를 Debug.Log 1줄로 안내한다.
+        /// </summary>
+        /// <param name="config">프로젝트 에디터 설정. null 이거나 기능이 꺼져 있으면 no-op(단, 후보 안내는 수행).</param>
+        /// <returns>복원에 사용할 핸들(항상 non-null).</returns>
+        public static AstcBlockHandle ApplyForBuild(AITEditorScriptObject config)
+        {
+            var handle = new AstcBlockHandle();
+
+            if (config == null || !config.enableAstcBlockEscalation)
+            {
+                // ASTC 비활성 — ASTC 서브타겟일 때만 후보 스캔 후 절감 가능 여부를 1줄 안내(후보 0이면 침묵).
+                if (config != null)
+                {
+                    ReportCandidateHint(config);
+                }
+
+                return handle;
+            }
+
+            // 서브타겟 게이트: ASTC 전용, DXT 서브타겟이면 경고 후 skip.
+#if UNITY_2022_3_OR_NEWER
+            if (EditorUserBuildSettings.webGLBuildSubtarget != WebGLTextureSubtarget.ASTC)
+            {
+                Debug.LogWarning("[AIT-AstcBlock] WebGL Texture Compression이 DXT(기본) 서브타겟입니다. " +
+                    "ASTC 블록 에스컬레이션은 ASTC 서브타겟 전용이며 DXT 서브타겟에서는 동작하지 않습니다. " +
+                    "DXT 환경에서는 crunch 를 사용하세요.");
+                return handle;
+            }
+#else
+            // Unity 2021.3: WebGLTextureSubtarget API 미지원 — 서브타겟 감지 불가.
+            Debug.LogWarning("[AIT-AstcBlock] Unity 2021.3에서는 WebGL 서브타겟 감지가 지원되지 않습니다. " +
+                "ASTC 블록 에스컬레이션을 건너뜁니다. Unity 2022.3 이상에서 사용하세요.");
+            return handle;
+#endif
+
+            try
+            {
+                int blockSize = config.astcBlockSize;
+                int maxCap = config.astcBlockMaxSize;       // 0 = 캡 안 함
+                bool doAtlas = config.astcBlockAtlas;
+                string[] dirs = SplitDirs(config.astcBlockDirs);           // null = 전체 Assets
+                string[] excludeDirs = SplitDirs(config.astcBlockExcludeDirs);
+                var targetFormat = BlockFormatFor(blockSize);
+
+                CreateMarker();
+
+                int tex = ApplyTexture2D(targetFormat, maxCap, dirs, excludeDirs);
+                int atl = doAtlas ? ApplySpriteAtlases(targetFormat, maxCap, dirs, excludeDirs) : 0;
+
+                AssetDatabase.Refresh();
+
+                handle.Active = (tex + atl) > 0;
+                handle.TextureCount = tex;
+                handle.AtlasCount = atl;
+
+                if (!handle.Active)
+                {
+                    // 대상 0건 → 마커 제거(복원할 것 없음).
+                    RemoveMarker();
+                }
+
+                string capStr = maxCap > 0 ? maxCap.ToString() : "원본";
+                Debug.Log($"[AIT-AstcBlock] ✓ 텍스처 {tex}개 + 아틀라스 {atl}개 ASTC_{blockSize}x{blockSize} 적용(maxSize 캡={capStr}).");
+                return handle;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-AstcBlock] 적용 예외 → 복원 후 건너뜀: {e}");
+                RestoreAllBackups();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                return new AstcBlockHandle();
+            }
+        }
+
+        /// <summary>빌드 종료 후(성공/실패 무관) 호출: 원본 임포트 설정으로 복원한다.</summary>
+        public static void RestoreForBuild(AstcBlockHandle handle)
+        {
+            if (handle == null || !handle.Active)
+            {
+                return;
+            }
+
+            try
+            {
+                int restored = RestoreAllBackups();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                Debug.Log($"[AIT-AstcBlock] 복원 완료: {restored}개 에셋 원본 임포트 설정 원상.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-AstcBlock] 복원 예외: {e}");
+            }
+        }
+
+        /// <summary>에디터 로드 시 안전망. 마커가 잔존하면(=이전 빌드가 복원 전에 종료) 백업을 자동 복원.</summary>
+        private static void SafetyNetRestore()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string markerFull = Path.Combine(projectRoot, MarkerRelative);
+                if (!File.Exists(markerFull))
+                {
+                    return; // 공통 경로: 잔존물 없음(빠른 반환)
+                }
+
+                int restored = RestoreAllBackups();
+                RemoveMarker();
+                if (restored > 0)
+                {
+                    AssetDatabase.Refresh();
+                    Debug.LogWarning($"[AIT-AstcBlock] 안전망: 이전 빌드 잔존 백업 {restored}개를 복원했습니다.");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-AstcBlock] 안전망 복원 중 예외(무시): {e}");
+            }
+        }
+
+        // ─────────────────────────── 후보 스캔 안내 ───────────────────────────
+
+        /// <summary>
+        /// ASTC 비활성 빌드에서 절감 후보 텍스처 수를 빠르게 세어
+        /// ASTC 서브타겟일 때만, 후보가 1개 이상이면 Debug.Log 1줄로 opt-in 안내를 출력한다.
+        /// 스캔 비용을 제한하기 위해 <see cref="CandidateScanLimit"/>개를 초과하면 중단.
+        /// </summary>
+        private static void ReportCandidateHint(AITEditorScriptObject config)
+        {
+            try
+            {
+#if UNITY_2022_3_OR_NEWER
+                // ASTC 서브타겟이 아닌 경우 안내 불필요(crunch 대상).
+                if (EditorUserBuildSettings.webGLBuildSubtarget != WebGLTextureSubtarget.ASTC)
+                {
+                    return;
+                }
+#else
+                // Unity 2021.3: 서브타겟 감지 불가 — 안내 생략.
+                return;
+#endif
+
+                string[] dirs = SplitDirs(config.astcBlockDirs);
+                string[] excludeDirs = SplitDirs(config.astcBlockExcludeDirs);
+                var targetFormat = BlockFormatFor(config.astcBlockSize);
+                int maxCap = config.astcBlockMaxSize;
+
+                var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets" });
+
+                int candidates = 0;
+                int scanned = 0;
+                bool hitLimit = false;
+
+                foreach (var g in guids)
+                {
+                    if (scanned >= CandidateScanLimit)
+                    {
+                        hitLimit = true;
+                        break;
+                    }
+
+                    string path = AssetDatabase.GUIDToAssetPath(g);
+                    if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/"))
+                    {
+                        continue;
+                    }
+
+                    if (dirs != null && !UnderAny(path, dirs))
+                    {
+                        continue;
+                    }
+
+                    if (IsExcludedPath(path, excludeDirs))
+                    {
+                        continue;
+                    }
+
+                    var ti = AssetImporter.GetAtPath(path) as TextureImporter;
+                    if (ti == null)
+                    {
+                        continue;
+                    }
+
+                    if (ti.textureCompression == TextureImporterCompression.Uncompressed)
+                    {
+                        continue;
+                    }
+
+                    var masterPs = ti.GetPlatformTextureSettings("DefaultTexturePlatform");
+                    var webglPs = ti.GetPlatformTextureSettings("WebGL");
+                    bool isOverridden = webglPs.overridden;
+                    int curMax = (isOverridden && webglPs.maxTextureSize > 0)
+                        ? webglPs.maxTextureSize
+                        : (masterPs.maxTextureSize > 0 ? masterPs.maxTextureSize : 2048);
+                    int targetMax = ResolveTargetMaxSize(curMax, maxCap);
+
+                    if (WouldChange(isOverridden, webglPs.format, curMax, targetFormat, targetMax))
+                    {
+                        candidates++;
+                    }
+
+                    scanned++;
+                }
+
+                if (candidates > 0)
+                {
+                    string countStr = hitLimit ? $"{CandidateScanLimit}+개" : $"{candidates}개";
+                    Debug.Log($"[AIT] ASTC 블록 에스컬레이션(opt-in): 후보 {countStr} 발견. " +
+                        "AIT Configuration에서 활성화하면 .data 크기를 줄일 수 있습니다" +
+                        "(품질 트레이드오프 있음 — lossy).");
+                }
+            }
+            catch (Exception e)
+            {
+                // 후보 스캔 실패는 빌드 차단이 아님(안내용).
+                Debug.LogWarning($"[AIT-AstcBlock] 후보 스캔 중 예외(무시): {e.Message}");
+            }
+        }
+
+        // ─────────────────────────── Texture2D ───────────────────────────
+
+        private static int ApplyTexture2D(TextureImporterFormat targetFormat, int maxCap, string[] dirs, string[] excludeDirs)
+        {
+            int n = 0;
+            var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets" });
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+
+            foreach (var g in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(g);
+                if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/"))
+                {
+                    continue;
+                }
+
+                if (dirs != null && !UnderAny(path, dirs))
+                {
+                    continue;
+                }
+
+                if (IsExcludedPath(path, excludeDirs))
+                {
+                    continue;
+                }
+
+                var ti = AssetImporter.GetAtPath(path) as TextureImporter;
+                if (ti == null)
+                {
+                    continue;
+                }
+
+                // 비압축(RGBA32 등) 텍스처는 ASTC 강제 시 오히려 팽창할 수 있으므로 skip.
+                if (ti.textureCompression == TextureImporterCompression.Uncompressed)
+                {
+                    continue;
+                }
+
+                var masterPs = ti.GetPlatformTextureSettings("DefaultTexturePlatform");
+                var ps = ti.GetPlatformTextureSettings("WebGL");
+                bool wasOverridden = ps.overridden;
+
+                // 현재 maxTextureSize 해석(스파이크와 동일):
+                //   WebGL 오버라이드가 있고 >0 이면 그 값, 아니면 DefaultTexturePlatform 마스터 >0 이면 그 값, 아니면 2048.
+                int curMax = (wasOverridden && ps.maxTextureSize > 0)
+                    ? ps.maxTextureSize
+                    : (masterPs.maxTextureSize > 0 ? masterPs.maxTextureSize : 2048);
+
+                // 현재 WebGL 오버라이드 format 이 비압축 계열이면 skip(팽창 방지).
+                if (wasOverridden && IsUncompressedFormat(ps.format))
+                {
+                    continue;
+                }
+
+                int targetMax = ResolveTargetMaxSize(curMax, maxCap);
+
+                // 이미 목표 상태이면 skip(재진입 비용 회피).
+                if (!WouldChange(wasOverridden, ps.format, curMax, targetFormat, targetMax))
+                {
+                    continue;
+                }
+
+                // 원본 .meta 백업(verbatim 복원용).
+                if (!BackupAssetMeta(path, projectRoot))
+                {
+                    continue;
+                }
+
+                ps.overridden = true;
+                ps.format = targetFormat;
+                ps.maxTextureSize = targetMax;
+                ti.SetPlatformTextureSettings(ps);
+                ti.SaveAndReimport();
+                n++;
+            }
+
+            return n;
+        }
+
+        // ─────────────────────────── SpriteAtlas ───────────────────────────
+
+        private static int ApplySpriteAtlases(TextureImporterFormat targetFormat, int maxCap, string[] dirs, string[] excludeDirs)
+        {
+            int n = 0;
+            var guids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { "Assets" });
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+
+            foreach (var g in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(g);
+                if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/"))
+                {
+                    continue;
+                }
+
+                if (dirs != null && !UnderAny(path, dirs))
+                {
+                    continue;
+                }
+
+                if (IsExcludedPath(path, excludeDirs))
+                {
+                    continue;
+                }
+
+                var atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(path);
+                if (atlas == null)
+                {
+                    continue;
+                }
+
+                // 아틀라스 에셋 파일 자체를 백업(플랫폼 설정이 .spriteatlasv2 안에 직렬화됨).
+                if (!BackupAssetFile(path, projectRoot))
+                {
+                    continue;
+                }
+
+                // SpriteAtlas 의 WebGL 플랫폼 설정에 오버라이드 적용.
+                var masterPs = atlas.GetPlatformSettings("DefaultTexturePlatform");
+                var ws = atlas.GetPlatformSettings("WebGL");
+                int curMax = masterPs.maxTextureSize > 0 ? masterPs.maxTextureSize : 2048;
+                int targetMax = ResolveTargetMaxSize(curMax, maxCap);
+
+                ws.overridden = true;
+                ws.format = targetFormat;
+                ws.maxTextureSize = targetMax;
+                atlas.SetPlatformSettings(ws);
+                EditorUtility.SetDirty(atlas);
+                n++;
+            }
+
+            if (n > 0)
+            {
+                AssetDatabase.SaveAssets();
+                try
+                {
+                    SpriteAtlasUtility.PackAllAtlases(BuildTarget.WebGL);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-AstcBlock]   PackAllAtlases 경고: {e.Message}");
+                }
+            }
+
+            return n;
+        }
+
+        // ─────────────────────────── 백업/복원 ───────────────────────────
+
+        /// <summary>에셋의 .meta 파일을 <path>.meta.aitastcbak 로 백업.</summary>
+        private static bool BackupAssetMeta(string assetPath, string projectRoot)
+        {
+            try
+            {
+                string metaFull = Path.Combine(projectRoot, assetPath + ".meta");
+                if (!File.Exists(metaFull))
+                {
+                    return false;
+                }
+
+                string bak = metaFull + BackupSuffix;
+                if (!File.Exists(bak))
+                {
+                    File.Copy(metaFull, bak, true);
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-AstcBlock] .meta 백업 실패({assetPath}): {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>에셋 본체 파일을 <path>.aitastcbak 로 백업(SpriteAtlas 용).</summary>
+        private static bool BackupAssetFile(string assetPath, string projectRoot)
+        {
+            try
+            {
+                string full = Path.Combine(projectRoot, assetPath);
+                if (!File.Exists(full))
+                {
+                    return false;
+                }
+
+                string bak = full + BackupSuffix;
+                if (!File.Exists(bak))
+                {
+                    File.Copy(full, bak, true);
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-AstcBlock] 에셋 백업 실패({assetPath}): {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>Assets 트리의 모든 *.aitastcbak 를 원본으로 되돌리고 백업을 삭제한다. 복원 개수 반환.</summary>
+        private static int RestoreAllBackups()
+        {
+            int restored = 0;
+            string assetsPath = Application.dataPath;
+            string projectRoot = Directory.GetParent(assetsPath).FullName;
+            string[] backups;
+            try
+            {
+                backups = Directory.GetFiles(assetsPath, "*" + BackupSuffix, SearchOption.AllDirectories);
+            }
+            catch
+            {
+                return 0;
+            }
+
+            foreach (var bak in backups)
+            {
+                // bak = "<original>.aitastcbak" → original 은 .meta(텍스처) 또는 .spriteatlasv2(아틀라스).
+                string original = bak.Substring(0, bak.Length - BackupSuffix.Length);
+                try
+                {
+                    File.Copy(bak, original, true);
+                    File.Delete(bak);
+
+                    // reimport 대상 에셋 경로 산출: .meta 면 본체, 아니면 그 파일 자체.
+                    string assetFull = original.EndsWith(".meta")
+                        ? original.Substring(0, original.Length - ".meta".Length)
+                        : original;
+                    string rel = AbsoluteToProjectRelative(assetFull, projectRoot);
+                    if (!string.IsNullOrEmpty(rel))
+                    {
+                        AssetDatabase.ImportAsset(rel, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                    }
+
+                    restored++;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-AstcBlock] 백업 복원 실패({bak}): {e.Message}");
+                }
+            }
+
+            return restored;
+        }
+
+        private static void CreateMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                File.WriteAllText(Path.Combine(projectRoot, MarkerRelative), "active");
+            }
+            catch
+            {
+                // 마커 생성 실패는 치명적이지 않음(안전망 가속용일 뿐).
+            }
+        }
+
+        private static void RemoveMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string m = Path.Combine(projectRoot, MarkerRelative);
+                if (File.Exists(m))
+                {
+                    File.Delete(m);
+                }
+            }
+            catch
+            {
+                // 무시
+            }
+        }
+
+        private static string AbsoluteToProjectRelative(string absolute, string projectRoot)
+        {
+            string norm = absolute.Replace('\\', '/');
+            string root = projectRoot.Replace('\\', '/').TrimEnd('/') + "/";
+            return norm.StartsWith(root) ? norm.Substring(root.Length) : null;
+        }
+
+        // ─────────────────────────── 순수 내부 헬퍼 (테스트용, 에셋 DB 비의존) ───────────────────────────
+
+        /// <summary>
+        /// ASTC 블록 크기(4/5/6/8/10/12)를 <see cref="TextureImporterFormat"/> 으로 변환한다.
+        /// 그 외 값은 ASTC_12x12 로 폴백.
+        /// </summary>
+        internal static TextureImporterFormat BlockFormatFor(int block)
+        {
+            switch (block)
+            {
+                case 4:  return TextureImporterFormat.ASTC_4x4;
+                case 5:  return TextureImporterFormat.ASTC_5x5;
+                case 6:  return TextureImporterFormat.ASTC_6x6;
+                case 8:  return TextureImporterFormat.ASTC_8x8;
+                case 10: return TextureImporterFormat.ASTC_10x10;
+                case 12: return TextureImporterFormat.ASTC_12x12;
+                default: return TextureImporterFormat.ASTC_12x12;
+            }
+        }
+
+        /// <summary>
+        /// 경로가 제외 대상인지 판별한다.
+        /// 내장 휴리스틱: 소문자 경로에 "/font", " sdf", "textmesh" 포함.
+        /// 추가: <paramref name="excludeDirs"/> 접두 일치(대소문자 무시).
+        /// </summary>
+        internal static bool IsExcludedPath(string assetPath, string[] excludeDirs)
+        {
+            // 사용자 제외 폴더 접두 일치 확인.
+            if (excludeDirs != null)
+            {
+                foreach (var d in excludeDirs)
+                {
+                    var t = d.Trim().TrimEnd('/');
+                    if (string.IsNullOrEmpty(t))
+                    {
+                        continue;
+                    }
+
+                    if (assetPath.StartsWith(t + "/", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(assetPath, t, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            // 내장 휴리스틱: 폰트/SDF/TextMeshPro (TMP 아틀라스 명명 규약 포함).
+            // 경로 세그먼트에 "font" 가 포함된 디렉터리, 파일명에 " sdf", "textmesh" 포함 여부를 검사한다.
+            var low = assetPath.ToLowerInvariant();
+            // " sdf", "textmesh" 는 전체 경로 문자열에서 검사.
+            if (low.Contains(" sdf") || low.Contains("textmesh")) return true;
+            // "font" 는 슬래시로 나뉜 각 경로 세그먼트가 해당 단어를 포함하는지 검사(예: "8.Fonts" 포함).
+            var segments = low.Split('/');
+            for (int i = 0; i < segments.Length - 1; i++) // 파일명(마지막 세그먼트) 제외, 디렉터리만 검사.
+            {
+                if (segments[i].Contains("font")) return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// 목표 maxTextureSize 를 결정한다.
+        /// <paramref name="cap"/> &lt;= 0 이면 캡 없음(currentMax 그대로).
+        /// 그 외 <paramref name="currentMax"/> 와 <paramref name="cap"/> 중 작은 값.
+        /// </summary>
+        internal static int ResolveTargetMaxSize(int currentMax, int cap)
+        {
+            if (cap <= 0)
+            {
+                return currentMax;
+            }
+
+            return Math.Min(currentMax, cap);
+        }
+
+        /// <summary>
+        /// 현재 상태가 이미 목표 상태인지 판별한다.
+        /// overridden=true + format==targetFormat + max==targetMax 이면 변경 불필요.
+        /// </summary>
+        internal static bool WouldChange(bool overridden, TextureImporterFormat currentFormat, int currentMax, TextureImporterFormat targetFormat, int targetMax)
+        {
+            if (!overridden)
+            {
+                return true;
+            }
+
+            if (currentFormat != targetFormat)
+            {
+                return true;
+            }
+
+            if (currentMax != targetMax)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 비압축 계열 format 인지 판별한다.
+        /// RGBA32/ARGB32/RGB24/Alpha8/R8/R16/RGBAHalf/RGBAFloat/RGB48/RGBA64 등 비압축 포맷.
+        /// </summary>
+        internal static bool IsUncompressedFormat(TextureImporterFormat f)
+        {
+            switch (f)
+            {
+                case TextureImporterFormat.RGBA32:
+                case TextureImporterFormat.ARGB32:
+                case TextureImporterFormat.RGB24:
+                case TextureImporterFormat.Alpha8:
+                case TextureImporterFormat.R8:
+                case TextureImporterFormat.R16:
+                case TextureImporterFormat.RGBAHalf:
+                case TextureImporterFormat.RGBAFloat:
+                case TextureImporterFormat.RGB48:
+                case TextureImporterFormat.RGBA64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>쉼표 구분 문자열을 배열로 분리. null/빈 문자열이면 null 반환.</summary>
+        internal static string[] SplitDirs(string v)
+            => string.IsNullOrEmpty(v) ? null : v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+        /// <summary>경로가 dirs 중 어느 하나의 하위에 있는지 확인.</summary>
+        internal static bool UnderAny(string path, string[] dirs)
+        {
+            foreach (var d in dirs)
+            {
+                var t = d.Trim().TrimEnd('/');
+                if (path.StartsWith(t + "/") || path == t)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Editor/AITAstcBlockProcessor.cs
+++ b/Editor/AITAstcBlockProcessor.cs
@@ -26,8 +26,9 @@
 //   try/finally 의 finally 에서 RestoreForBuild 를 호출한다.
 //
 // ⚠ 비용: ASTC reimport 는 무겁다(에셋 수에 비례). 빌드 시 apply + 복원으로 2회 reimport 가
-//   발생하므로, 명시적 opt-in 으로 기본 비활성이다. 대용량 ASTC 텍스처가 많은 프로젝트의
-//   다운로드 최적화용이다. ASTC 서브타겟 전용 — DXT 서브타겟 프로젝트에서는 crunch 를 사용할 것.
+//   발생한다. 기본은 자동 ON이며, 대용량 ASTC 텍스처 프로젝트에서 다운로드/.data 를 실감한다.
+//   필요시 AIT Configuration에서 비활성화할 수 있다.
+//   ASTC 서브타겟 전용 — DXT 서브타겟 프로젝트에서는 crunch 를 사용할 것.
 
 using System;
 using System.IO;
@@ -39,7 +40,7 @@ using UnityEngine.U2D;
 namespace AppsInToss.Editor
 {
     /// <summary>
-    /// 빌드 단계 ASTC 블록 에스컬레이션 처리기. <see cref="AITEditorScriptObject.enableAstcBlockEscalation"/>
+    /// 빌드 단계 ASTC 블록 에스컬레이션 처리기. <see cref="AITEditorScriptObject.astcBlockEscalation"/>
     /// 설정에 따라 동작한다. 런타임 컴포넌트는 없다(빌드 산출물만 작아질 뿐, 런타임 동작 동일).
     /// ASTC 서브타겟 전용 — DXT 서브타겟이면 skip.
     /// </summary>
@@ -83,9 +84,10 @@ namespace AppsInToss.Editor
         {
             var handle = new AstcBlockHandle();
 
-            if (config == null || !config.enableAstcBlockEscalation)
+            bool enabled = EffectiveEnabled(config);
+            if (config == null || !enabled)
             {
-                // ASTC 비활성 — ASTC 서브타겟일 때만 후보 스캔 후 절감 가능 여부를 1줄 안내(후보 0이면 침묵).
+                // ASTC 비활성화 — ASTC 서브타겟일 때만 후보 스캔 후 절감 가능 여부를 1줄 안내(후보 0이면 침묵).
                 if (config != null)
                 {
                     ReportCandidateHint(config);
@@ -137,7 +139,7 @@ namespace AppsInToss.Editor
                 }
 
                 string capStr = maxCap > 0 ? maxCap.ToString() : "원본";
-                Debug.Log($"[AIT-AstcBlock] ✓ 텍스처 {tex}개 + 아틀라스 {atl}개 ASTC_{blockSize}x{blockSize} 적용(maxSize 캡={capStr}).");
+                Debug.Log($"[AIT-AstcBlock] ✓ 텍스처 {tex}개 + 아틀라스 {atl}개 ASTC_{blockSize}x{blockSize} 적용(maxSize 캡={capStr}){(config.astcBlockEscalation < 0 ? " (자동)" : "")}.");
                 return handle;
             }
             catch (Exception e)
@@ -200,8 +202,8 @@ namespace AppsInToss.Editor
         // ─────────────────────────── 후보 스캔 안내 ───────────────────────────
 
         /// <summary>
-        /// ASTC 비활성 빌드에서 절감 후보 텍스처 수를 빠르게 세어
-        /// ASTC 서브타겟일 때만, 후보가 1개 이상이면 Debug.Log 1줄로 opt-in 안내를 출력한다.
+        /// ASTC 비활성화 빌드에서 절감 후보 텍스처 수를 빠르게 세어
+        /// ASTC 서브타겟일 때만, 후보가 1개 이상이면 Debug.Log 1줄로 재활성화 안내를 출력한다.
         /// 스캔 비용을 제한하기 위해 <see cref="CandidateScanLimit"/>개를 초과하면 중단.
         /// </summary>
         private static void ReportCandidateHint(AITEditorScriptObject config)
@@ -284,8 +286,8 @@ namespace AppsInToss.Editor
                 if (candidates > 0)
                 {
                     string countStr = hitLimit ? $"{CandidateScanLimit}+개" : $"{candidates}개";
-                    Debug.Log($"[AIT] ASTC 블록 에스컬레이션(opt-in): 후보 {countStr} 발견. " +
-                        "AIT Configuration에서 활성화하면 .data 크기를 줄일 수 있습니다" +
+                    Debug.Log($"[AIT] ASTC 블록 에스컬레이션 비활성화됨: 후보 {countStr} 존재. " +
+                        "AIT Configuration에서 자동/활성화로 되돌리면 .data 크기를 줄일 수 있습니다" +
                         "(품질 트레이드오프 있음 — lossy).");
                 }
             }
@@ -581,6 +583,18 @@ namespace AppsInToss.Editor
         }
 
         // ─────────────────────────── 순수 내부 헬퍼 (테스트용, 에셋 DB 비의존) ───────────────────────────
+
+        /// <summary>
+        /// ASTC 블록 에스컬레이션 실효 활성 여부를 반환한다(tri-state 해석).
+        /// null → false, astcBlockEscalation >= 0 → ==1, &lt;0 → GetDefaultAstcBlockEscalation().
+        /// </summary>
+        internal static bool EffectiveEnabled(AITEditorScriptObject config)
+        {
+            if (config == null) return false;
+            return config.astcBlockEscalation >= 0
+                ? config.astcBlockEscalation == 1
+                : AITDefaultSettings.GetDefaultAstcBlockEscalation();
+        }
 
         /// <summary>
         /// ASTC 블록 크기(4/5/6/8/10/12)를 <see cref="TextureImporterFormat"/> 으로 변환한다.

--- a/Editor/AITAstcBlockProcessor.cs.meta
+++ b/Editor/AITAstcBlockProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad95bd4a10a740499b8084e6cd886fab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -221,6 +221,11 @@ namespace AppsInToss.Editor
                 ? editorConfig.firstInteractiveLog == 1
                 : AITDefaultSettings.GetDefaultFirstInteractiveLog();
             Debug.Log($"[AIT]   - first-interactive 계측: {firstInteractiveEnabled}{(editorConfig.firstInteractiveLog < 0 ? " (자동)" : "")}");
+            // ASTC 블록 에스컬레이션은 BuildPlayer 직전 AITAstcBlockProcessor 에서 처리
+            bool astcBlockEnabled = editorConfig.astcBlockEscalation >= 0
+                ? editorConfig.astcBlockEscalation == 1
+                : AITDefaultSettings.GetDefaultAstcBlockEscalation();
+            Debug.Log($"[AIT]   - ASTC 블록 에스컬레이션: {astcBlockEnabled}{(editorConfig.astcBlockEscalation < 0 ? " (자동)" : "")}");
         }
 
         /// <summary>

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -453,6 +453,8 @@ namespace AppsInToss.Editor
 
             // first-interactive 계측
             DrawFirstInteractiveLogSetting();
+            // 콘텐츠 최적화 — ASTC 블록 에스컬레이션
+            DrawAstcBlockSetting();
 
             GUILayout.Space(10);
 
@@ -1016,12 +1018,80 @@ namespace AppsInToss.Editor
             return count;
         }
 
+        private void DrawAstcBlockSetting()
+        {
+            EditorGUILayout.LabelField("콘텐츠 최적화 — ASTC 블록 에스컬레이션", EditorStyles.boldLabel);
+
+            config.enableAstcBlockEscalation = EditorGUILayout.Toggle(
+                new GUIContent("ASTC 블록 에스컬레이션 활성화",
+                    "ASTC 서브타겟 전용: 텍스처를 더 큰 ASTC 블록으로 reimport 하여 .data 크기를 줄입니다. lossy."),
+                config.enableAstcBlockEscalation
+            );
+
+            if (config.enableAstcBlockEscalation)
+            {
+                EditorGUI.indentLevel++;
+
+                // 블록 크기 팝업
+                int[] blockSizes = { 4, 5, 6, 8, 10, 12 };
+                string[] blockSizeLabels = { "4x4 (최고화질, 최대용량)", "5x5", "6x6", "8x8", "10x10", "12x12 (최소용량, 최저화질)" };
+                int currentBlockIndex = Array.IndexOf(blockSizes, config.astcBlockSize);
+                if (currentBlockIndex < 0) currentBlockIndex = 5; // 기본값 12x12
+                int newBlockIndex = EditorGUILayout.IntPopup(
+                    "블록 크기",
+                    currentBlockIndex,
+                    blockSizeLabels,
+                    new int[] { 0, 1, 2, 3, 4, 5 }
+                );
+                config.astcBlockSize = blockSizes[newBlockIndex];
+
+                // maxTextureSize 캡
+                config.astcBlockMaxSize = EditorGUILayout.IntField(
+                    new GUIContent("maxTextureSize 캡", "0=캡 안 함(원본 크기 유지). 양수 입력 시 해당 크기로 제한."),
+                    config.astcBlockMaxSize
+                );
+
+                // SpriteAtlas 포함
+                config.astcBlockAtlas = EditorGUILayout.Toggle(
+                    new GUIContent("SpriteAtlas 포함", "SpriteAtlas 의 WebGL 플랫폼 설정도 오버라이드하고 repack합니다."),
+                    config.astcBlockAtlas
+                );
+
+                // 대상 폴더
+                config.astcBlockDirs = EditorGUILayout.TextField(
+                    new GUIContent("대상 폴더 (쉼표 구분)", "비우면 Assets 전체. 예: Assets/Textures,Assets/UI"),
+                    config.astcBlockDirs
+                );
+
+                // 제외 폴더
+                config.astcBlockExcludeDirs = EditorGUILayout.TextField(
+                    new GUIContent("제외 폴더 (쉼표 구분)", "폰트/SDF/TextMeshPro 는 항상 자동 제외됩니다."),
+                    config.astcBlockExcludeDirs
+                );
+
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.HelpBox(
+                "⚠ lossy: 원본보다 화질이 낮아집니다.\n" +
+                "ASTC 서브타겟 전용 — DXT(기본) 서브타겟 프로젝트에서는 빌드 시 자동 skip됩니다.\n" +
+                "빌드 완료 후 원본 임포트 설정이 자동으로 복원됩니다(비파괴).",
+                MessageType.Warning
+            );
+        }
+
         private void ResetWebGLSettings()
         {
             config.memorySize = -1;
             config.threadsSupport = -1;
             config.dataCaching = -1;
             config.firstInteractiveLog = -1;
+            config.enableAstcBlockEscalation = false;
+            config.astcBlockSize = 12;
+            config.astcBlockMaxSize = 0;
+            config.astcBlockAtlas = true;
+            config.astcBlockDirs = "";
+            config.astcBlockExcludeDirs = "";
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -1113,7 +1113,6 @@ namespace AppsInToss.Editor
             config.threadsSupport = -1;
             config.dataCaching = -1;
             config.firstInteractiveLog = -1;
-            config.enableAstcBlockEscalation = false;
             config.astcBlockEscalation = -1;
             config.astcBlockSize = 12;
             config.astcBlockMaxSize = 0;

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -1014,21 +1014,48 @@ namespace AppsInToss.Editor
 
             bool defaultFirstInteractive = AITDefaultSettings.GetDefaultFirstInteractiveLog();
             if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
+            bool defaultAstcBlock = AITDefaultSettings.GetDefaultAstcBlockEscalation();
+            if (config.astcBlockEscalation >= 0 && (config.astcBlockEscalation == 1) != defaultAstcBlock) count++;
 
             return count;
         }
 
         private void DrawAstcBlockSetting()
         {
+            bool defaultValue = AITDefaultSettings.GetDefaultAstcBlockEscalation();
+            bool isModified = config.astcBlockEscalation >= 0 && (config.astcBlockEscalation == 1) != defaultValue;
+
             EditorGUILayout.LabelField("콘텐츠 최적화 — ASTC 블록 에스컬레이션", EditorStyles.boldLabel);
 
-            config.enableAstcBlockEscalation = EditorGUILayout.Toggle(
-                new GUIContent("ASTC 블록 에스컬레이션 활성화",
-                    "ASTC 서브타겟 전용: 텍스처를 더 큰 ASTC 블록으로 reimport 하여 .data 크기를 줄입니다. lossy."),
-                config.enableAstcBlockEscalation
-            );
+            EditorGUILayout.BeginHorizontal();
 
-            if (config.enableAstcBlockEscalation)
+            DrawModifiedIndicator(isModified);
+
+            string autoLabel = defaultValue ? "활성화" : "비활성화";
+            string label = config.astcBlockEscalation < 0
+                ? $"ASTC 블록 에스컬레이션 (자동: {autoLabel})"
+                : "ASTC 블록 에스컬레이션";
+
+            string[] options = { $"자동 ({autoLabel})", "비활성화", "활성화" };
+            int currentIndex = config.astcBlockEscalation < 0 ? 0 : config.astcBlockEscalation + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "ASTC 서브타겟 전용: 텍스처를 더 큰 ASTC 블록으로 reimport 하여 .data 크기를 줄입니다. " +
+                    "lossy. 빌드 후 원본 임포트 설정으로 복원합니다."),
+                currentIndex,
+                options
+            );
+            config.astcBlockEscalation = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.astcBlockEscalation = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            bool effectiveEnabled = config.astcBlockEscalation >= 0 ? config.astcBlockEscalation == 1 : defaultValue;
+            if (effectiveEnabled)
             {
                 EditorGUI.indentLevel++;
 
@@ -1087,6 +1114,7 @@ namespace AppsInToss.Editor
             config.dataCaching = -1;
             config.firstInteractiveLog = -1;
             config.enableAstcBlockEscalation = false;
+            config.astcBlockEscalation = -1;
             config.astcBlockSize = 12;
             config.astcBlockMaxSize = 0;
             config.astcBlockAtlas = true;

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -993,6 +993,9 @@ namespace AppsInToss
             // .cs 파일 수정과 달리 .json은 스크립트 컴파일을 유발하지 않으므로 도메인 리로드 없음
             bool versionInfoWritten = WriteVersionInfoJson(out bool createdResourcesDir);
 
+            // 콘텐츠 최적화 — ASTC 블록 에스컬레이션 (빌드 산출물 .data 축소, 빌드 후 임포터 원복)
+            var astcBlockHandle = AITAstcBlockProcessor.ApplyForBuild(config);
+
             UnityEditor.Build.Reporting.BuildReport result;
             try
             {
@@ -1000,6 +1003,9 @@ namespace AppsInToss
             }
             finally
             {
+                // ASTC 블록 에스컬레이션 복원 (성공/실패 무관)
+                AITAstcBlockProcessor.RestoreForBuild(astcBlockHandle);
+
                 // 빌드 완료 후 (성공/실패 무관) 생성한 JSON 제거 — 사용자 프로젝트에 산출물 남기지 않음
                 if (versionInfoWritten)
                 {

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -497,6 +497,11 @@ namespace AppsInToss
         /// 픽셀 불변·세션당 1회 단일 이벤트·호스트 로딩 지표 표준화에 해당하므로 기본 ON.
         /// </summary>
         public static bool GetDefaultFirstInteractiveLog()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// 기본 ASTC 블록 에스컬레이션 활성화 여부.
         /// 블록 확대(예: 12x12)는 시각 저하가 통상 미미한 반면 다운로드/.data 절감이 커 기본 ON.
         /// 비-ASTC 서브타겟에서는 빌드 시 자동으로 건너뛰고(no-op), 빌드 후 임포터 설정은 항상 원상 복원된다.

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -210,10 +210,11 @@ namespace AppsInToss
         [Tooltip("first-interactive 계측: -1 = 자동 (활성), 0 = 비활성, 1 = 활성")]
         public int firstInteractiveLog = -1;
         [Header("콘텐츠 최적화 — ASTC 블록 에스컬레이션")]
-        [Tooltip("ASTC 서브타겟 WebGL 빌드에서 텍스처를 더 큰 ASTC 블록(기본 12x12)으로 reimport 하여 " +
+        [Tooltip("-1 = 자동 (true), 0 = 비활성, 1 = 활성. " +
+                 "ASTC 서브타겟 WebGL 빌드에서 텍스처를 더 큰 ASTC 블록(기본 12x12)으로 reimport 하여 " +
                  ".data on-wire 크기를 줄입니다. lossy(화질 저하 있음). 빌드 후 원본 임포트 설정으로 자동 복원. " +
                  "ASTC 서브타겟 전용 — DXT(기본) 서브타겟 프로젝트에서는 빌드 시 자동 skip됩니다.")]
-        public bool enableAstcBlockEscalation = false;
+        public int astcBlockEscalation = -1;
 
         [Tooltip("ASTC 블록 크기(4/5/6/8/10/12). 클수록 파일이 작아지고 화질이 낮아집니다. 기본값 12.")]
         public int astcBlockSize = 12;
@@ -496,6 +497,11 @@ namespace AppsInToss
         /// 픽셀 불변·세션당 1회 단일 이벤트·호스트 로딩 지표 표준화에 해당하므로 기본 ON.
         /// </summary>
         public static bool GetDefaultFirstInteractiveLog()
+        /// 기본 ASTC 블록 에스컬레이션 활성화 여부.
+        /// 블록 확대(예: 12x12)는 시각 저하가 통상 미미한 반면 다운로드/.data 절감이 커 기본 ON.
+        /// 비-ASTC 서브타겟에서는 빌드 시 자동으로 건너뛰고(no-op), 빌드 후 임포터 설정은 항상 원상 복원된다.
+        /// </summary>
+        public static bool GetDefaultAstcBlockEscalation()
         {
             return true;
         }

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -209,6 +209,27 @@ namespace AppsInToss
         [Header("계측 설정")]
         [Tooltip("first-interactive 계측: -1 = 자동 (활성), 0 = 비활성, 1 = 활성")]
         public int firstInteractiveLog = -1;
+        [Header("콘텐츠 최적화 — ASTC 블록 에스컬레이션")]
+        [Tooltip("ASTC 서브타겟 WebGL 빌드에서 텍스처를 더 큰 ASTC 블록(기본 12x12)으로 reimport 하여 " +
+                 ".data on-wire 크기를 줄입니다. lossy(화질 저하 있음). 빌드 후 원본 임포트 설정으로 자동 복원. " +
+                 "ASTC 서브타겟 전용 — DXT(기본) 서브타겟 프로젝트에서는 빌드 시 자동 skip됩니다.")]
+        public bool enableAstcBlockEscalation = false;
+
+        [Tooltip("ASTC 블록 크기(4/5/6/8/10/12). 클수록 파일이 작아지고 화질이 낮아집니다. 기본값 12.")]
+        public int astcBlockSize = 12;
+
+        [Tooltip("WebGL 플랫폼 오버라이드 maxTextureSize 캡. 0=캡 안 함(원본 크기 유지).")]
+        public int astcBlockMaxSize = 0;
+
+        [Tooltip("SpriteAtlas 도 포함하여 WebGL 플랫폼 설정을 오버라이드하고 repack합니다.")]
+        public bool astcBlockAtlas = true;
+
+        [Tooltip("ASTC 블록 에스컬레이션을 적용할 폴더(쉼표 구분). 비우면 Assets 전체가 대상입니다.")]
+        public string astcBlockDirs = "";
+
+        [Tooltip("ASTC 블록 에스컬레이션에서 제외할 폴더(쉼표 구분). " +
+                 "폰트/SDF/TextMeshPro 경로는 이 필드와 무관하게 항상 내장 휴리스틱으로 추가 제외됩니다.")]
+        public string astcBlockExcludeDirs = "";
 
         [Header("권한 설정")]
         public AITPermissionConfig permissionConfig = new AITPermissionConfig();

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAstcBlockProcessorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAstcBlockProcessorTests.cs
@@ -1,0 +1,291 @@
+// -----------------------------------------------------------------------
+// AITAstcBlockProcessorTests.cs - ASTC 블록 에스컬레이션 순수 로직 검증
+// Level 0: AssetDatabase 비의존 순수 헬퍼 함수 EditMode 테스트
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using AppsInToss;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITAstcBlockProcessorTests
+{
+    private AITEditorScriptObject _config;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (_config != null)
+        {
+            Object.DestroyImmediate(_config);
+            _config = null;
+        }
+    }
+
+    // =====================================================
+    // 1) BlockFormatFor — 6개 블록 전수 매핑
+    // =====================================================
+
+    [TestCase(4,  TextureImporterFormat.ASTC_4x4)]
+    [TestCase(5,  TextureImporterFormat.ASTC_5x5)]
+    [TestCase(6,  TextureImporterFormat.ASTC_6x6)]
+    [TestCase(8,  TextureImporterFormat.ASTC_8x8)]
+    [TestCase(10, TextureImporterFormat.ASTC_10x10)]
+    [TestCase(12, TextureImporterFormat.ASTC_12x12)]
+    public void BlockFormatFor_KnownValues_ReturnsCorrectFormat(int block, TextureImporterFormat expected)
+    {
+        var result = AITAstcBlockProcessor.BlockFormatFor(block);
+        Assert.AreEqual(expected, result, $"블록 크기 {block}에 대한 포맷 매핑이 올바르지 않습니다.");
+    }
+
+    // =====================================================
+    // 2) BlockFormatFor — 무효값(0, 7, 99, -1) → ASTC_12x12 폴백
+    // =====================================================
+
+    [TestCase(0)]
+    [TestCase(7)]
+    [TestCase(99)]
+    [TestCase(-1)]
+    public void BlockFormatFor_InvalidValues_FallsBackToAstc12x12(int block)
+    {
+        var result = AITAstcBlockProcessor.BlockFormatFor(block);
+        Assert.AreEqual(TextureImporterFormat.ASTC_12x12, result,
+            $"무효 블록 크기 {block}은 ASTC_12x12 로 폴백해야 합니다.");
+    }
+
+    // =====================================================
+    // 3) IsExcludedPath — 내장 휴리스틱(/font, " sdf", textmesh — 대소문자 무시)
+    // =====================================================
+
+    [TestCase("Assets/8.Fonts/UI/sprite.png", true,        "폰트 디렉터리 /font 포함")]
+    [TestCase("Assets/UI/Button SDF.png",     true,        "' sdf' 토큰 포함")]
+    [TestCase("Assets/TextMesh Pro/atlas.png", true,       "textmesh 포함")]
+    [TestCase("Assets/Textures/FONT/bg.png",  true,        "대문자 /FONT 도 제외")]
+    [TestCase("Assets/Textures/sprite.png",   false,       "일반 텍스처 경로")]
+    public void IsExcludedPath_BuiltinHeuristics(string path, bool expectedExcluded, string reason)
+    {
+        var result = AITAstcBlockProcessor.IsExcludedPath(path, null);
+        Assert.AreEqual(expectedExcluded, result, reason);
+    }
+
+    // =====================================================
+    // 4) IsExcludedPath — 사용자 제외 폴더 접두 일치/불일치
+    // =====================================================
+
+    [Test]
+    public void IsExcludedPath_UserExcludeDirs_MatchesPrefixCaseInsensitive()
+    {
+        // "Assets/UI" 제외 지정 시 하위 경로 모두 제외
+        var excludeDirs = new[] { "Assets/UI" };
+
+        Assert.IsTrue(AITAstcBlockProcessor.IsExcludedPath("Assets/UI/Button.png", excludeDirs),
+            "사용자 제외 폴더의 직접 하위 경로는 제외되어야 합니다.");
+        Assert.IsTrue(AITAstcBlockProcessor.IsExcludedPath("Assets/ui/Button.png", excludeDirs),
+            "대소문자 무시로 'Assets/ui'도 제외되어야 합니다.");
+        Assert.IsFalse(AITAstcBlockProcessor.IsExcludedPath("Assets/Textures/Button.png", excludeDirs),
+            "제외 폴더 외부의 경로는 포함되어야 합니다.");
+    }
+
+    // =====================================================
+    // 5) IsExcludedPath — 일반 경로는 false
+    // =====================================================
+
+    [Test]
+    public void IsExcludedPath_NormalPath_ReturnsFalse()
+    {
+        var result = AITAstcBlockProcessor.IsExcludedPath("Assets/Sprites/character.png", null);
+        Assert.IsFalse(result, "일반 텍스처 경로는 제외되어서는 안 됩니다.");
+    }
+
+    // =====================================================
+    // 6) ResolveTargetMaxSize — cap=0 / cap<현재 / cap>현재
+    // =====================================================
+
+    [Test]
+    public void ResolveTargetMaxSize_CapZero_ReturnsCurrent()
+    {
+        Assert.AreEqual(2048, AITAstcBlockProcessor.ResolveTargetMaxSize(2048, 0),
+            "cap=0 이면 현재 maxTextureSize 를 그대로 반환해야 합니다.");
+    }
+
+    [Test]
+    public void ResolveTargetMaxSize_CapLessThanCurrent_ReturnsCap()
+    {
+        Assert.AreEqual(512, AITAstcBlockProcessor.ResolveTargetMaxSize(2048, 512),
+            "cap < 현재 크기 이면 cap 을 반환해야 합니다.");
+    }
+
+    [Test]
+    public void ResolveTargetMaxSize_CapGreaterThanCurrent_ReturnsCurrent()
+    {
+        Assert.AreEqual(1024, AITAstcBlockProcessor.ResolveTargetMaxSize(1024, 4096),
+            "cap > 현재 크기 이면 현재 크기를 반환해야 합니다(Min).");
+    }
+
+    // =====================================================
+    // 7) WouldChange — 이미 목표 상태면 false
+    // =====================================================
+
+    [Test]
+    public void WouldChange_AlreadyTargetState_ReturnsFalse()
+    {
+        var fmt = TextureImporterFormat.ASTC_12x12;
+        var result = AITAstcBlockProcessor.WouldChange(
+            overridden: true,
+            currentFormat: fmt,
+            currentMax: 1024,
+            targetFormat: fmt,
+            targetMax: 1024
+        );
+        Assert.IsFalse(result, "이미 목표 상태(overridden=true, 포맷 일치, max 일치)이면 WouldChange=false 여야 합니다.");
+    }
+
+    // =====================================================
+    // 8) WouldChange — 포맷 상이 / 비오버라이드 / max 초과 각 true
+    // =====================================================
+
+    [Test]
+    public void WouldChange_FormatDiffers_ReturnsTrue()
+    {
+        var result = AITAstcBlockProcessor.WouldChange(
+            overridden: true,
+            currentFormat: TextureImporterFormat.ASTC_4x4,
+            currentMax: 1024,
+            targetFormat: TextureImporterFormat.ASTC_12x12,
+            targetMax: 1024
+        );
+        Assert.IsTrue(result, "포맷이 다를 때 WouldChange=true 여야 합니다.");
+    }
+
+    [Test]
+    public void WouldChange_NotOverridden_ReturnsTrue()
+    {
+        var fmt = TextureImporterFormat.ASTC_12x12;
+        var result = AITAstcBlockProcessor.WouldChange(
+            overridden: false,
+            currentFormat: fmt,
+            currentMax: 1024,
+            targetFormat: fmt,
+            targetMax: 1024
+        );
+        Assert.IsTrue(result, "오버라이드가 없으면 WouldChange=true 여야 합니다.");
+    }
+
+    [Test]
+    public void WouldChange_MaxDiffers_ReturnsTrue()
+    {
+        var fmt = TextureImporterFormat.ASTC_12x12;
+        var result = AITAstcBlockProcessor.WouldChange(
+            overridden: true,
+            currentFormat: fmt,
+            currentMax: 2048,
+            targetFormat: fmt,
+            targetMax: 512
+        );
+        Assert.IsTrue(result, "maxTextureSize 가 다를 때 WouldChange=true 여야 합니다.");
+    }
+
+    // =====================================================
+    // 9) IsUncompressedFormat — 양성/음성
+    // =====================================================
+
+    [TestCase(TextureImporterFormat.RGBA32,    true)]
+    [TestCase(TextureImporterFormat.ARGB32,    true)]
+    [TestCase(TextureImporterFormat.RGB24,     true)]
+    [TestCase(TextureImporterFormat.Alpha8,    true)]
+    [TestCase(TextureImporterFormat.R8,        true)]
+    [TestCase(TextureImporterFormat.RGBAHalf,  true)]
+    [TestCase(TextureImporterFormat.RGBAFloat, true)]
+    [TestCase(TextureImporterFormat.ASTC_4x4,  false)]
+    [TestCase(TextureImporterFormat.ASTC_12x12, false)]
+    [TestCase(TextureImporterFormat.DXT1,      false)]
+    public void IsUncompressedFormat_Correctness(TextureImporterFormat fmt, bool expectedUncompressed)
+    {
+        var result = AITAstcBlockProcessor.IsUncompressedFormat(fmt);
+        Assert.AreEqual(expectedUncompressed, result,
+            $"IsUncompressedFormat({fmt}) = {expectedUncompressed} 이어야 합니다.");
+    }
+
+    // =====================================================
+    // 10) SplitDirs / UnderAny — null/빈/정상 + 일치/불일치
+    // =====================================================
+
+    [Test]
+    public void SplitDirs_Null_ReturnsNull()
+    {
+        Assert.IsNull(AITAstcBlockProcessor.SplitDirs(null),
+            "null 입력 시 null 을 반환해야 합니다.");
+    }
+
+    [Test]
+    public void SplitDirs_Empty_ReturnsNull()
+    {
+        Assert.IsNull(AITAstcBlockProcessor.SplitDirs(""),
+            "빈 문자열 입력 시 null 을 반환해야 합니다.");
+    }
+
+    [Test]
+    public void SplitDirs_Normal_SplitsByComma()
+    {
+        var result = AITAstcBlockProcessor.SplitDirs("Assets/UI,Assets/Textures");
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Length, "쉼표로 2개로 분리되어야 합니다.");
+        Assert.AreEqual("Assets/UI", result[0]);
+        Assert.AreEqual("Assets/Textures", result[1]);
+    }
+
+    [Test]
+    public void UnderAny_MatchingDir_ReturnsTrue()
+    {
+        var dirs = new[] { "Assets/Textures" };
+        Assert.IsTrue(AITAstcBlockProcessor.UnderAny("Assets/Textures/sprite.png", dirs),
+            "지정 폴더 하위 경로는 UnderAny=true 여야 합니다.");
+    }
+
+    [Test]
+    public void UnderAny_NonMatchingDir_ReturnsFalse()
+    {
+        var dirs = new[] { "Assets/Textures" };
+        Assert.IsFalse(AITAstcBlockProcessor.UnderAny("Assets/Fonts/font.ttf", dirs),
+            "지정 폴더 외부 경로는 UnderAny=false 여야 합니다.");
+    }
+
+    // =====================================================
+    // 11) ApplyForBuild(null) / ApplyForBuild(enable=false) — 비활성 핸들 + 마커 파일 없음
+    // =====================================================
+
+    [Test]
+    public void ApplyForBuild_NullConfig_ReturnsInactiveHandle()
+    {
+        var handle = AITAstcBlockProcessor.ApplyForBuild(null);
+        Assert.IsNotNull(handle, "핸들은 non-null 이어야 합니다.");
+        Assert.IsFalse(handle.Active, "null config 시 비활성 핸들이어야 합니다.");
+    }
+
+    [Test]
+    public void ApplyForBuild_DisabledConfig_ReturnsInactiveHandleAndNoMarker()
+    {
+        _config.enableAstcBlockEscalation = false;
+
+        var handle = AITAstcBlockProcessor.ApplyForBuild(_config);
+
+        Assert.IsNotNull(handle, "핸들은 non-null 이어야 합니다.");
+        Assert.IsFalse(handle.Active, "기능 비활성 시 비활성 핸들이어야 합니다.");
+
+        // 마커 파일이 생성되지 않았는지 확인.
+        // Application.dataPath 는 EditMode 테스트에서도 유효.
+        string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+        string markerPath = Path.Combine(projectRoot, "Assets/.ait-astcblock-active");
+        Assert.IsFalse(File.Exists(markerPath),
+            "비활성 config 시 마커 파일 'Assets/.ait-astcblock-active' 가 생성되어서는 안 됩니다.");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAstcBlockProcessorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAstcBlockProcessorTests.cs
@@ -274,18 +274,38 @@ public class AITAstcBlockProcessorTests
     [Test]
     public void ApplyForBuild_DisabledConfig_ReturnsInactiveHandleAndNoMarker()
     {
-        _config.enableAstcBlockEscalation = false;
+        _config.astcBlockEscalation = 0; // 명시적 비활성(0)
 
         var handle = AITAstcBlockProcessor.ApplyForBuild(_config);
 
         Assert.IsNotNull(handle, "핸들은 non-null 이어야 합니다.");
-        Assert.IsFalse(handle.Active, "기능 비활성 시 비활성 핸들이어야 합니다.");
+        Assert.IsFalse(handle.Active, "기능 비활성(0) 시 비활성 핸들이어야 합니다.");
 
         // 마커 파일이 생성되지 않았는지 확인.
         // Application.dataPath 는 EditMode 테스트에서도 유효.
         string projectRoot = Directory.GetParent(Application.dataPath).FullName;
         string markerPath = Path.Combine(projectRoot, "Assets/.ait-astcblock-active");
         Assert.IsFalse(File.Exists(markerPath),
-            "비활성 config 시 마커 파일 'Assets/.ait-astcblock-active' 가 생성되어서는 안 됩니다.");
+            "비활성(0) config 시 마커 파일 'Assets/.ait-astcblock-active' 가 생성되어서는 안 됩니다.");
+    }
+
+    // =====================================================
+    // 12) EffectiveEnabled — tri-state 해석 + null → false
+    // =====================================================
+
+    [TestCase(-1, true,  "자동 기본값(-1)은 GetDefaultAstcBlockEscalation()==true 이어야 합니다.")]
+    [TestCase(0,  false, "명시적 비활성(0)은 false 이어야 합니다.")]
+    [TestCase(1,  true,  "명시적 활성(1)은 true 이어야 합니다.")]
+    public void EffectiveEnabled_TriState_ReturnsExpected(int value, bool expected, string reason)
+    {
+        _config.astcBlockEscalation = value;
+        Assert.AreEqual(expected, AITAstcBlockProcessor.EffectiveEnabled(_config), reason);
+    }
+
+    [Test]
+    public void EffectiveEnabled_NullConfig_ReturnsFalse()
+    {
+        Assert.IsFalse(AITAstcBlockProcessor.EffectiveEnabled(null),
+            "null config 시 EffectiveEnabled=false 이어야 합니다.");
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAstcBlockProcessorTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAstcBlockProcessorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b23e8230ab4e472ab3a34aed983ddd4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 개요

WebGL Texture Compression(ASTC 서브타겟) 프로젝트에서 빌드 시 대상 Texture2D/SpriteAtlas 의 WebGL 플랫폼 오버라이드를 일시적으로 ASTC 블록 NxN(기본 12x12) + maxTextureSize 캡으로 바꿔 .data/다운로드 텍스처 바이트를 줄이는 기능. opt-out(기본 자동 ON) 트라이스테이트로 동작합니다. 빌드 후 원본 임포트 설정 자동 복원(비파괴) + 에디터 재시작 안전망.

## 적용 조건

- `astcBlockEscalation` 트라이스테이트: -1=자동(기본 활성, zero-config)/0=비활성/1=활성 — AIT Configuration에서 비활성화 가능
- ASTC 서브타겟 전용 — DXT 면 빌드 시 자동 skip + 경고, 텍스처 crunch #762 와 상보적
- lossy: 블록↑=bpp↓·화질↓
- 폰트·SDF·TextMeshPro 경로 휴리스틱 자동 제외
- 비압축(RGBA32 계열) 텍스처 제외(팽창 방지)

## 측정

TTFF Δ는 perf 하네스(#754)가 perf 라벨 PR에서 측정/코멘트 예정

## 관련 PR

- #762 텍스처 Crunch(DXT 전용): 본 기능은 ASTC 측 대응

⚠ **3.0 beta→stable 이후 머지 예정 — 머지 금지**
