### PR TITLE
수정: heavy perf 빌드 하네스 콘텐츠 생성 NRE 해결 (perf CI 차단 해제)

### DIFF
--- a/Tests~/E2E/HeavySampleUnityProject-6000.0/ProjectSettings/ProjectSettings.asset
+++ b/Tests~/E2E/HeavySampleUnityProject-6000.0/ProjectSettings/ProjectSettings.asset
@@ -559,8 +559,8 @@ PlayerSettings:
   webGLExceptionSupport: 1
   webGLNameFilesAsHashes: 1
   webGLShowDiagnostics: 1
-  webGLDataCaching: 1
-  webGLDebugSymbols: 1
+  webGLDataCaching: 0
+  webGLDebugSymbols: 0
   webGLEmscriptenArgs: 
   webGLModulesDirectory: 
   webGLTemplate: PROJECT:AITTemplate

--- a/Tests~/E2E/HeavySampleUnityProject-6000.3/ProjectSettings/ProjectSettings.asset
+++ b/Tests~/E2E/HeavySampleUnityProject-6000.3/ProjectSettings/ProjectSettings.asset
@@ -561,8 +561,8 @@ PlayerSettings:
   webGLExceptionSupport: 1
   webGLNameFilesAsHashes: 1
   webGLShowDiagnostics: 1
-  webGLDataCaching: 1
-  webGLDebugSymbols: 1
+  webGLDataCaching: 0
+  webGLDebugSymbols: 0
   webGLEmscriptenArgs: 
   webGLModulesDirectory: 
   webGLTemplate: PROJECT:AITTemplate

--- a/Tests~/E2E/SharedScripts/Editor/HeavyBuildRunner.cs
+++ b/Tests~/E2E/SharedScripts/Editor/HeavyBuildRunner.cs
@@ -85,18 +85,15 @@ public class HeavyBuildRunner
         EnsureFolder(HeavyRoot + "/Meshes");
         EnsureFolder(HeavyRoot + "/Fonts");
 
-        AssetDatabase.StartAssetEditing();
-        try
-        {
-            for (int i = 0; i < textureCount; i++) GenerateTexture(i, textureSize);
-            for (int i = 0; i < audioCount; i++) GenerateAudio(i, audioSeconds);
-            for (int i = 0; i < meshCount; i++) GenerateMesh(i, meshGrid);
-            CopyFonts(fontCopies);
-        }
-        finally
-        {
-            AssetDatabase.StopAssetEditing();
-        }
+        // 주의: 이 루프를 StartAssetEditing/StopAssetEditing 배치로 감싸면 안 된다.
+        // 배치 중에는 AssetDatabase 임포트가 지연되어, GenerateTexture/GenerateAudio 내부의
+        // AssetImporter.GetAtPath()가 (아직 임포트 전이라) null 을 반환하고 importer.* 접근에서
+        // NullReferenceException 이 난다. 각 Generate* 는 "파일 기록 → ForceSynchronousImport →
+        // 임포터 설정 → SaveAndReimport" 를 자기 완결적으로 수행하므로 배치 없이 순차 호출한다.
+        for (int i = 0; i < textureCount; i++) GenerateTexture(i, textureSize);
+        for (int i = 0; i < audioCount; i++) GenerateAudio(i, audioSeconds);
+        for (int i = 0; i < meshCount; i++) GenerateMesh(i, meshGrid);
+        CopyFonts(fontCopies);
 
         AssetDatabase.SaveAssets();
         AssetDatabase.Refresh();
@@ -128,6 +125,10 @@ public class HeavyBuildRunner
         AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceSynchronousImport);
 
         var importer = (TextureImporter)AssetImporter.GetAtPath(assetPath);
+        if (importer == null)
+            throw new System.Exception(
+                $"[heavy] TextureImporter 가 null: {assetPath} (ForceSynchronousImport 후에도 임포트 안 됨 — " +
+                "StartAssetEditing 배치로 감싸면 임포트가 지연되어 이 NRE 가 난다)");
         importer.textureType = TextureImporterType.Default;
         importer.mipmapEnabled = true;            // L6 (mip stripping) 대상
         importer.isReadable = false;
@@ -161,6 +162,10 @@ public class HeavyBuildRunner
         AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceSynchronousImport);
 
         var importer = (AudioImporter)AssetImporter.GetAtPath(assetPath);
+        if (importer == null)
+            throw new System.Exception(
+                $"[heavy] AudioImporter 가 null: {assetPath} (ForceSynchronousImport 후에도 임포트 안 됨 — " +
+                "StartAssetEditing 배치로 감싸면 임포트가 지연되어 이 NRE 가 난다)");
         var settings = importer.defaultSampleSettings;
         settings.loadType = AudioClipLoadType.DecompressOnLoad; // L8: 대용량 AudioClip 외부화 대상
         settings.compressionFormat = AudioCompressionFormat.PCM; // PCM → .data 비중 큼(신호 강함)

