### PR TITLE
기능: first-interactive 로딩 계측 이벤트 발화 추가

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -216,6 +216,11 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - WASM Streaming: {editorConfig.wasmStreaming}");
 #endif
 #endif
+            // first-interactive 계측은 BuildPlayer 후 WebGLBuildCopier에서 처리
+            bool firstInteractiveEnabled = editorConfig.firstInteractiveLog >= 0
+                ? editorConfig.firstInteractiveLog == 1
+                : AITDefaultSettings.GetDefaultFirstInteractiveLog();
+            Debug.Log($"[AIT]   - first-interactive 계측: {firstInteractiveEnabled}{(editorConfig.firstInteractiveLog < 0 ? " (자동)" : "")}");
         }
 
         /// <summary>

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -451,6 +451,11 @@ namespace AppsInToss.Editor
 
             GUILayout.Space(10);
 
+            // first-interactive 계측
+            DrawFirstInteractiveLogSetting();
+
+            GUILayout.Space(10);
+
             // 변경된 설정 개수 표시
             int modifiedCount = CountModifiedWebGLSettings();
             if (modifiedCount > 0)
@@ -961,6 +966,37 @@ namespace AppsInToss.Editor
             }
         }
 
+        private void DrawFirstInteractiveLogSetting()
+        {
+            bool defaultValue = AITDefaultSettings.GetDefaultFirstInteractiveLog();
+            bool isModified = config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultValue;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string autoLabel = defaultValue ? "활성화" : "비활성화";
+            string label = config.firstInteractiveLog < 0
+                ? $"first-interactive 계측 (자동: {autoLabel})"
+                : "first-interactive 계측";
+
+            string[] options = { $"자동 ({autoLabel})", "비활성화", "활성화" };
+            int currentIndex = config.firstInteractiveLog < 0 ? 0 : config.firstInteractiveLog + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "원래 첫 씬 로드 완료 시점(time-to-original-scene)을 호스트에 전송합니다. " +
+                    "픽셀 불변·세션당 1회 단일 이벤트이므로 기본 활성화됩니다."),
+                currentIndex, options);
+            config.firstInteractiveLog = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.firstInteractiveLog = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
         private int CountModifiedWebGLSettings()
         {
             int count = 0;
@@ -974,6 +1010,9 @@ namespace AppsInToss.Editor
             bool defaultCaching = AITDefaultSettings.GetDefaultDataCaching();
             if (config.dataCaching >= 0 && (config.dataCaching == 1) != defaultCaching) count++;
 
+            bool defaultFirstInteractive = AITDefaultSettings.GetDefaultFirstInteractiveLog();
+            if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
+
             return count;
         }
 
@@ -982,6 +1021,7 @@ namespace AppsInToss.Editor
             config.memorySize = -1;
             config.threadsSupport = -1;
             config.dataCaching = -1;
+            config.firstInteractiveLog = -1;
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -206,6 +206,10 @@ namespace AppsInToss
         [Tooltip("빌드 전 에셋 최적화 검사를 활성화합니다")]
         public bool enableBuildOptimizationCheck = true;
 
+        [Header("계측 설정")]
+        [Tooltip("first-interactive 계측: -1 = 자동 (활성), 0 = 비활성, 1 = 활성")]
+        public int firstInteractiveLog = -1;
+
         [Header("권한 설정")]
         public AITPermissionConfig permissionConfig = new AITPermissionConfig();
 
@@ -465,6 +469,15 @@ namespace AppsInToss
             return false;
         }
 #endif
+
+        /// <summary>
+        /// first-interactive 계측 기본 활성 여부.
+        /// 픽셀 불변·세션당 1회 단일 이벤트·호스트 로딩 지표 표준화에 해당하므로 기본 ON.
+        /// </summary>
+        public static bool GetDefaultFirstInteractiveLog()
+        {
+            return true;
+        }
 
         /// <summary>
         /// 현재 Unity 버전의 버전 그룹 이름 반환

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -282,6 +282,7 @@ namespace AppsInToss.Editor.Package
                 // AIT 커스텀 플레이스홀더
                 .Replace("%AIT_IS_PRODUCTION%", isProduction)
                 .Replace("%AIT_ENABLE_DEBUG_CONSOLE%", enableDebugConsole)
