### PR TITLE
개선: Heavy 픽스처 Quality mip 제한 추가 (mip-stripping 레버 측정 가능화)

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/HeavyBuildRunner.cs
+++ b/Tests~/E2E/SharedScripts/Editor/HeavyBuildRunner.cs
@@ -95,6 +95,12 @@ public class HeavyBuildRunner
         for (int i = 0; i < meshCount; i++) GenerateMesh(i, meshGrid);
         CopyFonts(fontCopies);
 
+        // L6(mip stripping) 측정 가능화: 모든 Quality 레벨의 텍스처 mip 제한을 설정한다.
+        // 이 설정 단독으로는 .data 가 변하지 않는다(mipStripping=false 면 mip 전량 빌드 포함 →
+        // baseline on-wire 불변). L6 레버(PlayerSettings.mipStripping=true)가 켜졌을 때 비로소
+        // "어떤 Quality 레벨도 안 쓰는 최상위 mip"으로 분류되어 빌드에서 제거된다.
+        ApplyMipLimitToAllQualityLevels(GetEnvInt("AIT_HEAVY_MIP_LIMIT", 1));
+
         AssetDatabase.SaveAssets();
         AssetDatabase.Refresh();
         LogHeavyFootprint();
@@ -342,6 +348,38 @@ public class HeavyBuildRunner
         }
         Debug.Log($"[heavy] generated source footprint: {total / (1024.0 * 1024.0):F1} MB on disk " +
                   $"(빌드 .data 기여는 압축 포맷에 따라 상이; gitignore 대상)");
+    }
+
+    // ---- Quality mip 제한 (L6 mip stripping 레버 측정 가능화) ----
+    // Unity 의 mip stripping(PlayerSettings.mipStripping=true)은 "어떤 Quality 레벨도 필요로 하지
+    // 않는 mip"만 빌드에서 제거한다. 기본 Unity Quality 는 모든 레벨이 mip 제한 0(전체 해상도)이라
+    // 최상위 mip 이 항상 "사용됨"으로 분류 → mipStripping 플래그가 no-op 이 된다(진단 §9.32).
+    // 따라서 픽스처가 모든 레벨에 mip 제한 ≥1 을 설정해야, 레버가 켜졌을 때 mip0 이 "미사용"으로
+    // 분류되어 실제로 제거된다(2048² DXT5 의 ~1/4 절감). limit≤0 이면 no-op(설정 비활성).
+    //
+    // baseline 안전성: 이 설정은 .data 의 on-wire 바이트를 바꾸지 않는다. mipStripping=false 인
+    // baseline/타 레버 빌드는 mip 피라미드를 전량 포함하며(런타임 업로드 base 만 mip1 로 이동),
+    // 오직 L6 레버 빌드(mipStripping=true)에서만 mip0 이 제거된다.
+    private static void ApplyMipLimitToAllQualityLevels(int limit)
+    {
+        if (limit <= 0)
+            return;
+
+        int originalLevel = QualitySettings.GetQualityLevel();
+        int levelCount = QualitySettings.names.Length;
+        for (int i = 0; i < levelCount; i++)
+        {
+            QualitySettings.SetQualityLevel(i, applyExpensiveChanges: false);
+#if UNITY_2022_2_OR_NEWER
+            QualitySettings.globalTextureMipmapLimit = limit;
+#else
+            QualitySettings.masterTextureLimit = limit;
+#endif
+        }
+        QualitySettings.SetQualityLevel(originalLevel, applyExpensiveChanges: false);
+
+        Debug.Log($"[heavy] Quality mip limit = {limit} → {levelCount} 레벨 전부 적용 " +
+                  "(L6 mip stripping 이 mip0 제거 가능; baseline on-wire 불변)");
     }
 
     private static int GetEnvInt(string name, int defaultValue)


### PR DESCRIPTION
## 요약

Heavy perf 픽스처에 **Quality 텍스처 mip 제한**을 추가해, **mip-stripping perf 레버(#760)** 가 측정 가능해지도록 한다. 하네스(infra) 변경이라 `perf` 라벨은 부여하지 않는다.

## 배경 (진단)

`mip-stripping` 레버는 Heavy 픽스처에서 on-wire Δ~0(중립)으로 측정돼 왔다. 4-에이전트 진단 결과 근본원인 확정:

- Unity 의 `PlayerSettings.mipStripping=true` 는 **"어떤 Quality 레벨도 필요로 하지 않는 mip"** 만 빌드에서 제거한다.
- 기본 Unity Quality 는 **모든 레벨이 mip 제한 0(전체 해상도)** → 최상위 mip 이 항상 "사용됨"으로 분류 → 제거 대상 0개 → 레버가 **no-op**.

레버 자체는 정상이며(품질 저하 없이 못 깎는 안전 동작), 픽스처가 Quality mip 제한을 설정하지 않은 것이 원인이다.

## 변경

`HeavyBuildRunner.GenerateHeavyContent()` 가 빌드 직전 **모든 Quality 레벨**의 텍스처 mip 제한을 1 로 설정:

```csharp
ApplyMipLimitToAllQualityLevels(GetEnvInt("AIT_HEAVY_MIP_LIMIT", 1));
```

- `#if UNITY_2022_2_OR_NEWER` → `globalTextureMipmapLimit`, else → `masterTextureLimit`(2021.3). 6000.x 의 obsolete-as-error 회피.
- `AIT_HEAVY_MIP_LIMIT`(기본 1)로 조절. 0 이면 no-op.

이제 L6 레버(`mipStripping=true`)가 켜지면 mip0(2048²)이 "미사용"으로 분류되어 실제 제거(DXT5 ~1/4 절감).

## baseline 안전성 (★)

이 설정 단독으로는 **`.data` on-wire 바이트가 변하지 않는다**. `mipStripping=false` 인 baseline·타 레버 빌드는 mip 피라미드를 전량 포함하며(런타임 GPU 업로드 base 만 mip1 로 이동), **오직 #760 레버 빌드(`mipStripping=true`)에서만 mip0 이 제거**된다. → 기존 13개 레버의 단일-레버 Δ 측정 무효화 없음.

## 검증

- `./run-local-tests.sh --validate` ✅ (4 passed / 0 failed, meta GUID 위생 통과)
- 신규 바이너리 없음(HeavyGen 은 빌드타임 생성·gitignore). C# 변경 단일 파일.

## 머지/시퀀싱 (주의)

- ⚠️ **즉시 머지 금지.** perf 캠페인은 3.0 stable 게이트로 보류 중. 이 harness 변경은 머지 시 **baseline 재트리거** 가 필요하며, perf 레버 PR 재측정과 함께 캠페인 재개 시점에 처리한다.
- 텍스처 레버 나머지 3종(crunch/streaming/astc)은 baseline 무효화·구조 변경을 동반해 별도 후속에서 묶어 진행한다.