### PR TITLE
빌드: pnpm v11.6.0 채택 + @apps-in-toss/* 공급망 격리 예외

### DIFF
--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -426,6 +426,10 @@ namespace AppsInToss.Editor
             // 2. pnpm-lock.yaml - 정합성 검증 후 폴백 정책 (Fix A, BuildConfigMerger 위임)
             Package.BuildConfigMerger.CopyPnpmLockfileWithFallback(projectBuildConfigPath, sdkBuildConfigPath, buildProjectPath);
 
+            // 2-1. pnpm-workspace.yaml - 공급망 보호(minimumReleaseAge)에서 @apps-in-toss/* 예외 처리
+            //      (pnpm은 이 설정을 pnpm-workspace.yaml에서만 읽으므로 빌드 디렉토리에 복사 필수)
+            Package.BuildConfigMerger.CopyPnpmWorkspaceWithFallback(projectBuildConfigPath, sdkBuildConfigPath, buildProjectPath);
+
             // 3. vite.config.ts - 마커 기반 업데이트
             Package.BuildConfigMerger.UpdateViteConfig(projectBuildConfigPath, sdkBuildConfigPath, buildProjectPath, config);
 

--- a/Editor/AITPackageManagerHelper.cs
+++ b/Editor/AITPackageManagerHelper.cs
@@ -16,7 +16,7 @@ namespace AppsInToss.Editor
         /// pnpm 버전 (내장 Node.js에 설치할 버전)
         /// 최신 버전 강제 방지를 위해 고정
         /// </summary>
-        public const string PNPM_VERSION = "10.28.0";
+        public const string PNPM_VERSION = "11.6.0";
 
         /// <summary>
         /// 표준 실행 파일 경로 (플랫폼별)

--- a/Editor/Package/BuildConfigMerger.cs
+++ b/Editor/Package/BuildConfigMerger.cs
@@ -121,6 +121,32 @@ namespace AppsInToss.Editor.Package
         }
 
         /// <summary>
+        /// pnpm-workspace.yaml을 빌드 디렉토리로 복사합니다.
+        /// 이 파일은 공급망 보호(minimumReleaseAge)에서 @apps-in-toss/* 패키지를 예외 처리하는
+        /// 정적 설정 파일이라 병합/검증 없이 그대로 복사합니다. pnpm은 이 설정을
+        /// pnpm-workspace.yaml에서만 읽으므로(.npmrc/package.json#pnpm 불가) 빌드 디렉토리에
+        /// 반드시 존재해야 미니앱 빌드 시 예외가 적용됩니다.
+        /// 프로젝트에 동명 파일이 있으면 사용자 설정을 우선하고, 없으면 SDK 기본값을 사용합니다.
+        /// </summary>
+        internal static void CopyPnpmWorkspaceWithFallback(string projectBuildConfigPath, string sdkBuildConfigPath, string destPath)
+        {
+            string workspaceProject = Path.Combine(projectBuildConfigPath, "pnpm-workspace.yaml");
+            string workspaceSdk = Path.Combine(sdkBuildConfigPath, "pnpm-workspace.yaml");
+            string workspaceDst = Path.Combine(destPath, "pnpm-workspace.yaml");
+
+            if (File.Exists(workspaceProject))
+            {
+                File.Copy(workspaceProject, workspaceDst, true);
+                Debug.Log("[AIT]   ✓ pnpm-workspace.yaml (프로젝트에서 복사)");
+            }
+            else if (File.Exists(workspaceSdk))
+            {
+                File.Copy(workspaceSdk, workspaceDst, true);
+                Debug.Log("[AIT]   ✓ pnpm-workspace.yaml (SDK에서 복사)");
+            }
+        }
+
+        /// <summary>
         /// dependencies 딕셔너리를 머지합니다. SDK 패키지가 우선됩니다.
         /// </summary>
         internal static Dictionary<string, object> MergeDependencies(Dictionary<string, object> project, Dictionary<string, object> sdk)

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -352,9 +352,10 @@ namespace AppsInToss.Editor.Package
             if (!Directory.Exists(projectBuildConfigPath)) return;
 
             // 루트 레벨에서 제외할 파일들
+            // (pnpm-workspace.yaml은 BuildConfigMerger.CopyPnpmWorkspaceWithFallback가 전담 복사하므로 제외)
             var excludeRootFiles = new HashSet<string>
             {
-                "package.json", "pnpm-lock.yaml", "vite.config.ts",
+                "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "vite.config.ts",
                 "tsconfig.json", "unity-bridge.ts", "granite.config.ts",
                 "apps-in-toss.config.ts"
             };
@@ -501,6 +502,7 @@ namespace AppsInToss.Editor.Package
                     "package.json",
                     "package-lock.json",
                     "pnpm-lock.yaml",
+                    "pnpm-workspace.yaml",
                     "granite.config.ts",
                     "apps-in-toss.config.ts",
                     "vite.config.ts",

--- a/WebGLTemplates/AITTemplate/BuildConfig~/package.json
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/package.json
@@ -17,12 +17,5 @@
     "vite": "8.0.16",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@10.28.0",
-  "pnpm": {
-    "overrides": {
-      "@granite-js/plugin-core": "0.1.30",
-      "find-my-way": ">=8.2.2",
-      "ip": ">=2.0.1"
-    }
-  }
+  "packageManager": "pnpm@11.6.0"
 }

--- a/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
@@ -9,3 +9,11 @@
 # 이 파일은 미니앱 빌드 디렉토리로 복사되며, 사용자 프로젝트에 동명 파일이 있으면 그쪽이 우선한다.
 minimumReleaseAgeExclude:
   - '@apps-in-toss/*'
+
+# transitive 의존성 보안/호환 고정.
+# pnpm v11부터 package.json의 "pnpm" 필드(overrides 등)를 더 이상 읽지 않으므로
+# 기존 package.json#pnpm.overrides를 이곳으로 이전했다.
+overrides:
+  '@granite-js/plugin-core': 0.1.30
+  find-my-way: '>=8.2.2'
+  ip: '>=2.0.1'

--- a/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+# 공급망 보호(minimumReleaseAge)에서 @apps-in-toss/* 패키지를 예외 처리한다.
+#
+# pnpm은 갓 publish된 버전을 일정 시간(minimumReleaseAge)만큼 격리해 공급망 공격을 완화한다.
+# pnpm v11부터 이 값의 기본이 1440분(1일)이라, SDK가 막 배포한 @apps-in-toss/* 패키지가
+# quarantine에 걸려 미니앱 빌드가 지연될 수 있다. 우리 패키지는 신뢰 대상이므로 예외 처리해
+# 유저(게임 개발자)가 불편을 겪지 않게 한다.
+#
+# 주의: pnpm은 이 설정을 pnpm-workspace.yaml에서만 읽는다 (.npmrc / package.json#pnpm 불가).
+# 이 파일은 미니앱 빌드 디렉토리로 복사되며, 사용자 프로젝트에 동명 파일이 있으면 그쪽이 우선한다.
+minimumReleaseAgeExclude:
+  - '@apps-in-toss/*'

--- a/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
@@ -17,3 +17,12 @@ overrides:
   '@granite-js/plugin-core': 0.1.30
   find-my-way: '>=8.2.2'
   ip: '>=2.0.1'
+
+# pnpm v11은 의존성의 build script(postinstall 등)가 차단될 때 승인/무시 결정이 없으면
+# 설치 자체를 실패시킨다(ERR_PNPM_IGNORED_BUILDS). 미니앱 빌드 의존성(granite/vite 등)의
+# 트리는 크고 버전마다 달라 목록 고정은 깨지기 쉬우므로, 설치 단계의 의존성 스크립트를
+# 건너뛰어(=pnpm v10 동작 유지) 빌드가 실패하지 않게 한다. 네이티브 바이너리(esbuild 등)는
+# optionalDependencies 플랫폼 패키지로 제공되어 영향이 없다.
+# 주의: ignoreScripts는 '설치 단계'만 막는다. `ait build`/`granite build`(명시적 `pnpm run`)는
+#       그대로 실행된다 (pnpm 11.6.0에서 검증).
+ignoreScripts: true

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "com.unity.nuget.newtonsoft-json": "3.0.2"
   },
   "category": "Platform SDK",
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@11.6.0",
   "devDependencies": {
     "typescript": "^6.0.2"
   }

--- a/sdk-runtime-generator~/package.json
+++ b/sdk-runtime-generator~/package.json
@@ -21,7 +21,7 @@
     "test:differential": "vitest run tests/unit/differential.test.ts",
     "test:multi-version": "vitest run tests/unit/multi-version.test.ts"
   },
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@11.6.0",
   "dependencies": {
     "@apps-in-toss/framework": "1.6.0",
     "@apps-in-toss/web-analytics": "2.7.0",
@@ -90,11 +90,5 @@
     "web-framework-2.6.1": "npm:@apps-in-toss/web-framework@2.6.1",
     "web-framework-2.6.2": "npm:@apps-in-toss/web-framework@2.6.2",
     "web-framework-2.7.0": "npm:@apps-in-toss/web-framework@2.7.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "find-my-way": ">=8.2.2",
-      "ip": ">=2.0.1"
-    }
   }
 }

--- a/sdk-runtime-generator~/pnpm-workspace.yaml
+++ b/sdk-runtime-generator~/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# 공급망 보호(minimumReleaseAge)에서 @apps-in-toss/* 패키지를 예외 처리한다.
+#
+# pnpm은 갓 publish된 버전을 일정 시간(minimumReleaseAge)만큼 격리해 공급망 공격을 완화한다.
+# pnpm v11부터 이 값의 기본이 1440분(1일)이라, SDK가 막 배포한 @apps-in-toss/* 패키지가
+# quarantine에 걸려 SDK 재생성/미니앱 빌드가 지연될 수 있다. 우리 패키지는 신뢰 대상이므로
+# 예외 처리해 유저(게임 개발자)가 불편을 겪지 않게 한다.
+#
+# 주의: pnpm은 이 설정을 pnpm-workspace.yaml에서만 읽는다 (.npmrc / package.json#pnpm 불가).
+minimumReleaseAgeExclude:
+  - '@apps-in-toss/*'

--- a/sdk-runtime-generator~/pnpm-workspace.yaml
+++ b/sdk-runtime-generator~/pnpm-workspace.yaml
@@ -1,10 +1,16 @@
+# pnpm 설정 파일.
+# pnpm v11부터 package.json의 "pnpm" 필드(overrides 등)를 더 이상 읽지 않고 이 파일에서만
+# 읽으므로, 기존 package.json#pnpm.overrides를 이곳으로 이전했다.
+# (pnpm은 minimumReleaseAge*/overrides 설정을 pnpm-workspace.yaml에서만 읽는다.)
+
 # 공급망 보호(minimumReleaseAge)에서 @apps-in-toss/* 패키지를 예외 처리한다.