+                .Replace("%AIT_FIRST_INTERACTIVE_LOG%", EffectiveFirstInteractiveLog(config) ? "true" : "false")
                 .Replace("%AIT_DEVICE_PIXEL_RATIO%", config.devicePixelRatio.ToString())
                 .Replace("%AIT_ICON_URL%", config.iconUrl ?? "")
                 .Replace("%AIT_DISPLAY_NAME%", config.displayName ?? "")
@@ -478,6 +479,20 @@ namespace AppsInToss.Editor.Package
         }};
     }})();
     </script>";
+        }
+
+        /// <summary>
+        /// first-interactive 계측 실효 활성 여부를 반환한다(tri-state 해석).
+        /// 계측기는 픽셀 불변이며 설정 로드 실패가 계측을 침묵시키면 안 되므로 null → true(fail-open).
+        /// (파괴적 변환 프로세서와 달리 null→false 안전 전략을 쓰지 않는다)
+        /// firstInteractiveLog >= 0 이면 ==1, &lt;0 이면 GetDefaultFirstInteractiveLog().
+        /// </summary>
+        internal static bool EffectiveFirstInteractiveLog(AITEditorScriptObject config)
+        {
+            if (config == null) return true; // fail-open: 설정 로드 실패 시 계측 침묵 방지
+            return config.firstInteractiveLog >= 0
+                ? config.firstInteractiveLog == 1
+                : AITDefaultSettings.GetDefaultFirstInteractiveLog();
         }
 
         /// <summary>

--- a/Runtime/Helpers/AIT.PerformanceLogger.cs
+++ b/Runtime/Helpers/AIT.PerformanceLogger.cs
@@ -19,7 +19,9 @@ namespace AppsInToss
     /// <remarks>
     /// RuntimeInitializeOnLoadMethod로 자동 초기화되며, 사용자 코드 작성이 불필요합니다.
     /// 수집 이벤트: Scene 전환, Low Memory, 에러/예외, 앱 라이프사이클,
-    /// 프레임 스톨, 화면 변경, GC 수집, TimeScale 변경
+    /// 프레임 스톨, 화면 변경, GC 수집, TimeScale 변경, first-interactive
+    /// (first-interactive: 원래 첫 씬 로드 완료 시점 — time-to-original-scene.
+    ///  부팅 첫 씬 로드는 first-paint 직전에 발생하므로 base 빌드에서는 두 지표가 근접함)
     /// </remarks>
     [Preserve]
     internal static class AITPerformanceLogger
@@ -27,9 +29,17 @@ namespace AppsInToss
 #if UNITY_WEBGL && !UNITY_EDITOR
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __AITDebugLog_Send(string jsonStr);
+
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        private static extern int __AITDebugLog_FirstInteractiveEnabled();
 #endif
 
         private const string Tag = "[AITPerformanceLogger]";
+
+        // first-interactive 관련 상수 및 상태
+        private const string ProxyBootScenePrefix = "AITProxyBoot";
+        private static bool _firstInteractiveSent;
+        private static int _firstInteractiveEnabledCache = -1; // -1=미확인, 0=비활성, 1=활성
 
         // Rate limit constants
         private const float LowMemoryIntervalSec = 30f;
@@ -155,11 +165,74 @@ namespace AppsInToss
                     { "total_loaded_scenes", SceneManager.sceneCount },
                     { "time_since_start_sec", Math.Round(Time.realtimeSinceStartup, 1) }
                 });
