### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-import-error-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -144,7 +144,8 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // Unity AssetImporter 내부 워커/메인 에러 — SDK 외부 출처 (Unity 자체 에셋 임포트 경고).
             // 워커 prefix가 있는 변형: "[Worker2] Import Error Code:(4)" (SDK-RC/RD/RE)
-            // prefix 없이 UnityWarning으로 래핑된 변형: "UnityWarning: Import Error Code:(4)" (SDK-V7)
+            // prefix 없이 UnityWarning으로 래핑된 변형: "UnityWarning: Import Error Code:(4)" (SDK-V7, APPS-IN-TOSS-UNITY-SDK-111)
+            // Unity SourceAssetDB modification time 불일치 경고로 Unity 자체 에셋 임포트 시스템에서 출력되는 외부 노이즈 — SDK 식별자 없음.
             // prefix 유무·워커 번호·코드 숫자가 모두 가변이므로 공통 핵심 문구 "Import Error Code:(" 로 일반화.
             // SDK는 이 문자열을 출력하지 않으므로(AitKeywords에 없음) 보호 가드와 충돌 없음.
             "Import Error Code:(",

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -915,13 +915,14 @@ public class IsKnownNonSdkMessageTests
     [TestCase(
         "[Worker4] Import Error Code:(4)",
         TestName = "WorkerImportError_Worker4_ReturnsTrue")]
-    // Sentry APPS-IN-TOSS-UNITY-SDK-V7 — 워커 prefix 없이 UnityWarning으로 래핑된 변형
+    // Sentry APPS-IN-TOSS-UNITY-SDK-V7, APPS-IN-TOSS-UNITY-SDK-111 — 워커 prefix 없이 UnityWarning으로 래핑된 변형.
+    // Unity SourceAssetDB modification time 불일치 경고로 Unity 자체 에셋 임포트 시스템에서 출력되는 외부 노이즈 — SDK 식별자 없음.
     [TestCase(
         "UnityWarning: Import Error Code:(4)",
         TestName = "WorkerImportError_UnityWarningWrapped_ReturnsTrue")]
     public void WorkerImportError_RealisticVariants_ReturnsTrue(string message)
     {
-        // Sentry APPS-IN-TOSS-UNITY-SDK-RC/RD/RE/V7 — Unity AssetImporter 내부/메인 에셋 임포트 에러.
+        // Sentry APPS-IN-TOSS-UNITY-SDK-RC/RD/RE/V7/111 — Unity AssetImporter 내부/메인 에셋 임포트 에러.
         // 워커 prefix 유무·워커 번호·코드 숫자가 가변이지만 "Import Error Code:(" 부분 문자열로 모두 매칭.
         // SDK 코드에는 "Import Error Code" 문자열이 존재하지 않음 (grep으로 확인).
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(message));


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-111

## 묶음 항목

| source | id | title |
|--------|-----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-111 | "UnityWarning: Import Error Code:(4)" |

## 추출 패턴

기존 NonSdkMessagePatterns에 이미 "Import Error Code:(" 패턴이 존재하여 해당 이슈를 커버함 (SDK-RC/RD/RE/V7).
이번 PR은 APPS-IN-TOSS-UNITY-SDK-111(UnityWarning 래핑 변형)을 추가 Sentry ID로 주석/테스트에 명시하여 이슈 추적성을 강화.

- 패턴: "Import Error Code:(" (기존 — 변경 없음)
- 추가 위치: Editor/ErrorTracker/AITEditorErrorTracker.cs NonSdkMessagePatterns 주석
- 테스트 추가: IsKnownNonSdkMessageTests.cs WorkerImportError_RealisticVariants_ReturnsTrue 메서드 주석에 APPS-IN-TOSS-UNITY-SDK-111 명시

## 이슈 분석

Unity SourceAssetDB modification time 불일치 경고로 Unity 자체 에셋 임포트 시스템에서 출력되는 외부 노이즈 — SDK 식별자 없음, 과거 동일 패턴 처리 이력 있음.

## 검증 결과

./run-local-tests.sh --validate 통과 (3/3 passed):
- E2E Test Files Validation: PASS
- Playwright Config Validation: PASS
- SDK Generator Unit Tests (C# ↔ jslib invariants): PASS (18 tests passed)

## 주의

사람 머지 검토 필요 — squash merge 전 Sentry 이슈 자동 resolve 키워드(Fixes APPS-IN-TOSS-UNITY-SDK-111) 포함.