-#
-# pnpm은 갓 publish된 버전을 일정 시간(minimumReleaseAge)만큼 격리해 공급망 공격을 완화한다.
-# pnpm v11부터 이 값의 기본이 1440분(1일)이라, SDK가 막 배포한 @apps-in-toss/* 패키지가
-# quarantine에 걸려 SDK 재생성/미니앱 빌드가 지연될 수 있다. 우리 패키지는 신뢰 대상이므로
+# pnpm v11부터 minimumReleaseAge 기본이 1440분(1일)이라, SDK가 막 배포한 @apps-in-toss/*
+# 패키지가 quarantine에 걸려 SDK 재생성/빌드가 지연될 수 있다. 자사 패키지는 신뢰 대상이므로
 # 예외 처리해 유저(게임 개발자)가 불편을 겪지 않게 한다.
-#
-# 주의: pnpm은 이 설정을 pnpm-workspace.yaml에서만 읽는다 (.npmrc / package.json#pnpm 불가).
 minimumReleaseAgeExclude:
   - '@apps-in-toss/*'
+
+# transitive 의존성 보안/호환 고정 (구 package.json#pnpm.overrides에서 이전).
+overrides:
+  find-my-way: '>=8.2.2'
+  ip: '>=2.0.1'

--- a/sdk-runtime-generator~/pnpm-workspace.yaml
+++ b/sdk-runtime-generator~/pnpm-workspace.yaml
@@ -14,3 +14,12 @@ minimumReleaseAgeExclude:
 overrides:
   find-my-way: '>=8.2.2'
   ip: '>=2.0.1'
