### PR TITLE
기능: 텍스처 크기 클램프 레버(maxTextureSize 캡, crunch 비결합) 추가

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -221,6 +221,12 @@ namespace AppsInToss.Editor
                 ? editorConfig.firstInteractiveLog == 1
                 : AITDefaultSettings.GetDefaultFirstInteractiveLog();
             Debug.Log($"[AIT]   - first-interactive 계측: {firstInteractiveEnabled}{(editorConfig.firstInteractiveLog < 0 ? " (자동)" : "")}");
+
+            // 텍스처 크기 클램프는 BuildPlayer 직전 AITTextureSizeClampProcessor 에서 처리
+            bool textureSizeClampEnabled = editorConfig.textureSizeClamp >= 0
+                ? editorConfig.textureSizeClamp == 1
+                : AITDefaultSettings.GetDefaultTextureSizeClamp();
+            Debug.Log($"[AIT]   - 텍스처 크기 클램프: {textureSizeClampEnabled}{(editorConfig.textureSizeClamp < 0 ? " (자동)" : "")}{(textureSizeClampEnabled ? $" (≤{editorConfig.textureClampMaxSize})" : "")}");
         }
 
         /// <summary>

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -456,6 +456,11 @@ namespace AppsInToss.Editor
 
             GUILayout.Space(10);
 
+            // 콘텐츠 최적화 — 텍스처 크기 클램프 (maxTextureSize 캡)
+            DrawTextureSizeClampSetting();
+
+            GUILayout.Space(10);
+
             // 변경된 설정 개수 표시
             int modifiedCount = CountModifiedWebGLSettings();
             if (modifiedCount > 0)
@@ -472,6 +477,70 @@ namespace AppsInToss.Editor
             }
 
             EditorGUILayout.EndVertical();
+        }
+
+        private void DrawTextureSizeClampSetting()
+        {
+            bool defaultValue = AITDefaultSettings.GetDefaultTextureSizeClamp();
+            bool isModified = config.textureSizeClamp >= 0 && (config.textureSizeClamp == 1) != defaultValue;
+
+            EditorGUILayout.LabelField("콘텐츠 최적화 — 텍스처 크기 클램프", EditorStyles.boldLabel);
+
+            EditorGUILayout.BeginHorizontal();
+
+            DrawModifiedIndicator(isModified);
+
+            string autoLabel = defaultValue ? "활성화" : "비활성화";
+            string label = config.textureSizeClamp < 0
+                ? $"텍스처 크기 클램프 (자동: {autoLabel})"
+                : "텍스처 크기 클램프";
+
+            string[] options = { $"자동 ({autoLabel})", "비활성화", "활성화" };
+            int currentIndex = config.textureSizeClamp < 0 ? 0 : config.textureSizeClamp + 1;
+            int newIndex = EditorGUILayout.Popup(
+                new GUIContent(label,
+                    "대상 텍스처의 maxTextureSize만 빌드 시 일시적으로 캡(상한)으로 낮춰 reimport하여 텍셀 수를 줄입니다 " +
+                    "(format/compression/crunch 불변). 예) 2048→1024는 텍셀 1/4. 빌드 후 원본 임포트 설정으로 복원합니다."),
+                currentIndex,
+                options
+            );
+            config.textureSizeClamp = newIndex == 0 ? -1 : newIndex - 1;
+
+            if (isModified && DrawResetButton())
+            {
+                config.textureSizeClamp = -1;
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            bool effectiveEnabled = config.textureSizeClamp >= 0 ? config.textureSizeClamp == 1 : defaultValue;
+            if (effectiveEnabled)
+            {
+                EditorGUI.indentLevel++;
+                config.textureClampMaxSize = EditorGUILayout.IntField(
+                    new GUIContent("최대 텍스처 크기", "이 값보다 큰 텍스처만 축소합니다. 16 미만은 무시. 예) 512, 1024"),
+                    config.textureClampMaxSize);
+
+                int minBytesKb = EditorGUILayout.IntField(
+                    new GUIContent("소스 크기 필터(KB, 0=없음)", "소스 파일이 이 크기 미만이면 제외(작은 아이콘 보호)."),
+                    (int)(config.textureClampMinBytes / 1024));
+                config.textureClampMinBytes = (long)Mathf.Max(0, minBytesKb) * 1024;
+
+                config.textureClampDirs = EditorGUILayout.TextField(
+                    new GUIContent("대상 폴더(쉼표 구분)", "Assets/ 기준 경로. 비우면 프로젝트 전체 텍스처가 대상. 예) Assets/Art/Backgrounds"),
+                    config.textureClampDirs);
+
+                config.textureClampExcludeDirs = EditorGUILayout.TextField(
+                    new GUIContent("제외 폴더(쉼표 구분)", "Assets/ 기준 경로. 클램프에서 제외할 폴더(escape hatch)."),
+                    config.textureClampExcludeDirs);
+
+                EditorGUILayout.HelpBox(
+                    "크기 클램프는 표시 해상도를 낮추는 lossy 변경입니다(예: 2048→1024). UI/텍스트 텍스처에서 흐려짐이 " +
+                    "눈에 띌 수 있으므로 빌드 후 결과를 반드시 확인하세요. crunch와 달리 format/압축은 건드리지 않아 " +
+                    "ASTC로 굽는 프로젝트에서도 그대로 적용됩니다. 빌드 후 원본 임포트 설정은 자동 복원됩니다.",
+                    MessageType.Warning);
+                EditorGUI.indentLevel--;
+            }
         }
 
         private void DrawMemorySizeSetting()
@@ -1013,6 +1082,9 @@ namespace AppsInToss.Editor
             bool defaultFirstInteractive = AITDefaultSettings.GetDefaultFirstInteractiveLog();
             if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
 
+            bool defaultTextureClamp = AITDefaultSettings.GetDefaultTextureSizeClamp();
+            if (config.textureSizeClamp >= 0 && (config.textureSizeClamp == 1) != defaultTextureClamp) count++;
+
             return count;
         }
 