+
+                // first-interactive: 원래 첫 씬 로드 완료 시점 계측 (once-per-session).
+                // 활성 여부는 빌드 시 템플릿에 새겨진 상수(부재 시 fail-open=활성)라 세션 중 변하지 않으며,
+                // 최초 대상 씬에서 활성 여부와 무관하게 _firstInteractiveSent를 고정한다 — 이후 씬은 "first"가 아니다.
+                if (ShouldEmitFirstInteractive(scene.name, _firstInteractiveSent))
+                {
+                    bool enabled = IsFirstInteractiveLogEnabled();
+                    _firstInteractiveSent = true; // 활성 여부와 무관하게 "최초" 의미 고정 (이후 씬은 first가 아님)
+                    if (enabled)
+                    {
+                        SendLog("unity_first_interactive", new Dictionary<string, object>
+                        {
+                            { "event_type", "first_interactive" },
+                            { "scene_name", scene.name },
+                            { "scene_build_index", scene.buildIndex },
+                            { "time_since_start_ms", (long)Math.Round(Time.realtimeSinceStartup * 1000.0, 0) }
+                        });
+                    }
+                }
             }
             catch (Exception ex)
             {
                 Debug.LogWarning($"{Tag} OnSceneLoaded error: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// first-interactive 이벤트를 발화해야 하는지 판단한다.
+        /// </summary>
+        /// <param name="sceneName">로드된 씬 이름</param>
+        /// <param name="alreadySent">이미 발화된 경우 true</param>
+        /// <returns>
+        /// alreadySent=true 이면 false(중복 방지).
+        /// sceneName이 null/empty 이면 true(이름 없는 씬도 최초 실 씬으로 취급).
+        /// sceneName이 "AITProxyBoot"로 시작하면 false(SDK 주입 프록시 부팅 씬은 원래 첫 씬이 아님).
+        /// 그 외는 true.
+        /// </returns>
+        internal static bool ShouldEmitFirstInteractive(string sceneName, bool alreadySent)
+        {
+            if (alreadySent) return false;
+            if (string.IsNullOrEmpty(sceneName)) return true;
+            if (sceneName.StartsWith(ProxyBootScenePrefix, StringComparison.Ordinal)) return false;
+            return true;
+        }
+
+        /// <summary>
+        /// first-interactive 로그 활성 여부를 반환한다.
+        /// WebGL 비에디터 환경에서 jslib extern을 1회 호출한 뒤 캐시한다(fail-open).
+        /// 그 외 환경에서는 항상 false(SendLog가 어차피 no-op).
+        /// </summary>
+        private static bool IsFirstInteractiveLogEnabled()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            if (_firstInteractiveEnabledCache < 0)
+            {
+                try
+                {
+                    _firstInteractiveEnabledCache = __AITDebugLog_FirstInteractiveEnabled();
+                }
+                catch
+                {
+                    _firstInteractiveEnabledCache = 1; // fail-open
+                }
+            }
+            return _firstInteractiveEnabledCache == 1;
+#else
+            return false;
+#endif
         }
 
         private static void OnSceneUnloaded(Scene scene)

--- a/Runtime/Helpers/Plugins/AppsInToss-DebugLog.jslib
+++ b/Runtime/Helpers/Plugins/AppsInToss-DebugLog.jslib
@@ -12,5 +12,12 @@ mergeInto(LibraryManager.library, {
         } catch (e) {
             console.warn('[AIT] debugLog failed', e);
         }
+    },
+    __AITDebugLog_FirstInteractiveEnabled: function() {
+        try {
+            return (window.__AIT_FIRST_INTERACTIVE_LOG === false) ? 0 : 1; // 부재/미치환 → 기본 활성(fail-open)
+        } catch (e) {
+            return 1;
+        }
     }
 });

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFirstInteractiveLogTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFirstInteractiveLogTests.cs
@@ -1,0 +1,132 @@
+// -----------------------------------------------------------------------
+// AITFirstInteractiveLogTests.cs - first-interactive 계측 순수 로직 검증
+// Level 0: AssetDatabase 비의존 순수 헬퍼 함수 EditMode 테스트
+//   - EffectiveFirstInteractiveLog: null/tri-state 해석 (fail-open 포함)
+//   - ShouldEmitFirstInteractive: alreadySent, 프록시 씬 접두, null/빈 씬명, Ordinal 대소문자
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using UnityEngine;
+using AppsInToss;
+using AppsInToss.Editor;
+using AppsInToss.Editor.Package;
+
+[TestFixture]
+public class AITFirstInteractiveLogTests
+{
+    private AITEditorScriptObject _config;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (_config != null)
+        {
+            Object.DestroyImmediate(_config);
+            _config = null;
+        }
+    }
+
+    // =====================================================
+    // 1) EffectiveFirstInteractiveLog — null → true (fail-open)
+    // =====================================================
+
+    [Test]
+    public void EffectiveFirstInteractiveLog_NullConfig_ReturnsTrue_FailOpen()
+    {
+        // 계측기는 픽셀 불변이므로 설정 로드 실패 시에도 계측을 침묵시키면 안 됨
+        Assert.IsTrue(WebGLBuildCopier.EffectiveFirstInteractiveLog(null),
+            "null config 시 fail-open이어야 합니다(계측 침묵 방지).");
+    }
+
+    // =====================================================
+    // 2) EffectiveFirstInteractiveLog — tri-state 해석
+    //    -1 기본값이 GetDefaultFirstInteractiveLog()와 일치하는지 대조
+    // =====================================================
+
+    [TestCase(-1, true, "-1(자동)은 GetDefaultFirstInteractiveLog()==true 와 일치해야 합니다.")]
+    [TestCase(0, false, "명시적 비활성(0)은 false 이어야 합니다.")]
+    [TestCase(1, true, "명시적 활성(1)은 true 이어야 합니다.")]
+    public void EffectiveFirstInteractiveLog_TriState_ReturnsExpected(int storedValue, bool expected, string reason)
+    {
+        _config.firstInteractiveLog = storedValue;
+        Assert.AreEqual(expected, WebGLBuildCopier.EffectiveFirstInteractiveLog(_config), reason);
+    }
+
+    // =====================================================
+    // 3) ShouldEmitFirstInteractive — alreadySent=true 는 항상 false
+    // =====================================================
+
+    [Test]
+    public void ShouldEmitFirstInteractive_AlreadySent_ReturnsFalse()
+    {
+        Assert.IsFalse(AITPerformanceLogger.ShouldEmitFirstInteractive("Title", alreadySent: true),
+            "alreadySent=true 이면 씬명 무관하게 false 이어야 합니다.");
+    }
+
+    // =====================================================
+    // 4) ShouldEmitFirstInteractive — 정상 씬명 + alreadySent=false → true
+    // =====================================================
+
+    [Test]
+    public void ShouldEmitFirstInteractive_NormalScene_NotSent_ReturnsTrue()
+    {
+        Assert.IsTrue(AITPerformanceLogger.ShouldEmitFirstInteractive("Title", alreadySent: false),
+            "일반 씬명 + alreadySent=false 이면 true 이어야 합니다.");
+    }
+
+    // =====================================================
+    // 5) ShouldEmitFirstInteractive — "AITProxyBoot" 접두 씬 → false
+    //    (SDK 주입 프록시 부팅 씬은 원래 첫 씬이 아님)
+    // =====================================================
+
+    [Test]
+    public void ShouldEmitFirstInteractive_ProxyBootExact_ReturnsFalse()
+    {
+        Assert.IsFalse(AITPerformanceLogger.ShouldEmitFirstInteractive("AITProxyBoot", alreadySent: false),
+            "'AITProxyBoot' 씬은 false 이어야 합니다.");
+    }
+
+    [Test]
+    public void ShouldEmitFirstInteractive_ProxyBootPrefixScene_ReturnsFalse()
+    {
+        Assert.IsFalse(AITPerformanceLogger.ShouldEmitFirstInteractive("AITProxyBootScene01", alreadySent: false),
+            "'AITProxyBoot'로 시작하는 씬은 접두 일치로 false 이어야 합니다.");
+    }
+
+    // =====================================================
+    // 6) ShouldEmitFirstInteractive — null/빈 씬명 → true
+    //    (이름 없는 씬도 최초 실 씬으로 취급; StartsWith NRE 방어)
+    // =====================================================
+
+    [Test]
+    public void ShouldEmitFirstInteractive_NullSceneName_ReturnsTrue()
+    {
+        Assert.IsTrue(AITPerformanceLogger.ShouldEmitFirstInteractive(null, alreadySent: false),
+            "null 씬명은 true 이어야 합니다(StartsWith NRE 방어).");
+    }
+
+    [Test]
+    public void ShouldEmitFirstInteractive_EmptySceneName_ReturnsTrue()
+    {
+        Assert.IsTrue(AITPerformanceLogger.ShouldEmitFirstInteractive("", alreadySent: false),
+            "빈 씬명은 true 이어야 합니다.");
+    }
+
+    // =====================================================
+    // 7) ShouldEmitFirstInteractive — Ordinal 대소문자: 소문자 'aitproxyboot' → true
+    //    (StringComparison.Ordinal이므로 소문자 접두는 프록시 씬으로 취급하지 않음)
+    // =====================================================
+
+    [Test]
+    public void ShouldEmitFirstInteractive_LowercaseProxyBoot_ReturnsTrueOrdinalOnly()
+    {
+        Assert.IsTrue(AITPerformanceLogger.ShouldEmitFirstInteractive("aitproxyboot", alreadySent: false),
+            "소문자 'aitproxyboot'는 Ordinal 비교이므로 true 이어야 합니다(대소문자 구분).");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFirstInteractiveLogTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITFirstInteractiveLogTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52419f5ad9a7417188c7b514b442ce5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/WebGLTemplates/AITTemplate/index.html
+++ b/WebGLTemplates/AITTemplate/index.html
@@ -503,6 +503,11 @@
         // devicePixelRatio 설정: -1 = auto, 1/2/3 = 고정값
         var aitDevicePixelRatioSetting = %AIT_DEVICE_PIXEL_RATIO%;
 
+        // first-interactive 계측 활성 여부.
+        // 빌드 시 %AIT_FIRST_INTERACTIVE_LOG% 플레이스홀더가 "true"/"false"로 치환됨.
+        // 미치환 리터럴('%AIT_FIRST_INTERACTIVE_LOG%')은 "false"와 다르므로 true로 평가 — fail-open.
+        window.__AIT_FIRST_INTERACTIVE_LOG = '%AIT_FIRST_INTERACTIVE_LOG%' !== 'false';
+
         // 기기 성능에 따른 최적 devicePixelRatio 계산
         function getOptimalDevicePixelRatio() {
             var baseRatio = window.devicePixelRatio || 1;


### PR DESCRIPTION
## 개요

WebGL 빌드에 **first-interactive 계측 이벤트**(`unity_first_interactive`)를 추가합니다. first-paint(첫 페인트)만으로는 "화면은 빨리 떴지만 실제 플레이 가능 시점은 늦어지는" 류의 착시 회귀를 걸러낼 수 없어, 원래 첫 씬의 `sceneLoaded` 완료 시점을 함께 보는 **이중 메트릭**의 두 번째 축으로 추가합니다. 향후 로딩 체감 개선 레버를 검증할 때 상비 게이트로 사용합니다.

## 동작

- `AIT.PerformanceLogger`의 기존 `sceneLoaded` 훅에서, SDK 프록시 부트 씬(`AITProxyBoot*` prefix)이 아닌 최초 씬 로드 완료 시 `unity_first_interactive` 이벤트를 **세션당 1회** 발화
- 페이로드: `event_type`, `scene_name`, `scene_build_index`, `time_since_start_ms`
- 기존 호스트 debugLog 채널(`window.AppsInToss.debugLog`)을 재사용 — 픽셀 불변, 렌더링/로딩 경로에 영향 없음

## 설정 (tri-state, 기본 자동=활성)

- `AITEditorScriptObject.firstInteractiveLog`: `-1` 자동(기본) / `0` 비활성 / `1` 활성
- Configuration 윈도우 "계측 설정" 섹션에 Popup + 변경 표시 + 리셋 지원, 빌드 요약 로그에 "(자동)" 표기
- 빌드 시 템플릿 플레이스홀더 `%AIT_FIRST_INTERACTIVE_LOG%` → `window.__AIT_FIRST_INTERACTIVE_LOG` → jslib 게터로 런타임에 전달
- **fail-open**: 플레이스홀더 미치환·플래그 부재·예외 시 모두 활성으로 동작 (계측 침묵 방지 — AIT 파이프라인 밖 빌드도 기본 ON). 설정 로드 실패(null) 시에도 동일 — 픽셀 불변 계측이므로 콘텐츠 프로세서 계열의 null→비활성과 달리 의도적으로 fail-open

## 검증

- EditMode 테스트 11종 신규 (`AITFirstInteractiveLogTests`): tri-state 분기(-1/0/1/null) + 발화 조건 순수 로직(세션당 1회, 프록시 씬 prefix 제외, Ordinal 비교, null/empty 방어)
- 로컬 EditMode 전체 스위트 통과 (failed 0)

---

⚠️ 3.0 beta→stable 이후 머지 예정 — 머지 금지