### PR TITLE
수정: 잠복 E2E 블로커 2건 해소 (ValidateDistOutput LogAssert.Expect + ait-build 아티팩트 pnpm-workspace.yaml 누락)

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1954,6 +1954,12 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\n`);
           console.log(`Artifact name: ${name}`);
 
+      # pnpm-workspace.yaml은 pnpm-lock.yaml과 반드시 함께 업로드한다. 누락하면 다운스트림
+      # 잡(E2E/beta-release/perf)이 다운로드한 ait-build에서 `pnpm install --frozen-lockfile`
+      # 실행 시, pnpm v11이 overrides 설정을 pnpm-workspace.yaml에서만 읽으므로(.npmrc/
+      # package.json#pnpm 불가) overrides config가 비어 lockfile의 overrides 스냅샷과 어긋나
+      # ERR_PNPM_LOCKFILE_CONFIG_MISMATCH로 실패한다. ignoreScripts/minimumReleaseAgeExclude도
+      # 이 파일에서만 읽으므로 함께 전달되어야 한다.
       - name: Upload AIT Build
         if: inputs.run-build && (inputs.test-level || '2') != '0'
         uses: actions/upload-artifact@v7
@@ -1966,6 +1972,7 @@ jobs:
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/*.ait
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/package.json
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/pnpm-lock.yaml
+            Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/pnpm-workspace.yaml
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/granite.config.ts
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/build-validation.json
           if-no-files-found: error

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs
@@ -13,6 +13,9 @@
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
 using AppsInToss.Editor;
 using AppsInToss;
 
@@ -46,6 +49,9 @@ public class ValidateDistOutputTests
     public void ValidateDistOutput_NoAitFile_NoDistFolder_ReturnsAitFileMissing()
     {
         // buildProjectPath 에 아무 파일도 없는 경우
+        // .ait 파일이 없으면 ValidateDistOutput 이 의도적으로 LogError 를 남기므로 기대 등록
+        // (Unity Test Runner 는 미선언 LogError 를 자동으로 테스트 실패 처리함)
+        LogAssert.Expect(LogType.Error, new Regex(@"\.ait 파일이 생성되지 않았습니다"));
         var result = AITBuildValidator.ValidateDistOutput(tempDir);
         Assert.AreEqual(AITConvertCore.AITExportError.AIT_FILE_MISSING, result);
     }
@@ -59,6 +65,8 @@ public class ValidateDistOutputTests
         File.WriteAllText(Path.Combine(distPath, "bundle.ios.js"), "// js bundle");
         File.WriteAllText(Path.Combine(distPath, "bundle.android.js"), "// js bundle");
 
+        // .ait 파일이 없으면 ValidateDistOutput 이 의도적으로 LogError 를 남기므로 기대 등록
+        LogAssert.Expect(LogType.Error, new Regex(@"\.ait 파일이 생성되지 않았습니다"));
         var result = AITBuildValidator.ValidateDistOutput(tempDir);
         Assert.AreEqual(AITConvertCore.AITExportError.AIT_FILE_MISSING, result,
             "dist/ 에 .ait 파일이 없으면 AIT_FILE_MISSING 을 반환해야 한다");
@@ -70,6 +78,8 @@ public class ValidateDistOutputTests
         string distPath = Path.Combine(tempDir, "dist");
         Directory.CreateDirectory(distPath);
 
+        // .ait 파일이 없으면 ValidateDistOutput 이 의도적으로 LogError 를 남기므로 기대 등록
+        LogAssert.Expect(LogType.Error, new Regex(@"\.ait 파일이 생성되지 않았습니다"));
         var result = AITBuildValidator.ValidateDistOutput(tempDir);
         Assert.AreEqual(AITConvertCore.AITExportError.AIT_FILE_MISSING, result);
     }


### PR DESCRIPTION
## 배경

이 두 결함은 **둘 다 main에 잠복**해 있었다. `test-e2e.yml`은 `push`가 아니라 `workflow_dispatch`/`workflow_call`에서만 돌기 때문에, E2E로만 드러나는 회귀가 머지 후에도 누구도 수동 디스패치하기 전까지 탐지되지 않는다. #782 머지 후 검증용으로 E2E(level 2)를 수동 디스패치하면서 두 건이 동시에 드러났다.

## 변경 사항

### 1. `ValidateDistOutputTests` — `LogAssert.Expect` 누락 (커밋 1)
`AITBuildValidator.ValidateDistOutput`은 `.ait` 파일이 없으면 의도적으로 `Debug.LogError("[AIT] ✗ .ait 파일이 생성되지 않았습니다!...")`를 남긴다(정상 동작). Unity Test Runner는 `LogAssert.Expect`로 선언되지 않은 `LogError`를 **자동 실패** 처리하므로, `AitFileMissing` 3개 케이스가 어서션과 무관하게 실패했다(#766 `49d2b96`에서 테스트 추가 시 누락).
- 3개 테스트(`NoAitFile_NoDistFolder`, `DistFolderExists_ButOnlyNonAitFiles`, `EmptyDistFolder`)에 `LogAssert.Expect(LogType.Error, new Regex(@"\.ait 파일이 생성되지 않았습니다"))` 추가.
- 프로덕션 코드(`AITBuildValidator.cs`)는 변경 없음 — 테스트 측만 수정.
- 검증: 본 PR의 build 잡(EditMode)이 전 플랫폼 그린 → 픽스 확인됨.

### 2. `ait-build` 아티팩트에 `pnpm-workspace.yaml` 누락 (#795 회귀) (커밋 2)
#795가 pnpm v11.6.0 채택 시 `pnpm-workspace.yaml`(overrides/`ignoreScripts`/`minimumReleaseAgeExclude`)을 **빌드 시점엔** `ait-build`로 전파했으나(`CopyPnpmWorkspaceWithFallback`), `unity-build.yml`의 **아티팩트 업로드 목록은 갱신하지 않아** 누락됐다.

결과: 다운스트림 잡(E2E/beta-release/perf)이 아티팩트를 다운로드해 `pnpm install --frozen-lockfile`을 돌리면 —
- 아티팩트의 `pnpm-lock.yaml`에는 overrides 스냅샷(`@granite-js/plugin-core`/`find-my-way`/`ip`)이 있는데,
- pnpm v11은 overrides를 `pnpm-workspace.yaml`에서만 읽으므로(`.npmrc`/`package.json#pnpm` 불가) config가 **비어** lockfile 스냅샷과 어긋나 **`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`** 로 실패.

**근본 원인 로컬 재현(pnpm 11.6.0):** SDK `BuildConfig~`의 `package.json`+`pnpm-lock.yaml`로 frozen install 시
- `pnpm-workspace.yaml` **있음** → `Lockfile is up to date, resolution step is skipped` (정합)
- `pnpm-workspace.yaml` **없음** → CI와 정확히 동일한 `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH ... "overrides"`

**픽스:** `unity-build.yml`의 `Upload AIT Build` step 경로 목록에 `pnpm-workspace.yaml` 추가. 단일 업로드 step이라 E2E/beta-release/perf 변형(`heavy-`, `-v<version>`) 모두 동시에 해소된다. `ignoreScripts: true`도 함께 전달되어 후속 `ERR_PNPM_IGNORED_BUILDS`도 예방.

## 검증
- build 잡(EditMode): #1 픽스 확인 (전 플랫폼 그린).
- E2E(level 2) 재디스패치로 #2 픽스(Playwright/deploy 단계의 ait-build frozen install) 그린 확인 — 본 브랜치 ref로 실행(픽스가 워크플로 파일 자체이므로).