### PR TITLE
수정: 생성기 콜백 디스패치 템플릿의 C# 타입명 HTML escape (Dictionary 반환 타입)

### DIFF
--- a/sdk-runtime-generator~/src/templates/csharp-core.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-core.hbs
@@ -418,9 +418,9 @@ namespace AppsInToss
                 switch (typeName)
                 {
 {{#each eventDataTypes}}
-                    case "{{this}}":
-                        var data_{{@index}} = JsonConvert.DeserializeObject<{{this}}>(apiResponse.data);
-                        (rawCallback as Action<{{this}}>)?.Invoke(data_{{@index}});
+                    case "{{{this}}}":
+                        var data_{{@index}} = JsonConvert.DeserializeObject<{{{this}}}>(apiResponse.data);
+                        (rawCallback as Action<{{{this}}}>)?.Invoke(data_{{@index}});
                         break;
 {{/each}}
                     case "void":
@@ -473,12 +473,12 @@ namespace AppsInToss
             switch (typeName)
             {
 {{#each callbackTypes}}
-                case "{{this}}":
+                case "{{{this}}}":
                     if (apiResponse.success)
                     {
-                        if (TryGetCallback<{{this}}>(callbackId, out var callback{{@index}}) && callback{{@index}} != null)
+                        if (TryGetCallback<{{{this}}}>(callbackId, out var callback{{@index}}) && callback{{@index}} != null)
                         {
-                            var data{{@index}} = JsonConvert.DeserializeObject<{{this}}>(apiResponse.data);
+                            var data{{@index}} = JsonConvert.DeserializeObject<{{{this}}}>(apiResponse.data);
                             callback{{@index}}(data{{@index}});
                         }
                     }
@@ -486,7 +486,7 @@ namespace AppsInToss
                     {
                         if (TryGetErrorCallback(callbackId, out var errorCallback{{@index}}) && errorCallback{{@index}} != null)
                         {
-                            errorCallback{{@index}}(new AITException("{{this}}", apiResponse.error));
+                            errorCallback{{@index}}(new AITException("{{{this}}}", apiResponse.error));
                         }
                     }
                     break;

--- a/sdk-runtime-generator~/tests/unit/callback-dispatch-escape.test.ts
+++ b/sdk-runtime-generator~/tests/unit/callback-dispatch-escape.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from 'vitest';
+import { loadAllTemplates } from '../../src/generators/csharp/templates.js';
+
+/**
+ * 회귀 방지: csharp-core.hbs의 콜백 디스패치 switch는 C# 타입명을
+ * triple-stache({{{this}}})로 렌더해야 한다.
+ *
+ * double-stache({{this}})를 쓰면 Handlebars가 기본 HTML escape를 적용해
+ * `Dictionary<K, V>` 같은 제네릭 타입의 '<'/'>'가 '&lt;'/'&gt;'로 깨진다.
+ *   - 제네릭 인자: `TryGetCallback<Dictionary&lt;...&gt;>` → C# 컴파일 에러(CS1026 등)
+ *   - case 라벨: call-site(csharp-api.hbs의 "{{{callbackType}}}", raw)와 불일치 → 런타임 디스패치 실패
+ *
+ * 실제 사례: web-bridge 2.7.0 `getConsentedUserData`가
+ * `Dictionary<ConsentedUserDataKey, string>`를 반환하면서 이 버그가 표면화됨.
+ */
+describe('콜백 디스패치 템플릿 HTML escape 회귀 (csharp-core.hbs)', () => {
+  const DICT = 'Dictionary<ConsentedUserDataKey, string>';
+
+  test('Dictionary<K,V> 콜백 타입이 case 라벨/제네릭/예외 메시지에 raw angle bracket으로 렌더된다', async () => {
+    const cache = await loadAllTemplates();
+    expect(cache.coreTemplate).toBeDefined();
+
+    const rendered = cache.coreTemplate!({
+      callbackTypes: [DICT],
+      eventDataTypes: [DICT],
+      enumCallbackTypes: [],
+    });
+
+    // 디스패치 "코드"에 escape가 일어나면 안 됨 (컴파일/매칭 둘 다 깨짐).
+    // `///` XML doc 주석에는 의도적으로 escape된 정적 텍스트(예: Func&lt;T, bool&gt;)가
+    // 들어있고 이는 컴파일과 무관하므로 검사에서 제외한다.
+    const codeLines = rendered
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('///'));
+    const escapedCode = codeLines.filter(
+      (l) => l.includes('&lt;') || l.includes('&gt;'),
+    );
+    expect(escapedCode).toEqual([]);
+
+    // case 라벨은 call-site 등록명(raw)과 글자 그대로 일치해야 디스패치됨
+    expect(rendered).toContain(`case "${DICT}":`);
+
+    // 제네릭 인자가 raw여야 C# 컴파일 가능
+    expect(rendered).toContain(`TryGetCallback<${DICT}>`);
+    expect(rendered).toContain(`JsonConvert.DeserializeObject<${DICT}>`);
+
+    // 에러 콜백 AITException 메시지의 타입명도 raw
+    expect(rendered).toContain(`new AITException("${DICT}", apiResponse.error)`);
+
+    // eventDataTypes(구독 이벤트) 경로도 동일하게 raw
+    expect(rendered).toContain(`(rawCallback as Action<${DICT}>)`);
+  });
+
+  test('단순 타입명(UserInfo)은 triple-stache 전환 후에도 동일하게 렌더된다 (회귀 없음)', async () => {
+    const cache = await loadAllTemplates();
+    const rendered = cache.coreTemplate!({
+      callbackTypes: ['UserInfo'],
+      eventDataTypes: [],
+      enumCallbackTypes: [],
+    });
+
+    expect(rendered).toContain('case "UserInfo":');
+    expect(rendered).toContain('TryGetCallback<UserInfo>');
+    expect(rendered).not.toContain('&lt;');
+  });
+});


### PR DESCRIPTION
## 문제

`@apps-in-toss/web-framework` 2.7.0 업데이트 PR(#784)의 E2E가 **전 빌드 레그에서 C# 컴파일 에러**로 실패했다.

```
Runtime/SDK/AITCore.cs(635,57): error CS1026: ) expected
...
case "Dictionary&lt;ConsentedUserDataKey, string&gt;":
if (TryGetCallback<Dictionary&lt;ConsentedUserDataKey, string&gt;>(...))
```

## 원인

`src/templates/csharp-core.hbs`의 `RouteCallback`/`RouteSubscriptionCallback` switch가 콜백 타입명을 **double-stache(`{{this}}`)** 로 렌더한다. 생성기는 `Handlebars.compile()`을 기본 옵션(`noEscape` 없음)으로 쓰므로 double-stache는 **HTML escape**를 적용한다.

- 단순 타입명(`string`, `UserInfo` 등)에는 escape 대상 문자가 없어 영향이 없었음 (잠복 버그)
- 2.7.0 `getConsentedUserData`가 `Dictionary<ConsentedUserDataKey, string>` 처럼 **제네릭 angle bracket**을 가진 타입을 반환하면서 표면화:
  - 제네릭 인자: `TryGetCallback<Dictionary&lt;...&gt;>` → 컴파일 에러
  - `case` 라벨: call-site(`csharp-api.hbs`의 `"{{{callbackType}}}"`, **raw 등록**)와 불일치 → 런타임 디스패치 실패

## 수정

`csharp-core.hbs`의 `eventDataTypes`/`callbackTypes` 루프에서 C# 타입명을 렌더하는 위치(case 라벨, 제네릭 인자, `AITException` 메시지)를 **triple-stache(`{{{this}}}`)** 로 전환해 raw 렌더. call-site와 동일한 표현으로 맞춰 컴파일·매칭 모두 정상화.

- `enumCallbackTypes`(단순 식별자)는 escape 영향이 없어 그대로 둠
- `ConsentedUserDataKey`는 `AIT.Types.cs`에 enum으로 정상 생성되므로 `Dictionary<ConsentedUserDataKey, string>`는 유효 (CS0246 아님)

## 검증

- 프로덕션과 동일한 `Handlebars.compile`(기본 옵션) 경로로 수정 전/후 대조: **수정 전 디스패치 코드 7줄 escape(버그 재현) → 수정 후 0줄**
- 회귀 방지 단위 테스트 추가(`tests/unit/callback-dispatch-escape.test.ts`) — CI의 SDK Generator Tests에서 실행
- 통합 검증: 머지 후 sdk-update-rebase가 2.7.0 타입으로 #784 재생성 → E2E 컴파일 게이트

## 관련
- #784 (SDK 업데이트: v2.7.0) 의 E2E 차단 해소
- 선행 수정: #785(mapToCSharpType), #788(타입 검증 게이트) — 이번 PR은 **템플릿 렌더 escape**라는 별개 경로