### PR TITLE
수정: .meta 손-작성 GUID를 랜덤으로 교체 및 재발 방지 가드 추가 — GUID 충돌 해결 (techchat #4076)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,3 +99,8 @@ jobs:
           fi
 
           echo "✓ 모든 Unity 파일에 .meta 파일이 있습니다."
+
+      - name: Check .meta GUID hygiene
+        # 배포 .meta의 중복 GUID / 손-작성 순차 GUID 검사 (techchat #4076 재발 방지).
+        # Node stdlib만 사용 — ubuntu-latest 기본 Node로 충분.
+        run: node "scripts~/check-meta-guids.js"

--- a/Editor/AITBuildSessionRecovery.cs.meta
+++ b/Editor/AITBuildSessionRecovery.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5c3d7fab8e6f4c2b1a0d9e8f7a6b5c4d
+guid: 29f45e1db3874559a96d2df0617fc29d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Editor/AITEditorIdleWaiter.cs.meta
+++ b/Editor/AITEditorIdleWaiter.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7a1b3d8e6c4f9e2d1b0a8c7d6e5f4a3b
+guid: ab1a4dd9a1ec46809744c733e90f1345
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Editor/AppsInTossSDKEditor.asmdef
+++ b/Editor/AppsInTossSDKEditor.asmdef
@@ -4,7 +4,7 @@
     "references": [
         "GUID:343deaaf83e0cee4ca978e7df0b80d21",
         "GUID:69448af7b92c7f342b298e06a37122aa",
-        "GUID:8b2c4f6a3d1e5a7890bcdef123456789"
+        "GUID:3ef695279b5a46718ce875b0a45fa890"
     ],
     "includePlatforms": [
         "Editor"

--- a/Editor/Sentry.meta
+++ b/Editor/Sentry.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0
+guid: 08808edc0a074c40b0d5a3d37d570dee
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Runtime/Helpers.meta
+++ b/Runtime/Helpers.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7a1b3c5d9e2f4a6b8c0d1e3f5a7b9c1d
+guid: dcd918df317b400d9583deb8e1610711
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Runtime/Helpers/AIT.PerformanceLogger.cs.meta
+++ b/Runtime/Helpers/AIT.PerformanceLogger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a3b7c9d1e5f24680b8a4d2e6f1c3a5b7
+guid: cab3292b377047c19e00b1229673786c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Helpers/AITVersion.cs.meta
+++ b/Runtime/Helpers/AITVersion.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b2c3d4e5f6789012345678abcdef0123
+guid: 7a05ed4f9c0a4221aa8606c024f9431a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Helpers/AppsInToss.Helpers.asmdef.meta
+++ b/Runtime/Helpers/AppsInToss.Helpers.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8b2c4f6a3d1e5a7890bcdef123456789
+guid: 3ef695279b5a46718ce875b0a45fa890
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData:

--- a/Runtime/Helpers/Plugins.meta
+++ b/Runtime/Helpers/Plugins.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b
+guid: cf84ce0cf80c43a4a8df3863d0e7c55e
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Runtime/SDK/link.xml.meta
+++ b/Runtime/SDK/link.xml.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d
+guid: 9ca32935afca44cda7367c4004caeef8
 TextScriptImporter:
   externalObjects: {}
   userData:

--- a/Runtime/Sentry.meta
+++ b/Runtime/Sentry.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6
+guid: f28fcb8dd38c4b3d87b785bc024068ac
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/docs/claude/build-session-recovery.md.meta
+++ b/docs/claude/build-session-recovery.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4a8d3e7f9c6b2a1d5e0f7b8c9d4a6e5b
+guid: b2ecb70d19454ea5a4211a2c661134ad
 TextScriptImporter:
   externalObjects: {}
   userData:

--- a/run-local-tests.sh
+++ b/run-local-tests.sh
@@ -303,7 +303,7 @@ show_help() {
     echo "    $0 --list-unity               # 설치된 버전 확인"
     echo ""
     echo "실행 순서:"
-    echo "  --validate    : [1] 파일 구조 검증 → [2] Playwright 설정 → [3] SDK 유닛 테스트"
+    echo "  --validate    : [1] 파일 구조 검증 → [2] Playwright 설정 → [3] SDK 유닛 테스트 → [4] Meta GUID 위생"
     echo "  --editmode    : [1] Unity EditMode 테스트 (~10초, 빌드 불필요)"
     echo "  --unity-build : [1] Unity WebGL 빌드"
     echo "  --e2e         : [1] Playwright E2E 테스트 (빌드 결과물 필요)"
@@ -617,6 +617,24 @@ test_sdk_generator_unit() {
         return 0
     else
         print_failure "SDK Generator Unit Tests"
+        return 1
+    fi
+}
+
+# 5.6 .meta GUID 위생 검사 (중복/손-작성 순차 GUID — techchat #4076 재발 방지)
+test_meta_guids() {
+    print_header "Meta GUID Hygiene"
+
+    if ! command -v node >/dev/null 2>&1; then
+        print_skip "Meta GUID Hygiene - node 없음"
+        return 0
+    fi
+
+    if node "$SCRIPT_DIR/scripts~/check-meta-guids.js"; then
+        print_success "Meta GUID Hygiene"
+        return 0
+    else
+        print_failure "Meta GUID Hygiene"
         return 1
     fi
 }
@@ -1247,6 +1265,7 @@ main() {
             test_e2e_validation
             test_playwright_config
             test_sdk_generator_unit
+            test_meta_guids
             ;;
     esac
 

--- a/scripts~/check-meta-guids.js
+++ b/scripts~/check-meta-guids.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Unity .meta GUID 위생 검사
+ *
+ * 배포(published UPM)되는 .meta 파일의 GUID에 대해 두 가지를 검사한다:
+ *
+ *   1) 중복 GUID  — 배포 대상 .meta 중 같은 guid를 쓰는 파일이 2개 이상이면 실패.
+ *                   복붙/머지 사고로 인한 내부 충돌을 차단한다.
+ *   2) 구조적 GUID — 손으로 박은 순차/저엔트로피 GUID(예: b1c2d3e4f5a6...)를 검출.
+ *                   이런 값은 다른 패키지의 placeholder/순차 GUID와 충돌하기 쉽다
+ *                   (techchat #4076: Runtime/Sentry.meta ↔ com.unity.addressables).
+ *                   Unity가 생성하는 진짜 랜덤 GUID만 허용한다.
+ *
+ * 검사 범위(shipped)는 release.yml의 제거 규칙을 따른다:
+ *   - "~" 접미 디렉토리(Tests~, sdk-runtime-generator~, scripts~, *BuildConfig~ 등) 제외
+ *   - .github/ 제외
+ *   - 릴리즈 시 제거되는 루트 파일(.gitignore.meta, CLAUDE.md.meta, run-local-tests.sh.meta) 제외
+ *
+ * 사용법:  node scripts/check-meta-guids.js
+ * 종료코드: 위반이 하나라도 있으면 1, 없으면 0.
+ *
+ * 알려진 한계: 휴리스틱은 "명백히 구조적인" 손-작성 GUID를 잡는다. 우연히 랜덤처럼
+ * 보이게 손으로 친 고엔트로피 GUID는 검출하지 못하지만, 그런 값은 진짜 랜덤 GUID와
+ * 충돌 확률이 동일하므로 위험하지 않다. 외부 패키지와의 충돌 방지는 본질적으로
+ * "GUID를 랜덤으로 생성"해야만 보장된다.
+ */
+
+"use strict";
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+
+// ---------------------------------------------------------------------------
+// 구조적 GUID 판정 임계값
+//   현 저장소 배포 메타(~200개 진짜 랜덤 GUID)에 대해 오탐 0,
+//   기존 손-작성 가짜(순차/바이트등차/첫nibble순차/둘째nibble순환) 전부 검출로 보정됨.
+//   임의의 균일 랜덤 GUID가 걸릴 확률은 합산 ~0.04%(약 1/2200) 수준.
+// ---------------------------------------------------------------------------
+const NIBBLE_RUN_MIN = 7; // 연속 nibble ±1(mod16) 최장 런
+const BYTE_DELTA_RUN_MIN = 5; // 일정 delta 바이트 등차 최장 런 (예: +0x11 반복)
+const FIRST_NIBBLE_RUN_MIN = 6; // 바이트 첫-nibble ±1(mod16) 최장 런
+const SECOND_NIBBLE_PERIOD_MAX = 6; // 바이트 둘째-nibble 수열 완전 주기 (예: a,b,c,d,e,f 순환)
+
+function isShipped(p) {
+  if (p.split("/").some((seg) => seg.endsWith("~"))) return false;
+  if (p.startsWith(".github/")) return false;
+  if (
+    p === ".gitignore.meta" ||
+    p === "CLAUDE.md.meta" ||
+    p === "run-local-tests.sh.meta"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function readGuid(file) {
+  const text = fs.readFileSync(file, "utf8");
+  const m = text.match(/^guid:\s*([0-9a-fA-F]{32})\s*$/m);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function nibbles(guid) {
+  return Array.from(guid, (c) => parseInt(c, 16));
+}
+function bytesOf(guid) {
+  const b = [];
+  for (let i = 0; i < 32; i += 2) b.push(parseInt(guid.slice(i, i + 2), 16));
+  return b;
+}
+function longestPm1Run(seq, mod) {
+  let best = 1;
+  let cur = 1;
+  for (let i = 1; i < seq.length; i++) {
+    const d = (((seq[i] - seq[i - 1]) % mod) + mod) % mod;
+    if (d === 1 || d === mod - 1) {
+      cur += 1;
+      if (cur > best) best = cur;
+    } else {
+      cur = 1;
+    }
+  }
+  return best;
+}
+function constDeltaRun(bytes) {
+  let best = 1;
+  for (let s = 0; s < bytes.length - 1; s++) {
+    const d = (((bytes[s + 1] - bytes[s]) % 256) + 256) % 256;
+    let r = 2;
+    let k = s + 1;
+    while (
+      k + 1 < bytes.length &&
+      (((bytes[k + 1] - bytes[k]) % 256) + 256) % 256 === d
+    ) {
+      r += 1;
+      k += 1;
+    }
+    if (r > best) best = r;
+  }
+  return best;
+}
+function secondNibblePeriod(bytes) {
+  const sn = bytes.map((x) => x & 0xf);
+  for (let p = 1; p <= 6; p++) {
+    let ok = true;
+    for (let i = 0; i < sn.length; i++) {
+      if (sn[i] !== sn[i % p]) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return p;
+  }
+  return 99;
+}
+function structuredReason(guid) {
+  const nib = nibbles(guid);
+  const bytes = bytesOf(guid);
+  const fn = bytes.map((x) => x >> 4);
+  if (longestPm1Run(nib, 16) >= NIBBLE_RUN_MIN) return "연속 nibble 순차";
+  if (constDeltaRun(bytes) >= BYTE_DELTA_RUN_MIN) return "바이트 등차 수열";
+  if (longestPm1Run(fn, 16) >= FIRST_NIBBLE_RUN_MIN) return "첫-nibble 순차";
+  if (secondNibblePeriod(bytes) <= SECOND_NIBBLE_PERIOD_MAX)
+    return "둘째-nibble 주기 반복";
+  return null;
+}
+
+function main() {
+  let files;
+  try {
+    files = execSync("git ls-files '*.meta'", { encoding: "utf8" })
+      .split("\n")
+      .filter(Boolean);
+  } catch (e) {
+    console.error("::error::git ls-files 실행 실패 — git 저장소에서 실행하세요.");
+    process.exit(1);
+  }
+
+  const shipped = files.filter(isShipped);
+  const byGuid = new Map(); // guid -> [files]
+  const structured = []; // { file, guid, reason }
+  const invalid = []; // guid 라인 없음/형식 오류
+
+  for (const f of shipped) {
+    const guid = readGuid(f);
+    if (!guid) {
+      invalid.push(f);
+      continue;
+    }
+    if (!byGuid.has(guid)) byGuid.set(guid, []);
+    byGuid.get(guid).push(f);
+    const reason = structuredReason(guid);
+    if (reason) structured.push({ file: f, guid, reason });
+  }
+
+  const duplicates = [...byGuid.entries()].filter(([, fs2]) => fs2.length > 1);
+
+  let failed = false;
+
+  if (invalid.length > 0) {
+    failed = true;
+    console.log("::error::유효한 32자리 hex guid가 없는 .meta 파일이 있습니다:");
+    for (const f of invalid) console.log(`  - ${f}`);
+    console.log("");
+  }
+
+  if (duplicates.length > 0) {
+    failed = true;
+    console.log("::error::중복 GUID가 발견되었습니다 (배포 대상 .meta끼리 충돌):");
+    for (const [guid, fs2] of duplicates) {
+      console.log(`  guid ${guid}:`);
+      for (const f of fs2) console.log(`    - ${f}`);
+    }
+    console.log("");
+  }
+
+  if (structured.length > 0) {
+    failed = true;
+    console.log(
+      "::error::손으로 박은 듯한 구조적/순차 GUID가 발견되었습니다 (충돌 위험):"
+    );
+    for (const { file, guid, reason } of structured) {
+      console.log(`  - ${file}`);
+      console.log(`      guid ${guid} (${reason})`);
+    }
+    console.log("");
+    console.log("해결 방법: 해당 .meta의 guid를 새 랜덤 GUID로 교체하세요. 예:");
+    console.log("  node -e \"console.log(require('crypto').randomBytes(16).toString('hex'))\"");
+    console.log("");
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ 배포 대상 .meta ${shipped.length}개의 GUID 위생 검사 통과 (중복 없음, 구조적 GUID 없음).`
+  );
+}
+
+main();


### PR DESCRIPTION
## 배경

[techchat #4076](https://techchat-apps-in-toss.toss.im/t/guid/4076)에서 보고된 Unity `.meta` GUID 충돌:

> GUID `b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6` for asset `…/com.unity.addressables/…ContentStateSerializerTests.cs` conflicts with `…/im.toss.apps-in-toss-unity-sdk/Runtime/Sentry` (current owner).

`Runtime/Sentry.meta`가 **손으로 박은 순차 GUID**를 갖고 있어, 소비자 프로젝트의 다른 패키지(Addressables 등)와 GUID가 충돌하면 import가 실패한다. Addressables는 immutable 폴더라 우리 SDK 쪽에서 고쳐야 한다.

**근본 원인**: Sentry 모듈 추가 시 모든 `.meta`에 순차 GUID를 넣었고, 이후 수정이 `Runtime/Sentry/` 내부 파일 GUID만 교체하면서 폴더 메타·다른 디렉토리(`Editor/`, `Runtime/Helpers/`, `Runtime/SDK/link.xml`, `docs/`)에 남은 손-작성 GUID를 놓쳤다. 보고된 파일은 그중 하나일 뿐이며 같은 잠재 버그가 여러 파일에 남아 있었다.

## 변경 내용

- 배포 폴더(`Runtime/`, `Editor/`, `docs/`)의 손-작성/순차 GUID **11개를 CSPRNG 랜덤 GUID로 교체**
- `Editor/AppsInTossSDKEditor.asmdef`의 Helpers asmdef 참조 GUID **동반 갱신** (어셈블리 참조 무결성 보존)
- **재발 방지 가드** `scripts~/check-meta-guids.js` 추가
  - ① 배포 대상 `.meta` 간 **중복 GUID** hard fail
  - ② 손-작성 **구조적/순차 GUID** 휴리스틱 검출 (배포 코퍼스 203개에 오탐 0, 기존 가짜 전부 검출로 보정)
  - 배포 범위만 검사 (`~`접미 디렉토리·`.github/`·릴리즈 제거 루트파일 제외)
- `.github/workflows/lint.yml`(PR 게이트) 및 `run-local-tests.sh --validate`(로컬 push 전)에 가드 연결

## 검증

- 가드 실행 → 배포 203개 **위반 0** 통과
- Negative test: 가짜 GUID 일시 주입 → 정상 실패(exit 1) → 복원 확인
- 기존 가짜 GUID 11개 전부 저장소에서 소멸 확인
- asmdef 참조가 새 Helpers asmdef GUID와 일치 확인
- `run-local-tests.sh --validate`: E2E·Playwright·**Meta GUID Hygiene 통과** (`SDK Generator Unit Tests`는 로컬 pnpm/lockfile 환경 이슈로 실패 — 본 변경과 무관, generator/lockfile 미수정)

## 비고

- GUID 교체는 소비자 업그레이드 시 해당 에셋 재-import를 유발하지만, 대상이 모두 SDK 내부 폴더/asmdef/내부 스크립트/문서라 사용자 씬에서 참조되지 않아 무해 (asmdef 참조는 동반 갱신으로 보존)
- 이 수정은 다음 SDK 릴리즈에 포함되어 소비자에게 전달됨
