### PR TITLE
수정: perf measure-ttff 설치 --ignore-scripts (ERR_PNPM_IGNORED_BUILDS 회피)

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -160,16 +160,22 @@ jobs:
       - name: Install AIT Build Dependencies
         # ait-build/ 안에서 vite preview 서버를 띄우려면 node_modules 필요.
         # --no-frozen-lockfile: 측정용 임시 설치이므로 정확한 deps 가 TTFF 에 영향 없음.
-        # SDK 빌드 자체도 PnpmStoreManager.InstallStages(frozen→갱신→폐기→clean)로
-        # lockfile 드리프트에 내성이 있다 — 여기선 그 비-frozen 단계를 직접 채택해
-        # BuildConfig~ overrides 드리프트(#795)로 인한 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH 회피.
+        #   SDK 빌드 자체도 PnpmStoreManager.InstallStages(frozen→갱신→폐기→clean)로
+        #   lockfile 드리프트에 내성이 있다 — 여기선 그 비-frozen 단계를 직접 채택해
+        #   BuildConfig~ overrides 드리프트(#795)로 인한 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH 회피.
+        # --ignore-scripts: pnpm 11.6.0 은 비-frozen 설치 시 미승인 빌드 스크립트가 있으면
+        #   ERR_PNPM_IGNORED_BUILDS 로 exit 1 한다. esbuild/swc/sentry-cli/protobufjs 빌드
+        #   스크립트는 dist 를 정적 서빙하는 vite preview 에 불필요하고(esbuild 바이너리는
+        #   @esbuild/<platform> optional dep 가 제공), frozen 이던 직전 성공 baseline 도
+        #   빌드 스크립트를 돌리지 않았다 → 명시적 opt-out 으로 오류 회피. (로컬 검증 완료)
         working-directory: ${{ env.AIT_BUILD_DIR }}
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
 
       - name: Install Playwright Test Dependencies
         working-directory: Tests~/E2E/tests
-        # 브라우저는 runner image의 시스템 Chrome 사용(perf config: channel='chrome').
-        run: pnpm install --no-frozen-lockfile
+        # 브라우저는 runner image의 시스템 Chrome 사용(perf config: channel='chrome') →
+        # 빌드 스크립트/브라우저 다운로드 불필요. AIT 설치와 동일 정책(비-frozen + 스크립트 무시).
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
 
       - name: Run Perf (TTFF median-of-N)
         working-directory: Tests~/E2E/tests


### PR DESCRIPTION
## 요약

perf CI 의 `measure-ttff` job 이 pnpm 설치에서 하드 실패해 baseline 캐시가 생성되지 못하는 문제를 마저 수정한다 (infra-only, #799 후속).

## 배경

#799 가 `--frozen-lockfile` → `--no-frozen-lockfile` 로 바꿔 `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`(#795 의 overrides 드리프트)는 해소했으나, 그 다음 단계에서 **두 번째 실패가 드러났다**:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @sentry/cli, @swc/core, esbuild, protobufjs
##[error]Process completed with exit code 1.
```

pnpm 11.6.0 은 **비-frozen 설치 시 미승인 빌드 스크립트가 있으면 exit 1** 한다 (frozen 모드는 이 검사를 우회하므로, frozen 이던 직전 성공 baseline 에선 발생하지 않았다). frozen 은 overrides 로 실패하고 비-frozen 은 ignored-builds 로 실패 → 11.6.0 + 현 lockfile 에서 양쪽 순수 모드 모두 막힌다.

## 변경

`measure-ttff` 의 두 `pnpm install --no-frozen-lockfile` → `--no-frozen-lockfile --ignore-scripts`.

해당 빌드 스크립트(esbuild/@swc/core/@sentry/cli/protobufjs)는 dist 를 **정적 서빙**하는 `vite preview` 에 불필요하다 — esbuild 바이너리는 `@esbuild/<platform>` optional dependency 가 제공하므로 postinstall 이 없어도 동작한다.

## 로컬 검증 (pnpm 11.6.0, main BuildConfig~ 기준)

| 명령 | 결과 |
|---|---|
| `pnpm install --no-frozen-lockfile` | **exit 1** — `ERR_PNPM_IGNORED_BUILDS` (CI 실패 재현) |
| `pnpm install --no-frozen-lockfile --ignore-scripts` | **exit 0** — `vite --version` 정상 로드(esbuild eager import 성공), `@esbuild/<platform>` 패키지 `.pnpm/` 존재 |

## 검증 경로

`pull_request` 는 perf.yml 을 base(main)에서 읽어 PR self-CI 불가 → 머지 후 main push baseline run 이 `measure-ttff` 통과 + baseline 캐시 생성을 검증한다.

## 후속 (이 PR 범위 밖, 레포 위생)

근본 원인은 여전히 #795 가 `BuildConfig~/package.json` 의 `pnpm.overrides` 를 비우면서 동반 lockfile 을 재생성하지 않은 것. lockfile 재생성으로 frozen 경로를 복원하면 `--ignore-scripts`/`--no-frozen-lockfile` 우회 없이도 정합. `test-e2e.yml` scaffold 설치도 동일 드리프트 노출 가능 — 점검 권장.