### PR TITLE
[auto-resolve] 수정: WebGL codeOptimization DiskSizeLTO 멤버 미정의 시 DiskSize 폴백 추가

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -170,6 +170,25 @@ namespace AppsInToss.Editor
             PlayerSettings.SetIl2CppCompilerConfiguration(BuildTargetGroup.WebGL, il2cppConfig);
 #endif
 
+            // ===== WebGL Code Optimization (Meta 로드타임 스택의 실제 "Disk Size with LTO" 레버) =====
+            // IL2CPP 컴파일러 config(Master)는 WebGL emscripten 최적화/LTO에 영향을 주지 않으므로(no-op),
+            // 실제 LTO는 emscripten code optimization으로 켠다. 버전별 API 차이(2022.3/6: UserBuildSettings,
+            // 구버전: PlayerSettings.WebGL) + WebGL 모듈 어셈블리 참조 보장 부재 때문에
+            // AITWebGLCodeOptimization이 reflection으로 적용한다(멤버 없는 버전은 fail-safe로 건너뜀).
+            // editorConfig.webGLCodeOptimization: -1(자동)/1 → DiskSizeLTO 적용, 0 → 미적용(Unity 설정 유지).
+            bool applyWebGLCodeOpt = editorConfig.webGLCodeOptimization != 0;
+            string webGLCodeOptTarget = AITDefaultSettings.GetDefaultWebGLCodeOptimization();
+            bool webGLCodeOptApplied = false;
+            if (applyWebGLCodeOpt)
+            {
+                webGLCodeOptApplied = AITWebGLCodeOptimization.TrySetByName(webGLCodeOptTarget);
+                if (!webGLCodeOptApplied)
+                {
+                    Debug.LogWarning(
+                        $"[AIT] WebGL Code Optimization({webGLCodeOptTarget}) 미적용 — 이 Unity 버전에서 API/멤버 부재 (빌드는 계속)");
+                }
+            }
+
             // ===== Unity 6 (2023.3+) 전용 설정 =====
 #if UNITY_2023_3_OR_NEWER
             // 출처: UnityVersion.md:394-402
@@ -210,6 +229,10 @@ namespace AppsInToss.Editor
             Debug.Log($"[AIT]   - IL2CPP 설정: {il2cppConfig}{(!string.IsNullOrEmpty(il2cppConfigEnv) ? " (환경 변수)" : editorConfig.il2cppConfiguration < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Run In Background: {runInBackground}{(editorConfig.runInBackground < 0 ? " (자동)" : "")}");
             Debug.Log($"[AIT]   - Decompression Fallback: {decompressionFallback}{(editorConfig.decompressionFallback < 0 ? " (자동)" : "")}");
+            string webGLCodeOptLog = !applyWebGLCodeOpt ? "미적용 (off)"
+                : webGLCodeOptApplied ? $"{webGLCodeOptTarget}{(editorConfig.webGLCodeOptimization < 0 ? " (자동)" : "")}"
+                : "미적용 (API 부재)";
+            Debug.Log($"[AIT]   - WebGL Code Optimization: {webGLCodeOptLog}");
 #if UNITY_2023_3_OR_NEWER
             Debug.Log($"[AIT]   - Power Preference: {powerPreference}{(editorConfig.powerPreference < 0 ? " (자동)" : "")}");
 #if !UNITY_6000_0_OR_NEWER

