### PR TITLE
기능: 네이티브 프리페치 핸드오프 (nativeAssetSource 레버 + .ait prefetch 선언)

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -631,6 +631,189 @@ namespace AppsInToss.Editor
 
                 EditorGUI.indentLevel--;
             }
+
+            // warm manifest 산출 (tri-state) — pageCache 실효값이 OFF 이면 회색 비활성.
+            // if (pageCacheActive) 블록 바깥에 배치해 항상 렌더링(숨김 없음).
+            using (new EditorGUI.DisabledScope(!pageCacheActive))
+            {
+                DrawWarmManifestSetting();
+            }
+
+            // pageCache=OFF + warmManifest 실효값=ON 일 때 경고 HelpBox 표시.
+            if (!pageCacheActive)
+            {
+                bool warmManifestEffective = config.warmManifest < 0
+                    ? AITDefaultSettings.GetDefaultWarmManifest()
+                    : config.warmManifest == 1;
+
+                if (warmManifestEffective)
+                {
+                    EditorGUILayout.HelpBox(
+                        "페이지 캐시가 비활성이므로 Warm Manifest 도 산출되지 않습니다. " +
+                        "페이지 캐시를 활성화하거나 Warm Manifest 를 명시적으로 비활성화하세요.",
+                        MessageType.Warning
+                    );
+                }
+            }
+
+            // warm 페이지 산출 (tri-state) — pageCache·warmManifest 실효값이 모두 true 일 때만 편집 가능.
+            bool warmManifestEffectiveForPage = config.warmManifest < 0
+                ? AITDefaultSettings.GetDefaultWarmManifest()
+                : config.warmManifest == 1;
+            using (new EditorGUI.DisabledScope(!(pageCacheActive && warmManifestEffectiveForPage)))
+            {
+                DrawWarmPageSetting();
+            }
+
+            // pageCache 또는 warmManifest 실효값=OFF + warmPage 실효값=ON 일 때 경고 HelpBox 표시.
+            if (!(pageCacheActive && warmManifestEffectiveForPage))
+            {
+                bool warmPageEffective = config.warmPage < 0
+                    ? AITDefaultSettings.GetDefaultWarmPage()
+                    : config.warmPage == 1;
+
+                if (warmPageEffective)
+                {
+                    EditorGUILayout.HelpBox(
+                        "페이지 캐시 또는 Warm Manifest 가 비활성이므로 Warm 페이지도 산출되지 않습니다. " +
+                        "페이지 캐시와 Warm Manifest 를 활성화하거나 Warm 페이지를 명시적으로 비활성화하세요.",
+                        MessageType.Warning
+                    );
+                }
+            }
+
+            // 네이티브 에셋 소스 우선 (tri-state) — pageCache 실효값이 ON 일 때만 편집 가능(인터셉터 존재 전제).
+            // warmManifest/warmPage 와 독립: 인터셉터만 있으면 신호를 노출하므로 pageCache 에만 AND 게이팅.
+            using (new EditorGUI.DisabledScope(!pageCacheActive))
+            {
+                DrawNativeAssetSourceSetting();
+            }
+
+            // pageCache 실효값=OFF + nativeAssetSource 실효값=ON 일 때 경고 HelpBox 표시.
+            if (!pageCacheActive)
+            {
+                bool nativeSourceEffective = config.nativeAssetSource < 0
+                    ? AITDefaultSettings.GetDefaultNativeAssetSource()
+                    : config.nativeAssetSource == 1;
+
+                if (nativeSourceEffective)
+                {
+                    EditorGUILayout.HelpBox(
+                        "페이지 캐시가 비활성이므로 네이티브 에셋 소스도 동작하지 않습니다(인터셉터 없음). " +
+                        "페이지 캐시를 활성화하거나 네이티브 에셋 소스를 명시적으로 비활성화하세요.",
+                        MessageType.Warning
+                    );
+                }
+            }
+        }
+
+        private void DrawWarmManifestSetting()
+        {
+            bool defaultWarmManifest = AITDefaultSettings.GetDefaultWarmManifest();
+            bool isModified = config.warmManifest >= 0 && (config.warmManifest == 1) != defaultWarmManifest;
+
+            EditorGUI.indentLevel++;
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.warmManifest < 0
+                ? $"Warm Manifest 산출 (자동: {(defaultWarmManifest ? "활성화" : "비활성화")})"
+                : "Warm Manifest 산출";
+
+            string[] options = { $"자동 ({(defaultWarmManifest ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.warmManifest < 0 ? 0 : config.warmManifest + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "빌드 시 ait-warm-manifest.json 을 web 루트에 산출합니다. " +
+                    "호스트(슈퍼앱)가 선다운로드(warm) diff 기준으로 사용합니다. " +
+                    "페이지 캐시 실효값이 OFF 이면 회색 비활성화됩니다(AND 게이팅). " +
+                    "-1=자동(활성화), 0=비활성화, 1=활성화."),
+                currentIndex,
+                options
+            );
+            config.warmManifest = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.warmManifest = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUI.indentLevel--;
+        }
+
+        private void DrawWarmPageSetting()
+        {
+            bool defaultWarmPage = AITDefaultSettings.GetDefaultWarmPage();
+            bool isModified = config.warmPage >= 0 && (config.warmPage == 1) != defaultWarmPage;
+
+            EditorGUI.indentLevel++;
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.warmPage < 0
+                ? $"Warm 페이지 산출 (자동: {(defaultWarmPage ? "활성화" : "비활성화")})"
+                : "Warm 페이지 산출";
+
+            string[] options = { $"자동 ({(defaultWarmPage ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.warmPage < 0 ? 0 : config.warmPage + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다. " +
+                    "호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다. " +
+                    "페이지 캐시·Warm Manifest 실효값이 모두 OFF 이면 회색 비활성화됩니다(AND 게이팅). " +
+                    "-1=자동(활성화), 0=비활성화, 1=활성화."),
+                currentIndex,
+                options
+            );
+            config.warmPage = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.warmPage = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUI.indentLevel--;
+        }
+
+        private void DrawNativeAssetSourceSetting()
+        {
+            bool defaultNativeSource = AITDefaultSettings.GetDefaultNativeAssetSource();
+            bool isModified = config.nativeAssetSource >= 0 && (config.nativeAssetSource == 1) != defaultNativeSource;
+
+            EditorGUI.indentLevel++;
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.nativeAssetSource < 0
+                ? $"네이티브 에셋 소스 우선 (자동: {(defaultNativeSource ? "활성화" : "비활성화")})"
+                : "네이티브 에셋 소스 우선";
+
+            string[] options = { $"자동 ({(defaultNativeSource ? "활성화" : "비활성화")})", "비활성화", "활성화" };
+            int currentIndex = config.nativeAssetSource < 0 ? 0 : config.nativeAssetSource + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "페이지 캐시 인터셉터가 Build/* 요청에 대해 호스트 네이티브 프리페치 결과를 우선 사용합니다. " +
+                    "호스트가 window.__aitResolveAsset 리졸버를 주입하면 native→CacheStorage→network 순으로 해석합니다. " +
+                    "리졸버 미주입 시 신호만 노출되고 기존 캐시-퍼스트 동작으로 자동 폴백됩니다. " +
+                    "페이지 캐시 실효값이 OFF 이면 회색 비활성화됩니다(AND 게이팅). " +
+                    "-1=자동(활성화), 0=비활성화, 1=활성화."),
+                currentIndex,
+                options
+            );
+            config.nativeAssetSource = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.nativeAssetSource = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUI.indentLevel--;
         }
 
         private void DrawPermissionSettings()
@@ -1098,6 +1281,18 @@ namespace AppsInToss.Editor
             bool defaultPageCache = AITDefaultSettings.GetDefaultPageCache();
             if (config.pageCache >= 0 && (config.pageCache == 1) != defaultPageCache) count++;
 
+            // warm manifest: 기본 자동(true). 명시적으로 기본값과 다르게 설정된 경우만 변경으로 집계.
+            bool defaultWarmManifest = AITDefaultSettings.GetDefaultWarmManifest();
+            if (config.warmManifest >= 0 && (config.warmManifest == 1) != defaultWarmManifest) count++;
+
+            // warm 페이지: 기본 자동(true). 명시적으로 기본값과 다르게 설정된 경우만 변경으로 집계.
+            bool defaultWarmPage = AITDefaultSettings.GetDefaultWarmPage();
+            if (config.warmPage >= 0 && (config.warmPage == 1) != defaultWarmPage) count++;
+
+            // 네이티브 에셋 소스: 기본 자동(true). 명시적으로 기본값과 다르게 설정된 경우만 변경으로 집계.
+            bool defaultNativeSource = AITDefaultSettings.GetDefaultNativeAssetSource();
+            if (config.nativeAssetSource >= 0 && (config.nativeAssetSource == 1) != defaultNativeSource) count++;
+
             return count;
         }
 
@@ -1111,6 +1306,9 @@ namespace AppsInToss.Editor
             config.pageCacheName = "ait-page-cache";
             config.pageCache = -1;
             config.pageCacheName = "";
+            config.warmManifest = -1;
+            config.warmPage = -1;
+            config.nativeAssetSource = -1;
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -181,6 +181,43 @@ namespace AppsInToss
                  "비우면 appName(앱 식별자)에서 자동 파생합니다. 런타임 window.__AIT_CACHE_NAME 으로도 오버라이드 가능.")]
         public string pageCacheName = "";
 
+        /// <summary>
+        /// 빌드 시 ait-warm-manifest.json 산출 여부 (호스트 warm 연동용).
+        /// tri-state: -1=자동(true, 기본 ON), 0=비활성, 1=활성.
+        /// pageCache 실효값이 OFF 이면 warmManifest 도 no-op (AND 게이팅).
+        /// pageCache 실효값이 OFF 이면서 warmManifest 실효값이 ON 이면 경고 로그를 출력합니다.
+        /// </summary>
+        [Tooltip("빌드 시 ait-warm-manifest.json 을 산출합니다. 호스트(슈퍼앱)가 선다운로드(warm) diff 기준으로 사용합니다. " +
+                 "pageCache 실효값이 OFF 이면 회색 비활성 + no-op (AND 게이팅). -1=자동(true), 0=비활성, 1=활성.")]
+        public int warmManifest = -1;
+
+        /// <summary>
+        /// 빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다.
+        /// tri-state: -1=자동(true, 기본 ON), 0=비활성, 1=활성.
+        /// warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 동작합니다(AND 게이팅).
+        /// pageCache·warmManifest 실효값이 모두 ON 일 때만 실제 산출되는 AND 게이트이며,
+        /// 산출물은 정적 파일 1개 추가일 뿐 게임 런타임 동작에 영향이 없어 기본 ON.
+        /// </summary>
+        [Tooltip("-1 = 자동 (true), 0 = 비활성, 1 = 활성. " +
+                 "빌드 시 self-warming 페이지(ait-warm.html)를 함께 산출합니다. " +
+                 "호스트가 숨김 WebView 로 열면 매니페스트 변경분을 미리 캐시에 적재합니다. " +
+                 "warmManifest 실효값과 pageCache 실효값이 모두 ON 이어야 동작합니다.")]
+        public int warmPage = -1;
+
+        /// <summary>
+        /// 페이지 캐시 인터셉터가 호스트 네이티브 프리페치 결과를 우선 소스로 사용할지 여부.
+        /// tri-state: -1=자동(true, 기본 ON), 0=비활성, 1=활성.
+        /// 인터셉터가 존재해야(pageCache 실효값 ON) 동작하는 AND 게이트이며,
+        /// 호스트가 window.__aitResolveAsset(url) 리졸버를 주입하지 않으면 신호만 노출되고
+        /// 자동으로 CacheStorage→network 폴백으로 흡수되어 런타임 동작에 영향이 없어 기본 ON.
+        /// </summary>
+        [Tooltip("-1 = 자동 (true), 0 = 비활성, 1 = 활성. " +
+                 "페이지 캐시 인터셉터가 Build/* 요청에 대해 호스트 네이티브 프리페치 결과를 우선 사용합니다. " +
+                 "호스트가 window.__aitResolveAsset 리졸버를 주입하면 native→CacheStorage→network 순으로 해석합니다. " +
+                 "리졸버 미주입 시 신호만 노출되고 기존 캐시-퍼스트 동작으로 자동 폴백됩니다. " +
+                 "pageCache 실효값이 ON 이어야 동작합니다.")]
+        public int nativeAssetSource = -1;
+
         [Header("렌더링 품질 설정")]
         [Tooltip("devicePixelRatio 설정: -1 = auto (기기 성능에 따라 자동 결정), 1/2/3 = 고정값. 높을수록 고품질이지만 GPU 부하 증가")]
         public int devicePixelRatio = -1;
@@ -383,6 +420,36 @@ namespace AppsInToss
         /// 모든 Unity 버전에서 기본 활성화: 미지원 환경에서 무해 통과가 보장됨.
         /// </summary>
         public static bool GetDefaultPageCache()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// 기본 warm manifest 산출 여부.
+        /// pageCache 와 쌍으로 기본 ON: 호스트 warm 연동 zero-config 제공.
+        /// pageCache 실효값이 OFF 이면 게이팅으로 no-op 처리되므로 독립적으로 ON 해도 안전.
+        /// </summary>
+        public static bool GetDefaultWarmManifest()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// 기본 warm 페이지(ait-warm.html) 산출 여부.
+        /// pageCache·warmManifest 실효값이 모두 ON 일 때만 실제 산출되는 AND 게이트이며,
+        /// 산출물은 정적 파일 1개 추가일 뿐 게임 런타임 동작에 영향이 없어 기본 ON.
+        /// </summary>
+        public static bool GetDefaultWarmPage()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// 기본 네이티브 에셋 소스 우선 사용 여부.
+        /// pageCache 실효값이 ON 일 때만 인터셉터에 신호가 주입되는 AND 게이트이며,
+        /// 호스트가 리졸버를 주입하지 않으면 신호만 노출되고 캐시-퍼스트로 자동 폴백되어 기본 ON.
+        /// </summary>
+        public static bool GetDefaultNativeAssetSource()
         {
             return true;
         }

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -110,7 +110,7 @@ namespace AppsInToss.Editor
             CopyBuildConfigFromTemplate(buildProjectPath);
 
             Debug.Log("[AIT] Step 2/3: Unity WebGL 빌드 복사 중...");
-            var copyResult = Package.WebGLBuildCopier.CopyWebGLToPublic(webglPath, buildProjectPath, profile);
+            var copyResult = Package.WebGLBuildCopier.CopyWebGLToPublic(webglPath, buildProjectPath, out string inlinePrefetchJson, profile);
             if (copyResult != AITConvertCore.AITExportError.SUCCEED)
                 return (null, copyResult);
 
@@ -131,12 +131,20 @@ namespace AppsInToss.Editor
                 Package.NodeModulesValidator.CleanNodeModules(buildProjectPath);
             }
 