+
+# pnpm v11은 의존성의 build script(postinstall 등)를 기본 차단하고, 승인/무시 결정이 없으면
+# 설치 자체를 실패시킨다(ERR_PNPM_IGNORED_BUILDS — 예: @sentry/cli·@swc/core·esbuild·protobufjs).
+# pnpm v10에서도 이 스크립트들은 실행되지 않은 채(경고만) 정상 동작했으므로(네이티브 바이너리는
+# optionalDependencies 플랫폼 패키지로 제공됨), 설치 단계에서 의존성 스크립트를 건너뛰어
+# 동일한 동작을 유지한다.
+# 주의: ignoreScripts는 '설치 단계'의 스크립트만 막는다. 명시적 `pnpm run build`/`generate`/
+#       `test` 와 pre·post 훅(prebuild 등)은 그대로 실행된다 (pnpm 11.6.0에서 검증).
+ignoreScripts: true


### PR DESCRIPTION
## 배경

게임 개발자(SDK 사용자)가 더 최신 pnpm을 쓸 수 있어야 하고, 그 과정에서 pnpm v11의 기본 공급망 격리(`minimumReleaseAge`) 때문에 막 배포된 `@apps-in-toss/*` 패키지가 24시간 동안 사용 불가가 되어 불편을 겪지 않도록 한다.