@@ -1022,6 +1094,7 @@ namespace AppsInToss.Editor
             config.threadsSupport = -1;
             config.dataCaching = -1;
             config.firstInteractiveLog = -1;
+            config.textureSizeClamp = -1;
         }
 
         private void ResetAdvancedSettings()

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -993,6 +993,9 @@ namespace AppsInToss
             // .cs 파일 수정과 달리 .json은 스크립트 컴파일을 유발하지 않으므로 도메인 리로드 없음
             bool versionInfoWritten = WriteVersionInfoJson(out bool createdResourcesDir);
 
+            // 콘텐츠 최적화 — 텍스처 크기 클램프 (maxTextureSize 캡으로 .data 축소, 빌드 후 임포터 원복)
+            var textureClampHandle = Editor.AITTextureSizeClampProcessor.ApplyForBuild(config);
+
             UnityEditor.Build.Reporting.BuildReport result;
             try
             {
@@ -1000,6 +1003,9 @@ namespace AppsInToss
             }
             finally
             {
+                // 콘텐츠 최적화 — 텍스처 크기 클램프 임포터 설정 원복 (빌드 성공/실패 무관)
+                Editor.AITTextureSizeClampProcessor.RestoreForBuild(textureClampHandle);
+
                 // 빌드 완료 후 (성공/실패 무관) 생성한 JSON 제거 — 사용자 프로젝트에 산출물 남기지 않음
                 if (versionInfoWritten)
                 {

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -210,6 +210,25 @@ namespace AppsInToss
         [Tooltip("first-interactive 계측: -1 = 자동 (활성), 0 = 비활성, 1 = 활성")]
         public int firstInteractiveLog = -1;
 
+        [Header("콘텐츠 최적화 — 텍스처 크기 클램프 (lossy, opt-in)")]
+        [Tooltip("-1 = 자동(비활성), 0 = 비활성, 1 = 활성. " +
+                 "대상 텍스처의 maxTextureSize 만 빌드 시 일시적으로 캡(상한)으로 낮춰 reimport 하여 텍셀 수를 줄입니다 " +
+                 "(format/compression/crunch 불변). 예) 2048→1024 는 텍셀 1/4 → 압축 payload/on-wire 도 ~1/4. " +
+                 "표시 해상도가 낮아지는 lossy 변경이므로 기본 비활성입니다. 빌드 후 원본 임포트 설정으로 복원합니다.")]
+        public int textureSizeClamp = -1;
+
+        [Tooltip("텍스처 maxTextureSize 상한(이 값보다 큰 텍스처만 축소). 16 미만은 무시. 예) 512, 1024")]
+        public int textureClampMaxSize = 1024;
+
+        [Tooltip("소스 파일 크기 필터(바이트). 이 크기 미만 텍스처는 제외(작은 아이콘 보호). 0 = 필터 없음")]
+        public long textureClampMinBytes = 0;
+
+        [Tooltip("대상 폴더(쉼표 구분, Assets/ 기준). 비우면 프로젝트 전체 텍스처가 대상입니다. 예) Assets/Art/Backgrounds")]
+        public string textureClampDirs = "";
+
+        [Tooltip("제외할 폴더(쉼표 구분, Assets/ 기준). 사용자 escape hatch.")]
+        public string textureClampExcludeDirs = "";
+
         [Header("권한 설정")]
         public AITPermissionConfig permissionConfig = new AITPermissionConfig();
 
@@ -477,6 +496,16 @@ namespace AppsInToss
         public static bool GetDefaultFirstInteractiveLog()
         {
             return true;
+        }
+
+        /// <summary>
+        /// 텍스처 크기 클램프(maxTextureSize 캡) 기본 활성 여부.
+        /// 표시 해상도를 낮추는 lossy 변경이고, 안전한 자동 캡 값이 존재하지 않으므로(프로젝트마다 적정 상한이 다름)
+        /// 항상 명시적 opt-in 으로 기본 비활성이다. 빌드 후 임포터 설정은 항상 원상 복원된다.
+        /// </summary>
+        public static bool GetDefaultTextureSizeClamp()
+        {
+            return false;
         }
 
         /// <summary>

--- a/Editor/AITTextureSizeClampProcessor.cs
+++ b/Editor/AITTextureSizeClampProcessor.cs
@@ -1,0 +1,377 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITTextureSizeClampProcessor.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Texture Size Clamp (build-time importer override, crunch-decoupled)
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 빌드 직전, 대상 Texture2D 의 임포터 설정 중 maxTextureSize "만" 일시적으로 캡(상한)으로
+//   낮춰 reimport 하여, Unity 가 더 작은 텍셀의 텍스처를 .data 에 굽게 한다.
+//   빌드 종료(성공/실패 무관) 후 원본 임포트 설정으로 원상 복원한다.
+//
+// crunch 와의 차이(분리된 이유):
+//   AITTextureCrunchProcessor 는 maxTextureSize 캡을 crunch(=DXT 강제 + crunchedCompression=true +
+//   textureCompression/compressionQuality 변경)와 한 게이트(textureCrunch)에 묶어 둔다.
+//   즉 "크기만 줄이고 싶은데 DXT-crunch 는 원치 않는" 경우(이미 ASTC 로 굽거나, crunch reimport
+//   비용/화질 변화를 피하고 싶은 경우)에는 쓸 수 없다. 본 처리기는 format/compression/crunch 를
+//   일절 건드리지 않고 maxTextureSize 한 필드만 override 하므로, 빌드 파이프라인이 정하는 기본
+//   format(WebGL fallback = ASTC/DXT)을 그대로 유지한 채 텍셀 수만 줄인다.
+//
+// 효과: 부팅 텍스처를 예) 1024 로 캡하면 2048→1024 는 텍셀 1/4. 압축 포맷(ASTC/DXT)은 텍셀당
+//   고정 비트레이트이므로 압축 payload 도 ~1/4, on-wire(brotli) 도 감소하고 GPU 업로드 tail 도 일부
+//   완화된다. 단, 표시 해상도가 절반으로 떨어지는 lossy 변경(시각 품질 저하)이므로 기본 비활성이다.
+//
+// 비파괴: 각 텍스처의 원본 .meta 를 <path>.meta.aittexclampbak 로 백업, 빌드 후 원본을 그대로
+//   복원한다. 빌드가 비정상 종료되어 복원이 누락돼도, 다음 에디터 로드 시 안전망(SafetyNetRestore)이
+//   잔존 백업을 자동 복원한다.
+//
+// 통합: AITConvertCore.BuildWebGL 가 BuildPipeline.BuildPlayer 직전에 ApplyForBuild,
+//   try/finally 의 finally 에서 RestoreForBuild 를 호출한다(텍스처 crunch 와 동일 패턴).
+//   적용 순서는 crunch 직후(=crunch 가 같은 텍스처에 maxSize 를 더 낮게 캡했다면 그 값이 우선이도록
+//   wouldChange 게이트가 더 큰 쪽으로만 내린다). 복원은 적용 역순.
+//
+// ⚠ 비용: maxTextureSize 변경은 reimport 를 유발한다(crunch 처럼 codec 재인코딩까지는 아니지만
+//   대상 수에 비례). apply + 복원으로 2회 reimport 가 발생하므로 명시적 opt-in 으로 기본 비활성이다.
+
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 빌드 단계 텍스처 maxTextureSize 캡(crunch 비결합) 처리기.
+    /// <see cref="AITEditorScriptObject.textureSizeClamp"/> 설정에 따라 동작한다.
+    /// format/compression/crunch 는 건드리지 않고 maxTextureSize 한 필드만 override 한다.
+    /// 런타임 컴포넌트는 없다(빌드 산출물만 작아질 뿐, 런타임 동작 동일).
+    /// </summary>
+    [InitializeOnLoad]
+    public static class AITTextureSizeClampProcessor
+    {
+        /// <summary>원본 .meta 를 보관하는 백업 접미사.</summary>
+        private const string BackupSuffix = ".aittexclampbak";
+
+        /// <summary>apply 가 진행 중임을 표시하는 마커(Unity 가 무시하는 '.' 접두 숨김 파일).</summary>
+        private const string MarkerRelative = "Assets/.ait-texclamp-active";
+
+        /// <summary>캡 최소 하한. 너무 작은 값으로 인한 사고 방지(NPOT/타일 등). 16 미만은 무시.</summary>
+        private const int MinClampSize = 16;
+
+        /// <summary>한 번의 클램프 적용 결과 핸들. finally 에서 정확한 복원에 사용.</summary>
+        public sealed class ClampHandle
+        {
+            /// <summary>이번 빌드에서 클램프가 실제로 수행되었는지.</summary>
+            public bool Active;
+
+            /// <summary>처리된 텍스처 개수.</summary>
+            public int TextureCount;
+        }
+
+        static AITTextureSizeClampProcessor()
+        {
+            EditorApplication.delayCall += SafetyNetRestore;
+        }
+
+        /// <summary>
+        /// 빌드 직전 호출: 설정이 켜져 있으면 대상 텍스처의 maxTextureSize 만 캡으로 낮춰 reimport 한다.
+        /// </summary>
+        /// <param name="config">프로젝트 에디터 설정. null 이거나 기능이 꺼져 있으면 no-op.</param>
+        /// <returns>복원에 사용할 핸들(항상 non-null).</returns>
+        public static ClampHandle ApplyForBuild(AITEditorScriptObject config)
+        {
+            var handle = new ClampHandle();
+
+            // tri-state 게이트: -1 = 자동(AITDefaultSettings 기본값), 0 = 비활성, 1 = 활성.
+            bool enabled = config != null && (config.textureSizeClamp >= 0
+                ? config.textureSizeClamp == 1
+                : AITDefaultSettings.GetDefaultTextureSizeClamp());
+            if (!enabled)
+            {
+                return handle;
+            }
+
+            try
+            {
+                int clampMax = config.textureClampMaxSize;       // 0 이하 또는 하한 미만 = no-op
+                if (clampMax < MinClampSize)
+                {
+                    Debug.LogWarning($"[AIT-TextureSizeClamp] textureClampMaxSize({clampMax}) < 하한({MinClampSize}) → 건너뜀(no-op).");
+                    return handle;
+                }
+
+                long minBytes = config.textureClampMinBytes > 0 ? config.textureClampMinBytes : 0; // 0 = 크기 필터 없음
+                string[] dirs = SplitDirs(config.textureClampDirs);              // null = 전체 Assets
+                string[] excludeDirs = SplitDirs(config.textureClampExcludeDirs); // 사용자 escape hatch
+
+                CreateMarker();
+
+                int tex = ApplyTexture2D(clampMax, minBytes, dirs, excludeDirs);
+
+                AssetDatabase.Refresh();
+
+                handle.Active = tex > 0;
+                handle.TextureCount = tex;
+                if (!handle.Active)
+                {
+                    // 대상 0건 → 마커 제거(복원할 것 없음).
+                    RemoveMarker();
+                }
+
+                Debug.Log($"[AIT-TextureSizeClamp] ✓ 텍스처 {tex}개 maxTextureSize≤{clampMax} 캡(format/crunch 불변) 적용{(config.textureSizeClamp < 0 ? " (자동)" : "")}.");
+                return handle;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-TextureSizeClamp] 적용 예외 → 복원 후 건너뜀: {e}");
+                RestoreAllBackups();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                return new ClampHandle();
+            }
+        }
+
+        /// <summary>빌드 종료 후(성공/실패 무관) 호출: 원본 임포트 설정으로 복원한다.</summary>
+        public static void RestoreForBuild(ClampHandle handle)
+        {
+            if (handle == null || !handle.Active)
+            {
+                return;
+            }
+
+            try
+            {
+                int restored = RestoreAllBackups();
+                RemoveMarker();
+                AssetDatabase.Refresh();
+                Debug.Log($"[AIT-TextureSizeClamp] 복원 완료: {restored}개 텍스처 원본 임포트 설정 원상.");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[AIT-TextureSizeClamp] 복원 예외: {e}");
+            }
+        }
+
+        /// <summary>에디터 로드 시 안전망. 마커가 잔존하면(=이전 빌드가 복원 전에 종료) 백업을 자동 복원.</summary>
+        private static void SafetyNetRestore()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string markerFull = Path.Combine(projectRoot, MarkerRelative);
+                if (!File.Exists(markerFull))
+                {
+                    return; // 공통 경로: 잔존물 없음(빠른 반환)
+                }
+
+                int restored = RestoreAllBackups();
+                RemoveMarker();
+                if (restored > 0)
+                {
+                    AssetDatabase.Refresh();
+                    Debug.LogWarning($"[AIT-TextureSizeClamp] 안전망: 이전 빌드 잔존 백업 {restored}개를 복원했습니다.");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-TextureSizeClamp] 안전망 복원 중 예외(무시): {e}");
+            }
+        }
+
+        // ─────────────────────────── Texture2D ───────────────────────────
+        private static int ApplyTexture2D(int clampMax, long minBytes, string[] dirs, string[] excludeDirs)
+        {
+            int n = 0;
+            var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { "Assets" });
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+            foreach (var g in guids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(g);
+                if (string.IsNullOrEmpty(path) || !path.StartsWith("Assets/"))
+                {
+                    continue;
+                }
+
+                // 다른 처리기의 StreamingAssets 사본은 건드리지 않음(자기 외부화본 보호).
+                if (path.IndexOf("/ait-stream-", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    continue;
+                }
+
+                if (dirs != null && !UnderAny(path, dirs))
+                {
+                    continue;
+                }
+
+                if (excludeDirs != null && UnderAny(path, excludeDirs))
+                {
+                    continue; // 사용자 escape hatch
+                }
+
+                var ti = AssetImporter.GetAtPath(path) as TextureImporter;
+                if (ti == null)
+                {
+                    continue;
+                }
+
+                // maxTextureSize 가 이미 캡 이하면 줄일 것이 없음(재진입/이미 작은 텍스처) → 비용 회피.
+                // 이렇게 "더 큰 쪽만 내리는" 게이트라 crunch 가 이미 더 작게 캡했어도 그 값을 덮어쓰지 않는다.
+                if (ti.maxTextureSize <= clampMax)
+                {
+                    continue;
+                }
+
+                // 바이트 필터(선택): 소스 파일이 minBytes 미만이면 제외(작은 아이콘 보호).
+                if (minBytes > 0)
+                {
+                    string srcFull = Path.Combine(projectRoot, path);
+                    if (!File.Exists(srcFull) || new FileInfo(srcFull).Length < minBytes)
+                    {
+                        continue;
+                    }
+                }
+
+                // 원본 .meta 백업(verbatim 복원용).
+                if (!BackupAssetMeta(path, projectRoot))
+                {
+                    continue;
+                }
+
+                // maxTextureSize 한 필드만 override. format/compression/crunch/sRGB/sprite 설정은 보존.
+                ti.maxTextureSize = clampMax;
+                ti.SaveAndReimport();
+                n++;
+            }
+
+            return n;
+        }
+
+        // ─────────────────────────── 백업/복원 ───────────────────────────
+
+        /// <summary>에셋의 .meta 파일을 <path>.meta.aittexclampbak 로 백업.</summary>
+        private static bool BackupAssetMeta(string assetPath, string projectRoot)
+        {
+            try
+            {
+                string metaFull = Path.Combine(projectRoot, assetPath + ".meta");
+                if (!File.Exists(metaFull))
+                {
+                    return false;
+                }
+
+                string bak = metaFull + BackupSuffix;
+                if (!File.Exists(bak))
+                {
+                    File.Copy(metaFull, bak, true);
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-TextureSizeClamp] .meta 백업 실패({assetPath}): {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>Assets 트리의 모든 *.aittexclampbak 를 원본으로 되돌리고 백업을 삭제한다. 복원 개수 반환.</summary>
+        private static int RestoreAllBackups()
+        {
+            int restored = 0;
+            string assetsPath = Application.dataPath;
+            string projectRoot = Directory.GetParent(assetsPath).FullName;
+            string[] backups;
+            try
+            {
+                backups = Directory.GetFiles(assetsPath, "*" + BackupSuffix, SearchOption.AllDirectories);
+            }
+            catch
+            {
+                return 0;
+            }
+
+            foreach (var bak in backups)
+            {
+                // bak = "<original>.meta.aittexclampbak" → original 은 텍스처의 .meta.
+                string original = bak.Substring(0, bak.Length - BackupSuffix.Length);
+                try
+                {
+                    File.Copy(bak, original, true);
+                    File.Delete(bak);
+
+                    // reimport 대상 에셋 경로 산출: original 은 .meta 이므로 본체 경로로 환원.
+                    string assetFull = original.EndsWith(".meta")
+                        ? original.Substring(0, original.Length - ".meta".Length)
+                        : original;
+                    string rel = AbsoluteToProjectRelative(assetFull, projectRoot);
+                    if (!string.IsNullOrEmpty(rel))
+                    {
+                        AssetDatabase.ImportAsset(rel, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                    }
+
+                    restored++;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[AIT-TextureSizeClamp] 백업 복원 실패({bak}): {e.Message}");
+                }
+            }
+
+            return restored;
+        }
+
+        private static void CreateMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                File.WriteAllText(Path.Combine(projectRoot, MarkerRelative), "active");
+            }
+            catch
+            {
+                // 마커 생성 실패는 치명적이지 않음(안전망 가속용일 뿐).
+            }
+        }
+
+        private static void RemoveMarker()
+        {
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string m = Path.Combine(projectRoot, MarkerRelative);
+                if (File.Exists(m))
+                {
+                    File.Delete(m);
+                }
+            }
+            catch
+            {
+                // 무시
+            }
+        }
+
+        private static string AbsoluteToProjectRelative(string absolute, string projectRoot)
+        {
+            string norm = absolute.Replace('\\', '/');
+            string root = projectRoot.Replace('\\', '/').TrimEnd('/') + "/";
+            return norm.StartsWith(root) ? norm.Substring(root.Length) : null;
+        }
+
+        private static string[] SplitDirs(string v)
+            => string.IsNullOrEmpty(v) ? null : v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+        private static bool UnderAny(string path, string[] dirs)
+        {
+            foreach (var d in dirs)
+            {
+                var t = d.Trim().TrimEnd('/');
+                if (path.StartsWith(t + "/") || path == t)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Editor/AITTextureSizeClampProcessor.cs.meta
+++ b/Editor/AITTextureSizeClampProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c4e1a9b2f3d48d6a5e0c7b914268f3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 요약

빌드 직전 대상 `Texture2D` 의 **`maxTextureSize` 한 필드만** 일시적으로 캡(상한)으로 낮춰 reimport 하여, Unity 가 더 작은 텍셀의 텍스처를 `.data` 에 굽게 하는 콘텐츠 최적화 레버(**L13**). 빌드 종료(성공/실패 무관) 후 원본 임포트 설정으로 원상 복원한다.

## 배경 — crunch(#762)와 무엇이 다른가 (분리된 이유)

기존 `AITTextureCrunchProcessor`(#762)는 `maxTextureSize` 캡을 **crunch**(=DXT 강제 + `crunchedCompression=true` + compression/quality 변경)와 **한 게이트**(`textureCrunch`)에 묶어 둔다. 즉 "**크기만 줄이고 싶은데 DXT-crunch 는 원치 않는**" 경우 — 이미 **ASTC** 로 굽거나, crunch reimport 비용/화질 변화를 피하고 싶은 경우 — 에는 쓸 수 없다.

본 처리기는 **format/compression/crunch 를 일절 건드리지 않고** `maxTextureSize` 한 필드만 override 하므로, 빌드 파이프라인이 정하는 기본 format(WebGL fallback = ASTC/DXT)을 그대로 유지한 채 **텍셀 수만** 줄인다. → 5개 텍스처 레버 중 **유일하게 ASTC 서브타겟에서도 그대로 동작**.

**직교성**: 텍셀 수(본 레버) ⟂ 비트레이트(crunch #762 / astc-block #777) ⟂ mip 피라미드(mip-strip #760) ⟂ 위치(texture-streaming #764). 같은 텍스처에 중첩 적용 시 효과가 곱해진다. crunch 와 같은 텍스처에 적용돼도 "**더 큰 쪽만 내리는**" 게이트라 crunch 가 이미 더 작게 캡한 값을 덮어쓰지 않는다.

## 동작

- **tri-state 게이트** `textureSizeClamp`(-1 자동/0 비활성/1 활성). 표시 해상도를 낮추는 **lossy** 변경이고 안전한 자동 캡 값이 없으므로(프로젝트마다 적정 상한이 다름) **기본 OFF**(`GetDefaultTextureSizeClamp()=false`), 명시적 opt-in.
- 예) `maxTextureSize` 2048→1024 캡 = 텍셀 **1/4** → 압축 payload(ASTC/DXT 고정 비트레이트)·on-wire(brotli) 도 ~1/4, GPU 업로드 tail 일부 완화.
- 옵션: `textureClampMaxSize`(상한, 16 미만 무시), `textureClampMinBytes`(소스 크기 필터 — 작은 아이콘 보호), `textureClampDirs`/`textureClampExcludeDirs`(대상/제외 폴더, escape hatch).
- **비파괴**: 각 텍스처 원본 `.meta` 를 `.aittexclampbak` 로 백업 → 빌드 후 복원. 빌드 비정상 종료 시 다음 에디터 로드의 `SafetyNetRestore` 가 잔존 백업 자동 복원.
- 통합: `AITConvertCore.BuildWebGL` 의 `BuildPipeline.BuildPlayer` 직전 `ApplyForBuild`, `finally` 에서 `RestoreForBuild`(텍스처 crunch 와 동일 패턴).

## 측정 Δ (perf CI 가 코멘트로 채움)

| 버전 | TTFF Δ | on-wire(wasm/data) Δ |
|------|--------|----------------------|
| 2021.3 | _(perf CI)_ | _(perf CI)_ |
| 6000.0 | _(perf CI)_ | _(perf CI)_ |
| 6000.3 | _(perf CI)_ | _(perf CI)_ |

> 합성 Heavy 픽스처는 2048² 텍스처를 생성하므로, 이 레버는 픽스처에서 **비-0 Δ로 측정 가능**(crunch/streaming/astc 와 달리 포맷·경로 게이트에 막히지 않음 — maxTextureSize 캡은 모든 포맷에 유효).

## 머지 시점

성능 레버 캠페인(**3.0 beta → stable 이후**)에 다른 perf PR 과 함께 진행. **지금 머지하지 말 것.**

## 검증

- `./run-local-tests.sh --validate` → **4 passed / 0 failed** (Playwright 설정 + SDK 유닛(C#↔jslib invariants 18) + meta GUID 위생 208개).
- 실제 TTFF/on-wire Δ 는 머지 후 perf CI(2021.3 / 6000.0 / 6000.3) 빌드에서 확정.