--- a/Tests~/E2E/SharedScripts/Editor/HeavyBuildRunner.cs
+++ b/Tests~/E2E/SharedScripts/Editor/HeavyBuildRunner.cs
@@ -170,7 +170,11 @@ public class HeavyBuildRunner
         settings.loadType = AudioClipLoadType.DecompressOnLoad; // L8: 대용량 AudioClip 외부화 대상
         settings.compressionFormat = AudioCompressionFormat.PCM; // PCM → .data 비중 큼(신호 강함)
         importer.defaultSampleSettings = settings;
-        importer.preloadAudioData = true;
+        // preloadAudioData 는 명시 설정하지 않는다(임포트 기본값이 true). Unity 6 에서
+        // AudioImporter.preloadAudioData 는 obsolete-as-error(CS0619)로 빌드를 깨고
+        // (per-platform SampleSettings 로 이전됨), 2021.3 에는 그 대체 필드가 없어 버전 간
+        // 통일이 불가하다. L8 측정 대상인 .data 비중은 loadType/compressionFormat 이 결정하므로
+        // preload 명시는 불필요하다.
         importer.SaveAndReimport();
     }
 


### PR DESCRIPTION
## 무엇을 / 왜

`perf.yml`의 heavy 빌드(`build-heavy`) 잡이 **3버전 매트릭스(2021.3 · 6000.0 · 6000.3) 전부** `Build Unity WebGL` 단계에서 `NullReferenceException`으로 실패하던 문제를 해결한다. 이 실패로 PR별 TTFF Δ가 전혀 게시되지 못하고 있었다(perf CI 전면 차단).

> 참고: 이 실패는 하네스 PR(#754) 자체 CI에서는 드러나지 않았다 — `build-heavy`가 `perf` 라벨 게이트(`if: contains(... 'perf')`) 뒤에 있어, 라벨 없는 인프라 PR에서는 빌드 잡이 통째로 skip 되어 "success(빈 실행)"로 보였기 때문이다. 실제 heavy 빌드는 #754가 main에 머지된 뒤 (main push baseline + perf 라벨 PR들에서) 처음 실행되며 전부 실패했다.

## 근본 원인

`HeavyBuildRunner.GenerateHeavyContent()`가 콘텐츠 생성 루프를 `AssetDatabase.StartAssetEditing()`/`StopAssetEditing()` 배치로 감싸고 있었다.

- 배치 구간에서는 AssetDatabase 임포트가 `StopAssetEditing`까지 **지연**되며, `ImportAssetOptions.ForceSynchronousImport`로도 이 지연을 우회할 수 없다.
- 그 결과 `GenerateTexture`/`GenerateAudio` 내부의 `AssetImporter.GetAtPath()`가 (아직 임포트 전이라) `null`을 반환하고, `importer.*` 첫 접근에서 NRE.
- 로그 말미의 `Unity license error / code 42`는 래퍼가 exit-code-1 빌드 실패를 라이선스 오류로 오분류한 **red herring**으로, 실제 원인이 아니다(인프라/flaky 아님 — 순수 하네스 코드 버그).

## 변경

- **배치 래퍼 제거.** 각 `Generate*`는 `파일 기록 → ForceSynchronousImport → 임포터 설정 → SaveAndReimport`를 자기 완결적으로 수행하므로 배치 없이 순차 호출해도 정확하다(정확성 우선 — 배치는 속도 목적이었으나 기능을 깼다).
- `GenerateTexture`/`GenerateAudio`에 `importer == null` **방어 가드** 추가 — 동일 실패 재발 시 맨 NRE 대신 원인이 적힌 예외로 즉시 드러나게 한다.
- **측정 정합(부수):** `HeavySampleUnityProject-6000.0`/`-6000.3`의 `webGLDataCaching`·`webGLDebugSymbols`를 `0`으로 정렬(2021.3 기준과 동일). `DataCaching=1`은 median-of-5 cold-load 반복을 IndexedDB warm으로 오염시키고, `DebugSymbols=1`은 wasm을 비대화해 레버별 size 귀속을 흐린다. 둘 다 빌드를 깨뜨리지 않는 측정 정합 변경.

## 검증

- 로컬 Unity 에디터가 없어 컴파일/빌드 사전 검증이 불가하여, 이 PR에 **일시적으로 `perf` 라벨을 부여**해 `perf.yml` `build-heavy`(3버전)가 이 브랜치 head에서 그린으로 도는지 확인한다. (perf.yml은 PR head SHA를 빌드하므로 이 브랜치 자체에서 실증 가능.)
- 머지 후: main baseline 빌드 복구 + 기존 perf 플릿 PR들을 재-rebase하여 head에 본 수정을 반영해야 PR별 Δ가 다시 게시된다.

## 범위 / 안전

- `Tests~/E2E/` 하네스 한정 변경 — 런타임/SDK/Editor 프로덕션 코드 무영향.
- `perf` 라벨은 **CI 검증용 일시 부여**이며 본 PR은 성능 레버가 아닌 **인프라 수정**이다.