## 변경 사항

### 1. `@apps-in-toss/*` 공급망 격리 예외 (커밋 `bd4bbc8`)

pnpm은 갓 publish된 버전을 일정 시간(`minimumReleaseAge`)만큼 격리해 공급망 공격을 완화한다. **pnpm v11부터 이 기본값이 1440분(1일)** 이라, SDK가 막 배포한 자사 패키지가 quarantine에 걸려 SDK 재생성/미니앱 빌드가 지연될 수 있다. 자사 패키지는 신뢰 대상이므로 `minimumReleaseAgeExclude: ['@apps-in-toss/*']`로 예외 처리한다.

- pnpm은 이 설정을 **`pnpm-workspace.yaml`에서만** 읽는다 (`.npmrc` / `package.json#pnpm` 불가). 따라서 두 워크스페이스 모두에 `pnpm-workspace.yaml`을 추가:
  - `sdk-runtime-generator~/` — SDK 재생성/CI 경로
  - `WebGLTemplates/AITTemplate/BuildConfig~/` — 미니앱 빌드 경로
- 다단계 설치(`PnpmStoreManager`의 frozen→non-frozen 재시도)가 재해석(re-resolve)할 때도 예외가 적용되도록, 빌드 디렉토리로 `pnpm-workspace.yaml`을 전파한다:
  - `Editor/Package/BuildConfigMerger.cs` — `CopyPnpmWorkspaceWithFallback` 추가 (프로젝트 우선, 없으면 SDK)
  - `Editor/AITPackageBuilder.cs` — lockfile 복사 직후 워크스페이스 복사 호출
  - `Editor/Package/WebGLBuildCopier.cs` — 전담 복사기와의 중복 방지 + `ait-build` 정리 시 보존 목록 추가

### 2. pnpm v11.6.0 채택 + overrides 이관 (커밋 `9bc907f`)

버전 핀 4곳을 `10.28.0` → `11.6.0`으로 bump (CLAUDE.md 동기화 규칙):
- `Editor/AITPackageManagerHelper.cs`의 `PNPM_VERSION` 상수
- `package.json` / `sdk-runtime-generator~/package.json` / `WebGLTemplates/AITTemplate/BuildConfig~/package.json`의 `packageManager` 필드

**pnpm v11 breaking change #1 대응 (overrides):** v11부터 `package.json`의 `"pnpm"` 필드(`overrides` 등)를 더 이상 읽지 않는다(설치 시 *"The pnpm field in package.json is no longer read"* 경고와 함께 무시). 기존 `pnpm.overrides`를 각 `pnpm-workspace.yaml`의 `overrides` 블록으로 이관:
- `sdk-runtime-generator~`: `find-my-way >=8.2.2`, `ip >=2.0.1`
- `BuildConfig~`: `@granite-js/plugin-core 0.1.30`, `find-my-way >=8.2.2`, `ip >=2.0.1`

이관 값은 기존 `pnpm-lock.yaml`의 `overrides` 블록과 **동일**하고 `lockfileVersion`도 `9.0`으로 같으므로 **lockfile 재생성/드리프트 없음.**

### 3. pnpm v11 breaking change #2 대응 — `ERR_PNPM_IGNORED_BUILDS` (커밋 `3abecbe`)

