### PR TITLE
수정: perf measure-ttff pnpm 설치 정합 (버전핀 제거 + 비-frozen)

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -153,23 +153,23 @@ jobs:
           node-version: 24
 
       - name: Setup pnpm
+        # version 미지정 → action-setup@v6 가 package.json 의 packageManager(pnpm@11.6.0)를
+        # 그대로 설치. version 을 추가로 핀하면 "Multiple versions of pnpm specified" 충돌.
         uses: pnpm/action-setup@v6
-        with:
-          # 프로젝트 핀(AITPackageManagerHelper.PNPM_VERSION / package.json packageManager)과 동일.
-          # version 미지정 시 action-setup@v6 가 latest pnpm 을 끌어오는데, v11.6.0 부터
-          # frozen install 의 overrides 직렬화를 엄격 검사해 lockfile(10.28.0 생성)과 불일치하면
-          # ERR_PNPM_LOCKFILE_CONFIG_MISMATCH 로 실패한다 → lockfile 생성 버전으로 고정.
-          version: 10.28.0
 
       - name: Install AIT Build Dependencies
-        # ait-build/ 안에서 vite preview 서버를 띄우려면 node_modules 필요
+        # ait-build/ 안에서 vite preview 서버를 띄우려면 node_modules 필요.
+        # --no-frozen-lockfile: 측정용 임시 설치이므로 정확한 deps 가 TTFF 에 영향 없음.
+        # SDK 빌드 자체도 PnpmStoreManager.InstallStages(frozen→갱신→폐기→clean)로
+        # lockfile 드리프트에 내성이 있다 — 여기선 그 비-frozen 단계를 직접 채택해
+        # BuildConfig~ overrides 드리프트(#795)로 인한 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH 회피.
         working-directory: ${{ env.AIT_BUILD_DIR }}
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
         # 브라우저는 runner image의 시스템 Chrome 사용(perf config: channel='chrome').
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run Perf (TTFF median-of-N)
         working-directory: Tests~/E2E/tests


### PR DESCRIPTION
## 요약

perf CI 의 `measure-ttff` job 이 pnpm 설치 단계에서 하드 실패해 baseline 캐시가 생성되지 못하는 문제를 수정한다 (infra-only, perf 레버 의미 없음).

## 배경: 두 겹의 실패

**1. #798 의 `version: 10.28.0` 핀은 잘못된 진단이었다.**
프로젝트는 모든 곳에서 `pnpm@11.6.0` 을 핀한다 (root/generator/BuildConfig~ `packageManager` + `AITPackageManagerHelper.PNPM_VERSION`). `pnpm/action-setup@v6` 는 `version:` 입력이 주어지면 `package.json` 의 `packageManager` 와 교차검증하므로, 11.6.0 과 충돌해 step "Setup pnpm" 에서 하드 실패했다:

```
Error: Multiple versions of pnpm specified:
  - version 10.28.0 in the GitHub Action config with the key "version"
  - version pnpm@11.6.0 in the package.json with the key "packageManager"
```

→ `version:` 핀을 제거해 action 이 `packageManager(11.6.0)` 를 그대로 쓰게 한다.

**2. 원래의 `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` 근본 원인은 #795 의 lockfile 미재생성이다.**
#795 (83a4882) 가 `WebGLTemplates/AITTemplate/BuildConfig~/package.json` 의 `pnpm.overrides` 를 `{}` 로 비웠지만 동반 lockfile 을 재생성하지 않아, lockfile 에 stale `overrides:` 가 남았다. SDK 빌드는 `PnpmStoreManager.InstallStages` (frozen→갱신→폐기→clean 재시도) 의 비-frozen 폴백으로 복구되지만, perf.yml 의 plain `pnpm install --frozen-lockfile` 은 폴백이 없어 거부한다.

→ `measure-ttff` 의 두 설치를 `--no-frozen-lockfile` 로 완화해 빌드 자체의 비-frozen 내성과 동일하게 드리프트를 조정한다. 측정용 임시 설치(vite preview 서빙)이므로 정확한 deps 핀은 TTFF 측정에 무관하다.

## 변경

- `.github/workflows/perf.yml` — `Setup pnpm` 의 `version:` 핀 제거 + `measure-ttff` 의 두 `pnpm install --frozen-lockfile` → `--no-frozen-lockfile`

## 검증

머지 후 main push 가 perf baseline 매트릭스(3 Unity 버전)를 돌려 `measure-ttff` 가 success 로 통과하고 baseline 캐시가 생성되는지 확인한다.

## 후속 (이 PR 범위 밖, 레포 위생)

#795 가 남긴 `BuildConfig~/pnpm-lock.yaml` 의 stale `overrides:` 는 별도로 lockfile 재생성이 필요하다 (현재는 빌드 retry 폴백이 흡수 중). `test-e2e.yml` 의 scaffold frozen 설치도 동일 드리프트에 노출될 수 있어 점검 권장.