+            // 인라인 프리페치 카탈로그를 .ait 메타데이터에 패치(post-copy: 실제 Build/* 크기 필요).
+            var unityMetadataEnv = AITUnityMetadata.BuildEnvironmentVariables();
+            if (!string.IsNullOrEmpty(inlinePrefetchJson) &&
+                unityMetadataEnv.TryGetValue("UNITY_METADATA", out var metadataJson))
+            {
+                unityMetadataEnv["UNITY_METADATA"] = AITUnityMetadata.WithPrefetch(metadataJson, inlinePrefetchJson);
+            }
+
             return (new PackageContext
             {
                 BuildProjectPath = buildProjectPath,
                 PnpmPath = pnpmPath,
                 LocalCachePath = storePath,
-                UnityMetadataEnv = AITUnityMetadata.BuildEnvironmentVariables()
+                UnityMetadataEnv = unityMetadataEnv
             }, AITConvertCore.AITExportError.SUCCEED);
         }
 
@@ -226,7 +234,7 @@ namespace AppsInToss.Editor
             onProgress?.Invoke(AITConvertCore.BuildPhase.CopyingFiles, 0.15f, "WebGL 빌드 파일 복사 중...");
             Debug.Log("[AIT] [병렬] WebGL 빌드를 ait-build/public으로 복사 중...");
 
-            var copyResult = Package.WebGLBuildCopier.CopyWebGLToPublic(webglPath, earlyCtx.BuildProjectPath, profile);
+            var copyResult = Package.WebGLBuildCopier.CopyWebGLToPublic(webglPath, earlyCtx.BuildProjectPath, out string inlinePrefetchJson, profile);
             if (copyResult != AITConvertCore.AITExportError.SUCCEED)
             {
                 earlyCtx.CancelAndDisposePnpm();
@@ -234,6 +242,15 @@ namespace AppsInToss.Editor
                 finally { AITBuildSession.EndBuild(); }
                 onComplete?.Invoke(copyResult);
                 return;
+            }
+
+            // 인라인 프리페치 카탈로그를 .ait 메타데이터에 패치(post-copy: 실제 Build/* 크기 필요).
+            // 병렬 경로는 UnityMetadataEnv 를 빌드 전 미리 구성하므로 여기서 보정한다.
+            if (!string.IsNullOrEmpty(inlinePrefetchJson) &&
+                earlyCtx.UnityMetadataEnv != null &&
+                earlyCtx.UnityMetadataEnv.TryGetValue("UNITY_METADATA", out var metadataJson))
+            {
+                earlyCtx.UnityMetadataEnv["UNITY_METADATA"] = AITUnityMetadata.WithPrefetch(metadataJson, inlinePrefetchJson);
             }
 
             // Step 2: 백그라운드 pnpm install 완료 확인

--- a/Editor/AITUnityMetadata.cs
+++ b/Editor/AITUnityMetadata.cs
@@ -8,17 +8,22 @@ namespace AppsInToss.Editor
     /// <summary>
     /// Unity 빌드 메타데이터를 수집하여 UNITY_METADATA 환경변수용 JSON을 생성합니다.
     /// granite build가 이 환경변수를 읽어 .ait 파일의 protobuf 헤더에 포함시킵니다.
