### PR TITLE
수정: 생성기 Partial<Record<K,V>> 반환 타입을 Dictionary로 매핑

### DIFF
--- a/sdk-runtime-generator~/src/parser/type-parser.ts
+++ b/sdk-runtime-generator~/src/parser/type-parser.ts
@@ -138,6 +138,24 @@ export function parseType(typeNode: any): ParsedType {
     };
   }
 
+  // Partial<T> / Readonly<T> 유틸리티 타입: C# 매핑 관점에서는 내부 타입 T와 동일
+  // (Partial은 키를 optional로 만들 뿐이고 Readonly는 수정 가능 여부만 다름 — 타입 구조는 그대로).
+  // 예: Partial<Record<ConsentedUserDataKey, string>> -> Record<...> -> Dictionary<...>
+  // 주의: nullable unwrap(위) 등 텍스트 기반 재귀에서 오는 pseudo-node는 ts-morph 메서드가
+  // 없으므로, alias 타입 인자를 못 얻으면 텍스트 슬라이스로 내부 타입을 추출해 재귀 파싱한다.
+  const utilityWrapperMatch = typeText.match(/^(Partial|Readonly)<(.+)>$/s);
+  if (utilityWrapperMatch) {
+    const aliasArgs = typeNode.getAliasTypeArguments?.();
+    const innerNode = aliasArgs && aliasArgs.length === 1
+      ? aliasArgs[0]
+      : { getText: () => utilityWrapperMatch[2] };
+    const parsed = parseType(innerNode);
+    return {
+      ...parsed,
+      raw: typeText,
+    };
+  }
+
   // Record 타입 (Record<K, V> -> Dictionary<K, V>)
   if (typeText.startsWith('Record<')) {
     const typeArgs = typeNode.getTypeArguments?.();
@@ -150,7 +168,22 @@ export function parseType(typeNode: any): ParsedType {
         raw: typeText,
       };
     }
