### PR TITLE
수정: bot SDK 업데이트 PR의 필수 scan 체크 영구 pending 해소

### DIFF
--- a/.github/workflows/sdk-update-rebase.yml
+++ b/.github/workflows/sdk-update-rebase.yml
@@ -11,6 +11,8 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  # 필수 'scan' 체크를 bot PR 새 head에 재보고하기 위해 필요 (아래 'scan 체크 충족' step)
+  statuses: write
 
 concurrency:
   group: sdk-update-rebase
@@ -363,6 +365,23 @@ jobs:
             gh api "repos/${{ github.repository }}/actions/workflows/216286654/dispatches" \
             -X POST --input -
           echo "✅ E2E 테스트 트리거 완료: PR #${PR_NUMBER}"
+
+      # 필수 'scan' 체크 충족. force-push로 head가 바뀌면 기존 scan status가
+      # 무효화되는데, GITHUB_TOKEN bot PR은 string-check.yml을 트리거하지 못해
+      # scan이 영구 pending → 머지 불가가 된다. 새 head에 scan=success를 재보고
+      # (update.yml / update-changelog.yml과 같은 패턴).
+      - name: 필수 scan 체크 충족 (bot PR)
+        if: steps.author-check.outputs.skip != 'true' && steps.push.outputs.pushed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+          gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" -X POST \
+            -f state=success \
+            -f context=scan \
+            -f description="bot SDK 업데이트 PR(리베이스) — scan skipped (github-actions[bot])"
+          echo "✅ scan status 보고 완료: ${HEAD_SHA}"
 
       - name: 실패 시 PR 코멘트
         if: failure() && steps.author-check.outputs.skip != 'true'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,6 +20,8 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  # 필수 'scan' 체크를 bot PR에 직접 보고하기 위해 필요 (아래 'scan 체크 충족' step)
+  statuses: write
 
 jobs:
   # =====================================================
@@ -434,6 +436,24 @@ jobs:
             gh api "repos/${{ github.repository }}/actions/workflows/216286654/dispatches" \
             -X POST --input -
           echo "✅ E2E 테스트 트리거 완료: PR #${PR_NUMBER}"
+
+      # 필수 'scan' 체크 충족. GITHUB_TOKEN으로 만든 PR은 GitHub 정책상
+      # string-check.yml(pull_request)을 트리거하지 못해 scan이 영구 pending →
+      # 머지 불가가 된다(PR #771에서 확인). string-check.yml의 'bot PR → scan skip'
+      # 정책과 동일하게 scan=success를 직접 보고한다(update-changelog.yml과 같은 패턴).
+      - name: 필수 scan 체크 충족 (bot PR)
+        if: steps.create-pr.outputs.pr_created == 'true' && steps.create-pr.outputs.pr_number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
+        run: |
+          HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" -X POST \
+            -f state=success \
+            -f context=scan \
+            -f description="bot SDK 업데이트 PR — scan skipped (github-actions[bot])"
+          echo "✅ scan status 보고 완료: ${HEAD_SHA}"
 
       - name: 업데이트 요약
         if: always()


### PR DESCRIPTION
## 문제

`SDK 업데이트: vX.Y.Z` bot PR이 필수 `scan` 체크 미보고로 머지 불가 (PR #771에서 확인 — "E2E Tests" status는 success인데 `mergeable_state: blocked`).

원인: GitHub 재귀 방지 정책상 **`GITHUB_TOKEN`으로 생성/갱신된 PR은 `pull_request` 워크플로를 트리거하지 않음** → string-check.yml(`scan`)이 시작조차 안 됨 → main 룰셋의 required check `scan`이 영구 pending.

update.yml은 E2E에 대해선 이 문제를 workflow_dispatch로 우회하고 있었으나(L422 주석), `scan`에 대한 우회가 누락. update-changelog.yml에는 동일 문제의 해결 선례(bot PR head에 `context=scan` status 직접 게시, L62-69)가 이미 있음.

## 수정

string-check.yml의 "bot PR → scan skip" 정책 및 update-changelog.yml의 기존 패턴과 동일하게, bot PR에 한해 `scan=success` status를 직접 보고:

| 파일 | 변경 |
|------|------|
| `update.yml` | PR 생성 직후 head SHA에 `scan` status 보고 step 추가 |
| `sdk-update-rebase.yml` | force-push로 head가 바뀐 뒤 **새 head에 재보고** step 추가 (기존 status는 head 변경 시 무효화) |
| 두 파일 공통 | `permissions`에 `statuses: write` 추가 — 명시적 permissions 블록에서 미기재 scope는 none이라 필수 |

보안 정책 변화 없음: string-check.yml이 이미 bot PR(`dependabot[bot]`/`github-actions[bot]`)은 secret 접근 불가를 이유로 scan을 skip-success 처리하는 정책을 갖고 있으며, 이 PR은 그 정책이 "워크플로가 아예 트리거되지 않는 경우"에도 동작하게 한 것.

## 참고

- PR #771은 동일 방식의 수동 status 게시로 unblock 완료 (`mergeable_state: clean`)
- 검증: actionlint 통과
