### PR TITLE
[auto-resolve] 수정: AITSentry GetLocale WebGL 브리지 핸들러 미등록 경고 Sentry 노이즈 차단

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1056,6 +1056,19 @@ namespace AppsInToss.Editor.ErrorTracker
             if (message.IndexOf("[AITSentryTransport] 네트워크 오류", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // AITSentryContextEnricher가 WebGL JS 브리지 API 호출 실패 시 출력하는 경고.
+            // "is not a constant handler" 에러는 window.AppsInToss.getXxx 핸들러가 등록되지 않은
+            // 환경(sandbox, 구버전 웹뷰 등)에서 발생하는 예상된 플랫폼 미지원 상황이며,
+            // CollectSafe가 "unavailable"로 폴백 처리하므로 SDK 동작은 정상이다.
+            // 신규 SDK 버전은 source에서 LogWarning → Log로 다운그레이드해 이 경로를 막지만,
+            // 이전 버전 클라이언트의 잔여 이벤트를 backstop으로 흡수하기 위한 메시지 필터.
+            // "[AITSentry]" prefix가 AitKeywords("[AIT")에 걸려 SDK 보호 가드를 통과하므로
+            // 가드보다 먼저 매칭하여 Sentry 캡처를 차단한다.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-11J.
+            if (message.IndexOf("[AITSentry]", StringComparison.Ordinal) >= 0
+                && message.IndexOf("is not a constant handler", StringComparison.Ordinal) >= 0)
+                return true;
+
             // 외부 정책 파일 fetch의 일시적 네트워크 오류 — SDK가 외부 호스트에 띄운 메시지이지만
             // SubmitResult/콘솔로 사용자 가시성은 유지되고, 재시도 시 자연 회복되는 케이스.
             // Sentry APPS-IN-TOSS-UNITY-SDK-M9.

--- a/Runtime/Sentry/AITSentryContextEnricher.cs
+++ b/Runtime/Sentry/AITSentryContextEnricher.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using AppsInToss;
 using Sentry;
 using Sentry.Unity;
 using UnityEngine;
@@ -98,7 +99,18 @@ namespace AppsInToss.Sentry
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"{Tag} {apiName} 호출 실패: {ex.Message}");
+                // IsPlatformUnavailable 예외(예: "getLocale is not a constant handler")는
+                // WebGL JS 브리지 핸들러가 없는 환경에서 발생하는 예상된 동작이므로
+                // Warning이 아닌 Info 레벨로 기록하여 Sentry 노이즈를 방지한다.
+                var aitEx = ex as AITException;
+                if (aitEx != null && aitEx.IsPlatformUnavailable)
+                {
+                    Debug.Log($"{Tag} {apiName} 플랫폼 미지원 (예상됨): {ex.Message}");
+                }
+                else
+                {
+                    Debug.LogWarning($"{Tag} {apiName} 호출 실패: {ex.Message}");
+                }
                 return Unavailable;
             }
         }
@@ -120,7 +132,18 @@ namespace AppsInToss.Sentry
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"{Tag} {apiName} 호출 실패: {ex.Message}");
+                // IsPlatformUnavailable 예외(예: "getLocale is not a constant handler")는
+                // WebGL JS 브리지 핸들러가 없는 환경에서 발생하는 예상된 동작이므로
+                // Warning이 아닌 Info 레벨로 기록하여 Sentry 노이즈를 방지한다.
+                var aitEx = ex as AITException;
+                if (aitEx != null && aitEx.IsPlatformUnavailable)
+                {
+                    Debug.Log($"{Tag} {apiName} 플랫폼 미지원 (예상됨): {ex.Message}");
+                }
+                else
+                {
+                    Debug.LogWarning($"{Tag} {apiName} 호출 실패: {ex.Message}");
+                }
                 return Unavailable;
             }
         }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2308,6 +2308,57 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region AITSentry WebGL JS 브리지 핸들러 미등록 노이즈 (APPS-IN-TOSS-UNITY-SDK-11J)