-    // Fallback: 기본 Dictionary<string, object>
+    // Fallback 1: 텍스트에서 K, V 추출 (pseudo-node 재귀 경로 — getTypeArguments 없음)
+    // import("...").TypeName 형식은 TypeName만 남긴다 (프로퍼티 레벨 Record 처리와 동일한 패턴).
+    const recordMatch = typeText.match(/^Record<([^,]+),\s*(.+)>$/s);
+    if (recordMatch) {
+      const stripImport = (s: string) => s.replace(/import\((?:"[^"]*"|'[^']*')\)\./g, '').trim();
+      const keyText = stripImport(recordMatch[1]);
+      const valueText = stripImport(recordMatch[2]);
+      return {
+        name: 'Record',
+        kind: 'record',
+        keyType: { name: keyText, kind: 'primitive', raw: recordMatch[1].trim() },
+        valueType: { name: valueText, kind: 'primitive', raw: recordMatch[2].trim() },
+        raw: typeText,
+      };
+    }
+    // Fallback 2: 기본 Dictionary<string, object>
     return {
       name: 'Record',
       kind: 'record',

--- a/sdk-runtime-generator~/src/validators/types.ts
+++ b/sdk-runtime-generator~/src/validators/types.ts
@@ -404,6 +404,13 @@ function mapToCSharpTypeCore(type: ParsedType): string {
       return 'Dictionary<string, object>';
 
     case 'unknown':
+      // 제네릭 텍스트(Record<K, V>, Partial<Record<...>> 등)가 unknown으로 떨어진 경우,
+      // 아래 split/strip은 "ConsentedUserDataKeystring" 같은 깨진 식별자를 만들므로
+      // (CS0246 — 존재하지 않는 타입) 안전한 Dictionary 매핑으로 우회한다.
+      // 정상 경로는 parser가 kind:'record'로 분류하는 것이고, 이 분기는 방어선이다.
+      if (type.name && type.name.includes('Record<')) {
+        return 'Dictionary<string, object>';
+      }
       // unknown 타입이지만 name에 import 경로가 있으면 타입 이름 추출
       // 예: import("...").GameCenterGameProfileResponse -> GameCenterGameProfileResponse
       if (type.name && type.name.includes('.')) {

--- a/sdk-runtime-generator~/tests/unit/record-mapping.test.ts
+++ b/sdk-runtime-generator~/tests/unit/record-mapping.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect } from 'vitest';
+import { Project } from 'ts-morph';
+import { parseType } from '../../src/parser/type-parser.js';
+import { mapToCSharpType } from '../../src/validators/types.js';
+import { determineCallbackType } from '../../src/generators/csharp/api-data-preparer.js';
+
+function makeProject(): Project {
+  return new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: {
+      strictNullChecks: true,
+      moduleResolution: 99, // NodeNext
+    },
+  });
+}
+
+function getFunctionType(source: string, funcName: string) {
+  const project = makeProject();
+  const sf = project.createSourceFile('/test.d.ts', source);
+  const fn = sf.getFunctionOrThrow(funcName);
+  return { project, sf, fn };
+}
+
+describe('Record / Partial<Record> 반환 타입 매핑 (web-framework 2.7.0 getConsentedUserData 회귀)', () => {
+  // 회귀: web-framework 2.7.0의 getConsentedUserData가 반환하는
+  // Promise<Partial<Record<ConsentedUserDataKey, string>> | undefined> 가
+  // "ConsentedUserDataKeystring" 같은 깨진 식별자(CS0246)로 매핑되던 버그
+  const GCUD_SOURCE = `
+export type ConsentedUserDataKey = "USER_NAME" | "USER_GENDER" | "USER_NATIONALITY" | "USER_BIRTHDAY" | "USER_PHONE" | "USER_ADDRESS" | "USER_EMAIL" | "USER_CONSUMPTION_HISTORY";
+export interface GetConsentedUserDataOptions {
+  consentedUserDataKey: string;
+  shouldRequestAgreementWhenUserDeclined?: boolean;
+}
+export declare function getConsentedUserData(options: GetConsentedUserDataOptions): Promise<Partial<Record<ConsentedUserDataKey, string>> | undefined>;
+`;
+
+  test('Partial<Record<K, string>> | undefined 반환은 record로 파싱되고 Dictionary로 매핑', () => {
+    const { fn } = getFunctionType(GCUD_SOURCE, 'getConsentedUserData');
+    const parsed = parseType(fn.getReturnType());
+
+    expect(parsed.kind).toBe('promise');
+    expect(parsed.promiseType?.kind).toBe('record');
+    expect(parsed.promiseType?.isNullable).toBe(true);
+
+    const csharpType = mapToCSharpType(parsed.promiseType!);
+    expect(csharpType).toBe('Dictionary<ConsentedUserDataKey, string>');
+  });
+
+  test('깨진 식별자(ConsentedUserDataKeystring)가 다시는 생성되지 않음', () => {
+    const { fn } = getFunctionType(GCUD_SOURCE, 'getConsentedUserData');
+    const parsed = parseType(fn.getReturnType());
+    const csharpType = mapToCSharpType(parsed.promiseType!);
+
+    // 제네릭 구분자가 strip된 흔적이 없어야 함
+    expect(csharpType).not.toContain('Keystring');
+    expect(csharpType).not.toBe('ConsentedUserDataKeystring');
+  });
+
+  test('determineCallbackType도 Dictionary 타입을 그대로 사용', () => {
+    const { fn } = getFunctionType(GCUD_SOURCE, 'getConsentedUserData');
+    const returnType = parseType(fn.getReturnType());
+    const api = {
+      name: 'getConsentedUserData',
+      pascalName: 'GetConsentedUserData',
+      returnType,
+      parameters: [],
+    } as any;
+
+    expect(determineCallbackType(api)).toBe('Dictionary<ConsentedUserDataKey, string>');
+  });
+
+  test('bare Record<string, number> 반환은 Dictionary<string, double>로 매핑', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(): Promise<Record<string, number>>;`,
+      'foo',
+    );
+    const parsed = parseType(fn.getReturnType());
+    expect(parsed.promiseType?.kind).toBe('record');
+    expect(mapToCSharpType(parsed.promiseType!)).toBe('Dictionary<string, double>');
+  });
+
+  test('Record<string, string> | undefined 는 nullable record로 파싱 (참조 타입이라 ? 미부착)', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(): Promise<Record<string, string> | undefined>;`,
+      'foo',
+    );
+    const parsed = parseType(fn.getReturnType());
+    expect(parsed.promiseType?.kind).toBe('record');
+    expect(parsed.promiseType?.isNullable).toBe(true);
+    expect(mapToCSharpType(parsed.promiseType!)).toBe('Dictionary<string, string>');
+  });
+
+  test('Readonly<Record<string, string>> 도 내부 Record로 unwrap', () => {
+    const { fn } = getFunctionType(
+      `export declare function foo(): Promise<Readonly<Record<string, string>>>;`,
+      'foo',
+    );
+    const parsed = parseType(fn.getReturnType());
+    expect(parsed.promiseType?.kind).toBe('record');
+    expect(mapToCSharpType(parsed.promiseType!)).toBe('Dictionary<string, string>');
+  });
+
+  test('Partial<인터페이스> 는 mangle 없이 안전한 C# 타입으로 매핑', () => {
+    const { fn } = getFunctionType(
+      `export interface UserInfo { name: string; age?: number; }
+export declare function foo(): Promise<Partial<UserInfo> | undefined>;`,
+      'foo',
+    );
+    const parsed = parseType(fn.getReturnType());
+    // nullable 텍스트 unwrap 경로(pseudo-node)에서는 명명 타입 해석이 불가하므로
+    // 내부 타입 텍스트(import("...").UserInfo)까지만 unwrap된다. 핵심 회귀 조건:
+    // 1) 'Partial<...>' 텍스트가 그대로 남아 mangle('PartialUserInfo' 등)되지 않을 것
+    // 2) 최종 C# 매핑이 유효한 식별자일 것 (unknown 경로가 import 경로를 정리)
+    expect(parsed.promiseType?.name).not.toContain('Partial');
+    const csharpType = mapToCSharpType(parsed.promiseType!);
+    expect(csharpType).not.toContain('Partial');
+    expect(/^[A-Za-z_][A-Za-z0-9_]*$/.test(csharpType)).toBe(true);
+  });
+
+  test('방어선: unknown kind에 Record< 텍스트가 남아 있으면 Dictionary<string, object>로 우회', () => {
+    const broken = {
+      name: 'Partial<Record<import("/x").ConsentedUserDataKey, string>>',
+      kind: 'unknown' as const,
+      raw: 'Partial<Record<import("/x").ConsentedUserDataKey, string>> | undefined',
+    };
+    expect(mapToCSharpType(broken)).toBe('Dictionary<string, object>');
+  });
+});


