### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — android-keystore-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -290,6 +290,15 @@ namespace AppsInToss.Editor.ErrorTracker
             //     "[pnpm] 비동기 명령 실패 (Exit Code: -1): pnpm exec granite build" (SDK-VG/VD/VB)
             "[pnpm] 명령 실패 (Exit Code:",
             "[pnpm] 비동기 명령 실패",
+
+            // Android 키스토어 경로/비밀번호 잘못 설정 시 OpenJDK + sdktools.jar가 직접 출력하는 오류.
+            // Unity Android 빌드 시 사용자가 Project Settings > Player > Publishing Settings에
+            // 잘못된 키스토어 경로 또는 비밀번호를 입력했을 때 발생. AIT SDK 식별자 없음.
+            // 예: "UnityError: Unable to list keys in the keystore. Please make sure the location
+            //      and password of the keystore is correct." (APPS-IN-TOSS-UNITY-SDK-118)
+            // SDK 코드는 키스토어 경로/비밀번호를 직접 다루지 않으므로 SDK 버그 아님.
+            // SDK는 이 문자열을 출력하지 않음(AitKeywords에 없음).
+            "Unable to list keys in the keystore",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2277,6 +2277,36 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region Android 키스토어 노이즈 (APPS-IN-TOSS-UNITY-SDK-118)
+
+    [Test]
+    public void AndroidKeystore_UnableToListKeys_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-118 — Unity Android 빌드 시 사용자가 잘못된 키스토어
+        // 경로/비밀번호를 설정했을 때 OpenJDK + sdktools.jar가 직접 출력하는 오류.
+        // AIT SDK 식별자 없음, SDK 코드는 키스토어를 직접 다루지 않으므로 SDK 버그 아님.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Unable to list keys in the keystore. Please make sure the location and password of the keystore is correct."));
+    }
+
+    [Test]
+    public void AndroidKeystore_UnableToListKeys_BareMessage_ReturnsTrue()
+    {
+        // prefix 없이 핵심 문구만 도달하는 변형도 동일하게 드롭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Unable to list keys in the keystore. Please make sure the location and password of the keystore is correct."));
+    }
+
+    [Test]
+    public void AndroidKeystore_UnableToListKeys_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Unable to list keys in the keystore."));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-118

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-118 | "UnityError: Unable to list keys in the keystore. Please make sure the location and password of the keystore is correct." |

## 추출 패턴

- \`"Unable to list keys in the keystore"\` → \`NonSdkMessagePatterns\` 추가

## 추가 위치

\`Editor/ErrorTracker/AITEditorErrorTracker.cs\` — \`NonSdkMessagePatterns\` 배열 말미

## 근거

Unity Android 빌드 시 사용자가 Project Settings > Player > Publishing Settings에 잘못된 키스토어 경로 또는 비밀번호를 입력했을 때 OpenJDK + sdktools.jar가 직접 출력하는 외부 오류. AIT SDK 식별자 없음, SDK 코드는 키스토어 경로/비밀번호를 직접 다루지 않음.

## --validate 결과

동시 빌드 회피로 검증 skip — 사람 확인 필요
(실행 시점에 다수의 run-local-tests 프로세스가 이미 동작 중이어서 런북 정책에 따라 검증을 건너뜀)

## 주의

사람 머지 검토 필요