### PR TITLE
수정: 배포 경로 빌드를 release 프로필로 전환(fast-build 옵트아웃) + preview 배포 실패 시 job 실패 처리

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -349,6 +349,11 @@ jobs:
       web-framework-version: ${{ needs.beta-prepare.outputs.npm_version }}
       sdk-version: ${{ needs.beta-prepare.outputs.pkg_version }}
       run-build: true
+      # 이 산출물은 e2e-beta-macos의 deploy 게이트에서 ait deploy로 실 콘솔에
+      # 배포되므로 E2E 고속 프로필(dev build)을 끄고 SDK 기본 프로필(release 빌드)로
+      # 빌드한다. dev 빌드 wasm(6000.x ~134MiB)은 콘솔 번들 크기 제한을 초과해
+      # 서버측 BUILD_FAILED가 난다 (2026-06 진단).
+      fast-build: false
     secrets:
       AIT_AD_INTERSTITIAL_ID: ${{ secrets.AIT_AD_INTERSTITIAL_ID }}
       AIT_AD_REWARDED_ID: ${{ secrets.AIT_AD_REWARDED_ID }}
@@ -379,6 +384,9 @@ jobs:
       web-framework-version: ${{ needs.beta-prepare.outputs.npm_version }}
       sdk-version: ${{ needs.beta-prepare.outputs.pkg_version }}
       run-build: true
