### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — android-keystore-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -290,6 +290,12 @@ namespace AppsInToss.Editor.ErrorTracker
             //     "[pnpm] 비동기 명령 실패 (Exit Code: -1): pnpm exec granite build" (SDK-VG/VD/VB)
             "[pnpm] 명령 실패 (Exit Code:",
             "[pnpm] 비동기 명령 실패",
+
+            // Unity Android 빌드 시스템(sdktools.jar)의 키스토어 설정 오류 — 사용자 프로젝트의
+            // 키스토어 경로·비밀번호 설정 문제이며 AIT SDK 식별자 없음. SDK로 분기/조치 불가.
+            // 예: "UnityError: Unable to list keys in the keystore. Please make sure the location and password of the keystore is correct."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-118.
+            "Unable to list keys in the keystore",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2277,6 +2277,35 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region Android 키스토어 설정 오류 (APPS-IN-TOSS-UNITY-SDK-118)
+
+    [Test]
+    public void AndroidKeystoreUnableToListKeys_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-118 — Unity Android 빌드 시스템(sdktools.jar)이
+        // 키스토어 경로·비밀번호 설정 오류 시 직접 출력하는 진단. 사용자 프로젝트 설정 문제이며 AIT SDK 식별자 없음.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Unable to list keys in the keystore. Please make sure the location and password of the keystore is correct."));
+    }
+
+    [Test]
+    public void AndroidKeystoreUnableToListKeys_PlainMessage_ReturnsTrue()
+    {
+        // Unity가 로그 핸들러를 통해 전달하는 변형 — "UnityError:" prefix 없이 핵심 문구만 도달하는 경우도 동일하게 드롭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Unable to list keys in the keystore. Please make sure the location and password of the keystore is correct."));
+    }
+
+    [Test]
+    public void AndroidKeystoreUnableToListKeys_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Unable to list keys in the keystore. Please make sure the location and password of the keystore is correct."));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-118

## 묶음 항목

| source | id | title |
|--------|----|-------|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-118 | "UnityError: Unable to list keys in the keystore. Please make sure the location and password of the keystore is correct." |

## 추출 패턴

- `"Unable to list keys in the keystore"` → `NonSdkMessagePatterns` 추가

## 추가 위치

`Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열 말미

## 근거

Unity Android 빌드 시스템(sdktools.jar)이 키스토어 경로·비밀번호 설정이 잘못된 경우 직접 출력하는 진단 메시지. AIT SDK 식별자를 포함하지 않으며 사용자 프로젝트의 키스토어 설정 문제이므로 SDK로 분기/조치 불가.

## --validate 결과

- E2E Test Files Validation: ✓
- Playwright Config Validation: ✓
- SDK Generator Unit Tests: ✗ (pnpm lockfile 포맷 이슈 — origin/main에서도 동일하게 실패하는 pre-existing 문제, 이번 변경과 무관)

## 검토 사항

사람 머지 검토 필요 (squash merge)