### PR TITLE
수정: Windows Unity 빌드 step timeout 30→45분 상향

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1646,7 +1646,11 @@ jobs:
           AIT_IL2CPP_CONFIGURATION: ${{ inputs.fast-build && 'Debug' || '' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         with:
-          timeout_minutes: 30
+          # Windows 러너의 release 프로필(fast-build=false) 6000.x 빌드는 Brotli 압축
+          # 포함 ~28분(warm Library 캐시 실측, 2026-06 베타 릴리즈 run 27433833844)으로
+          # 30분 한도에 아슬아슬하고, cold 캐시에서는 timeout으로 실패가 재발한다 →
+          # 45분으로 상향 (job 한도 90분 내 여유 충분. macOS는 30분 내 안정 통과라 유지).
+          timeout_minutes: 45
           max_attempts: 3
           retry_wait_seconds: 0
           retry_on_exit_code: 42


### PR DESCRIPTION
## 배경

2026-06-12 베타 채널 re-release(run 27433833844) attempt 1에서 **Windows 6000.0/6000.2/6000.3 빌드 3개 leg가 동시에 step timeout(`Timeout of 1800000ms hit`)으로 실패**했습니다.

- 행이 아니라 느린 빌드: timeout 시점에 wasm Brotli 압축이 활발히 진행 중 (`[BUSY 358s] Brotli ...wasm.unityweb`)
- 원인 조합: #779의 `fast-build: false`(release 프로필 → Brotli 압축 + IL2CPP release 활성화) × Windows 러너 × 6000.x 대형 wasm
- attempt 2(rerun-failed-jobs, warm Library 캐시)는 통과했으나 **~28분 소요로 30분 한도에 잔여 2분**뿐 → cold 캐시에서 재발 확정적
- macOS leg는 동일 프로필로 30분 내 안정 통과 (러너 성능 차이)

## 변경

`unity-build.yml` Windows 빌드 step(`nick-invision/retry`)의 attempt당 `timeout_minutes`: **30 → 45**

- job 한도 90분 내 여유 충분 (retry는 라이선스 에러 exit 42에만 발동, timeout은 즉시 실패라 worst-case 45분)
- macOS step은 30분 유지 (상향 근거 없음)

## 검증

- `actionlint` 통과 (기존 shellcheck 노이즈 외 신규 지적 없음)
- `./run-local-tests.sh --validate` 통과 (3/3)
- 실측 근거: run 27433833844 attempt 1(실패)/attempt 2(28분 통과)

## 영향

- full strategy 베타 릴리즈(`fast-build: false` Windows 6000.x leg)의 cold 캐시 timeout 재발 차단
- E2E 등 fast-build 기본 경로는 빌드가 짧아 영향 없음 (한도만 완화)