+      # macOS leg와 동일한 release 프로필로 빌드해 게시 게이트 검증의 일관성을
+      # 유지한다 (베타 게시 대상 산출물은 dev 프로필이어선 안 됨).
+      fast-build: false
     secrets:
       AIT_AD_INTERSTITIAL_ID: ${{ secrets.AIT_AD_INTERSTITIAL_ID }}
       AIT_AD_REWARDED_ID: ${{ secrets.AIT_AD_REWARDED_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -201,6 +201,10 @@ jobs:
       os: ${{ matrix.target.os }}
       unity-version: ${{ matrix.target.unity-version }}
       run-build: true
+      # preview 산출물은 ait deploy로 실 콘솔에 배포되므로 E2E 고속 프로필(dev build)을
+      # 끄고 SDK 기본 프로필(release 빌드)로 빌드한다. dev 빌드 wasm(6000.x ~134MiB)은
+      # 콘솔 번들 크기 제한을 초과해 서버측 BUILD_FAILED가 난다 (2026-06 진단).
+      fast-build: false
     secrets:
       AIT_AD_INTERSTITIAL_ID: ${{ secrets.AIT_AD_INTERSTITIAL_ID }}
       AIT_AD_REWARDED_ID: ${{ secrets.AIT_AD_REWARDED_ID }}
@@ -305,6 +309,7 @@ jobs:
 
           DEPLOY_RESULTS=""
           HAS_SUCCESS=false
+          HAS_FAILURE=false
 
           for build_dir in ait-builds/ait-build-*/; do
             if [ -d "$build_dir" ]; then
@@ -344,7 +349,43 @@ jobs:
                 fi
               else
                 echo "❌ Deploy failed (exit code: $DEPLOY_STATUS)"
-                DEPLOY_RESULTS="${DEPLOY_RESULTS}| ${OS_DISPLAY} | ${UNITY_VERSION} | ❌ | Failed | - |\n"
+                HAS_FAILURE=true
+                if [ "$DEPLOY_STATUS" -eq 124 ]; then
+                  FAIL_DETAIL="Failed (타임아웃 5분)"
+                else
+                  FAIL_DETAIL="Failed (exit ${DEPLOY_STATUS})"
+                fi
+                DEPLOY_RESULTS="${DEPLOY_RESULTS}| ${OS_DISPLAY} | ${UNITY_VERSION} | ❌ | ${FAIL_DETAIL} | - |\n"
+
+                # 실패 시: 서버측(레이어 3) 빌드 상태를 deployment GET으로 직접 조회해
+                # CI 로그/요약에 덤프 (beta-release.yml 게이트와 동일 진단 경로).
+                # ait CLI는 응답에서 reviewStatus enum만 읽고 나머지를 버리므로,
+                # 실패 사유가 응답 본문에 있는지 raw JSON으로 확인한다.
+                CLEANED_OUTPUT=$(echo "$DEPLOY_OUTPUT" | sed 's/\x1b\[[0-9;]*m//g' | tr -d '\r')
+                DEPLOYMENT_ID=$(echo "$CLEANED_OUTPUT" | grep -oE '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}' | head -1 || true)
+                AIT_FILE=$(ls -1 "${build_dir}"*.ait 2>/dev/null | head -1 || true)
+                APP_NAME=$(basename "${AIT_FILE%.ait}")
+                echo "::group::서버측 배포 상태 조회 (${OS_DISPLAY} ${UNITY_VERSION})"
+                echo "appName=${APP_NAME:-(미발견)} deploymentId=${DEPLOYMENT_ID:-(미발견)}"
+                if [ -n "$DEPLOYMENT_ID" ] && [ -n "$APP_NAME" ]; then
+                  STATUS_JSON=$(curl -sS \
+                    -H "Authorization: Bearer ${AIT_DEPLOY_KEY}" \
+                    -H "Accept: application/json" \
+                    "https://apps-in-toss.toss.im/console/api-public/v3/openapi/bundles/${APP_NAME}/deployments/${DEPLOYMENT_ID}" 2>&1 || true)
+                  echo "$STATUS_JSON" | jq . 2>/dev/null || echo "$STATUS_JSON"
+                  {
+                    echo "## 🔎 서버측 배포 상태 (${OS_DISPLAY} ${UNITY_VERSION}) — 실패 진단"
+                    echo ""
+                    echo "appName: \`${APP_NAME}\` · deploymentId: \`${DEPLOYMENT_ID}\`"
+                    echo ""
+                    echo '```json'
+                    echo "$STATUS_JSON" | jq . 2>/dev/null || echo "$STATUS_JSON"
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+                else
+                  echo "deploymentId 또는 appName 파싱 실패 — 서버 상태 조회 건너뜀"
+                fi
+                echo "::endgroup::"
               fi
             fi
           done
@@ -360,13 +401,27 @@ jobs:
             echo "has_success=false" >> $GITHUB_OUTPUT
           fi
 
+          # 배포 실패가 하나라도 있으면 step/job을 실패로 종료 (outputs는 위에서 이미 기록됨 —
+          # Summary/PR 코멘트 step은 !cancelled() 조건으로 계속 실행되어 결과 표를 남긴다).
+          if [ "$HAS_FAILURE" = true ]; then
+            echo "::error::하나 이상의 preview 배포가 실패했습니다 — Step Summary의 서버측 진단(deployment GET) 참조"
+            exit 1
+          fi
+
       - name: Write Job Summary
+        if: ${{ !cancelled() }}
         run: |
           REF="${{ needs.parse-targets.outputs.ref }}"
           DEPLOY_RESULTS='${{ steps.deploy.outputs.deploy_results }}'
 
+          if [ "${{ steps.deploy.outputs.has_success }}" = "true" ] && [ "${{ steps.deploy.outcome }}" = "success" ]; then
+            TITLE="## 🎉 Preview Deploy Complete"
+          else
+            TITLE="## ❌ Preview Deploy Failed"
+          fi
+
           cat <<EOF >> $GITHUB_STEP_SUMMARY
-          ## 🎉 Preview Deploy Complete
+          ${TITLE}
 
           **Branch:** \`${REF}\`
 
@@ -386,7 +441,7 @@ jobs:
           EOF
 
       - name: Post PR Comment
-        if: needs.parse-targets.outputs.pr_number != ''
+        if: ${{ !cancelled() && needs.parse-targets.outputs.pr_number != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -395,7 +450,7 @@ jobs:
           DEPLOY_RESULTS='${{ steps.deploy.outputs.deploy_results }}'
           HAS_SUCCESS="${{ steps.deploy.outputs.has_success }}"
 
-          if [ "$HAS_SUCCESS" = "true" ]; then
+          if [ "$HAS_SUCCESS" = "true" ] && [ "${{ steps.deploy.outcome }}" = "success" ]; then
             STATUS_EMOJI="🎉"
             STATUS_TEXT="Preview deploy complete"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,7 +355,10 @@ jobs:
     uses: ./.github/workflows/unity-build.yml
     with:
       ref: ${{ needs.regenerate-sdk.outputs.ref }}
-      os: windows
+      # afbbd23(2026-03)에서 macOS 러너 라이선스 hang 회피로 windows로 임시
+      # 전환했던 잔재를 원복. 근본 원인은 #559(unity-<version> 라벨 1:1 머신 핀)로
+      # 해결됐고, beta-release/preview는 이미 macOS 러너에서 정상 빌드 중.
+      os: macos
       unity-version: ${{ matrix.unity-version }}
       web-framework-version: ${{ needs.release.outputs.version }}
       sdk-version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,6 +360,11 @@ jobs:
       web-framework-version: ${{ needs.release.outputs.version }}
       sdk-version: ${{ needs.release.outputs.version }}
       run-build: true
+      # 이 산출물은 deploy-ait에서 ait deploy로 실 릴리즈 콘솔에 배포되므로
+      # E2E 고속 프로필(dev build)을 끄고 SDK 기본 프로필(release 빌드)로 빌드한다.
+      # dev 빌드 wasm(6000.x ~134MiB)은 콘솔 번들 크기 제한을 초과해 서버측
+      # BUILD_FAILED가 난다 (2026-06 진단).
+      fast-build: false
     secrets:
       AIT_AD_INTERSTITIAL_ID: ${{ secrets.AIT_AD_INTERSTITIAL_ID }}
       AIT_AD_REWARDED_ID: ${{ secrets.AIT_AD_REWARDED_ID }}
@@ -390,6 +395,8 @@ jobs:
       web-framework-version: ${{ needs.release.outputs.version }}
       sdk-version: ${{ needs.release.outputs.version }}
       run-build: true
+      # macOS 빌드와 동일한 release 프로필 — 배포 대상 산출물은 dev 프로필 금지.
+      fast-build: false
     secrets:
       AIT_AD_INTERSTITIAL_ID: ${{ secrets.AIT_AD_INTERSTITIAL_ID }}
       AIT_AD_REWARDED_ID: ${{ secrets.AIT_AD_REWARDED_ID }}

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -66,6 +66,11 @@ on:
         type: string
         required: false
         default: '2'
+      fast-build:
+        description: 'E2E 고속 빌드 프로필 (dev build + 압축 비활성화 + IL2CPP Debug, PR #551). 산출물을 ait deploy로 콘솔에 배포하는 호출자(preview 등)는 false 필수 — dev 빌드 wasm(6000.x 기준 ~134MiB)이 콘솔 번들 크기 제한을 초과해 서버측 BUILD_FAILED가 남. false면 env 오버라이드 없이 SDK 기본 프로필(release 빌드)로 빌드.'
+        type: boolean
+        required: false
+        default: true
     secrets:
       AIT_AD_INTERSTITIAL_ID:
         description: 'Interstitial ad ID for testing'
@@ -1480,19 +1485,21 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: 압축 비활성화. E2E는 vite dev/preview 서버에서만 로드되며
-          # 배포되지 않으므로 압축이 불필요. Brotli/Gzip 단계 자체를 건너뛰어
-          # wallclock 절감(~120s).
-          AIT_COMPRESSION_FORMAT: "0"
-          # E2E 한정: Development Build 활성화 — Link_WebGL_wasm 단계가 단독 실행
+          # fast-build(기본 true, E2E용) 한정: 압축 비활성화. E2E는 vite dev/preview 서버에서만
+          # 로드되며 배포되지 않으므로 압축이 불필요. Brotli/Gzip 단계 자체를 건너뛰어
+          # wallclock 절감(~120s). 빈 문자열이면 오버라이드 없음(SDK 기본 프로필).
+          AIT_COMPRESSION_FORMAT: ${{ inputs.fast-build && '0' || '' }}
+          # fast-build 한정: Development Build 활성화 — Link_WebGL_wasm 단계가 단독 실행
           # critical path에서 ~163s를 차지(Emscripten 옵티마이저 -O3 풀스피드).
           # Development Build로 옵티마이저 단축, Build wallclock 대폭 절감 기대.
           # E2E는 SDK API 동작만 검증하며 런타임 성능을 보지 않으므로 무관.
-          AIT_DEVELOPMENT_BUILD: "true"
-          # E2E 한정: IL2CPP 컴파일러 옵티마이저 레벨도 Debug로 강제. developmentBuild
+          # 주의: dev 빌드 wasm은 콘솔 번들 크기 제한을 초과할 수 있어(6000.x ~134MiB)
+          # 배포 목적 호출자는 fast-build=false로 비활성화해야 함.
+          AIT_DEVELOPMENT_BUILD: ${{ inputs.fast-build && 'true' || '' }}
+          # fast-build 한정: IL2CPP 컴파일러 옵티마이저 레벨도 Debug로 강제. developmentBuild
           # 플래그는 Player 측 설정이라 IL2CPP 옵티마이저(C_WebGL_wasm/Link_WebGL_wasm)에는
           # 영향이 없어 별도 변수로 페어링. -O3 → -O0/-Og 수준으로 wasm 컴파일/링크 단축.
-          AIT_IL2CPP_CONFIGURATION: "Debug"
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.fast-build && 'Debug' || '' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30
@@ -1633,10 +1640,10 @@ jobs:
         uses: nick-invision/retry@v4
         env:
           AIT_DEBUG_CONSOLE: "true"
-          # E2E 한정: macOS step의 동일 주석 참조.
-          AIT_COMPRESSION_FORMAT: "0"
-          AIT_DEVELOPMENT_BUILD: "true"
-          AIT_IL2CPP_CONFIGURATION: "Debug"
+          # fast-build 한정: macOS step의 동일 주석 참조.
+          AIT_COMPRESSION_FORMAT: ${{ inputs.fast-build && '0' || '' }}
+          AIT_DEVELOPMENT_BUILD: ${{ inputs.fast-build && 'true' || '' }}
+          AIT_IL2CPP_CONFIGURATION: ${{ inputs.fast-build && 'Debug' || '' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
           timeout_minutes: 30


### PR DESCRIPTION
## 문제

### 1. preview 배포가 서버측 BUILD_FAILED로 실패
PR #551이 E2E wallclock 단축용으로 unity-build.yml 빌드 step에 dev build + 압축 비활성화 + IL2CPP Debug를 **하드코딩**했는데, unity-build.yml은 공유 reusable workflow라 E2E뿐 아니라 preview/beta/release 등 **모든 호출자**가 dev 빌드 산출물을 받게 됨. dev 빌드 wasm은 콘솔 번들 크기 제한을 초과해 서버측 BUILD_FAILED 발생.

증거 (격리 실험으로 크기 단일 변수 확정):
| 케이스 | wasm 크기 | 결과 |
|---|---|---|
| 6000.2 dev 빌드 (현행 preview) | 140,347,448 B (~134MiB) | ❌ 서버측 BUILD_FAILED |
| 2021.3 dev 빌드 (동일 preview 경로, run 27364938537) | 80,533,522 B (~77MiB) | ✅ 배포 성공 |
| 2026-03 release 빌드 (run 22662609019) | — | ✅ 전 버전(2021.3~6000.3) 배포 성공 |

### 2. 배포가 실패해도 job이 success로 표시
preview.yml의 Deploy All Builds step이 실패를 결과 표에만 ❌로 기록하고 항상 exit 0으로 종료 → 전 배포 실패 시에도 job/commit status가 success.

## 수정

- **unity-build.yml**: `fast-build` 입력 추가 (기본 `true` = 기존 E2E 동작 100% 유지). `false`면 세 env 오버라이드를 빈 문자열로 전달 → `AITBuildInitializer`가 빈 값을 skip해 SDK 기본 프로필(release 빌드)로 빌드 — 2026-03 전 버전 배포 성공 당시와 동일 구성.
- **preview.yml**: `fast-build: false` + 배포 실패 시 `exit 1`로 job 실패 처리 + 실패 시 서버측 deployment GET 진단 JSON을 로그/Step Summary에 덤프 (beta-release.yml 게이트와 동일 경로). Summary/PR 코멘트는 `!cancelled()`로 실패 시에도 결과 표를 남기되 제목/상태를 ❌로 표기.
- **beta-release.yml / release.yml**: 산출물이 ait deploy로 실 콘솔에 배포되는 빌드 job에 동일하게 `fast-build: false` 적용 (배포 대상 산출물은 dev 프로필 금지).
- **release.yml**: build-ait-macos의 `os: windows` → `macos` 원복 (afbbd23의 macOS 러너 라이선스 hang 임시 회피 잔재 — 근본 원인은 #559 라벨 1:1 핀으로 해결됨).

## 영향 범위

- E2E 경로(`fast-build` 미지정 = 기본 true): 변경 없음 — dev 고속 프로필 그대로.
- preview/beta/release 배포 경로: release 프로필로 빌드 (빌드 시간 증가 대신 배포 가능 산출물 보장).

## 검증

- actionlint 통과 (신규 오류 없음 — release.yml:659 sentry_auth_token 경고는 main 기존 이슈)
- 2021.3 격리 실험으로 preview 경로 자체(global ait 2.6.1)는 정상임을 확인 — 크기만이 변수
- 머지 후: preview를 `targets=macos-6000.2`로 디스패치해 release 빌드 배포 성공 확인 예정 (workflow_dispatch는 main의 정의를 사용하므로 머지 후에만 검증 가능)