### PR DESCRIPTION
## 배경

#784 (SDK 업데이트: v2.7.0)의 E2E가 전 레그 컴파일 에러로 실패:

```
AIT.Other.cs(76,39): error CS0246: The type or namespace name 'ConsentedUserDataKeystring' could not be found
```

web-framework 2.7.0의 신규 API `getConsentedUserData` 반환 타입이
`Promise<Partial<Record<ConsentedUserDataKey, string>> | undefined>` 인데,
생성기가 이를 깨진 식별자 `ConsentedUserDataKeystring`으로 매핑했습니다.

## 원인

1. `type-parser.ts`의 nullable 텍스트 unwrap(`T | undefined`)이 ts-morph 메서드가 없는 pseudo-node로 재귀
2. `Partial<Record<...>>`는 `Record<` 프리픽스 매치에 걸리지 않아 `kind: 'unknown'` 폴백으로 추락
3. unknown 경로의 `split('.').pop()` + 특수문자 strip이 제네릭 구분자를 뭉개며 `ConsentedUserDataKey, string>>` → `ConsentedUserDataKeystring` 생성

## 수정

- **type-parser.ts**: `Partial<T>` / `Readonly<T>` 유틸리티 타입 unwrap 추가 (C# 매핑 관점에서 내부 타입과 동일). pseudo-node 경로용 `Record<K, V>` 텍스트 파싱 폴백 추가 → `kind: 'record'`로 정상 분류되어 `Dictionary<ConsentedUserDataKey, string>` 매핑
- **validators/types.ts**: 방어선 — unknown 폴백에 `Record<` 텍스트가 남아 있으면 `Dictionary<string, object>`로 우회 (깨진 식별자 생성 차단)
- **tests/unit/record-mapping.test.ts**: 회귀 테스트 8건 (2.7.0 `getConsentedUserData` 실제 시그니처, bare Record, nullable Record, Readonly unwrap, Partial<인터페이스>, 방어선)

## 검증

- 유닛 스위트 484/484 통과
- `./run-local-tests.sh --validate` 통과
- 재현 스크립트로 수정 전(`ConsentedUserDataKeystring`) → 수정 후(`Dictionary<ConsentedUserDataKey, string>`) 확인
- Dictionary callbackType 하류 경로 검증 완료: csharp-core.hbs switch/Deserialize, `using System.Collections.Generic`, Newtonsoft enum 키 파싱 (enum 멤버명 = wire 값)

머지 후 sdk-update-rebase.yml이 #784를 재생성 리베이스하여 E2E가 재실행됩니다.