### PR TITLE
수정: 생성기 타입 검증 게이트의 Record key/value 명명 타입 처리

### DIFF
--- a/sdk-runtime-generator~/src/parser/type-parser.ts
+++ b/sdk-runtime-generator~/src/parser/type-parser.ts
@@ -4,6 +4,39 @@ import { DOM_TYPES } from './constants.js';
 import { cleanTypeName } from './utils.js';
 
 /**
+ * Record<K, V>의 K/V를 텍스트에서 분류할 때 원시 타입으로 인정하는 이름 집합.
+ * (validators/types.ts의 SUPPORTED_PRIMITIVES와 정렬)
+ */
+const RECORD_PRIMITIVE_NAMES = new Set([
+  'string', 'number', 'boolean', 'void', 'any', 'unknown', 'object', 'null', 'undefined', 'never', 'symbol',
+]);
+
+/**
+ * 텍스트 기반 Record 파싱(실제 ts-morph 노드가 없는 pseudo-node 경로 및 프로퍼티 레벨)에서
+ * Record<K, V>의 K 또는 V 텍스트를 ParsedType으로 분류한다.
+ *
+ * 텍스트 경로는 타입을 재해석할 수 없으므로, key/value를 무조건 kind:'primitive'로 두면
+ * 명명 타입(enum/union-alias)이 "지원되지 않는 타입"으로 검증 실패하거나
+ * Dictionary<..., Primitive> 같은 존재하지 않는 C# 식별자(CS0246)를 만든다. 이를 방지:
+ *  - 원시 타입 이름 → primitive (TYPE_MAPPING으로 매핑, 검증 통과)
+ *  - KEY의 명명 타입 → object kind로 이름 보존
+ *    (Record 키는 enum(문자열 리터럴 union)으로 생성되므로 이름이 유효; object kind는
+ *     프로퍼티가 없으면 isTypeSupported 통과 + mapToCSharpType가 이름을 그대로 보존)
+ *  - VALUE의 명명/복합 타입 → C#에서 항상 안전한 object로 collapse
+ *    (예: Primitive = string|number|...|symbol union-alias → Dictionary<string, object>)
+ */
+function classifyRecordArg(rawText: string, role: 'key' | 'value'): ParsedType {
+  const name = rawText.replace(/import\((?:"[^"]*"|'[^']*')\)\./g, '').trim();
+  if (RECORD_PRIMITIVE_NAMES.has(name)) {
+    return { name, kind: 'primitive', raw: rawText.trim() };
+  }
+  if (role === 'key' && /^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    return { name, kind: 'object', raw: rawText.trim() };
+  }
+  return { name: 'object', kind: 'primitive', raw: rawText.trim() };
+}
+
+/**
  * 타입 파싱 (ts-morph Type 객체 사용)
  */
 export function parseType(typeNode: any): ParsedType {
@@ -20,7 +53,7 @@ export function parseType(typeNode: any): ParsedType {
   }
 
   // Primitive 타입 (string literal도 포함)
-  if (['string', 'number', 'boolean', 'void', 'any', 'unknown', 'undefined', 'null', 'never'].includes(typeText)) {
+  if (['string', 'number', 'boolean', 'void', 'any', 'unknown', 'undefined', 'null', 'never', 'symbol'].includes(typeText)) {
     return {
       name: typeText,
       kind: 'primitive',
@@ -169,17 +202,14 @@ export function parseType(typeNode: any): ParsedType {
       };
     }
     // Fallback 1: 텍스트에서 K, V 추출 (pseudo-node 재귀 경로 — getTypeArguments 없음)
-    // import("...").TypeName 형식은 TypeName만 남긴다 (프로퍼티 레벨 Record 처리와 동일한 패턴).
+    // 명명 키(enum)는 이름 보존, 명명/복합 값은 object로 collapse (classifyRecordArg 참조).
     const recordMatch = typeText.match(/^Record<([^,]+),\s*(.+)>$/s);
     if (recordMatch) {
-      const stripImport = (s: string) => s.replace(/import\((?:"[^"]*"|'[^']*')\)\./g, '').trim();
-      const keyText = stripImport(recordMatch[1]);
-      const valueText = stripImport(recordMatch[2]);
       return {
         name: 'Record',
         kind: 'record',
-        keyType: { name: keyText, kind: 'primitive', raw: recordMatch[1].trim() },
-        valueType: { name: valueText, kind: 'primitive', raw: recordMatch[2].trim() },
+        keyType: classifyRecordArg(recordMatch[1], 'key'),
+        valueType: classifyRecordArg(recordMatch[2], 'value'),
         raw: typeText,
       };
     }
@@ -615,13 +645,11 @@ export function parseTypeMembers(members: any[]): any[] {
           // Record<K, V> 타입
           const recordMatch = propTypeText.match(/^Record<([^,]+),\s*([^>]+)>/);
           if (recordMatch) {
-            const keyTypeText = recordMatch[1].trim();
-            const valueTypeText = recordMatch[2].trim();
             parsedType = {
               name: 'Record',
               kind: 'record',
-              keyType: { name: keyTypeText, kind: 'primitive', raw: keyTypeText },
-              valueType: { name: valueTypeText, kind: 'primitive', raw: valueTypeText },
+              keyType: classifyRecordArg(recordMatch[1], 'key'),
+              valueType: classifyRecordArg(recordMatch[2], 'value'),
               raw: propTypeText,
             };
           } else {

--- a/sdk-runtime-generator~/src/validators/types.ts
+++ b/sdk-runtime-generator~/src/validators/types.ts
@@ -4,7 +4,7 @@ import picocolors from 'picocolors';
 /**
  * 지원되는 타입 목록
  */
-const SUPPORTED_PRIMITIVES = new Set(['string', 'number', 'boolean', 'void', 'any', 'unknown', 'object', 'null', 'undefined', 'never']);
+const SUPPORTED_PRIMITIVES = new Set(['string', 'number', 'boolean', 'void', 'any', 'unknown', 'object', 'null', 'undefined', 'never', 'symbol']);
 
 /**
  * C# 타입 매핑 테이블
@@ -17,6 +17,7 @@ export const TYPE_MAPPING: Record<string, string> = {
   void: 'void',
   any: 'void', // any는 void로 처리 (Promise<any> → Task)
   unknown: 'object',
+  symbol: 'object', // C#에 대응 타입 없음 — object로 매핑 (예: Record<string, Primitive> 값)
 
   // Unity types
   Date: 'DateTime',

--- a/sdk-runtime-generator~/tests/unit/record-mapping.test.ts
+++ b/sdk-runtime-generator~/tests/unit/record-mapping.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import { Project } from 'ts-morph';
 import { parseType } from '../../src/parser/type-parser.js';
-import { mapToCSharpType } from '../../src/validators/types.js';
+import { mapToCSharpType, validateTypeMapping, isTypeSupported } from '../../src/validators/types.js';
 import { determineCallbackType } from '../../src/generators/csharp/api-data-preparer.js';
 
 function makeProject(): Project {
@@ -19,6 +19,18 @@ function getFunctionType(source: string, funcName: string) {
   const sf = project.createSourceFile('/test.d.ts', source);
   const fn = sf.getFunctionOrThrow(funcName);
   return { project, sf, fn };
+}
+
+// 생성기가 API를 검증하는 것과 동일하게 파라미터/반환 타입을 파싱한 ParsedAPI를 만든다.
+// (pnpm generate의 validateAllTypes 게이트를 그대로 재현 — 이 게이트가 실제로 실패했었다)
+function buildApi(source: string, funcName: string): any {
+  const { fn } = getFunctionType(source, funcName);
+  return {
+    name: funcName,
+    pascalName: funcName.charAt(0).toUpperCase() + funcName.slice(1),
+    parameters: fn.getParameters().map(p => ({ name: p.getName(), type: parseType(p.getType()) })),
+    returnType: parseType(fn.getReturnType()),
+  };
 }
 
 describe('Record / Partial<Record> 반환 타입 매핑 (web-framework 2.7.0 getConsentedUserData 회귀)', () => {
@@ -44,6 +56,14 @@ export declare function getConsentedUserData(options: GetConsentedUserDataOption
 
     const csharpType = mapToCSharpType(parsed.promiseType!);
     expect(csharpType).toBe('Dictionary<ConsentedUserDataKey, string>');
+  });
+
+  test('getConsentedUserData가 타입 검증 게이트(validateAllTypes)를 통과', () => {
+    // 회귀의 핵심: 첫 수정은 mapToCSharpType만 고쳐 통과했지만 generate를 막은 건
+    // isTypeSupported 게이트였다 (record 키 ConsentedUserDataKey가 primitive로 분류되어 거부됨).
+    const api = buildApi(GCUD_SOURCE, 'getConsentedUserData');
+    expect(isTypeSupported(api.returnType)).toBe(true);
+    expect(validateTypeMapping(api)).toHaveLength(0);
   });
 
   test('깨진 식별자(ConsentedUserDataKeystring)가 다시는 생성되지 않음', () => {
@@ -124,5 +144,37 @@ export declare function foo(): Promise<Partial<UserInfo> | undefined>;`,
       raw: 'Partial<Record<import("/x").ConsentedUserDataKey, string>> | undefined',
     };
     expect(mapToCSharpType(broken)).toBe('Dictionary<string, object>');
+  });
+
+  // 회귀: web-framework 2.7.0의 eventLog 파라미터
+  // EventLogParams.params: Record<string, Primitive> (Primitive = ...|symbol union-alias)
+  const EVENTLOG_SOURCE = `
+export type Primitive = string | number | boolean | null | undefined | symbol;
+export interface EventLogParams {
+  log_name: string;
+  log_type: "debug" | "info" | "warn" | "error" | "event" | "screen" | "impression" | "click" | "popup";
+  params: Record<string, Primitive>;
+}
+export declare function eventLog(params: EventLogParams): Promise<void>;
+`;
+
+  test('eventLog(EventLogParams)가 타입 검증 게이트를 통과 (Record<string, Primitive> 포함)', () => {
+    const api = buildApi(EVENTLOG_SOURCE, 'eventLog');
+    expect(validateTypeMapping(api)).toHaveLength(0);
+  });
+
+  test('Record<string, Primitive>의 값(symbol 포함 union-alias)은 object로 collapse', () => {
+    const api = buildApi(EVENTLOG_SOURCE, 'eventLog');
+    const paramsProp = api.parameters[0].type.properties.find((p: any) => p.name === 'params');
+    expect(paramsProp.type.kind).toBe('record');
+    expect(isTypeSupported(paramsProp.type)).toBe(true);
+    // 깨진 식별자(Dictionary<string, Primitive>)가 아니라 안전한 object여야 함
+    expect(mapToCSharpType(paramsProp.type)).toBe('Dictionary<string, object>');
+  });
+
+  test('symbol은 지원 primitive로 인정되고 object로 매핑', () => {
+    const symType = { name: 'symbol', kind: 'primitive' as const, raw: 'symbol' };
+    expect(isTypeSupported(symType)).toBe(true);
+    expect(mapToCSharpType(symType)).toBe('object');
   });
 });


### PR DESCRIPTION
## 배경

#785(Partial<Record> 매핑 수정) 머지 후 `sdk-update-rebase.yml`이 #784(v2.7.0)를 재생성했으나 `pnpm generate`가 **여전히 실패**했습니다. 커밋 메시지에 "(타입 오류 포함)"이 붙고 `Runtime/SDK/`가 갱신되지 않았습니다.

원인: generate 직전의 **타입 검증 게이트(`validateAllTypes` / `isTypeSupported`)** 가 두 신규 2.7.0 API를 거부. #785는 `mapToCSharpType`만 고쳤고 이 게이트는 손대지 않았습니다 (테스트도 게이트를 검사하지 않아 통과해버린 회귀 갭).

```
❌ 지원되지 않는 타입: EventLogParams        (eventLog)
❌ 지원되지 않는 반환 타입: Promise<Partial<Record<...ConsentedUserDataKey, string>> | undefined>
```

## 원인

텍스트 기반 Record 파싱(pseudo-node fallback + 프로퍼티 레벨)이 `Record<K, V>`의 K/V를 **무조건 `kind:'primitive'`** 로 분류 → 명명 타입이 `SUPPORTED_PRIMITIVES`에 없어 `isTypeSupported`가 거부:

- **getConsentedUserData**: `Promise<Partial<Record<ConsentedUserDataKey, string>> | undefined>` — Record 키 `ConsentedUserDataKey`(string-literal enum)가 primitive로 분류되어 거부
- **eventLog**: `EventLogParams.params: Record<string, Primitive>` — 값 `Primitive`(= `string|number|boolean|null|undefined|symbol` union-alias)가 primitive로 분류되어 거부 (게다가 `Dictionary<string, Primitive>`로 CS0246 위험)

## 수정

- **type-parser.ts**: `classifyRecordArg` 헬퍼로 K/V 비대칭 분류
  - 원시 타입 → `primitive` (TYPE_MAPPING 매핑, 검증 통과)
  - **KEY** 명명 타입 → `object` kind로 이름 보존 (Record 키는 enum으로 생성되므로 유효; `isTypeSupported` 통과 + 매핑 시 이름 보존)
  - **VALUE** 명명/복합 타입 → C#에서 항상 안전한 `object`로 collapse
  - 메인 fallback + 프로퍼티 레벨 양쪽에 적용. `symbol`을 primitive로 인식
- **validators/types.ts**: `SUPPORTED_PRIMITIVES`/`TYPE_MAPPING`에 `symbol` 추가 (→ `object`)
- **tests**: `validateTypeMapping`/`isTypeSupported` 게이트 검사 추가 + eventLog/symbol 회귀 4건 (실제 2.7.0 타입 정의 사용)

## 검증

실제 web-bridge 2.7.0 타입 정의를 in-memory ts-morph로 재현하여 실제 파서+검증기로 확인:

| API | 검증 | C# 매핑 |
|-----|------|---------|
| `eventLog` | ✅ PASS | `params` → `Dictionary<string, object>` |
| `getConsentedUserData` | ✅ PASS | 반환 → `Dictionary<ConsentedUserDataKey, string>` |

- 유닛 스위트 488/488 통과
- `./run-local-tests.sh --validate` 통과

머지 후 sdk-update-rebase.yml이 #784를 다시 재생성하면 이번엔 generate가 성공해야 합니다.