### PR TITLE
수정: perf measure-ttff pnpm 버전 핀(10.28.0) — pnpm v11.6.0 frozen-lockfile 회귀 차단

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -154,6 +154,12 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          # 프로젝트 핀(AITPackageManagerHelper.PNPM_VERSION / package.json packageManager)과 동일.
+          # version 미지정 시 action-setup@v6 가 latest pnpm 을 끌어오는데, v11.6.0 부터
+          # frozen install 의 overrides 직렬화를 엄격 검사해 lockfile(10.28.0 생성)과 불일치하면
+          # ERR_PNPM_LOCKFILE_CONFIG_MISMATCH 로 실패한다 → lockfile 생성 버전으로 고정.
+          version: 10.28.0
 
       - name: Install AIT Build Dependencies
         # ait-build/ 안에서 vite preview 서버를 띄우려면 node_modules 필요


### PR DESCRIPTION
## 배경

`perf.yml` 의 `measure-ttff` 잡이 **모든 Unity 버전에서 `Install AIT Build Dependencies` 단계에서 실패**하기 시작했다. baseline 푸시 run 에서도 build-heavy 3종은 success 인데 measure-ttff 3종이 전부 같은 지점에서 깨진다.

```
Switching pnpm from v11.1.1 to v11.6.0 ...
 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
 The "overrides" configuration doesn't match the value found in the lockfile
```

## 원인

`Setup pnpm` 단계가 `pnpm/action-setup@v6` 를 **`version` 미지정**으로 호출하고 있어, action 이 항상 최신 pnpm 을 설치한다. 방금 릴리스된 **pnpm v11.6.0** 부터 `--frozen-lockfile` 설치 시 `overrides` 직렬화를 엄격히 검사하는데, 이 저장소의 lockfile 들은 프로젝트 핀 버전(`AITPackageManagerHelper.PNPM_VERSION` = `package.json` `packageManager` = **10.28.0**)으로 생성되어 직렬화 형식이 달라 불일치로 거부된다. 코드 변경과 무관한 **상류 회귀**이며, 동일 코드가 직전 run(v11.1.1)에서는 통과했다.

## 변경

`measure-ttff` 의 `Setup pnpm` 에 lockfile 생성 버전을 명시 고정:

```yaml
      - name: Setup pnpm
        uses: pnpm/action-setup@v6
        with:
          version: 10.28.0
```

이 한 단계가 ait-build 와 Tests~ 두 frozen install 을 모두 지배하므로 단일 핀으로 정합이 복원된다.

## 성격 / 게이트

- **인프라 수정** — perf 레버 의미 변경 없음(워크플로 파일만). 3.0 beta→stable 게이트 대상 아님.
- `pull_request` 이벤트는 워크플로 정의를 **base(main)** 에서 읽으므로 이 PR 자체로는 자체 검증 불가 — **머지 후 baseline 푸시 run 이 검증**한다(이중 효과: pnpm 핀 검증 + baseline 캐시 채움).
- 머지 후 perf 라벨 PR run 들도 동일하게 정합 install 을 받는다.

## 후속 (별도 PR 제안)

`test-e2e.yml` 도 동일하게 `pnpm/action-setup@v6` 를 `version` 미지정으로 3곳에서 호출 중 — 동일 v11.6.0 회귀에 잠재 노출. 핵심 E2E 게이트라 신중한 검증과 함께 별도 PR 로 핀 권장.