+    ///
+    /// prefetch 카탈로그(metadata.extra.unityMetaData.prefetch)는 여기서 만들지 않습니다.
+    /// 실제 Build/* 파일 크기·인코딩이 필요한 인라인 카탈로그는 WebGL 복사가 끝난 뒤
+    /// <see cref="Package.AITWarmManifestEmitter.WriteManifest"/> 가 산출한 compact JSON 을
+    /// <see cref="WithPrefetch"/> 로 메타데이터에 끼워 넣습니다(post-copy 패치).
     /// </summary>
     internal static class AITUnityMetadata
     {
         /// <summary>
-        /// Unity 빌드 메타데이터를 compact JSON 문자열로 반환합니다.
+        /// Unity 빌드 메타데이터를 compact JSON 문자열로 반환합니다(prefetch 선언 없음).
         /// 환경변수로 전달되므로 줄바꿈 없는 single-line JSON이어야 합니다.
         /// (MiniJson.Serialize는 pretty-print하여 PowerShell 이스케이프 문제 발생)
         /// </summary>
         internal static string BuildMetadataJson()
         {
-            var pairs = new string[]
+            var pairs = new List<string>
             {
                 $"\"unityVersion\":{JsonEscape(Application.unityVersion)}",
                 $"\"bundleVersion\":{JsonEscape(PlayerSettings.bundleVersion)}",
@@ -28,7 +33,37 @@ namespace AppsInToss.Editor
                 $"\"companyName\":{JsonEscape(PlayerSettings.companyName)}",
                 $"\"buildTimestamp\":{JsonEscape(DateTime.UtcNow.ToString("o"))}",
             };
+
             return "{" + string.Join(",", pairs) + "}";
+        }
+
+        /// <summary>
+        /// 기존 메타데이터 JSON 에 prefetch 인라인 카탈로그를 끼워 넣은 새 JSON 을 반환합니다.
+        ///
+        /// <paramref name="metadataJson"/> 는 <see cref="BuildMetadataJson"/> 가 만든
+        /// <c>{...}</c> 형태의 compact JSON 이어야 하며, 마지막 닫는 중괄호 직전에
+        /// <c>,"prefetch":&lt;catalog&gt;</c> 를 삽입합니다.
+        ///
+        /// <paramref name="compactCatalogJson"/> 가 비어 있거나 metadataJson 이 <c>}</c> 로
+        /// 끝나지 않으면 원본을 그대로 반환합니다(안전 폴백 — 기존 출력과 byte-identical).
+        /// </summary>
+        /// <param name="metadataJson">BuildMetadataJson 산출물(single-line JSON).</param>
+        /// <param name="compactCatalogJson">AITWarmManifestEmitter 가 반환한 compact v2 카탈로그. null/빈 문자열이면 무시.</param>
+        internal static string WithPrefetch(string metadataJson, string compactCatalogJson)
+        {
+            if (string.IsNullOrEmpty(metadataJson)) return metadataJson;
+            if (string.IsNullOrEmpty(compactCatalogJson)) return metadataJson;
+
+            string trimmed = metadataJson.TrimEnd();
+            if (!trimmed.EndsWith("}", StringComparison.Ordinal)) return metadataJson;
+
+            // 마지막 '}' 직전에 prefetch 키를 삽입.
+            int lastBrace = trimmed.LastIndexOf('}');
+            string head = trimmed.Substring(0, lastBrace);
+            // head 가 "{...필드" 면 ',' 로, "{"(빈 객체)면 콤마 없이 이어 붙임.
+            bool hasFields = head.TrimStart().Length > 1; // "{" 보다 길면 필드가 존재.
+            string separator = hasFields ? "," : "";
+            return head + separator + "\"prefetch\":" + compactCatalogJson + "}";
         }
 
         private static string JsonEscape(string value)
@@ -43,6 +78,7 @@ namespace AppsInToss.Editor
 
         /// <summary>
         /// granite build에 전달할 환경변수 딕셔너리를 반환합니다.
+        /// prefetch 카탈로그는 WebGL 복사 이후 <see cref="WithPrefetch"/> 로 별도 패치됩니다.
         /// </summary>
         internal static Dictionary<string, string> BuildEnvironmentVariables()
         {

--- a/Editor/Package/AITPageCacheEmitter.cs
+++ b/Editor/Package/AITPageCacheEmitter.cs
@@ -155,6 +155,13 @@ namespace AppsInToss.Editor.Package
             string allowlistJson = "[" + string.Join(",", allowlist.ConvertAll(JsString)) + "]";
             string cacheNameJs = JsString(cacheName);
 
+            // 네이티브 에셋 소스 레버 (tri-state -1=자동→기본값true, 0=비활성, 1=활성).
+            // pageCache 가 ON 일 때만(인터셉터 존재 전제) 이 분기에 도달하므로 AND 게이트가 성립.
+            bool nativeEnabled = config.nativeAssetSource < 0
+                ? AITDefaultSettings.GetDefaultNativeAssetSource()
+                : config.nativeAssetSource == 1;
+            string nativeEnabledJs = nativeEnabled ? "true" : "false";
+
             // 주의: 이 스니펫에는 %대문자_퍼센트% 토큰을 포함하지 않습니다(ValidatePlaceholderSubstitution 안전).
             // 설치 순서: index.html 에서 본 스니펫은 %AIT_EARLY_FETCH_SCRIPT% 보다 '앞'에 위치합니다.
             // 따라서 priorFetch 캡처 시점의 window.fetch 는 native 이며, 그 위를 이후 Early Fetch 가 래핑합니다.
@@ -174,6 +181,14 @@ namespace AppsInToss.Editor.Package
 
             // 부팅 무효화 allowlist: 현재 빌드의 Build/* 상대경로. 설치 직후 1회 정리에 사용.
             var ALLOWLIST = " + allowlistJson + @";
+
+            // 네이티브 에셋 소스: 호스트(슈퍼앱)가 window.__aitResolveAsset(url) 리졸버를 주입하면
+            // Build/* 요청을 native→CacheStorage→network 순으로 해석합니다(리졸버 미주입 시 신호만 노출).
+            // 보안/CacheStorage 가드(위 return) 이후에 정의되므로 미지원 환경에선 신호가 미정의로 남습니다(의도).
+            var NATIVE_SOURCE = " + nativeEnabledJs + @";
+            var NATIVE_TIMEOUT_MS = 3000;
+            // 호스트가 리졸버 주입 가치를 판단할 수 있도록 신호를 노출(레버 OFF 면 false → 호스트가 주입 생략).
+            window.__aitNativeSourceEnabled = NATIVE_SOURCE;
 
             // 통계 훅(perf CI/검증용, 운영 무영향).
             window.__aitCacheStats = { hits: [], misses: [], puts: [], errors: [] };
@@ -209,13 +224,9 @@ namespace AppsInToss.Editor.Package
             // 설치 시점의 fetch 를 캡처(여기선 native; Early Fetch 는 아직 미설치).
             var priorFetch = window.fetch.bind(window);
 
-            window.fetch = function (resource, init) {
-                var url = absUrl(resource);
-                // 비대상/비GET 은 그대로 위임(StreamingAssets/TemplateData/Document/loader.js 등).
-                if (!url || !isCacheable(url) || isNonGet(resource, init)) {
-                    return priorFetch(resource, init);
-                }
-                // cache-first: 어떤 네트워크/Early-Fetch 경로보다 CacheStorage 를 먼저 시도.
+            // cache-first 체인: CacheStorage 히트 → 단락, 미스 → priorFetch 후 비차단 put.
+            // native-first 분기가 실패/미설정/타임아웃일 때의 폴백 경로로도 재사용됩니다.
+            function cacheFirst(resource, init, url) {
                 return getCache().then(function (cache) {
                     return cache.match(url).then(function (hit) {
                         if (hit) {
@@ -248,6 +259,58 @@ namespace AppsInToss.Editor.Package
                     window.__aitCacheStats.errors.push('match ' + url + ': ' + (e && e.message || e));
                     return priorFetch(resource, init);
                 });
+            }
+
+            window.fetch = function (resource, init) {
+                var url = absUrl(resource);
+                // 비대상/비GET 은 그대로 위임(StreamingAssets/TemplateData/Document/loader.js 등).
+                if (!url || !isCacheable(url) || isNonGet(resource, init)) {
+                    return priorFetch(resource, init);
+                }
+                // native-first: 레버 ON + 호스트가 리졸버를 주입했으면 네이티브 프리페치 결과를 우선 시도.
+                // 리졸버 계약: window.__aitResolveAsset(url) => Promise<Response|null>(동기 Response/null 도 허용).
+                //  · Response 반환 → 그대로 서빙(cache.put 하지 않음: 네이티브가 자체 스토어 소유).
+                //  · null/throw/reject/타임아웃 → cacheFirst 폴백(native→CacheStorage→network 우선순위).
+                if (NATIVE_SOURCE && typeof window.__aitResolveAsset === 'function') {
+                    var nativeCall;
+                    try {
+                        // 동기/비동기 모두 흡수(동기 Response/null 도 Promise 로 정규화).
+                        nativeCall = Promise.resolve(window.__aitResolveAsset(url));
+                    } catch (e) {
+                        // 동기 throw → 폴백.
+                        window.__aitCacheStats.errors.push('native-throw ' + url + ': ' + (e && e.message || e));
+                        return cacheFirst(resource, init, url);
+                    }
+                    var nativeTimer = null;
+                    var timeoutP = new Promise(function (resolve) {
+                        // setTimeout 콜백은 동기적으로 등록되므로 race 호출 전에 nativeTimer 가 할당됩니다.
+                        nativeTimer = setTimeout(function () { resolve(null); }, NATIVE_TIMEOUT_MS);
+                    });
+                    return Promise.race([nativeCall, timeoutP]).then(function (nativeResp) {
+                        if (nativeTimer) { clearTimeout(nativeTimer); nativeTimer = null; } // 타이머 누수 방지.
+                        if (nativeResp) {
+                            // 방어적 검사: raw-only 계약(네이티브는 해제된 bytes 를 Content-Encoding 없이 반환)을 위반해
+                            // 압축 응답을 CE 헤더와 함께 돌려주면 loader.js 가 Unity 마커를 못 찾아 깨질 수 있음.
+                            // 차단하진 않되(호스트 책임) 경고를 남겨 진단 가능하게 한다.
+                            try {
+                                if (nativeResp.headers && nativeResp.headers.get && nativeResp.headers.get('Content-Encoding')) {
+                                    window.__aitCacheStats.errors.push('native-ce ' + url + ': resolver Content-Encoding 동반(raw-only 계약 위반)');
+                                }
+                            } catch (e) {}
+                            window.__aitCacheStats.hits.push('native:' + url);
+                            return nativeResp; // 네이티브 응답은 cache.put 하지 않음(스토어 이중화 방지).
+                        }
+                        // null/타임아웃 → cache-first 폴백.
+                        return cacheFirst(resource, init, url);
+                    }).catch(function (e) {
+                        if (nativeTimer) { clearTimeout(nativeTimer); nativeTimer = null; } // 타이머 누수 방지.
+                        // 비동기 reject → 폴백.
+                        window.__aitCacheStats.errors.push('native-reject ' + url + ': ' + (e && e.message || e));
+                        return cacheFirst(resource, init, url);
+                    });
+                }
+                // 레버 OFF 또는 리졸버 미주입 → 기존 cache-first(어떤 네트워크/Early-Fetch 경로보다 우선).
+                return cacheFirst(resource, init, url);
             };
 
             // 부팅 무효화(설치 직후 1회, 비차단): allowlist 에 없는 옛 해시 엔트리를 백그라운드 정리.

--- a/Editor/Package/AITWarmManifestEmitter.cs
+++ b/Editor/Package/AITWarmManifestEmitter.cs
@@ -1,0 +1,630 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// 빌드 시 <c>ait-warm-manifest.json</c> 을 산출합니다.
+    ///
+    /// 목적: 호스트(슈퍼앱)가 미니앱 목록 화면에서 Build 자산을 선다운로드(warm)할 때
+    /// diff 기준으로 쓸 기계가독 계약 파일입니다.
+    /// <see cref="AITPageCacheEmitter"/> 인터셉터의 allowlist 와 '같은 빌드의 같은 입력 변수'에서
+    /// 생성되므로 두 파일 사이에 drift 가 불가능합니다.
+    ///
+    /// === 게이팅 규칙 (tri-state) ===
+    ///  · <c>config == null</c> → stale 파일 삭제 후 no-op 반환.
+    ///  · warmManifest 실효값 = (warmManifest == -1) ? GetDefaultWarmManifest() : (warmManifest == 1)
+    ///  · 실효값 false → stale 파일 삭제 후 no-op 반환.
+    ///  · pageCache 실효값 = (pageCache == -1) ? GetDefaultPageCache() : (pageCache == 1)
+    ///  · warmManifest 실효값 true + pageCache 실효값 false → 경고 로그 출력 후 no-op 반환.
+    ///    (manifest 단독으로는 의미가 없습니다. 인터셉터 없이 배포하면 호스트가 참조할 캐시 버킷이 존재하지 않음.)
+    ///  · 둘 다 실효값 true 일 때만 실제 파일을 산출합니다.
+    ///
+    /// === 호스트(슈퍼앱) 연동 계약 (코드 주석으로 명문화) ===
+    ///  · cacheName: 호스트 백그라운드 pre-fill 페이지와 '동일한 캐시명'을 사용해야 같은 버킷을 공유합니다.
+    ///    <c>config.pageCacheName</c> 이 비어 있으면 <see cref="AITPageCacheEmitter.DefaultCacheName"/> 으로 보정합니다.
+    ///  · assets: data/framework/wasm 3종만 포함합니다. loader 와 symbols 는 excluded 에만 기재합니다.
+    ///  · wireBytes: 실제 디스크 상의 (압축 포함) 파일 크기입니다.
+    ///  · rawBytes: gzip/brotli 해제 후 바이트 수입니다. 탐지 불가 시 필드를 생략합니다.
+    ///  · encoding: "gzip" | "br" | "none".
+    ///
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
+    /// </summary>
+    internal static class AITWarmManifestEmitter
+    {
+        internal const string FileName = "ait-warm-manifest.json";
+
+        /// <summary>
+        /// <paramref name="destPath"/> 아래에 <c>ait-warm-manifest.json</c> 을 산출합니다.
+        /// </summary>
+        /// <param name="config">AIT Editor 설정 오브젝트. null 이면 no-op.</param>
+        /// <param name="destPath">web 루트 경로 (index.html 이 놓이는 디렉토리).</param>
+        /// <param name="loaderFile">Build/ 내 loader 파일명 (excluded 항목).</param>
+        /// <param name="dataFile">Build/ 내 data 파일명 (assets 항목).</param>
+        /// <param name="frameworkFile">Build/ 내 framework 파일명 (assets 항목).</param>
+        /// <param name="wasmFile">Build/ 내 wasm 파일명 (assets 항목).</param>
+        /// <param name="symbolsFile">Build/ 내 symbols 파일명 (excluded 항목, 비어 있으면 생략).</param>
+        /// <returns>
+        /// 성공 시 .ait 메타데이터 <c>prefetch</c> 키에 인라인으로 실을 compact v2 카탈로그 JSON(single-line).
+        /// 게이팅으로 미산출되거나 안전 검사 실패 시 <c>null</c>.
+        /// (파일 <c>ait-warm-manifest.json</c> 은 warm 페이지가 소비하므로 별개로 계속 산출합니다.)
+        /// </returns>
+        internal static string WriteManifest(
+            AITEditorScriptObject config,
+            string destPath,
+            string loaderFile,
+            string dataFile,
+            string frameworkFile,
+            string wasmFile,
+            string symbolsFile)
+        {
+            string outputPath = Path.Combine(destPath, FileName);
+
+            // 게이팅 1: config 가 null 이거나 warmManifest 실효값이 false 이면 stale 파일 삭제 후 종료.
+            // tri-state: -1=자동(GetDefaultWarmManifest()), 0=비활성, 1=활성.
+            if (config == null)
+            {
+                DeleteStale(outputPath);
+                return null;
+            }
+
+            bool warmManifestEffective = config.warmManifest < 0
+                ? AITDefaultSettings.GetDefaultWarmManifest()
+                : config.warmManifest == 1;
+
+            if (!warmManifestEffective)
+            {
+                DeleteStale(outputPath);
+                return null;
+            }
+
+            // 게이팅 2: warmManifest 실효값 true 이지만 pageCache 실효값 false 이면 무의미 — 미산출 + 경고.
+            // 호스트 pre-fill 없이 manifest 만 내보내면 참조할 캐시 버킷 자체가 없어 활용 불가.
+            // pageCache tri-state: -1=자동(GetDefaultPageCache()), 0=비활성, 1=활성.
+            bool pageCacheEffective = config.pageCache < 0
+                ? AITDefaultSettings.GetDefaultPageCache()
+                : config.pageCache == 1;
+
+            if (!pageCacheEffective)
+            {
+                Debug.LogWarning(
+                    "[AIT] ait-warm-manifest.json 미산출: warmManifest 실효값=true 이지만 pageCache 실효값=false 입니다. " +
+                    "manifest 는 페이지 캐시 인터셉터(pageCache) 없이는 호스트가 참조할 캐시 버킷이 존재하지 않으므로 무의미합니다."
+                );
+                DeleteStale(outputPath);
+                return null;
+            }
+
+            // 캐시명: 비어 있으면 AITPageCacheEmitter 와 동일한 기본값으로 보정.
+            string cacheName = string.IsNullOrEmpty(config.pageCacheName)
+                ? AITPageCacheEmitter.DefaultCacheName
+                : config.pageCacheName;
+
+            // 버전 문자열: package.json 에서 추출. 실패 시 버전 없이 식별자만.
+            string sdkVersion = ReadSdkVersion();
+            string generator = string.IsNullOrEmpty(sdkVersion)
+                ? "apps-in-toss.unity"
+                : "apps-in-toss.unity@" + sdkVersion;
+
+            // assets 및 totals 계산.
+            long totalWire = 0;
+            long totalRaw = 0;
+            bool allRawKnown = true;
+
+            var assets = new System.Collections.Generic.List<AssetEntry>();
+
+            foreach (var tuple in new[]
+            {
+                (file: dataFile,      role: "data",      mime: "application/octet-stream"),
+                (file: frameworkFile, role: "framework",  mime: "text/javascript"),
+                (file: wasmFile,      role: "wasm",       mime: "application/wasm"),
+            })
+            {
+                if (string.IsNullOrEmpty(tuple.file)) continue;
+
+                string fullPath = Path.Combine(destPath, "Build", tuple.file);
+                if (!File.Exists(fullPath))
+                {
+                    Debug.LogWarning($"[AIT] ait-warm-manifest.json: Build/{tuple.file} 파일을 찾을 수 없어 해당 항목을 건너뜁니다.");
+                    allRawKnown = false;
+                    continue;
+                }
+
+                long wireBytes = new FileInfo(fullPath).Length;
+                string encoding;
+                long rawBytes;
+                bool rawKnown;
+                DetectEncoding(fullPath, tuple.file, wireBytes, out encoding, out rawBytes, out rawKnown);
+
+                totalWire += wireBytes;
+                if (rawKnown)
+                {
+                    totalRaw += rawBytes;
+                }
+                else
+                {
+                    allRawKnown = false;
+                }
+
+                assets.Add(new AssetEntry
+                {
+                    path = "Build/" + tuple.file,
+                    role = tuple.role,
+                    mime = tuple.mime,
+                    wireBytes = wireBytes,
+                    rawBytes = rawBytes,
+                    rawKnown = rawKnown,
+                    encoding = encoding,
+                });
+            }
+
+            // excluded 목록 구성.
+            var excluded = new System.Collections.Generic.List<ExcludedEntry>();
+            if (!string.IsNullOrEmpty(loaderFile))
+            {
+                excluded.Add(new ExcludedEntry
+                {
+                    path = "Build/" + loaderFile,
+                    role = "loader",
+                    reason = "script-src 로드 — page fetch 비경유, 인터셉터 서빙 불가",
+                });
+            }
+            if (!string.IsNullOrEmpty(symbolsFile))
+            {
+                excluded.Add(new ExcludedEntry
+                {
+                    path = "Build/" + symbolsFile,
+                    role = "symbols",
+                    reason = "부팅 임계경로 밖",
+                });
+            }
+
+            // JSON 직렬화 (StringBuilder 수작업, 2-space pretty, 키 순서 고정).
+            string json = BuildJson(generator, cacheName, assets, excluded, totalWire, allRawKnown ? (long?)totalRaw : null);
+
+            // 안전 검사: %대문자_언더스코어% 토큰이 산출물에 없어야 한다.
+            if (Regex.IsMatch(json, @"%[A-Z0-9_]+%"))
+            {
+                Debug.LogError("[AIT] ait-warm-manifest.json 내부 오류: 미치환 플레이스홀더 토큰이 감지되어 파일을 산출하지 않습니다.");
+                return null;
+            }
+
+            File.WriteAllText(outputPath, json, Encoding.UTF8);
+            Debug.Log($"[AIT] ✓ ait-warm-manifest.json 산출 완료: {outputPath}");
+
+            // .ait 메타데이터 prefetch 에 인라인으로 실을 compact v2 카탈로그를 산출.
+            // nativeSource 실효값(tri-state: -1=자동, 0=비활성, 1=활성)을 카탈로그에 동봉.
+            bool nativeSourceEffective = config.nativeAssetSource < 0
+                ? AITDefaultSettings.GetDefaultNativeAssetSource()
+                : config.nativeAssetSource == 1;
+            string compactCatalog = BuildCompactCatalogJson(
+                cacheName, nativeSourceEffective, assets, totalWire, allRawKnown ? (long?)totalRaw : null);
+
+            // 안전 검사: compact 카탈로그에도 미치환 플레이스홀더가 없어야 한다.
+            if (Regex.IsMatch(compactCatalog, @"%[A-Z0-9_]+%"))
+            {
+                Debug.LogError("[AIT] 프리페치 인라인 카탈로그 내부 오류: 미치환 플레이스홀더 토큰이 감지되어 prefetch 를 방출하지 않습니다.");
+                return null;
+            }
+
+            return compactCatalog;
+        }
+
+        // -----------------------------------------------------------------------
+        // 내부 자료형
+        // -----------------------------------------------------------------------
+
+        private struct AssetEntry
+        {
+            public string path;
+            public string role;
+            public string mime;
+            public long wireBytes;
+            public long rawBytes;
+            public bool rawKnown;
+            public string encoding;
+        }
+
+        private struct ExcludedEntry
+        {
+            public string path;
+            public string role;
+            public string reason;
+        }
+
+        // -----------------------------------------------------------------------
+        // JSON 빌더 (외부 라이브러리 의존 없음, 키 순서 고정, 2-space indent)
+        // -----------------------------------------------------------------------
+
+        private static string BuildJson(
+            string generator,
+            string cacheName,
+            System.Collections.Generic.List<AssetEntry> assets,
+            System.Collections.Generic.List<ExcludedEntry> excluded,
+            long totalWire,
+            long? totalRaw)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("{");
+            sb.AppendLine("  \"schemaVersion\": 1,");
+            sb.AppendLine("  \"generator\": " + JsonString(generator) + ",");
+            sb.AppendLine("  \"cacheName\": " + JsonString(cacheName) + ",");
+
+            // assets 배열
+            sb.AppendLine("  \"assets\": [");
+            for (int i = 0; i < assets.Count; i++)
+            {
+                var a = assets[i];
+                bool last = (i == assets.Count - 1);
+                sb.AppendLine("    {");
+                sb.AppendLine("      \"path\": " + JsonString(a.path) + ",");
+                sb.AppendLine("      \"role\": " + JsonString(a.role) + ",");
+                sb.AppendLine("      \"mime\": " + JsonString(a.mime) + ",");
+                sb.AppendLine("      \"wireBytes\": " + a.wireBytes + ",");
+                if (a.rawKnown)
+                {
+                    sb.AppendLine("      \"rawBytes\": " + a.rawBytes + ",");
+                }
+                sb.AppendLine("      \"encoding\": " + JsonString(a.encoding));
+                sb.Append("    }");
+                sb.AppendLine(last ? "" : ",");
+            }
+            sb.AppendLine("  ],");
+
+            // excluded 배열
+            sb.AppendLine("  \"excluded\": [");
+            for (int i = 0; i < excluded.Count; i++)
+            {
+                var e = excluded[i];
+                bool last = (i == excluded.Count - 1);
+                sb.AppendLine("    {");
+                sb.AppendLine("      \"path\": " + JsonString(e.path) + ",");
+                sb.AppendLine("      \"role\": " + JsonString(e.role) + ",");
+                sb.AppendLine("      \"reason\": " + JsonString(e.reason));
+                sb.Append("    }");
+                sb.AppendLine(last ? "" : ",");
+            }
+            sb.AppendLine("  ],");
+
+            // totals 오브젝트
+            sb.AppendLine("  \"totals\": {");
+            sb.Append("    \"wireBytes\": " + totalWire);
+            if (totalRaw.HasValue)
+            {
+                sb.AppendLine(",");
+                sb.AppendLine("    \"rawBytes\": " + totalRaw.Value);
+            }
+            else
+            {
+                sb.AppendLine();
+            }
+            sb.AppendLine("  }");
+
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        // -----------------------------------------------------------------------
+        // 인라인 카탈로그 빌더 (compact v2, single-line — .ait 메타데이터 prefetch 용)
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// .ait 메타데이터 <c>prefetch</c> 키에 인라인으로 실을 compact v2 카탈로그 JSON 을 생성합니다.
+        ///
+        /// 파일(<c>ait-warm-manifest.json</c>, schemaVersion 1) 과 같은 입력에서 만들어지지만,
+        /// 환경변수로 전달되므로 줄바꿈/들여쓰기 없는 single-line 이며 호스트(RN/콘솔)가
+        /// 별도 파일 fetch 없이 카탈로그만으로 사전 다운로드할 수 있도록
+        /// per-asset <c>mime/encoding/wireBytes/rawBytes</c> 를 모두 인라인합니다.
+        ///
+        /// v1 파일과의 차이: <c>generator</c>·<c>excluded</c> 생략(부팅 임계경로 밖 자산은 카탈로그 비대상),
+        /// <c>nativeSource</c> 추가(인터셉터 native 우선 신호와 정합).
+        /// </summary>
+        private static string BuildCompactCatalogJson(
+            string cacheName,
+            bool nativeSource,
+            System.Collections.Generic.List<AssetEntry> assets,
+            long totalWire,
+            long? totalRaw)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"schemaVersion\":2");
+            sb.Append(",\"cacheName\":").Append(JsonString(cacheName));
+            sb.Append(",\"nativeSource\":").Append(nativeSource ? "true" : "false");
+            sb.Append(",\"assets\":[");
+            for (int i = 0; i < assets.Count; i++)
+            {
+                var a = assets[i];
+                if (i > 0) sb.Append(',');
+                sb.Append("{\"path\":").Append(JsonString(a.path));
+                sb.Append(",\"role\":").Append(JsonString(a.role));
+                sb.Append(",\"mime\":").Append(JsonString(a.mime));
+                sb.Append(",\"encoding\":").Append(JsonString(a.encoding));
+                sb.Append(",\"wireBytes\":").Append(a.wireBytes);
+                if (a.rawKnown) sb.Append(",\"rawBytes\":").Append(a.rawBytes);
+                sb.Append('}');
+            }
+            sb.Append(']');
+            sb.Append(",\"totals\":{\"wireBytes\":").Append(totalWire);
+            if (totalRaw.HasValue) sb.Append(",\"rawBytes\":").Append(totalRaw.Value);
+            sb.Append("}}");
+            return sb.ToString();
+        }
+
+        // -----------------------------------------------------------------------
+        // 인코딩/압축 탐지
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// 파일의 압축 인코딩과 해제 바이트 수를 탐지합니다.
+        /// </summary>
+        /// <param name="fullPath">파일의 전체 경로.</param>
+        /// <param name="fileName">파일명 (확장자 기반 brotli 추론용).</param>
+        /// <param name="wireBytes">알려진 파일 크기 (rawBytes 폴백 시 사용).</param>
+        /// <param name="encoding">탐지된 인코딩: "gzip" | "br" | "none".</param>
+        /// <param name="rawBytes">해제 후 바이트 수 (탐지 불가 시 wireBytes 와 같거나 무의미).</param>
+        /// <param name="rawKnown">rawBytes 를 신뢰할 수 있으면 true.</param>
+        private static void DetectEncoding(
+            string fullPath,
+            string fileName,
+            long wireBytes,
+            out string encoding,
+            out long rawBytes,
+            out bool rawKnown)
+        {
+            encoding = "none";
+            rawBytes = wireBytes;
+            rawKnown = false;
+
+            try
+            {
+                // 첫 2바이트로 gzip 마커 확인.
+                byte[] header = new byte[2];
+                using (var fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    int read = fs.Read(header, 0, 2);
+                    if (read < 2)
+                    {
+                        // 파일이 너무 작으면 그냥 "none".
+                        rawKnown = true;
+                        return;
+                    }
+                }
+
+                // gzip: 0x1f 0x8b
+                if (header[0] == 0x1f && header[1] == 0x8b)
+                {
+                    encoding = "gzip";
+                    long counted = CountDecompressedBytes_GZip(fullPath);
+                    if (counted >= 0)
+                    {
+                        rawBytes = counted;
+                        rawKnown = true;
+                    }
+                    return;
+                }
+
+                // brotli: 직접 타입 참조 금지(Unity mono BCL 에 System.IO.Compression.BrotliStream 이 없을 수 있음).
+                // 리플렉션으로 BrotliStream 타입을 탐색한 뒤 있으면 스트리밍 디코드 시도.
+                // (Unity mono BCL 은 .NET Standard 2.0 기반으로 BrotliStream 이 미포함인 버전이 많음.)
+                long brotliBytes = TryCountDecompressedBytes_Brotli(fullPath);
+                if (brotliBytes >= 0)
+                {
+                    encoding = "br";
+                    rawBytes = brotliBytes;
+                    rawKnown = true;
+                    return;
+                }
+
+                // 타입 부재 또는 디코드 예외 폴백: .unityweb 확장자이면 brotli 로 간주하되 rawBytes 생략.
+                if (fileName.EndsWith(".unityweb", StringComparison.OrdinalIgnoreCase))
+                {
+                    encoding = "br";
+                    rawKnown = false;
+                    return;
+                }
+
+                // 그 외: none, rawBytes = wireBytes.
+                encoding = "none";
+                rawBytes = wireBytes;
+                rawKnown = true;
+            }
+            catch
+            {
+                // 탐지 과정 예외 — encoding "none", rawKnown=false 로 안전 처리.
+                encoding = "none";
+                rawKnown = false;
+            }
+        }
+
+        /// <summary>
+        /// GZipStream 을 64KB 버퍼로 스트리밍하여 해제 바이트 수를 카운트합니다.
+        /// 메모리에 전체를 적재하지 않습니다.
+        /// 실패 시 -1 반환.
+        /// </summary>
+        private static long CountDecompressedBytes_GZip(string fullPath)
+        {
+            try
+            {
+                const int bufferSize = 64 * 1024;
+                byte[] buffer = new byte[bufferSize];
+                long total = 0;
+                using (var fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var gz = new GZipStream(fs, CompressionMode.Decompress))
+                {
+                    int read;
+                    while ((read = gz.Read(buffer, 0, bufferSize)) > 0)
+                    {
+                        total += read;
+                    }
+                }
+                return total;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// 리플렉션으로 BrotliStream 타입을 탐색해 스트리밍 카운트를 시도합니다.
+        /// Unity mono BCL 에 BrotliStream 이 없을 수 있으므로 직접 타입 참조 대신 리플렉션을 사용합니다.
+        /// (Unity 2021.3 LTS 의 mono BCL 은 .NET Standard 2.0 기반 — BrotliStream 은 .NET Standard 2.1 추가.)
+        /// 성공 시 해제 바이트 수, 실패/타입 부재 시 -1 반환.
+        /// </summary>
+        private static long TryCountDecompressedBytes_Brotli(string fullPath)
+        {
+            // AppDomain 내 로드된 어셈블리에서 BrotliStream 타입 탐색.
+            Type brotliStreamType = null;
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    Type t = asm.GetType("System.IO.Compression.BrotliStream");
+                    if (t != null)
+                    {
+                        brotliStreamType = t;
+                        break;
+                    }
+                }
+                catch
+                {
+                    // 어셈블리 열거 중 예외(리플렉션 권한 등) — 무시하고 계속.
+                }
+            }
+
+            if (brotliStreamType == null)
+            {
+                return -1;
+            }
+
+            try
+            {
+                const int bufferSize = 64 * 1024;
+                byte[] buffer = new byte[bufferSize];
+                long total = 0;
+
+                using (var fs = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    // Activator.CreateInstance(BrotliStream, Stream, CompressionMode.Decompress)
+                    object brotliStream = Activator.CreateInstance(
+                        brotliStreamType,
+                        new object[] { fs, CompressionMode.Decompress }
+                    );
+
+                    using (var stream = (Stream)brotliStream)
+                    {
+                        int read;
+                        while ((read = stream.Read(buffer, 0, bufferSize)) > 0)
+                        {
+                            total += read;
+                        }
+                    }
+                }
+                return total;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        // SDK 버전 읽기
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// SDK package.json 에서 "version" 값을 읽어 반환합니다.
+        /// 파일을 찾지 못하거나 파싱 실패 시 null 반환.
+        /// </summary>
+        private static string ReadSdkVersion()
+        {
+            try
+            {
+                // AITPackagePathResolver 를 이용해 package.json 의 부모 디렉토리(패키지 루트)를 탐색.
+                // SdkPathResolver.GetSdkBuildConfigPath() → "WebGLTemplates/AITTemplate/BuildConfig~" 경로를 반환.
+                // 패키지 루트는 그 위 3단계.
+                string buildConfigPath = SdkPathResolver.GetSdkBuildConfigPath();
+                if (!string.IsNullOrEmpty(buildConfigPath))
+                {
+                    // BuildConfig~ → AITTemplate → WebGLTemplates → 패키지루트
+                    string packageRoot = Path.GetFullPath(Path.Combine(buildConfigPath, "..", "..", ".."));
+                    string packageJsonPath = Path.Combine(packageRoot, "package.json");
+                    if (File.Exists(packageJsonPath))
+                    {
+                        string text = File.ReadAllText(packageJsonPath, Encoding.UTF8);
+                        var match = Regex.Match(text, "\"version\"\\s*:\\s*\"([^\"]+)\"");
+                        if (match.Success)
+                        {
+                            return match.Groups[1].Value;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // 버전 탐지 실패는 빌드를 멈추지 않음.
+            }
+
+            return null;
+        }
+
+        // -----------------------------------------------------------------------
+        // 유틸리티
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// stale 파일이 있으면 예외 흡수하며 삭제합니다.
+        /// </summary>
+        private static void DeleteStale(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch
+            {
+                // 삭제 실패는 무시 (읽기 전용 파일시스템 등).
+            }
+        }
+
+        /// <summary>
+        /// 문자열을 안전한 JSON 문자열 리터럴로 인코딩합니다(따옴표/역슬래시/제어문자 이스케이프).
+        /// </summary>
+        private static string JsonString(string value)
+        {
+            if (value == null) return "\"\"";
+            var sb = new StringBuilder("\"");
+            foreach (char c in value)
+            {
+                switch (c)
+                {
+                    case '\\': sb.Append("\\\\"); break;
+                    case '"':  sb.Append("\\\""); break;
+                    case '\n': sb.Append("\\n");  break;
+                    case '\r': sb.Append("\\r");  break;
+                    case '\t': sb.Append("\\t");  break;
+                    default:
+                        if (c < 0x20)
+                        {
+                            sb.AppendFormat("\\u{0:x4}", (int)c);
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                        break;
+                }
+            }
+            sb.Append('"');
+            return sb.ToString();
+        }
+    }
+}

--- a/Editor/Package/AITWarmManifestEmitter.cs.meta
+++ b/Editor/Package/AITWarmManifestEmitter.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a96aed6984e01415cb0ea13c9a7d7c89
+guid: cfd9e0fe5fd49091b08ebdabc9eaff0f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Editor/Package/AITWarmPageEmitter.cs
+++ b/Editor/Package/AITWarmPageEmitter.cs
@@ -1,0 +1,416 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// 빌드 시 <c>ait-warm.html</c> (self-warming 페이지)을 산출합니다.
+    ///
+    /// 목적: 호스트(슈퍼앱)가 게임 진입 전에 숨김 WebView 로 이 페이지를 열면,
+    /// <c>ait-warm-manifest.json</c> 을 읽어 변경분(diff warm)만 내려받아
+    /// CacheStorage(인터셉터와 동일 버킷)에 decode-free 로 적재합니다.
+    ///
+    /// === 게이팅 규칙 (tri-state) ===
+    ///  · <c>config == null</c> → stale 파일 삭제 후 no-op 반환.
+    ///  · warmPage 실효값 = (warmPage == -1) ? GetDefaultWarmPage() : (warmPage == 1)
+    ///  · 실효값 false → stale 파일 삭제 후 no-op 반환.
+    ///  · warmPage 실효값 true 이지만 warmManifest 실효값 false 또는 pageCache 실효값 false → 경고 로그 출력 후 no-op 반환.
+    ///    (매니페스트 없이는 읽을 대상이 없고, 인터셉터(pageCache) 없이는 채운 캐시를 소비할 주체가 없음.)
+    ///  · 세 조건 모두 실효값 true 일 때만 실제 파일을 산출합니다.
+    ///
+    /// === 호스트(슈퍼앱) 통합 계약 ===
+    /// 1. 게임 진입 전(예: 목록 화면)에 숨김 WebView 로 <c>https://&lt;게임 오리진&gt;/ait-warm.html</c> 을 연다.
+    ///    반드시 게임을 띄울 WebView 와 같은 프로파일/데이터스토어를 사용해야 CacheStorage 버킷이 공유된다.
+    /// 2. 페이지는 <c>./ait-warm-manifest.json</c> 을 읽어 변경분만 내려받아 CacheStorage(설정된 cacheName)에
+    ///    decode-free 로 저장한다. 이미 캐시된 자산(절대 URL 키 일치)은 네트워크를 타지 않는다(diff warm).
+    ///    decode-free: <c>Content-Encoding</c> 없는 raw bytes 로 저장해 loader.js 가 Worker brotli 해제를 스킵(S2c).
+    ///    CE:br 응답을 받으면 <c>arrayBuffer()</c> 재합성으로 CE 를 제거한다. CE 없는 응답은 <c>clone()</c> 그대로 저장.
+    /// 3. 신호: <c>postMessage</c> type <c>ait:warm:progress|done|error</c> + <c>ReactNativeWebView.postMessage</c>
+    ///    + <c>document.title</c> + <c>window.__aitWarmStats</c>.
+    ///    <c>targetOrigin='*'</c>: 호스트 오리진을 빌드 시점에 알 수 없고 페이로드는 카운트뿐(비밀 없음).
+    ///    호스트는 done 신호(또는 자체 타임아웃) 후 WebView 를 닫으면 된다.
+    ///    warm 실패/미실행이어도 게임 로딩은 정상(캐시 miss 시 네트워크).
+    /// 4. 쿼리 파라미터: <c>?timeout=&lt;ms&gt;</c>(기본 120000), <c>?concurrency=&lt;n&gt;</c>(기본 4).
+    /// 5. 전제: pageCache 인터셉터와 동일한 cacheName, nameFilesAsHashes=true(기본).
+    ///    멀티앱 주의: 같은 오리진의 여러 미니앱이 동일 cacheName 공유 시 stale 정리가 서로의 엔트리를
+    ///    오삭제할 수 있음 — 앱별 고유 pageCacheName 을 권장한다.
+    ///
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
+    /// </summary>
+    internal static class AITWarmPageEmitter
+    {
+        internal const string FileName = "ait-warm.html";
+
+        // HTML 템플릿 내 치환 마커 (ValidatePlaceholderSubstitution 의 %[A-Z0-9_]+% 정규식과 충돌하지 않음).
+        private const string MarkerCacheName    = "__AIT_CACHE_NAME__";
+        private const string MarkerManifestFile = "__AIT_MANIFEST_FILE__";
+
+        /// <summary>
+        /// <paramref name="destPath"/> 아래에 <c>ait-warm.html</c> 을 산출합니다.
+        /// </summary>
+        /// <param name="config">AIT Editor 설정 오브젝트. null 이면 no-op.</param>
+        /// <param name="destPath">
+        ///   Vite 정적 루트(publicPath). <c>ait-warm.html</c> 과 <c>ait-warm-manifest.json</c> 이 같은
+        ///   웹 루트에 서빙되어 <c>./ait-warm-manifest.json</c> 상대 fetch 가 성립하고,
+        ///   <c>Build/*</c> 도 같은 오리진에 위치합니다.
+        /// </param>
+        internal static void WritePage(AITEditorScriptObject config, string destPath)
+        {
+            string outputPath = Path.Combine(destPath, FileName);
+
+            // 게이팅 1: config 가 null 이거나 warmPage 실효값이 false 이면 stale 파일 삭제 후 종료.
+            // tri-state: -1=자동(GetDefaultWarmPage()), 0=비활성, 1=활성.
+            if (config == null)
+            {
+                DeleteStale(outputPath);
+                return;
+            }
+
+            bool warmPageEffective = config.warmPage < 0
+                ? AITDefaultSettings.GetDefaultWarmPage()
+                : config.warmPage == 1;
+
+            if (!warmPageEffective)
+            {
+                DeleteStale(outputPath);
+                return;
+            }
+
+            // 게이팅 2: warmPage 실효값 true 이지만 warmManifest 실효값 false 또는 pageCache 실효값 false → 미산출.
+            // 매니페스트 없이는 warm 페이지가 읽을 대상이 없고,
+            // 인터셉터(pageCache) 없이는 채운 캐시를 소비할 주체가 없음.
+            bool warmManifestEffective = config.warmManifest < 0
+                ? AITDefaultSettings.GetDefaultWarmManifest()
+                : config.warmManifest == 1;
+            bool pageCacheEffective    = config.pageCache < 0
+                ? AITDefaultSettings.GetDefaultPageCache()
+                : config.pageCache == 1;
+            if (!warmManifestEffective || !pageCacheEffective)
+            {
+                Debug.LogWarning(
+                    "[AIT] ait-warm.html 미산출: warmPage 실효값=true 이지만 " +
+                    $"warmManifest 실효값={warmManifestEffective}, pageCache 실효값={pageCacheEffective} 입니다. " +
+                    "warm 페이지는 매니페스트를 읽고 인터셉터 캐시 버킷에 기록합니다."
+                );
+                DeleteStale(outputPath);
+                return;
+            }
+
+            // 캐시명: 비어 있으면 AITPageCacheEmitter 와 동일한 기본값으로 보정.
+            string cacheName = string.IsNullOrEmpty(config.pageCacheName)
+                ? AITPageCacheEmitter.DefaultCacheName
+                : config.pageCacheName;
+
+            // 마커 치환 (치환값 이스케이프: JS 단일따옴표 문자열용).
+            string html = HtmlTemplate
+                .Replace(MarkerCacheName,    EscapeJsSingleQuote(cacheName))
+                .Replace(MarkerManifestFile, EscapeJsSingleQuote(AITWarmManifestEmitter.FileName));
+
+            // 안전 검사 1: 마커 잔존 없음.
+            if (html.Contains(MarkerCacheName) || html.Contains(MarkerManifestFile))
+            {
+                Debug.LogWarning("[AIT] ait-warm.html 내부 오류: 치환 마커가 산출물에 잔존합니다. 파일을 산출하지 않습니다.");
+                return;
+            }
+
+            // 안전 검사 2: %[A-Z0-9_]+% 토큰 없음 (ValidatePlaceholderSubstitution 과 동일 기준).
+            if (Regex.IsMatch(html, @"%[A-Z0-9_]+%"))
+            {
+                Debug.LogWarning("[AIT] ait-warm.html 내부 오류: 미치환 플레이스홀더 토큰이 감지되어 파일을 산출하지 않습니다.");
+                return;
+            }
+
+            File.WriteAllText(outputPath, html, Encoding.UTF8);
+            Debug.Log($"[AIT] ✓ ait-warm.html 산출 완료{(config.warmPage < 0 ? " (자동)" : "")}: {outputPath}");
+        }
+
+        // -----------------------------------------------------------------------
+        // 유틸리티
+        // -----------------------------------------------------------------------
+
+        /// <summary>stale 파일이 있으면 예외 흡수하며 삭제합니다.</summary>
+        private static void DeleteStale(string path)
+        {
+            try
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch
+            {
+                // 삭제 실패는 무시 (읽기 전용 파일시스템 등).
+            }
+        }
+
+        /// <summary>
+        /// JS 단일따옴표 문자열에 안전하게 삽입할 수 있도록 이스케이프합니다.
+        /// 실질적으로 cacheName 은 영숫자-하이픈이지만 방어적으로 처리합니다.
+        /// </summary>
+        private static string EscapeJsSingleQuote(string value)
+        {
+            if (value == null) return "";
+            return value
+                .Replace("\\", "\\\\")
+                .Replace("'", "\\'");
+        }
+
+        // -----------------------------------------------------------------------
+        // HTML 템플릿 (C# verbatim string — 내부 따옴표는 "" 이스케이프, JS 단일따옴표 위주)
+        // 결정적 출력: 타임스탬프/난수/버전 문자열 0 — 같은 config 로 2회 호출 시 byte-identical.
+        // -----------------------------------------------------------------------
+
+        private const string HtmlTemplate = @"<!DOCTYPE html>
+<html lang=""ko"">
+<head>
+  <meta charset=""UTF-8"">
+  <meta name=""viewport"" content=""width=device-width, initial-scale=1"">
+  <title>ait-warm:idle</title>
+</head>
+<body>
+  <noscript>JavaScript 가 필요합니다.</noscript>
+  <p id=""status"">워밍 중...</p>
+<script>
+(function () {
+  'use strict';
+
+  // 빌드 시 주입된 상수.
+  var BAKED_CACHE_NAME  = '__AIT_CACHE_NAME__';
+  var MANIFEST_FILE     = '__AIT_MANIFEST_FILE__';
+  var SCHEMA_VERSION    = 1;
+
+  // 쿼리 파라미터 파싱 헬퍼: 정수 파라미터(기본값·최솟값·최댓값 포함).
+  function qsInt(name, def, min, max) {
+    try {
+      var v = parseInt(new URLSearchParams(location.search).get(name), 10);
+      if (isNaN(v)) { return def; }
+      return Math.min(Math.max(v, min), max);
+    } catch (e) { return def; }
+  }
+
+  var timeout     = qsInt('timeout',     120000, 1000, 600000);
+  var concurrency = qsInt('concurrency', 4,      1,    16);
+
+  // 절대 URL 생성: 인터셉터·매니페스트와 동일한 캐시 키 규약.
+  function absUrl(path) {
+    return new URL(path, location.href).href;
+  }
+
+  // 신호 발신: postMessage(부모·opener) + ReactNativeWebView + document.title + 전역 폴링용 변수.
+  // targetOrigin='*': 호스트 오리진을 빌드 시점에 알 수 없고 페이로드는 카운트뿐(비밀 없음).
+  function signal(msg) {
+    window.__aitWarmStats = msg;
+    var titleSuffix = (msg.type === 'ait:warm:done')
+      ? ('done' + (msg.ok ? '' : ':error'))
+      : msg.type.replace('ait:warm:', '');
+    document.title = 'ait-warm:' + titleSuffix;
+    var statusEl = document.getElementById('status');
+    if (statusEl) { statusEl.textContent = document.title; }
+    try { if (window.parent !== window) { window.parent.postMessage(msg, '*'); } } catch (e) {}
+    try { if (window.opener) { window.opener.postMessage(msg, '*'); } } catch (e) {}
+    try {
+      if (window.ReactNativeWebView) {
+        window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+      }
+    } catch (e) {}
+  }
+
+  // decode-free 저장: Content-Encoding 이 있으면 body 를 arrayBuffer 로 읽어 CE 없는
+  // 새 Response 로 재합성한다(S2c: loader.js 가 Unity 마커를 못 찾아 Worker brotli 해제 스킵).
+  // CE 부재 시에는 clone 그대로 cache.put(zero-copy, S2c 또는 S2b 강등).
+  // 반환값: 저장 바이트 수(buf.byteLength 또는 매니페스트 wireBytes/rawBytes 폴백, 실패 시 -1).
+  function storeDecodeFree(cache, url, resp, wireBytes, rawBytes) {
+    var ce = resp.headers.get('content-encoding');
+    if (ce) {
+      // 브라우저가 이미 자동 해제한 body 를 읽어 CE 없는 합성 Response 로 저장.
+      return resp.arrayBuffer().then(function (buf) {
+        var headers = { 'content-type': resp.headers.get('content-type') || 'application/octet-stream' };
+        var synthetic = new Response(buf, { status: 200, headers: headers });
+        return cache.put(url, synthetic).then(function () { return buf.byteLength; });
+      });
+    } else {
+      // CE 없음: clone 그대로 put(zero-copy).
+      var clone = resp.clone();
+      return cache.put(url, clone).then(function () {
+        // 바이트 수 추정: rawBytes 있으면 우선, 아니면 wireBytes.
+        return (typeof rawBytes === 'number') ? rawBytes : (typeof wireBytes === 'number' ? wireBytes : 0);
+      });
+    }
+  }
+
+  // 동시성 풀: todo 배열을 workerCount 개의 루프가 소비.
+  // 각 루프는 배열에서 splice(0,1) 로 하나씩 꺼내 처리한다.
+  function runPool(workerCount, todo, deadline, cache, onProgress) {
+    return new Promise(function (resolve) {
+      var stored = 0, skipped = 0, failed = 0, bytes = 0;
+      var stopReason = null;
+      // 종료 카운터 = 워커 루프 수(아이템 수 아님). 각 루프는 종료 분기에서 정확히 1회 감소시키므로
+      // 아이템 수로 초기화하면 todo.length > workerCount 일 때 0 에 도달하지 못해 resolve 가 누락된다.
+      var workers = Math.min(workerCount, todo.length);
+      var remaining = workers;
+
+      if (todo.length === 0) { resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: null }); return; }
+
+      function next() {
+        if (todo.length === 0 || stopReason) {
+          remaining--;
+          if (remaining <= 0) {
+            resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: stopReason });
+          }
+          return;
+        }
+        if (Date.now() > deadline) {
+          stopReason = 'timeout';
+          remaining--;
+          if (remaining <= 0) {
+            resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: stopReason });
+          }
+          return;
+        }
+        var asset = todo.splice(0, 1)[0];
+        fetch(asset.url, { cache: 'no-store' }).then(function (resp) {
+          if (!resp.ok) {
+            failed++;
+            onProgress({ stored: stored, skipped: skipped, failed: failed, bytes: bytes });
+            next();
+            return;
+          }
+          storeDecodeFree(cache, asset.url, resp, asset.wireBytes, asset.rawBytes).then(function (b) {
+            stored++;
+            if (b > 0) { bytes += b; }
+            onProgress({ stored: stored, skipped: skipped, failed: failed, bytes: bytes });
+            next();
+          }).catch(function (e) {
+            // QuotaExceededError 시 전체 중단(쿼터 소진 후 계속은 무의미).
+            var msg = (e && e.name) || '';
+            if (msg === 'QuotaExceededError' || (e && e.message && e.message.indexOf('quota') >= 0)) {
+              failed++;
+              stopReason = 'quota';
+              remaining--;
+              if (remaining <= 0) {
+                resolve({ stored: stored, skipped: skipped, failed: failed, bytes: bytes, reason: stopReason });
+              }
+              return;
+            }
+            failed++;
+            onProgress({ stored: stored, skipped: skipped, failed: failed, bytes: bytes });
+            next();
+          });
+        }).catch(function () {
+          failed++;
+          onProgress({ stored: stored, skipped: skipped, failed: failed, bytes: bytes });
+          next();
+        });
+      }
+
+      for (var i = 0; i < workers; i++) { next(); }
+    });
+  }
+
+  async function main() {
+    // 미지원/비보안 환경: no-op 강등 (인터셉터의 secure-context 가드와 동일 철학).
+    if (!window.isSecureContext || !('caches' in window)) {
+      signal({ type: 'ait:warm:done', ok: true, total: 0, stored: 0, skipped: 0, failed: 0, bytes: 0, elapsedMs: 0, reason: 'no-cache-api' });
+      return;
+    }
+
+    var startMs  = Date.now();
+    var deadline = startMs + timeout;
+
+    // 매니페스트 취득.
+    var manifest;
+    try {
+      var mResp = await fetch(MANIFEST_FILE, { cache: 'no-store' });
+      if (!mResp.ok) { throw new Error('HTTP ' + mResp.status); }
+      manifest = await mResp.json();
+    } catch (e) {
+      signal({ type: 'ait:warm:error', message: String(e) });
+      signal({ type: 'ait:warm:done', ok: false, total: 0, stored: 0, skipped: 0, failed: 0, bytes: 0, elapsedMs: Date.now() - startMs, reason: 'manifest-fetch-failed' });
+      return;
+    }
+
+    // 스키마 버전 체크.
+    if (manifest.schemaVersion !== SCHEMA_VERSION) {
+      signal({ type: 'ait:warm:done', ok: false, total: 0, stored: 0, skipped: 0, failed: 0, bytes: 0, elapsedMs: Date.now() - startMs, reason: 'schema-mismatch' });
+      return;
+    }
+
+    // cacheName: 매니페스트 우선(빌드 skew 시 안전), 없으면 빌드 시 박힌 값.
+    var cacheName = manifest.cacheName || BAKED_CACHE_NAME;
+    var cache = await caches.open(cacheName);
+
+    // 기캐시 URL 집합 구성 (절대 URL 키 규약).
+    var existingKeys = await cache.keys();
+    var existing = {};
+    for (var i = 0; i < existingKeys.length; i++) { existing[existingKeys[i].url] = true; }
+
+    // 자산 목록 절대화 + diff 계산.
+    var assets = (manifest.assets || []);
+    var targets = assets.map(function (a) {
+      return { url: absUrl(a.path), wireBytes: a.wireBytes, rawBytes: a.rawBytes, path: a.path };
+    });
+    var manifestUrlSet = {};
+    targets.forEach(function (t) { manifestUrlSet[t.url] = true; });
+
+    var todo    = targets.filter(function (t) { return !existing[t.url]; });
+    var skipped = targets.length - todo.length;
+    var total   = targets.length;
+
+    // 진행 신호 발신 헬퍼.
+    function onProgress(counts) {
+      signal({ type: 'ait:warm:progress', total: total, stored: counts.stored, skipped: skipped, failed: counts.failed, bytes: counts.bytes });
+    }
+
+    // 초기 진행 신호(skip 만 있는 경우 포함).
+    signal({ type: 'ait:warm:progress', total: total, stored: 0, skipped: skipped, failed: 0, bytes: 0 });
+
+    // 동시성 풀로 다운로드·저장.
+    var result = await runPool(concurrency, todo, deadline, cache, onProgress);
+
+    // stale 정리: 동일 오리진 && /Build/ 포함 && 매니페스트에 없는 엔트리 삭제.
+    // 인터셉터 부팅 sweep 과 동일 원천(매니페스트=빌드 파일 목록)이라 일관적.
+    // 비-Build 키는 보수적으로 불간섭.
+    try {
+      var staleKeys = await cache.keys();
+      for (var j = 0; j < staleKeys.length; j++) {
+        var k = staleKeys[j].url;
+        try {
+          var u = new URL(k);
+          if (u.origin === location.origin && u.pathname.indexOf('/Build/') >= 0 && !manifestUrlSet[k]) {
+            cache.delete(staleKeys[j]).catch(function () {});
+          }
+        } catch (e) {}
+      }
+    } catch (e) {}
+
+    var elapsedMs = Date.now() - startMs;
+    signal({
+      type: 'ait:warm:done',
+      ok: (result.failed === 0 && !result.reason),
+      total: total,
+      stored: result.stored,
+      skipped: skipped,
+      failed: result.failed,
+      bytes: result.bytes,
+      elapsedMs: elapsedMs,
+      reason: result.reason || null
+    });
+  }
+
+  // 전역 에러 안전망.
+  window.addEventListener('error', function (e) {
+    signal({ type: 'ait:warm:error', message: (e && e.message) || 'unknown error' });
+  });
+  window.addEventListener('unhandledrejection', function (e) {
+    signal({ type: 'ait:warm:error', message: (e && e.reason && String(e.reason)) || 'unhandled rejection' });
+  });
+
+  main();
+})();
+</script>
+</body>
+</html>
+";
+    }
+}

--- a/Editor/Package/AITWarmPageEmitter.cs.meta
+++ b/Editor/Package/AITWarmPageEmitter.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a96aed6984e01415cb0ea13c9a7d7c89
+guid: d15d887e6a8d483597db8a5d490b17cf
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -21,8 +21,11 @@ namespace AppsInToss.Editor.Package
         /// Unity WebGL 빌드를 public 폴더로 복사합니다.
         /// </summary>
         /// <returns>성공 시 SUCCEED, 실패 시 해당 에러 코드</returns>
-        internal static AITConvertCore.AITExportError CopyWebGLToPublic(string webglPath, string buildProjectPath, AITBuildProfile profile = null)
+        internal static AITConvertCore.AITExportError CopyWebGLToPublic(string webglPath, string buildProjectPath, out string inlinePrefetchJson, AITBuildProfile profile = null)
         {
+            // prefetch 인라인 카탈로그는 성공 경로(WriteManifest 산출)에서만 채워짐. 그 외 경로는 null 유지.
+            inlinePrefetchJson = null;
+
             // 프로필이 없으면 기본 프로필 사용
             if (profile == null)
             {
@@ -341,9 +344,46 @@ namespace AppsInToss.Editor.Package
                 Debug.Log($"[AIT] appsintoss-unity-bridge.js Mock 브릿지 모드: {(profile.enableMockBridge ? "활성화" : "비활성화")}");
             }
 
+            // Build 파일 복사 및 index.html 치환 완료 후 warm manifest 를 산출합니다.
+            // [destPath = publicPath] 명세 원문은 'index.html 이 놓이는 web 루트(buildProjectPath)' 라 기술하나,
+            // Build/* 파일은 publicPath(buildProjectPath/public/)에 복사되므로 wireBytes 계산이
+            // buildProjectPath 기준이면 FileInfo.Length 가 실패합니다. publicPath 를 전달해야
+            // Path.Combine(destPath, "Build", file) 이 실제 파일 위치와 일치합니다.
+            // Vite 가 public/ 을 정적 루트로 서빙하므로 호스트는 /ait-warm-manifest.json 으로 취득합니다.
+            inlinePrefetchJson = AITWarmManifestEmitter.WriteManifest(config, publicPath, loaderFile, dataFile, frameworkFile, wasmFile, symbolsFile);
+            AITWarmPageEmitter.WritePage(config, publicPath);
+
             Debug.Log("[AIT] Unity WebGL 빌드 복사 완료");
             Debug.Log("[AIT]   - index.html → 프로젝트 루트");
             Debug.Log("[AIT]   - Build, TemplateData, Runtime → public/");
+
+            // 네이티브 에셋 소스 레버 실효값 빌드 요약 + 침묵 열화(silent degradation) 경고.
+            // pageCache 가 ON 일 때만 인터셉터에 신호가 주입되므로 AND 게이트.
+            bool pageCacheEffective = config.pageCache < 0
+                ? AITDefaultSettings.GetDefaultPageCache()
+                : config.pageCache == 1;
+            bool nativeSourceEffective = config.nativeAssetSource < 0
+                ? AITDefaultSettings.GetDefaultNativeAssetSource()
+                : config.nativeAssetSource == 1;
+            if (pageCacheEffective && nativeSourceEffective)
+            {
+                Debug.Log("[AIT]   - 네이티브 에셋 소스 우선: 활성 (호스트 window.__aitResolveAsset 주입 시 native→CacheStorage→network)");
+
+                // 네이티브가 프리페치 대상 목록을 얻으려면 ait-warm-manifest.json 이 필요하다.
+                // warmManifest 가 OFF 면 매니페스트가 없어 네이티브 우선 경로가 사실상 무력화(폴백)된다 → 경고.
+                bool warmManifestEffective = config.warmManifest < 0
+                    ? AITDefaultSettings.GetDefaultWarmManifest()
+                    : config.warmManifest == 1;
+                if (!warmManifestEffective)
+                {
+                    Debug.LogWarning(
+                        "[AIT] 네이티브 에셋 소스가 활성이지만 Warm Manifest 가 비활성입니다. " +
+                        "호스트 네이티브가 프리페치 대상 목록(ait-warm-manifest.json)을 얻을 수 없어 " +
+                        "네이티브 우선 경로가 사실상 동작하지 않고 CacheStorage/network 로 폴백됩니다. " +
+                        "Warm Manifest 를 활성화하세요."
+                    );
+                }
+            }
 
             return AITConvertCore.AITExportError.SUCCEED;
         }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPageCacheEmitterTests.cs
@@ -289,4 +289,89 @@ public class AITPageCacheEmitterTests
         Assert.AreEqual(AITPageCacheEmitter.DefaultCacheName, result,
             "캐시명·appName 모두 비어 있으면 기본값으로 폴백해야 한다");
     }
+
+    // === 네이티브 에셋 소스 레버 (nativeAssetSource tri-state) ===
+
+    [Test]
+    public void NativeAssetSource_Default_IsEnabled()
+    {
+        Assert.IsTrue(AITDefaultSettings.GetDefaultNativeAssetSource(),
+            "네이티브 에셋 소스 기본값은 자동(true)이어야 한다");
+    }
+
+    [Test]
+    public void NativeAuto_EmitsResolverGuardAndSignal()
+    {
+        config.pageCache = 1;
+        config.nativeAssetSource = -1; // 자동 (기본 true)
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        Assert.IsNotEmpty(result);
+        StringAssert.Contains("var NATIVE_SOURCE = true", result,
+            "자동(-1)이면 기본값 true 가 NATIVE_SOURCE 에 박혀야 한다");
+        StringAssert.Contains("window.__aitNativeSourceEnabled", result,
+            "호스트가 리졸버 주입 여부를 판단할 신호를 노출해야 한다");
+        StringAssert.Contains("window.__aitResolveAsset", result,
+            "호스트 리졸버 진입점(__aitResolveAsset) 분기가 있어야 한다");
+        StringAssert.Contains("NATIVE_TIMEOUT_MS", result,
+            "네이티브 응답 타임아웃 상수가 있어야 한다");
+        StringAssert.Contains("clearTimeout", result,
+            "타이머 누수 방지를 위해 clearTimeout 으로 타이머를 해제해야 한다");
+    }
+
+    [Test]
+    public void NativeAuto_KeepsCacheFirstFallback()
+    {
+        config.pageCache = 1;
+        config.nativeAssetSource = -1;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        // 네이티브 우선 분기가 추가되어도 cacheFirst 폴백 경로는 보존되어야 한다(native→CacheStorage→network).
+        StringAssert.Contains("function cacheFirst", result,
+            "cacheFirst 폴백 함수가 추출되어 있어야 한다");
+        StringAssert.Contains("getCache", result,
+            "CacheStorage 폴백 경로가 유지되어야 한다");
+        StringAssert.Contains("native:", result,
+            "네이티브 히트 통계 라벨(native:)이 있어야 한다");
+    }
+
+    [Test]
+    public void NativeExplicitOff_DisablesSignalButKeepsCacheFirst()
+    {
+        config.pageCache = 1;
+        config.nativeAssetSource = 0; // 명시적 비활성
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        Assert.IsNotEmpty(result, "pageCache 가 ON 이면 인터셉터 자체는 여전히 생성되어야 한다");
+        StringAssert.Contains("var NATIVE_SOURCE = false", result,
+            "명시적 비활성(0)이면 NATIVE_SOURCE 가 false 여야 한다");
+        StringAssert.Contains("getCache", result,
+            "네이티브가 OFF 여도 cache-first 경로는 유지되어야 한다");
+    }
+
+    [Test]
+    public void NativeOn_PageCacheOff_NoInterceptor()
+    {
+        config.pageCache = 0; // 인터셉터 없음 → 신호 주입 지점 자체가 없음
+        config.nativeAssetSource = 1; // 명시적 활성이어도 무의미
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        Assert.AreEqual(string.Empty, result,
+            "pageCache==0 이면 인터셉터가 없으므로 nativeAssetSource 와 무관하게 빈 문자열이어야 한다(AND 게이트)");
+    }
+
+    [Test]
+    public void NativeSignal_AfterSecureContextGuard()
+    {
+        config.pageCache = 1;
+        config.nativeAssetSource = 1;
+        string result = AITPageCacheEmitter.GenerateInterceptorScript(config, DataFile, FrameworkFile, WasmFile);
+
+        // 신호는 보안/CacheStorage 가드(return) '이후'에 정의되어야 미지원 환경에서 미정의로 남는다(의도).
+        int guardIdx = result.IndexOf("'caches' in window");
+        int signalIdx = result.IndexOf("window.__aitNativeSourceEnabled");
+        Assert.Greater(guardIdx, -1, "보안/CacheStorage 가드가 있어야 한다");
+        Assert.Greater(signalIdx, guardIdx,
+            "네이티브 신호는 미지원 가드 이후에 정의되어야 한다(미지원 환경 미정의 보장)");
+    }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs
@@ -1,0 +1,479 @@
+// -----------------------------------------------------------------------
+// AITWarmManifestEmitterTests.cs - EditMode warm manifest 산출기 테스트
+// Level 0: AITWarmManifestEmitter.WriteManifest 의 게이팅/스키마/인코딩/
+//          결정성/플레이스홀더 안전 검증 (순수 파일 I/O, 빌드 불필요)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss;
+using AppsInToss.Editor.Package;
+
+[TestFixture]
+public class AITWarmManifestEmitterTests
+{
+    // 테스트용 파일명 상수
+    private const string LoaderFile    = "game.loader.js";
+    private const string DataFile      = "game.data";
+    private const string FrameworkFile = "game.framework.js";
+    private const string WasmFile      = "game.wasm";
+    private const string SymbolsFile   = "game.symbols.json";
+
+    // 알려진 gzip raw 크기 검증용
+    private const int KnownRawSize = 1024; // 바이트
+
+    private string _tempDir;
+    private string _buildDir;
+    private AITEditorScriptObject _config;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // 임시 디렉토리 생성 (GUID 기반으로 충돌 방지)
+        _tempDir = Path.Combine(Path.GetTempPath(), "AITWarmManifestTests_" + Guid.NewGuid().ToString("N"));
+        _buildDir = Path.Combine(_tempDir, "Build");
+        Directory.CreateDirectory(_buildDir);
+
+        // 가짜 빌드 파일 생성
+        CreateGzipFile(Path.Combine(_buildDir, DataFile), KnownRawSize);
+        CreatePlainFile(Path.Combine(_buildDir, WasmFile),      256);
+        CreatePlainFile(Path.Combine(_buildDir, FrameworkFile), 128);
+        CreatePlainFile(Path.Combine(_buildDir, LoaderFile),     64);
+        CreatePlainFile(Path.Combine(_buildDir, SymbolsFile),    32);
+
+        // config 생성 — tri-state: -1=자동(ON), 0=비활성, 1=활성
+        _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+        _config.pageCache     = 1;  // 명시적 활성
+        _config.warmManifest  = 1;  // 명시적 활성
+        _config.pageCacheName = "ait-page-cache";
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (_config != null)
+        {
+            UnityEngine.Object.DestroyImmediate(_config);
+        }
+
+        // 임시 디렉토리 정리
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // 정리 실패는 무시
+        }
+    }
+
+    // ===== 케이스 1: warmManifest=0(명시적 비활성) → 파일 미산출, stale 파일 삭제 =====
+
+    [Test]
+    public void Disabled_NoFileEmitted_AndStaleDeleted()
+    {
+        // stale 파일을 미리 생성
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        File.WriteAllText(manifestPath, "stale", Encoding.UTF8);
+        Assert.IsTrue(File.Exists(manifestPath), "SetUp: stale 파일이 있어야 한다");
+
+        _config.warmManifest = 0; // 명시적 비활성
+        WriteManifest();
+
+        Assert.IsFalse(File.Exists(manifestPath),
+            "warmManifest=0(명시적 비활성) 이면 기존 stale 파일도 삭제되어야 한다");
+    }
+
+    // ===== 케이스 1b: warmManifest=-1(자동=ON) → 정상 산출 =====
+
+    [Test]
+    public void AutoDefault_EmitsFile()
+    {
+        _config.warmManifest = -1; // 자동 (기본값 true)
+        _config.pageCache    = 1;  // 명시적 활성
+        WriteManifest();
+
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        Assert.IsTrue(File.Exists(manifestPath),
+            "warmManifest=-1(자동=ON) + pageCache 활성이면 manifest 를 산출해야 한다");
+    }
+
+    // ===== 케이스 2: warmManifest 실효값=true + pageCache=0(명시적 비활성) → 경고 + 미산출 =====
+
+    [Test]
+    public void EnabledManifest_ButPageCacheDisabled_WarnsAndNoFile()
+    {
+        _config.pageCache    = 0; // 명시적 비활성
+        _config.warmManifest = 1; // 명시적 활성
+
+        // 경고 로그가 발생해야 한다
+        LogAssert.Expect(LogType.Warning, new Regex("ait-warm-manifest\\.json 미산출"));
+
+        WriteManifest();
+
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        Assert.IsFalse(File.Exists(manifestPath),
+            "pageCache=0(명시적 비활성) 이면 manifest 를 산출하지 않아야 한다");
+    }
+
+    // ===== 케이스 2b: warmManifest=-1(자동=ON) + pageCache=-1(자동=ON) → 정상 산출 =====
+
+    [Test]
+    public void BothAuto_ProducesManifest()
+    {
+        _config.warmManifest = -1; // 자동
+        _config.pageCache    = -1; // 자동 (기본값 true)
+        WriteManifest();
+
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        Assert.IsTrue(File.Exists(manifestPath),
+            "warmManifest=-1(자동=ON) + pageCache=-1(자동=ON) 이면 manifest 를 산출해야 한다(zero-config)");
+    }
+
+    // ===== 케이스 3: 정상 산출 — 파일 존재, 경로 포함, cacheName 에코 =====
+
+    [Test]
+    public void NormalEmit_FileExists_ContainsBuildPaths()
+    {
+        WriteManifest();
+
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        Assert.IsTrue(File.Exists(manifestPath), "manifest 파일이 존재해야 한다");
+
+        string json = File.ReadAllText(manifestPath, Encoding.UTF8);
+
+        StringAssert.Contains("Build/" + DataFile,      json, "data 파일 경로가 포함되어야 한다");
+        StringAssert.Contains("Build/" + FrameworkFile, json, "framework 파일 경로가 포함되어야 한다");
+        StringAssert.Contains("Build/" + WasmFile,      json, "wasm 파일 경로가 포함되어야 한다");
+    }
+
+    [Test]
+    public void NormalEmit_CacheName_IsEchoed()
+    {
+        _config.pageCacheName = "my-custom-cache";
+        WriteManifest();
+
+        string json = ReadManifest();
+        StringAssert.Contains("my-custom-cache", json, "지정한 cacheName 이 manifest 에 포함되어야 한다");
+    }
+
+    [Test]
+    public void NormalEmit_EmptyCacheName_FallsBackToDefault()
+    {
+        _config.pageCacheName = "";
+        WriteManifest();
+
+        string json = ReadManifest();
+        StringAssert.Contains(AITPageCacheEmitter.DefaultCacheName, json,
+            "pageCacheName 이 비면 기본값 ait-page-cache 로 보정되어야 한다");
+    }
+
+    // ===== 케이스 4: wireBytes == 실제 파일 크기 =====
+
+    [Test]
+    public void NormalEmit_WireBytes_MatchActualFileSize()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        // wasm 파일은 plain bytes 이므로 wireBytes == 256 이어야 한다
+        long expectedWire = new FileInfo(Path.Combine(_buildDir, WasmFile)).Length;
+        StringAssert.Contains("\"wireBytes\": " + expectedWire, json,
+            "wireBytes 는 실제 파일 크기와 일치해야 한다");
+    }
+
+    // ===== 케이스 5: gzip 파일 rawBytes == 기지 raw 크기, encoding == "gzip" =====
+
+    [Test]
+    public void NormalEmit_GzipDataFile_HasCorrectRawBytesAndEncoding()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        // data 파일은 gzip 으로 만들었으므로 encoding "gzip" 이어야 한다
+        StringAssert.Contains("\"encoding\": \"gzip\"", json,
+            "gzip 파일은 encoding 이 gzip 이어야 한다");
+
+        // rawBytes 는 KnownRawSize 와 같아야 한다
+        StringAssert.Contains("\"rawBytes\": " + KnownRawSize, json,
+            "gzip rawBytes 는 알려진 raw 크기와 일치해야 한다");
+    }
+
+    // ===== 케이스 6: loader/symbols 는 excluded 에만 있고 assets 에 없음 =====
+
+    [Test]
+    public void NormalEmit_Loader_OnlyInExcluded_NotInAssets()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        // excluded 에 loader 경로가 있어야 한다
+        StringAssert.Contains("\"role\": \"loader\"", json, "loader 가 excluded 에 있어야 한다");
+
+        // assets 배열에는 loader 경로가 없어야 한다.
+        // assets 블록과 excluded 블록을 분리해서 검증.
+        int assetsStart = json.IndexOf("\"assets\"", StringComparison.Ordinal);
+        int excludedStart = json.IndexOf("\"excluded\"", StringComparison.Ordinal);
+        Assert.IsTrue(assetsStart >= 0 && excludedStart > assetsStart,
+            "assets 와 excluded 섹션 순서가 올바라야 한다");
+
+        string assetsSection = json.Substring(assetsStart, excludedStart - assetsStart);
+        StringAssert.DoesNotContain(LoaderFile, assetsSection,
+            "assets 섹션에 loader 파일이 포함되면 안 된다");
+    }
+
+    [Test]
+    public void NormalEmit_Symbols_OnlyInExcluded_NotInAssets()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        StringAssert.Contains("\"role\": \"symbols\"", json, "symbols 가 excluded 에 있어야 한다");
+
+        int assetsStart = json.IndexOf("\"assets\"", StringComparison.Ordinal);
+        int excludedStart = json.IndexOf("\"excluded\"", StringComparison.Ordinal);
+        string assetsSection = json.Substring(assetsStart, excludedStart - assetsStart);
+        StringAssert.DoesNotContain(SymbolsFile, assetsSection,
+            "assets 섹션에 symbols 파일이 포함되면 안 된다");
+    }
+
+    // ===== 케이스 7: %[A-Z_]+% 토큰 부재 =====
+
+    [Test]
+    public void NormalEmit_NoUnreplacedPlaceholderTokens()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        var matches = Regex.Matches(json, @"%[A-Z0-9_]+%");
+        Assert.AreEqual(0, matches.Count,
+            "manifest 에 %대문자_퍼센트% 토큰이 있으면 ValidatePlaceholderSubstitution 이 빌드를 실패시킨다");
+    }
+
+    // ===== 케이스 8: 결정성 — 2회 호출 산출물이 byte-identical =====
+
+    [Test]
+    public void NormalEmit_Deterministic_TwiceProducesBytesIdenticalOutput()
+    {
+        WriteManifest();
+        string first = ReadManifest();
+
+        WriteManifest();
+        string second = ReadManifest();
+
+        Assert.AreEqual(first, second,
+            "같은 입력에 대해 두 번 호출하면 byte-identical 산출물이어야 한다(타임스탬프/랜덤 없음)");
+    }
+
+    // ===== 케이스 9: schemaVersion, generator 필드 존재 =====
+
+    [Test]
+    public void NormalEmit_ContainsSchemaVersionAndGenerator()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        StringAssert.Contains("\"schemaVersion\": 1", json,
+            "schemaVersion 이 1 이어야 한다");
+        StringAssert.Contains("\"generator\":", json,
+            "generator 필드가 있어야 한다");
+        StringAssert.Contains("apps-in-toss.unity", json,
+            "generator 에 apps-in-toss.unity 가 포함되어야 한다");
+    }
+
+    // ===== 케이스 10: totals.wireBytes 가 파일 크기의 합 =====
+
+    [Test]
+    public void NormalEmit_TotalsWireBytes_IsSumOfAssets()
+    {
+        WriteManifest();
+        string json = ReadManifest();
+
+        long expectedTotal =
+            new FileInfo(Path.Combine(_buildDir, DataFile)).Length +
+            new FileInfo(Path.Combine(_buildDir, FrameworkFile)).Length +
+            new FileInfo(Path.Combine(_buildDir, WasmFile)).Length;
+
+        // totals 섹션 이후의 부분 문자열에서 wireBytes 를 탐색해
+        // per-asset wireBytes 와 우연히 일치하는 false-positive 를 방지한다.
+        int totalsIdx = json.IndexOf("\"totals\"", StringComparison.Ordinal);
+        Assert.Greater(totalsIdx, -1, "totals 섹션이 존재해야 한다");
+        string totalsSection = json.Substring(totalsIdx);
+        StringAssert.Contains("\"wireBytes\": " + expectedTotal, totalsSection,
+            "totals.wireBytes 는 assets wireBytes 의 합이어야 한다");
+    }
+
+    // ===== 인라인 카탈로그 (반환값, schemaVersion 2 — .ait 메타데이터 prefetch 용) =====
+
+    [Test]
+    public void InlineCatalog_ReturnedOnSuccess_SchemaVersion2()
+    {
+        string catalog = WriteManifestCatalog();
+
+        Assert.IsNotNull(catalog, "산출 성공 시 compact 카탈로그를 반환해야 한다");
+        StringAssert.Contains("\"schemaVersion\":2", catalog,
+            "인라인 카탈로그는 schemaVersion 2 여야 한다(파일은 1)");
+    }
+
+    [Test]
+    public void InlineCatalog_IsSingleLine_NoNewlines()
+    {
+        string catalog = WriteManifestCatalog();
+
+        Assert.IsNotNull(catalog);
+        StringAssert.DoesNotContain("\n", catalog, "환경변수 전달용이므로 줄바꿈이 없어야 한다");
+        StringAssert.DoesNotContain("\r", catalog, "환경변수 전달용이므로 CR 이 없어야 한다");
+    }
+
+    [Test]
+    public void InlineCatalog_ContainsAssetPaths_OmitsExcludedAndGenerator()
+    {
+        string catalog = WriteManifestCatalog();
+
+        StringAssert.Contains("Build/" + DataFile,      catalog, "data 경로가 포함되어야 한다");
+        StringAssert.Contains("Build/" + FrameworkFile, catalog, "framework 경로가 포함되어야 한다");
+        StringAssert.Contains("Build/" + WasmFile,      catalog, "wasm 경로가 포함되어야 한다");
+
+        // v2 카탈로그는 부팅 임계경로 밖 자산(excluded)과 generator 를 싣지 않는다.
+        StringAssert.DoesNotContain("\"excluded\"",  catalog, "카탈로그는 excluded 를 생략해야 한다");
+        StringAssert.DoesNotContain("\"generator\"", catalog, "카탈로그는 generator 를 생략해야 한다");
+        // loader/symbols 도 카탈로그 대상이 아니다.
+        StringAssert.DoesNotContain(LoaderFile,  catalog, "loader 는 카탈로그에 없어야 한다");
+        StringAssert.DoesNotContain(SymbolsFile, catalog, "symbols 는 카탈로그에 없어야 한다");
+    }
+
+    [Test]
+    public void InlineCatalog_GzipDataFile_HasCompactRawBytesAndEncoding()
+    {
+        string catalog = WriteManifestCatalog();
+
+        // compact(공백 없음) 형식의 encoding/rawBytes 를 검증.
+        StringAssert.Contains("\"encoding\":\"gzip\"", catalog,
+            "gzip 파일은 compact encoding 이 gzip 이어야 한다");
+        StringAssert.Contains("\"rawBytes\":" + KnownRawSize, catalog,
+            "gzip rawBytes 는 알려진 raw 크기와 일치해야 한다(compact)");
+    }
+
+    [Test]
+    public void InlineCatalog_NativeSourceExplicitOn_True()
+    {
+        _config.nativeAssetSource = 1; // 명시 활성
+        string catalog = WriteManifestCatalog();
+
+        StringAssert.Contains("\"nativeSource\":true", catalog,
+            "nativeAssetSource=1 이면 카탈로그 nativeSource 가 true 여야 한다");
+    }
+
+    [Test]
+    public void InlineCatalog_NativeSourceExplicitOff_False()
+    {
+        _config.nativeAssetSource = 0; // 명시 비활성
+        string catalog = WriteManifestCatalog();
+
+        StringAssert.Contains("\"nativeSource\":false", catalog,
+            "nativeAssetSource=0 이면 카탈로그 nativeSource 가 false 여야 한다");
+    }
+
+    [Test]
+    public void InlineCatalog_Disabled_ReturnsNull()
+    {
+        _config.warmManifest = 0; // 명시 비활성
+        string catalog = WriteManifestCatalog();
+
+        Assert.IsNull(catalog, "warmManifest=0 이면 카탈로그를 반환하지 않아야 한다(null)");
+    }
+
+    [Test]
+    public void InlineCatalog_PageCacheDisabled_ReturnsNull()
+    {
+        _config.pageCache    = 0; // 명시 비활성
+        _config.warmManifest = 1; // 명시 활성
+
+        LogAssert.Expect(LogType.Warning, new Regex("ait-warm-manifest\\.json 미산출"));
+
+        string catalog = WriteManifestCatalog();
+
+        Assert.IsNull(catalog, "pageCache=0 이면 카탈로그를 반환하지 않아야 한다(null)");
+    }
+
+    // -----------------------------------------------------------------------
+    // 헬퍼
+    // -----------------------------------------------------------------------
+
+    private void WriteManifest()
+    {
+        AITWarmManifestEmitter.WriteManifest(
+            _config,
+            _tempDir,
+            LoaderFile,
+            DataFile,
+            FrameworkFile,
+            WasmFile,
+            SymbolsFile
+        );
+    }
+
+    /// <summary>WriteManifest 의 반환값(인라인 compact v2 카탈로그 또는 null)을 그대로 반환합니다.</summary>
+    private string WriteManifestCatalog()
+    {
+        return AITWarmManifestEmitter.WriteManifest(
+            _config,
+            _tempDir,
+            LoaderFile,
+            DataFile,
+            FrameworkFile,
+            WasmFile,
+            SymbolsFile
+        );
+    }
+
+    private string ReadManifest()
+    {
+        string manifestPath = Path.Combine(_tempDir, AITWarmManifestEmitter.FileName);
+        return File.ReadAllText(manifestPath, Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// 알려진 raw 크기(<paramref name="rawSize"/> 바이트)를 gzip 으로 압축한 파일을 생성합니다.
+    /// gzip rawBytes 검증용.
+    /// </summary>
+    private static void CreateGzipFile(string path, int rawSize)
+    {
+        byte[] rawData = new byte[rawSize];
+        // 검증 가능한 패턴으로 채움 (0 만으로 채우면 압축률이 너무 높아도 무관)
+        for (int i = 0; i < rawSize; i++)
+        {
+            rawData[i] = (byte)(i % 251);
+        }
+
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+        using (var gz = new GZipStream(fs, CompressionMode.Compress, leaveOpen: false))
+        {
+            gz.Write(rawData, 0, rawData.Length);
+        }
+    }
+
+    /// <summary>
+    /// <paramref name="size"/> 바이트의 plain 파일을 생성합니다.
+    /// </summary>
+    private static void CreatePlainFile(string path, int size)
+    {
+        byte[] data = new byte[size];
+        for (int i = 0; i < size; i++)
+        {
+            // 1 offset: i=0 → 1(0x01), i=1 → 2(0x02), ...
+            // 첫 바이트=0x01(≠0x1f), 두 번째 바이트=0x02(≠0x8b) → gzip 매직 바이트(0x1f 0x8b) 절대 불일치.
+            data[i] = (byte)(i % 127 + 1);
+        }
+        File.WriteAllBytes(path, data);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmManifestEmitterTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a96aed6984e01415cb0ea13c9a7d7c89
+guid: 204c8bc9dd9530906c9961c10862cac7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs
@@ -1,0 +1,295 @@
+// -----------------------------------------------------------------------
+// AITWarmPageEmitterTests.cs - EditMode warm page 산출기 테스트
+// Level 0: AITWarmPageEmitter.WritePage 의 게이팅/내용/결정성/
+//          마커잔존/플레이스홀더 안전 검증 (순수 파일 I/O, 빌드 불필요)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss;
+using AppsInToss.Editor.Package;
+
+[TestFixture]
+public class AITWarmPageEmitterTests
+{
+    private string _tempDir;
+    private AITEditorScriptObject _config;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // GUID 기반 임시 디렉토리(충돌 방지).
+        _tempDir = Path.Combine(Path.GetTempPath(), "AITWarmPageTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        // 세 값 모두 명시적 활성(tri-state: 1=활성) 인 기본 config.
+        _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+        _config.pageCache     = 1;  // 명시적 활성
+        _config.warmManifest  = 1;  // 명시적 활성
+        _config.warmPage      = 1;  // 명시적 활성
+        _config.pageCacheName = "ait-page-cache";
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (_config != null)
+        {
+            UnityEngine.Object.DestroyImmediate(_config);
+        }
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // 정리 실패는 무시.
+        }
+    }
+
+    // ===== 케이스 1: config null → 파일 미산출, stale 있으면 삭제 =====
+
+    [Test]
+    public void WritePage_ConfigNull_DoesNotEmit()
+    {
+        // stale 파일 사전 배치.
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        File.WriteAllText(pagePath, "stale", Encoding.UTF8);
+
+        AITWarmPageEmitter.WritePage(null, _tempDir);
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "config null 이면 stale 파일도 삭제되고 신규 산출 없어야 한다");
+    }
+
+    // ===== 케이스 1b: warmPage=-1(자동=ON) + 업스트림 ON → 산출됨 =====
+
+    [Test]
+    public void AutoDefault_EmitsFile()
+    {
+        // GetDefaultWarmPage()=true 전제: warmPage=-1 이면 기본 ON.
+        _config.warmPage = -1; // 자동 (기본값 true)
+        _config.pageCache    = 1;
+        _config.warmManifest = 1;
+        WritePage();
+
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        Assert.IsTrue(File.Exists(pagePath),
+            "warmPage=-1(자동=ON) + pageCache·warmManifest 활성이면 ait-warm.html 을 산출해야 한다");
+    }
+
+    // ===== 케이스 2: warmPage=0(명시적 비활성) → stale 삭제 =====
+
+    [Test]
+    public void WritePage_WarmPageOff_DeletesStale()
+    {
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        File.WriteAllText(pagePath, "stale", Encoding.UTF8);
+
+        _config.warmPage = 0; // 명시적 비활성
+        WritePage();
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "warmPage=0(명시적 비활성) 이면 기존 stale 파일이 삭제되어야 한다");
+    }
+
+    // ===== 케이스 2b: warmPage=-1(자동=ON) + pageCache=0(명시적 비활성) → 미산출 =====
+
+    [Test]
+    public void AutoDefault_PageCacheOff_DoesNotEmit()
+    {
+        _config.warmPage  = -1; // 자동 (기본값 true)
+        _config.pageCache = 0;  // 명시적 비활성
+
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+
+        LogAssert.Expect(LogType.Warning, new Regex(@"ait-warm\.html 미산출"));
+
+        WritePage();
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "warmPage=-1(자동=ON) + pageCache=0(비활성) 이면 ait-warm.html 미산출이어야 한다");
+    }
+
+    // ===== 케이스 3: warmPage=1, warmManifest=0(명시적 비활성) → 경고 + 미산출 =====
+
+    [Test]
+    public void WritePage_WarmManifestOff_Warns_AndDeletesStale()
+    {
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        File.WriteAllText(pagePath, "stale", Encoding.UTF8);
+
+        _config.warmManifest = 0; // 명시적 비활성
+
+        LogAssert.Expect(LogType.Warning, new Regex(@"ait-warm\.html 미산출"));
+
+        WritePage();
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "warmManifest=0(명시적 비활성) 이면 ait-warm.html 미산출 + stale 삭제");
+    }
+
+    // ===== 케이스 4: warmPage=1, pageCache=0(명시적 비활성) → 경고 + 미산출 =====
+
+    [Test]
+    public void WritePage_PageCacheOff_Warns_AndDeletesStale()
+    {
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        File.WriteAllText(pagePath, "stale", Encoding.UTF8);
+
+        _config.pageCache = 0; // 명시적 비활성
+
+        LogAssert.Expect(LogType.Warning, new Regex(@"ait-warm\.html 미산출"));
+
+        WritePage();
+
+        Assert.IsFalse(File.Exists(pagePath),
+            "pageCache=0(명시적 비활성) 이면 ait-warm.html 미산출 + stale 삭제");
+    }
+
+    // ===== 케이스 5: 세 값 모두 명시적 활성 → 파일 존재, 길이 > 0 =====
+
+    [Test]
+    public void WritePage_AllFlagsOn_EmitsFile()
+    {
+        WritePage();
+
+        string pagePath = Path.Combine(_tempDir, AITWarmPageEmitter.FileName);
+        Assert.IsTrue(File.Exists(pagePath), "세 값 모두 명시적 활성이면 파일이 산출되어야 한다");
+        Assert.Greater(new FileInfo(pagePath).Length, 0L, "산출 파일 크기가 0 보다 커야 한다");
+    }
+
+    // ===== 케이스 6: 산출물에 cacheName 과 매니페스트 파일명 포함 =====
+
+    [Test]
+    public void WritePage_OutputContainsCacheNameAndManifestFileName()
+    {
+        _config.pageCacheName = "my-cache";
+        WritePage();
+
+        string html = ReadPage();
+        StringAssert.Contains("my-cache", html,
+            "지정한 pageCacheName 이 산출물에 포함되어야 한다");
+        StringAssert.Contains(AITWarmManifestEmitter.FileName, html,
+            "매니페스트 파일명(" + AITWarmManifestEmitter.FileName + ")이 산출물에 포함되어야 한다");
+    }
+
+    // ===== 케이스 7: pageCacheName 비어 있으면 기본값 사용 =====
+
+    [Test]
+    public void WritePage_EmptyCacheName_FallsBackToDefault()
+    {
+        _config.pageCacheName = "";
+        WritePage();
+
+        string html = ReadPage();
+        StringAssert.Contains(AITPageCacheEmitter.DefaultCacheName, html,
+            "pageCacheName 이 비면 기본값 ait-page-cache 로 보정되어야 한다");
+    }
+
+    // ===== 케이스 8: 결정성 — 동일 config 2회 호출 산출물 byte-identical =====
+
+    [Test]
+    public void WritePage_Deterministic_TwoCallsByteIdentical()
+    {
+        WritePage();
+        byte[] first = ReadPageBytes();
+
+        WritePage();
+        byte[] second = ReadPageBytes();
+
+        Assert.AreEqual(first.Length, second.Length,
+            "두 번 호출의 산출물 크기가 같아야 한다");
+        for (int i = 0; i < first.Length; i++)
+        {
+            if (first[i] != second[i])
+            {
+                Assert.Fail("산출물이 byte-identical 이어야 한다 (오프셋 " + i + " 불일치)");
+            }
+        }
+    }
+
+    // ===== 케이스 9: HTML 구조 최소 검사 =====
+
+    [Test]
+    public void WritePage_HtmlStructureSanity()
+    {
+        WritePage();
+        string html = ReadPage();
+
+        StringAssert.StartsWith("<!DOCTYPE html>", html.TrimStart(),
+            "HTML 파일이 <!DOCTYPE html> 로 시작해야 한다");
+        StringAssert.Contains("<script>", html,
+            "인라인 <script> 블록이 있어야 한다");
+        StringAssert.Contains("ait:warm:progress", html,
+            "progress 신호 타입 문자열이 포함되어야 한다");
+        StringAssert.Contains("ait:warm:done", html,
+            "done 신호 타입 문자열이 포함되어야 한다");
+        StringAssert.Contains("ait:warm:error", html,
+            "error 신호 타입 문자열이 포함되어야 한다");
+    }
+
+    // ===== 케이스 10: 마커 잔존 없음 + %[A-Z0-9_]+% 없음 =====
+
+    [Test]
+    public void WritePage_NoMarkerOrPlaceholderRemains()
+    {
+        WritePage();
+        string html = ReadPage();
+
+        StringAssert.DoesNotContain("__AIT_", html,
+            "__AIT_ 마커가 산출물에 잔존하면 안 된다");
+        Assert.IsFalse(Regex.IsMatch(html, @"%[A-Z0-9_]+%"),
+            "산출물에 %대문자_퍼센트% 토큰이 있으면 ValidatePlaceholderSubstitution 이 빌드를 실패시킨다");
+    }
+
+    // ===== 케이스 11: 합성 Response 에 Content-Encoding 을 헤더로 넣지 않음 =====
+
+    [Test]
+    public void WritePage_NoContentEncodingInSyntheticResponse()
+    {
+        WritePage();
+        string html = ReadPage();
+
+        // storeDecodeFree 에서 new Response 생성 시 content-encoding 을 헤더에 추가하지 않음을 검증.
+        // 합성 Response 생성부(new Response(buf, { status:200, headers: ... })) 직후에
+        // 'content-encoding' 을 headers 객체 키로 넣는 코드가 없어야 한다.
+        // 구현이 단일따옴표 위주이므로 양쪽 모두 체크.
+        int syntheticIdx = html.IndexOf("new Response(buf", StringComparison.Ordinal);
+        Assert.Greater(syntheticIdx, -1, "합성 Response 생성 코드가 존재해야 한다");
+
+        // 합성 Response 생성 이후 150자 이내에서 content-encoding 헤더 추가 여부 체크.
+        int checkEnd = Math.Min(syntheticIdx + 300, html.Length);
+        string surroundingCode = html.Substring(syntheticIdx, checkEnd - syntheticIdx);
+
+        StringAssert.DoesNotContain("content-encoding", surroundingCode.ToLowerInvariant(),
+            "합성 Response headers 에 content-encoding 을 추가하면 decode-free 계약 위반이다");
+    }
+
+    // -----------------------------------------------------------------------
+    // 헬퍼
+    // -----------------------------------------------------------------------
+
+    private void WritePage()
+    {
+        AITWarmPageEmitter.WritePage(_config, _tempDir);
+    }
+
+    private string ReadPage()
+    {
+        return File.ReadAllText(Path.Combine(_tempDir, AITWarmPageEmitter.FileName), Encoding.UTF8);
+    }
+
+    private byte[] ReadPageBytes()
+    {
+        return File.ReadAllBytes(Path.Combine(_tempDir, AITWarmPageEmitter.FileName));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWarmPageEmitterTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a96aed6984e01415cb0ea13c9a7d7c89
+guid: c287d79fe19a4b4995ed65bffafaadb8
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## 개요

호스트(슈퍼앱)가 앱 목록 페이지 등에서 게임의 `Build/*` 에셋을 **네이티브로 사전 다운로드**하고, 게임 WebView 안에서 그 결과를 우선 소비하게 하는 SDK 기능입니다. warm 3부작(#768 인터셉터 · #769 매니페스트 · #772 warm 페이지)의 형제 레버로, **CacheStorage 파티션 공유 게이트를 우회**(네이티브가 자체 스토어 소유)하여 첫 방문(cold) 가속을 노립니다.

> Base = `perf/webgl-warm-page` (warm 3부작 위에 스택). main 아님.

## 산출물

### ① 프리페치 정책 선언 — `.ait` `metadata.extra.unityMetaData.prefetch`
`AITUnityMetadata.cs`. **Approach A**: 인라인 카탈로그를 복제하지 않고 정책 + in-bundle 매니페스트(`web/ait-warm-manifest.json`) 포인터만 선언합니다. protobuf `index[]` 가 `mimeType`/오프셋이 결여돼 콘솔이 per-asset 상세를 얻으려면 매니페스트(mime/encoding/wireBytes)를 직접 파싱해야 하기 때문입니다. `pageCache`·`warmManifest` 실효값이 모두 ON 일 때만(매니페스트가 실제 산출되는 조건) 방출 → 그 외에는 `prefetch` 키 생략으로 **기존 출력과 byte-identical**(하위호환).

선언 형태 (트리거 정책은 **미선언** — 언제 프리페치할지는 호스트가 런타임 네트워크·저데이터 모드로 결정. SDK 는 "무엇을·어디서"만 선언):
```json
{"schemaVersion":1,"manifestUrl":"/ait-warm-manifest.json","bundleEntry":"web/ait-warm-manifest.json","cacheName":"<derived>","nativeSource":true}
```

### ② `nativeAssetSource` tri-state 레버 — 인터셉터 네이티브 소스 리졸버
`AITPageCacheEmitter.cs`. 페이지 캐시 인터셉터가 호스트의 `window.__aitResolveAsset(url)` 리졸버를 **native→CacheStorage→network** 순으로 해석합니다.

**리졸버 계약**:
- `window.__aitResolveAsset(url) => Promise<Response|null>` (동기 `Response`/`null` 도 허용 — `Promise.resolve` 정규화)
- `Response` 반환 → 그대로 서빙(**`cache.put` 안 함**: 네이티브가 자체 스토어 소유, 이중화 방지)
- `null`/throw/reject/**타임아웃(3000ms)** → `cacheFirst` 폴백
- **raw-only**: 네이티브는 해제된 bytes 를 `Content-Encoding` 없이 반환(CE 헤더 동반 시 진단 경고)
- 리졸버 미주입 시 신호(`window.__aitNativeSourceEnabled`)만 노출되고 기존 캐시-퍼스트로 **자동 폴백** → 기본 자동 ON 이 안전

## tri-state 표준 (기본 자동 ON)

`-1` 자동(true) / `0` 비활성 / `1` 활성. Configuration 윈도우 Popup·변경표시·리셋 + `CountModifiedWebGLSettings`/`ResetWebGLSettings` 배선 + 빌드 요약 로그 + `warmManifest` OFF 시 silent degradation 경고를 포함합니다. `pageCache` 실효값 ON 이 전제인 **AND 게이트**(인터셉터가 존재해야 신호 주입).

## 안전성

- **픽셀 불변**: 첫 프레임 렌더 경로 불변. 리졸버 미주입/실패/타임아웃은 모두 기존 캐시-퍼스트로 흡수.
- **하위호환**: prefetch 선언은 조건부(둘 다 ON)라 기존 빌드 메타데이터와 byte-identical.
- **타이머 누수 방지**: `then`/`catch` 양쪽에서 `clearTimeout`.

## 검증

- EditMode 신규 6종(`AITPageCacheEmitterTests`): 기본값 · 자동 방출(신호/리졸버 가드/타임아웃) · 캐시-퍼스트 폴백 · 명시 OFF · `pageCache` OFF 시 무인터셉터 · 보안 가드 이후 신호 순서.
- 전체 EditMode 스위트 **31/31 통과**, 컴파일 에러 0.

---

⚠️ **머지 금지** — 이 perf 레버 PR은 3.0 beta→stable 이후에 머지 트랙에 올립니다. 그 전까지 리뷰/측정 용도로만 열어둡니다.
