### PR TITLE
[auto-resolve] 개선: AITSentryContextEnricher CollectSafe 수집 실패 경고 Sentry 노이즈 차단

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1337,6 +1337,19 @@ namespace AppsInToss.Editor.ErrorTracker
                 && message.IndexOf("미달", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // AITSentryContextEnricher의 CollectSafe가 플랫폼 API 수집 실패 시 출력하는 경고.
+            // 예: "[AITSentry] GetTossAppVersion 호출 실패: Cannot read properties of undefined (reading 'getTossAppVersion')"
+            //     "[AITSentry] GetDeviceId 호출 실패: ..."
+            // WebGL 브리지(window.AppsInToss)가 초기화되기 전에 SDK가 먼저 호출되는 타이밍 조건이거나,
+            // 에디터 PlayMode에서 WebGL jslib이 없어 발생하는 정상 실패 경로다.
+            // CollectSafe는 예외를 잡아 "unavailable"를 반환하고 계속 진행하므로 SDK 동작은 중단되지 않는다.
+            // Sentry로 전송하면 조치 불가한 노이즈가 되고 transport 자기참조 위험도 있으므로 차단한다.
+            // "[AITSentry]" prefix는 AitKeywords("[AIT")에 막히므로 반드시 가드보다 먼저 매칭해야 한다.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-11G.
+            if (message.IndexOf("[AITSentry]", StringComparison.Ordinal) >= 0
+                && message.IndexOf("호출 실패:", StringComparison.Ordinal) >= 0)
+                return true;
+
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용
             if (MessageContainsSdkKeyword(message))
                 return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2308,6 +2308,64 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region AITSentryContextEnricher CollectSafe 수집 실패 노이즈 (APPS-IN-TOSS-UNITY-SDK-11G)
+
+    [Test]
+    public void AITSentryCollectSafe_GetTossAppVersionFailure_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-11G — WebGL 빌드에서 window.AppsInToss가 초기화되기 전에
+        // AITSentryContextEnricher.CollectSafe가 GetTossAppVersion을 호출하면 jslib에서
+        // "Cannot read properties of undefined (reading 'getTossAppVersion')" 예외가 발생한다.
+        // CollectSafe는 이 예외를 잡아 "unavailable"를 반환하므로 SDK 동작은 중단되지 않는다.
+        // 에디터 Sentry로 전송하면 조치 불가한 노이즈가 되므로 차단한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentry] GetTossAppVersion 호출 실패: Cannot read properties of undefined (reading 'getTossAppVersion')"));
+    }
+
+    [Test]
+    public void AITSentryCollectSafe_GetTossAppVersionFailure_UnityWarningPrefix_ReturnsTrue()
+    {
+        // Unity가 Debug.LogWarning을 에디터 콘솔로 보낼 때 "UnityWarning: " prefix가 붙는 변형.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [AITSentry] GetTossAppVersion 호출 실패: Cannot read properties of undefined (reading 'getTossAppVersion')"));
+    }
+
+    [Test]
+    public void AITSentryCollectSafe_GetDeviceIdFailure_ReturnsTrue()
+    {
+        // 동일 CollectSafe 경로 — GetDeviceId API도 동일 패턴으로 실패할 수 있음.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentry] GetDeviceId 호출 실패: Cannot read properties of undefined (reading 'getDeviceId')"));
+    }
+
+    [Test]
+    public void AITSentryCollectSafe_GenericApiFailure_ReturnsTrue()
+    {
+        // CollectSafe가 감싸는 모든 AIT API의 실패 변형을 포괄적으로 드롭한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentry] GetOperationalEnvironment 호출 실패: some platform error"));
+    }
+
+    [Test]
+    public void AITSentryCollectSafe_OtherDiagnostic_NotFiltered()
+    {
+        // "[AITSentry]" prefix라도 "호출 실패:" 패턴이 없는 다른 진단 메시지는 통과해야 한다.
+        // (CollectSafe 경로 전용 필터이므로 다른 [AITSentry] 경고는 영향받지 않음.)
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentry] AIT 컨텍스트 수집 완료 (device=abc, platform=WebGL, locale=ko)"));
+    }
+
+    [Test]
+    public void AITSentryCollectSafe_NoAITSentryPrefix_NotFiltered()
+    {
+        // "호출 실패:" 패턴만 있고 "[AITSentry]" prefix가 없으면 드롭하지 않는다.
+        // (다른 SDK 모듈의 "호출 실패" 메시지와 충돌하지 않도록 AND 조건 사용.)
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] GetTossAppVersion 호출 실패: some error"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
**범위**: 원 이슈 `APPS-IN-TOSS-UNITY-SDK-11G`의 실제 증상(WebGL 브리지 undefined 근본 원인)은 미해결 — 참조만. 별도 조사 필요.

## 변경 개요

WebGL 빌드에서 `window.AppsInToss.getTossAppVersion`이 undefined인 상태로 SDK가 호출되면 JS 예외가 발생하고, `AITSentryContextEnricher.CollectSafe`가 이를 잡아 `Debug.LogWarning("[AITSentry] GetTossAppVersion 호출 실패: ...")` 를 출력한다. 이 경고는 `[AIT` 키워드 가드를 통과해 에디터 Sentry로 전송되지만, CollectSafe는 이미 gracefully 처리하므로 Sentry에서 조치할 정보가 없는 노이즈다.

`IsKnownNonSdkMessage`에 `[AITSentry]` + `호출 실패:` 합성 필터를 추가해 이 경로의 경고를 차단한다.

## 묶음 항목

| # | 이슈 ID | 처리 |
|---|---------|------|
| 1 | APPS-IN-TOSS-UNITY-SDK-11G | 노이즈 차단 (인접 개선, 원 증상 미해결) |

## 재현 시도

- WebGL 브리지(`window.AppsInToss`)가 미초기화된 상태에서 `GetTossAppVersion` jslib 호출 → `CollectSafe`가 잡아 UnityWarning 출력 → 에디터 Sentry 전송 흐름을 코드로 추적해 확인
- EditMode 테스트로는 WebGL jslib 실행 환경 재현 불가 (WebGL 빌드 전용)
- 실제 WebGL 빌드에서의 `window.AppsInToss` 초기화 타이밍 문제는 별도 조사 필요

## 변경 내용

- `Editor/ErrorTracker/AITEditorErrorTracker.cs`: `IsKnownNonSdkMessage`에 `[AITSentry] + 호출 실패:` 합성 필터 추가 (AitKeywords 가드보다 먼저 실행)
- `Tests~/.../IsKnownNonSdkMessageTests.cs`: 회귀 테스트 6개 추가

## 검증

- E2E Test Files Validation: PASS
- Playwright Config Validation: PASS
- Meta GUID Hygiene: PASS
- SDK Generator Unit Tests: FAIL (pnpm nexus.toss.bz 404 — 인프라 문제, 변경과 무관)

## 원 이슈 조사 메모

근본 원인: WebGL 빌드 시 `window.AppsInToss` 객체가 `AITSentryContextEnricher.EnrichAsync()` 호출 시점에 아직 초기화되지 않은 경우. `CollectSafe`와 jslib try/catch는 정상 동작하므로 SDK 기능에는 영향 없음. 단, 이 경고가 에디터 Sentry에 노이즈로 전송되는 문제가 이 PR로 해결됨. 실제 WebGL 브리지 초기화 순서 문제는 별도 분석이 필요하다.