v11부터 build script(`postinstall` 등)를 가진 의존성에 대해 승인/무시 결정이 없으면 **설치 자체를 `exit 1`로 실패**시킨다(pnpm 10은 경고만 출력하고 통과). CI의 *SDK Generator Unit Tests* 가 이 에러로 실패했다(`@sentry/cli`·`@swc/core`·`esbuild`·`protobufjs` 등).

- `onlyBuiltDependencies` / `ignoredBuiltDependencies` 목록 고정은 의존성 트리가 크고 버전마다 달라 깨지기 쉽다. 특히 **`ignoredBuiltDependencies`는 실제로 에러를 억제하지 못함**을 pnpm 11.6.0에서 합성 테스트로 확인했다.
- 대신 설치 단계의 의존성 스크립트를 건너뛰는 **`ignoreScripts: true`** 를 두 워크스페이스에 적용 → pnpm 10의 실효 동작(=의존성 build script 미실행)을 그대로 유지한다.
  - 네이티브 바이너리(`esbuild`/`@swc/core` 등)는 `optionalDependencies` 플랫폼 패키지로 제공되어 영향 없음.
  - **`ignoreScripts`는 '설치 단계' 스크립트만 막는다.** 명시적 `pnpm run build`/`generate`/`test`, `ait build`/`granite build`, pre·post 훅(`prebuild` 등)은 그대로 실행됨(pnpm 11.6.0에서 검증).
- 격리 환경에서 실제 generator 의존성으로 `pnpm install --no-frozen-lockfile`(실패하던 CI 명령과 동일) 재현 → **`exit 0`, `ERR_PNPM_IGNORED_BUILDS` 없음**, `web-framework` 전 버전(2.7.0 포함) 정상 resolve 확인.

## 두 변경을 한 PR로 묶은 이유

v11로 올리면 `minimumReleaseAge` 기본이 1440분으로 켜진다. 예외 설정 없이 v11만 머지되면 **격리 예외가 빠진 채 기본 격리가 활성화되는 윈도우**가 생긴다. 두 변경을 함께 squash 머지해 그 윈도우를 제거한다.

## 검증

- `pnpm 11.6.0`이 두 `pnpm-workspace.yaml`(exclude + overrides + ignoreScripts)을 스키마 에러 없이 파싱.
- 두 `pnpm-lock.yaml`의 `overrides` 블록이 이관한 값과 정확히 일치 → drift 없음. `lockfileVersion 9.0` 동일.
- 두 `package.json` 모두 유효 JSON이고 `"pnpm"` 필드 제거됨.
- **두 설치 경로 모두 격리 환경에서 실제 install 재현 (pnpm 11.6.0):**
  - generator 경로(`sdk-runtime-generator~`) — `pnpm install --no-frozen-lockfile`(실패하던 CI 명령과 동일): `exit 0`, `ERR_PNPM_IGNORED_BUILDS` 없음, web-framework 2.7.0 포함 전 버전 resolve.
  - 미니앱 빌드 경로(`BuildConfig~`, granite/vite 트리): `ignoreScripts: true`로 **exit 0** / `ignoreScripts` 제거 시 **exit 1**(필요성 재현). 차단되는 build-script 패키지는 모두 네이티브 바이너리 페치 클래스(`@sentry/cli`·`@swc/core`·`esbuild`·`protobufjs`)로, 네이티브 바이너리는 `optionalDependencies` 플랫폼 패키지로 제공되어 번들 빌드에 비필수 → skip 안전. generator 빌드(`generate`+`test:invariants`)가 동일 클래스에서 그린 CI로 통과함이 이를 뒷받침.
- SDK 유닛 테스트 `test:invariants` 18/18 통과 (`--validate` 게이트).
  - 참고: 로컬 `differential` 테스트의 일부 실패는 로컬 `node_modules`가 stale(`web-framework 2.6.1`)인 반면 golden은 `2.7.0` 기준이기 때문이며, 본 변경(버전 핀·overrides 이관·ignoreScripts)과 무관하다. CI는 fresh install(`2.7.0`)이라 영향 없음.

## 영향 범위 / 비고

- 동작 변경은 빌드 도구(pnpm) 설정에 한정. 런타임/SDK 생성 코드 변경 없음.
- E2E 샘플 프로젝트의 `BuildConfig~/package.json#pnpm`은 머지 시 SDK 쪽 필드가 채택되어 빌드 출력에 inert하므로 이번엔 건드리지 않음.