--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -181,7 +181,9 @@ namespace AppsInToss.Editor
             bool webGLCodeOptApplied = false;
             if (applyWebGLCodeOpt)
             {
-                webGLCodeOptApplied = AITWebGLCodeOptimization.TrySetByName(webGLCodeOptTarget);
+                // TrySetDiskSizeLTO: DiskSizeLTO 미지원 버전에서 DiskSize로 자동 폴백
+                // (Sentry APPS-IN-TOSS-UNITY-SDK-10W: 멤버 미정의 시 건너뛰던 동작 개선)
+                webGLCodeOptApplied = AITWebGLCodeOptimization.TrySetDiskSizeLTO();
                 if (!webGLCodeOptApplied)
                 {
                     Debug.LogWarning(

--- a/Editor/AITBuildSession.cs
+++ b/Editor/AITBuildSession.cs
@@ -24,6 +24,9 @@ namespace AppsInToss.Editor
         public WebGLExceptionSupport exceptionSupport;
         public bool decompressionFallback;
         public bool nameFilesAsHashes;
+        // WebGL code optimization(Disk Size with LTO)은 버전별 enum이 달라 멤버 "이름"으로 보관.
+        // API 부재 버전에서는 null(복원 시 no-op). 적용/읽기는 AITWebGLCodeOptimization(reflection).
+        public string webGLCodeOptimization;
 
         // 일반 설정
         public Texture2D defaultCursor;
@@ -67,6 +70,7 @@ namespace AppsInToss.Editor
                 exceptionSupport = PlayerSettings.WebGL.exceptionSupport,
                 decompressionFallback = PlayerSettings.WebGL.decompressionFallback,
                 nameFilesAsHashes = PlayerSettings.WebGL.nameFilesAsHashes,
+                webGLCodeOptimization = AITWebGLCodeOptimization.GetCurrentName(),
 
                 defaultCursor = PlayerSettings.defaultCursor,
                 cursorHotspot = PlayerSettings.cursorHotspot,
@@ -128,6 +132,9 @@ namespace AppsInToss.Editor
             PlayerSettings.WebGL.exceptionSupport = exceptionSupport;
             PlayerSettings.WebGL.decompressionFallback = decompressionFallback;
             PlayerSettings.WebGL.nameFilesAsHashes = nameFilesAsHashes;
+            // 빌드 시 DiskSizeLTO로 바꿨더라도 빌드 후 사용자의 원래 설정으로 되돌린다(영구 오염 방지).
+            // null이면(캡처 당시 API 부재) no-op.
+            AITWebGLCodeOptimization.TrySetByName(webGLCodeOptimization);
 
             PlayerSettings.defaultCursor = defaultCursor;
             PlayerSettings.cursorHotspot = cursorHotspot;

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -663,6 +663,10 @@ namespace AppsInToss.Editor
             // IL2CPP 컴파일러 설정
             DrawIl2CppConfigurationSetting();
 
+            // WebGL 코드 최적화 (Disk Size with LTO) — Meta 로드타임 스택의 실제 LTO 레버
+            // (전 버전 reflection 적용이라 #if 가드 없음. API 부재 버전은 fail-safe)
+            DrawWebGLCodeOptimizationSetting();
+
 #if UNITY_2023_3_OR_NEWER
             GUILayout.Space(10);
             EditorGUILayout.LabelField("Unity 6 전용 설정", EditorStyles.boldLabel);
@@ -743,6 +747,43 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawWebGLCodeOptimizationSetting()
+        {
+            // 기본 동작 = 적용(DiskSizeLTO). 토글: -1=자동(적용) / 0=미적용 / 1=적용.
+            // (config.webGLCodeOptimization==1)은 기본(적용)과 동일하므로 "미적용"(0)만 modified.
+            bool isModified = config.webGLCodeOptimization == 0;
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string label = config.webGLCodeOptimization < 0
+                ? "WebGL 코드 최적화 (자동: Disk Size with LTO)"
+                : "WebGL 코드 최적화";
+
+            string[] options = { "자동 (Disk Size with LTO)", "미적용", "적용 (Disk Size with LTO)" };
+            int currentIndex = config.webGLCodeOptimization < 0 ? 0 : config.webGLCodeOptimization + 1;
+            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+            config.webGLCodeOptimization = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.webGLCodeOptimization = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            // 이 Unity 버전에서 codeOptimization API가 없으면 fail-safe로 무시됨을 안내
+            if (config.webGLCodeOptimization != 0 && !AITWebGLCodeOptimization.IsSupported)
+            {
+                EditorGUILayout.HelpBox(
+                    "이 Unity 버전에는 WebGL code optimization API가 없어 이 설정은 빌드 시 무시됩니다 " +
+                    "(빌드는 정상 진행, LTO 이득만 없음).",
+                    MessageType.Info
+                );
+            }
         }
 
 #if UNITY_2023_3_OR_NEWER
@@ -1028,6 +1069,7 @@ namespace AppsInToss.Editor
         {
             config.stripEngineCode = true;
             config.il2cppConfiguration = -1;
+            config.webGLCodeOptimization = -1;
             config.powerPreference = -1;
 #if !UNITY_6000_0_OR_NEWER
             config.wasmStreaming = true;

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -177,8 +177,11 @@ namespace AppsInToss
         [Header("IL2CPP/Stripping 설정")]
         public bool stripEngineCode = true;
 
-        [Tooltip("-1 = 자동 (Release)")]
+        [Tooltip("-1 = 자동 (Release). WebGL에서 Master는 emscripten 최적화/LTO에 영향을 주지 않음(no-op)")]
         public int il2cppConfiguration = -1;
+
+        [Tooltip("-1 = 자동 (Disk Size with LTO 적용 — Coatsink/Meta 로드타임 스택의 실제 LTO 레버). 0 = 미적용(Unity 설정 유지), 1 = 적용")]
+        public int webGLCodeOptimization = -1;
 
         [Header("Unity 6 전용 설정")]
         [Tooltip("-1 = 자동 (HighPerformance)")]
@@ -400,12 +403,29 @@ namespace AppsInToss
         }
 
         /// <summary>
-        /// 기본 IL2CPP 컴파일러 설정
-        /// 출처: StartupOptimization.md:85
+        /// 기본 IL2CPP 컴파일러 설정: Release
+        /// 주의: 과거 이 값을 Master로 두고 Coatsink "Disk Size with LTO"의 LTO 파트라 가정했으나,
+        /// 실측 결과 WebGL에서 컴파일러 config(Master)는 emscripten 최적화/LTO에 영향을 주지 않아
+        /// Release와 바이트 단위로 동일한 산출물을 냈다(no-op). 실제 LTO 레버는
+        /// emscripten code optimization = "Disk Size with LTO"이며 GetDefaultWebGLCodeOptimization()이 담당한다.
         /// </summary>
         public static Il2CppCompilerConfiguration GetDefaultIl2CppConfiguration()
         {
             return Il2CppCompilerConfiguration.Release;
+        }
+
+        /// <summary>
+        /// 기본 WebGL Code Optimization: "Disk Size with LTO"(DiskSizeLTO)
+        /// Meta+Unity 로드타임 스택의 실제 LTO 레버. emscripten Link Time Optimization으로
+        /// cross-module dead-code를 제거해 wasm 코드 크기를 추가로 축소한다(실측 기준 압축전 ~-21%).
+        /// trade-off: 빌드 시간 증가(LTO 링크). API가 버전마다 다르고(2022.3/6: UserBuildSettings,
+        /// 구버전: PlayerSettings.WebGL) 모듈 어셈블리 참조 보장이 없어 AITWebGLCodeOptimization이
+        /// reflection으로 적용한다. 멤버가 없는 버전(예: 2021.3)에서는 fail-safe로 건너뛴다.
+        /// 출처: Unity Manual web-optimization-c-sharp, Coatsink "Ready, Set, Cook!" 케이스 스터디
+        /// </summary>
+        public static string GetDefaultWebGLCodeOptimization()
+        {
+            return AppsInToss.Editor.AITWebGLCodeOptimization.DiskSizeLTO;
         }
 
 #if UNITY_2023_3_OR_NEWER

--- a/Editor/AITWebGLCodeOptimization.cs
+++ b/Editor/AITWebGLCodeOptimization.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Reflection;
+using UnityEngine;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// WebGL "code optimization" 레버(Coatsink/Meta 로드타임 스택의 "Disk Size with LTO")를
+    /// Unity 버전 차이를 흡수해 reflection으로 읽고 쓴다.
+    ///
+    /// 왜 IL2CPP 컴파일러 config(Master)가 아니라 이쪽인가:
+    /// IL2CPP 컴파일러 config(Master)는 WebGL의 emscripten 최적화/LTO에 영향을 주지 않는다.
+    /// 실측상 Master 빌드 산출물은 Release와 바이트 단위로 동일(no-op)했다. 실제로 LTO를
+    /// 켜고 wasm 코드 크기를 줄이는 레버는 emscripten code optimization = "Disk Size with LTO"다.
+    ///
+    /// 왜 reflection인가:
+    /// - Unity 2022.3/6(6000.x): UnityEditor.WebGL.UserBuildSettings.codeOptimization
+    ///   (enum UnityEditor.WebGL.WasmCodeOptimization). WebGL 모듈 어셈블리에 있어 Editor
+    ///   asmdef가 이를 참조한다는 보장이 없다 → 직접 참조 시 CS0103 위험.
+    /// - 구버전(존재 시): PlayerSettings.WebGL.codeOptimization (enum WebGLCodeOptimization).
+    ///   Unity 6에서 제거됨 → 직접 참조 시 컴파일 실패.
+    /// 두 API의 enum 멤버명(DiskSizeLTO 등)이 동일하므로 멤버 "이름"으로 다룬다.
+    ///
+    /// 멤버가 없는 버전(예: 2021.3에 codeOptimization 부재)에서는 fail-safe로 동작한다 —
+    /// 설정을 건너뛰고 경고만 남기며 빌드는 계속된다(해당 버전에서 LTO 이득만 없음).
+    /// </summary>
+    internal static class AITWebGLCodeOptimization
+    {
+        /// <summary>Coatsink/Meta 로드타임 스택의 권장값(enum 멤버 이름).</summary>
+        public const string DiskSizeLTO = "DiskSizeLTO";
+
+        private static bool _resolved;
+        private static PropertyInfo _prop;
+
+        /// <summary>
+        /// 현재 Unity 버전에서 codeOptimization 정적 프로퍼티를 찾아 캐시한다.
+        /// 신규 API(UserBuildSettings)를 먼저, 구버전 API(PlayerSettings.WebGL)를 폴백으로 본다.
+        /// API가 없으면 null을 캐시.
+        /// </summary>
+        private static PropertyInfo ResolveProperty()
+        {
+            if (_resolved) return _prop;
+            _resolved = true;
+
+            // 신규 API: UnityEditor.WebGL.UserBuildSettings.codeOptimization (static)
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type t;
+                try { t = asm.GetType("UnityEditor.WebGL.UserBuildSettings"); }
+                catch { continue; }
+                if (t == null) continue;
+
+                var p = t.GetProperty("codeOptimization",
+                    BindingFlags.Public | BindingFlags.Static);
+                if (p != null && p.PropertyType.IsEnum && p.CanRead && p.CanWrite)
+                {
+                    _prop = p;
+                    return _prop;
+                }
+            }
+
+            // 구버전 API: PlayerSettings.WebGL.codeOptimization (중첩 static 타입)
+            var webglNested = typeof(UnityEditor.PlayerSettings)
+                .GetNestedType("WebGL", BindingFlags.Public | BindingFlags.Static);
+            var legacy = webglNested?.GetProperty("codeOptimization",
+                BindingFlags.Public | BindingFlags.Static);
+            if (legacy != null && legacy.PropertyType.IsEnum && legacy.CanRead && legacy.CanWrite)
+            {
+                _prop = legacy;
+                return _prop;
+            }
+
+            return _prop; // null — 이 버전엔 API 없음
+        }
+
+        /// <summary>이 Unity 버전에서 codeOptimization 설정이 가능한지.</summary>
+        public static bool IsSupported => ResolveProperty() != null;
+
+        /// <summary>현재 값의 enum 멤버 이름. API 부재 시 null.</summary>
+        public static string GetCurrentName()
+        {
+            var p = ResolveProperty();
+            if (p == null) return null;
+            try { return p.GetValue(null)?.ToString(); }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// 멤버 이름으로 값을 설정한다. name이 null/빈 문자열이거나 API 부재/멤버 미정의 시 false.
+        /// fail-safe: 실패해도 예외를 던지지 않고 경고만 남긴다(빌드 계속).
+        /// </summary>
+        public static bool TrySetByName(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return false;
+
+            var p = ResolveProperty();
+            if (p == null) return false;
+
+            try
+            {
+                if (!Enum.IsDefined(p.PropertyType, name))
+                {
+                    Debug.LogWarning(
+                        $"[AIT] WebGL codeOptimization 멤버 미정의: '{name}' (enum={p.PropertyType.Name}) — 건너뜀");
+                    return false;
+                }
+
+                var val = Enum.Parse(p.PropertyType, name);
+                p.SetValue(null, val);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] WebGL codeOptimization 설정 실패('{name}'): {e.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/Editor/AITWebGLCodeOptimization.cs
+++ b/Editor/AITWebGLCodeOptimization.cs
@@ -29,6 +29,12 @@ namespace AppsInToss.Editor
         /// <summary>Coatsink/Meta 로드타임 스택의 권장값(enum 멤버 이름).</summary>
         public const string DiskSizeLTO = "DiskSizeLTO";
 
+        /// <summary>
+        /// DiskSizeLTO 미지원 버전에서 사용하는 폴백 멤버 이름.
+        /// DiskSize는 LTO 없는 disk-size 최적화로, DiskSizeLTO와 동일한 방향의 최선 근사다.
+        /// </summary>
+        internal const string DiskSizeFallback = "DiskSize";
+
         private static bool _resolved;
         private static PropertyInfo _prop;
 
@@ -114,6 +120,35 @@ namespace AppsInToss.Editor
                 Debug.LogWarning($"[AIT] WebGL codeOptimization 설정 실패('{name}'): {e.Message}");
                 return false;
             }
+        }
+
+        /// <summary>
+        /// DiskSizeLTO(disk-size 최적화 + cross-module LTO)를 적용한다.
+        /// DiskSizeLTO 멤버가 이 Unity 버전의 enum에 없으면 DiskSize(LTO 없는 disk-size)로 폴백한다.
+        /// 두 멤버 모두 없거나 API 자체가 없으면 false를 반환하고 호출자가 경고를 남긴다.
+        ///
+        /// Sentry APPS-IN-TOSS-UNITY-SDK-10W: DiskSizeLTO 미정의 버전에서 경고만 남기고
+        /// 설정을 완전 건너뛰던 동작을 DiskSize 폴백으로 개선.
+        /// </summary>
+        public static bool TrySetDiskSizeLTO()
+        {
+            var p = ResolveProperty();
+            if (p == null) return false;
+
+            // 1순위: DiskSizeLTO (cross-module LTO 포함, 권장)
+            if (Enum.IsDefined(p.PropertyType, DiskSizeLTO))
+                return TrySetByName(DiskSizeLTO);
+
+            // 2순위: DiskSize (LTO 없는 disk-size 최적화, 동일 방향의 폴백)
+            if (Enum.IsDefined(p.PropertyType, DiskSizeFallback))
+            {
+                Debug.Log(
+                    $"[AIT] WebGL codeOptimization: '{DiskSizeLTO}' 미지원 버전 — '{DiskSizeFallback}'(폴백) 적용");
+                return TrySetByName(DiskSizeFallback);
+            }
+
+            // 둘 다 없는 경우: 호출자가 별도 경고를 남기므로 여기서는 false만 반환
+            return false;
         }
     }
 }

--- a/Editor/AITWebGLCodeOptimization.cs.meta
+++ b/Editor/AITWebGLCodeOptimization.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f72fe6aa56b54be79487ea3ba3f7b65e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  references: []

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWebGLCodeOptimizationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWebGLCodeOptimizationTests.cs
@@ -1,0 +1,135 @@
+// -----------------------------------------------------------------------
+// AITWebGLCodeOptimizationTests.cs - WebGL codeOptimization 반영 헬퍼 검증
+// Level 0: AITWebGLCodeOptimization.TrySetByName / TrySetDiskSizeLTO 순수 로직 검증
+// Sentry 이슈 APPS-IN-TOSS-UNITY-SDK-10W 재발 방지용 회귀 테스트:
+//   DiskSizeLTO 멤버 미정의 시 경고 후 건너뛰던 동작을 DiskSize 폴백으로 개선
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss.Editor;
+using System.Text.RegularExpressions;
+
+[TestFixture]
+public class AITWebGLCodeOptimizationTests
+{
+    // =================================================================
+    // APPS-IN-TOSS-UNITY-SDK-10W 재현: TrySetByName 멤버 미정의 경고 경로
+    // =================================================================
+
+    /// <summary>
+    /// Sentry APPS-IN-TOSS-UNITY-SDK-10W 재현:
+    /// codeOptimization API가 있지만 요청한 멤버명이 enum에 없는 경우
+    /// "[AIT] WebGL codeOptimization 멤버 미정의: ..." 경고가 발생하고 false를 반환해야 한다.
+    ///
+    /// 실제 버그는 DiskSizeLTO 미지원 Unity 버전(codeOptimization API가 있지만 DiskSizeLTO가 없는 버전)에서
+    /// 발생했다. 이 테스트는 존재하지 않는 멤버명("__NoSuchMember__")을 직접 전달해
+    /// 동일한 경고 경로를 재현한다.
+    /// </summary>
+    [Test]
+    public void TrySetByName_WhenMemberNotDefined_EmitsWarningAndReturnsFalse()
+    {
+        // codeOptimization API가 없는 Unity 버전(예: 2021.3)에서는 ResolveProperty()가 null을 반환하므로
+        // IsSupported == false인 경우 이 경로는 실행되지 않는다. 그 경우는 건너뜀.
+        if (!AITWebGLCodeOptimization.IsSupported)
+        {
+            Assert.Ignore("이 Unity 버전은 codeOptimization API를 지원하지 않아 멤버 미정의 경로를 검증할 수 없습니다.");
+            return;
+        }
+
+        // 존재하지 않는 멤버명으로 Sentry APPS-IN-TOSS-UNITY-SDK-10W의 경고 경로를 재현
+        const string nonExistentMember = "__NoSuchMember__";
+        LogAssert.Expect(LogType.Warning, new Regex(
+            @"\[AIT\] WebGL codeOptimization 멤버 미정의: '__NoSuchMember__' \(enum=\w+\) — 건너뜀"));
+
+        bool result = AITWebGLCodeOptimization.TrySetByName(nonExistentMember);
+
+        Assert.IsFalse(result,
+            "멤버가 enum에 없으면 TrySetByName은 false를 반환해야 합니다.");
+    }
+
+    // =================================================================
+    // APPS-IN-TOSS-UNITY-SDK-10W 수정 검증: TrySetDiskSizeLTO 폴백 동작
+    // =================================================================
+
+    /// <summary>
+    /// DiskSizeLTO 미지원 버전에서의 폴백 동작을 검증한다.
+    /// API가 있고 DiskSizeLTO가 없지만 DiskSize가 있는 경우: DiskSize 폴백 적용 + Log(Info) 출력.
+    /// 이 테스트는 Unity 2022.3.62f2에서 DiskSizeLTO가 지원되므로 조건부 실행.
+    /// </summary>
+    [Test]
+    public void TrySetDiskSizeLTO_WhenApiSupported_ReturnsTrueAndAppliesValue()
+    {
+        if (!AITWebGLCodeOptimization.IsSupported)
+        {
+            Assert.Ignore("이 Unity 버전은 codeOptimization API를 지원하지 않습니다.");
+            return;
+        }
+
+        // 수정 전 값 기억 (복원용)
+        string before = AITWebGLCodeOptimization.GetCurrentName();
+
+        try
+        {
+            bool result = AITWebGLCodeOptimization.TrySetDiskSizeLTO();
+
+            Assert.IsTrue(result,
+                "TrySetDiskSizeLTO는 DiskSizeLTO 또는 DiskSize 폴백 적용 성공 시 true를 반환해야 합니다.");
+
+            string after = AITWebGLCodeOptimization.GetCurrentName();
+            Assert.IsNotNull(after, "적용 후 현재 값이 null이어서는 안 됩니다.");
+
+            bool isBestAvailable =
+                after == AITWebGLCodeOptimization.DiskSizeLTO ||
+                after == AITWebGLCodeOptimization.DiskSizeFallback;
+            Assert.IsTrue(isBestAvailable,
+                $"TrySetDiskSizeLTO 적용 후 값은 '{AITWebGLCodeOptimization.DiskSizeLTO}' 또는 " +
+                $"'{AITWebGLCodeOptimization.DiskSizeFallback}'이어야 합니다. 실제: '{after}'");
+        }
+        finally
+        {
+            // 복원: 테스트가 PlayerSettings를 오염시키지 않도록
+            if (before != null)
+                AITWebGLCodeOptimization.TrySetByName(before);
+        }
+    }
+
+    /// <summary>
+    /// TrySetDiskSizeLTO가 DiskSizeLTO를 성공적으로 적용할 때 경고를 남기지 않음을 검증.
+    /// DiskSizeLTO 지원 버전에서 TrySetByName 멤버 미정의 경고가 억제되어야 한다.
+    /// </summary>
+    [Test]
+    public void TrySetDiskSizeLTO_WhenDiskSizeLTODefined_NoWarningEmitted()
+    {
+        if (!AITWebGLCodeOptimization.IsSupported)
+        {
+            Assert.Ignore("이 Unity 버전은 codeOptimization API를 지원하지 않습니다.");
+            return;
+        }
+
+        string before = AITWebGLCodeOptimization.GetCurrentName();
+
+        try
+        {
+            // DiskSizeLTO가 지원되는 버전에서는 경고 없이 성공해야 한다
+            // LogAssert.NoUnexpectedReceived는 경고를 감시하지 않으므로
+            // 경고가 발생하면 테스트 프레임워크가 자동으로 실패시킨다.
+            bool result = AITWebGLCodeOptimization.TrySetDiskSizeLTO();
+
+            if (result)
+            {
+                string after = AITWebGLCodeOptimization.GetCurrentName();
+                // DiskSizeLTO가 지원되는 버전이라면 DiskSizeLTO 그대로 적용되어야 한다
+                // (DiskSize 폴백 메시지 없이)
+                Assert.AreEqual(AITWebGLCodeOptimization.DiskSizeLTO, after,
+                    "DiskSizeLTO 지원 버전에서는 DiskSizeLTO가 직접 적용되어야 합니다.");
+            }
+        }
+        finally
+        {
+            if (before != null)
+                AITWebGLCodeOptimization.TrySetByName(before);
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWebGLCodeOptimizationTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITWebGLCodeOptimizationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5861c05b62c44bc2bce81d25bbdd3988
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-10W

## 묶음 항목

| # | 이슈 | 제목 |
|---|------|------|
| 1 | APPS-IN-TOSS-UNITY-SDK-10W | [AIT] WebGL codeOptimization 멤버 미정의: 'DiskSizeLTO' (enum=CodeOptimization) — 건너뜀 |

## 재현 절차

1. `AITWebGLCodeOptimization.TrySetByName("DiskSizeLTO")` 호출
2. codeOptimization API는 존재하지만 DiskSizeLTO 멤버가 enum에 없는 Unity 버전에서:
   - `Enum.IsDefined(p.PropertyType, "DiskSizeLTO")` → false
   - `Debug.LogWarning("[AIT] WebGL codeOptimization 멤버 미정의: 'DiskSizeLTO' (enum=WasmCodeOptimization) — 건너뜀")` 발화
   - TrySetByName이 false 반환 → 설정 완전 건너뜀

**재현 테스트**: `AITWebGLCodeOptimizationTests.TrySetByName_WhenMemberNotDefined_EmitsWarningAndReturnsFalse`

## 원인

`perf/webgl-lto` 브랜치 (PR #756)에서 도입한 `AITWebGLCodeOptimization.TrySetByName`이
DiskSizeLTO가 없는 Unity 버전에서 경고만 남기고 폴백 없이 설정을 건너뜀.

## 수정 내용

- `AITWebGLCodeOptimization.DiskSizeFallback` 상수 추가 (`"DiskSize"`)
- `AITWebGLCodeOptimization.TrySetDiskSizeLTO()` 신규 메서드: DiskSizeLTO 우선, DiskSize 폴백
- `AITBuildInitializer`: `TrySetByName` → `TrySetDiskSizeLTO` 교체
- `perf/webgl-lto` (PR #756) 기능 코드 cherry-pick 포함

## 검증

- `AITWebGLCodeOptimizationTests` EditMode 테스트 3 cases 추가
- `./run-local-tests.sh --validate` 통과