+
+    [Test]
+    public void AitSentryGetLocaleConstantHandlerFailure_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-11J — AITSentryContextEnricher.CollectSafe가
+        // window.AppsInToss.getLocale 핸들러가 없는 환경(sandbox, 구버전 웹뷰 등)에서 발생하는
+        // "getLocale is not a constant handler" AITException을 잡아 출력한 경고.
+        // CollectSafe가 "unavailable"로 폴백 처리하므로 SDK 동작은 정상이며 Sentry 캡처 대상이 아님.
+        // "[AITSentry]" prefix가 AitKeywords("[AIT")에 걸려 SDK 보호 가드를 통과하므로
+        // 가드보다 먼저 매칭하는 composite AND 필터로 차단.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [AITSentry] GetLocale 호출 실패: getLocale is not a constant handler"));
+    }
+
+    [Test]
+    public void AitSentryGetDeviceIdConstantHandlerFailure_ReturnsTrue()
+    {
+        // 동일 패턴의 다른 API 변형 (GetDeviceId, GetPlatformOS 등) 도 동일하게 드롭됨을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [AITSentry] GetDeviceId 호출 실패: getDeviceId is not a constant handler"));
+    }
+
+    [Test]
+    public void AitSentryConstantHandlerFailure_BareMessage_ReturnsTrue()
+    {
+        // "UnityWarning:" prefix 없이 메시지 본문만 도달하는 변형도 드롭됨을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentry] GetLocale 호출 실패: getLocale is not a constant handler"));
+    }
+
+    [Test]
+    public void AitSentryConstantHandlerFailure_RealApiCallFailed_StillCaptured()
+    {
+        // "is not a constant handler"가 없는 실제 API 호출 실패(예: NullReference)는 드롭하지 않음.
+        // composite AND 조건 중 "is not a constant handler" 부분이 빠지면 true를 반환하지 않는다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentry] GetLocale 호출 실패: Object reference not set to an instance of an object"));
+    }
+
+    [Test]
+    public void AitSentryConstantHandlerFailure_WithoutAitSentryPrefix_StillFiltered()
+    {
+        // "is not a constant handler"가 있으면 "[AITSentry]" prefix와 함께 드롭됨을 검증.
+        // 다른 prefix이지만 "[AITSentry]" + "is not a constant handler" 합성 조건을 충족하지 않으면 통과.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SomeOtherSystem is not a constant handler"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-11J

## 묶음 항목

| # | 이슈 ID | 제목 |
|---|---------|------|
| 1 | APPS-IN-TOSS-UNITY-SDK-11J | UnityWarning: [AITSentry] GetLocale 호출 실패: getLocale is not a constant handler |

## 원인 분석

AITSentryContextEnricher.CollectSafe가 WebGL JS 브리지 API 호출 실패 시 모든 예외에 대해 Debug.LogWarning을 출력하고 있었다. WebGL 환경에서 window.AppsInToss.getLocale 핸들러가 등록되지 않은 경우(sandbox, 구버전 웹뷰 등) 발생하는 "getLocale is not a constant handler" 예외는 AITException.IsPlatformUnavailable = true로 분류되는 예상된 플랫폼 미지원 상황이다.

CollectSafe는 이 예외를 잡아 "unavailable"로 폴백 처리하므로 SDK 동작은 정상이지만, Debug.LogWarning이 [AITSentry] prefix와 함께 출력되어 AITEditorErrorTracker의 AitKeywords 가드([AIT)를 통과해 Sentry로 전송되고 있었다.

## 수정 내용

1. Runtime/Sentry/AITSentryContextEnricher.cs: CollectSafe에서 AITException.IsPlatformUnavailable인 경우 Debug.LogWarning 대신 Debug.Log(Info 레벨)로 기록하도록 변경.

2. Editor/ErrorTracker/AITEditorErrorTracker.cs: IsKnownNonSdkMessage에 [AITSentry] + "is not a constant handler" 합성 AND 필터 추가. 이전 버전 SDK 클라이언트의 잔여 이벤트를 backstop으로 차단.

3. Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs: 회귀 테스트 5개 추가.

## 재현 및 검증

- 증상: UnityWarning: [AITSentry] GetLocale 호출 실패: getLocale is not a constant handler 메시지가 Sentry APPS-IN-TOSS-UNITY-SDK-11J로 지속 수집됨
- 원인 확인: AITSentryContextEnricher.CollectSafe가 IsPlatformUnavailable 예외에도 Debug.LogWarning을 출력하여 AITEditorErrorTracker에 캡처됨 (코드 분석으로 확인)
- 수정 후: IsPlatformUnavailable인 경우 Debug.Log로 다운그레이드 → 에디터 오류 트래커에 잡히지 않음
- run-local-tests.sh --validate: SDK Generator Unit Tests pnpm install 실패는 nexus.toss.bz 네트워크 차단으로 인한 pre-existing 환경 이슈 (main 브랜치에서도 동일 실패 확인). 나머지 3개 검증 모두 통과.