### PR TITLE
[auto-resolve] 개선: BuildOutputValidator framework.js 누락 감지 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
+++ b/Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs
@@ -137,6 +137,7 @@ public static class BuildOutputValidator
         bool hasLoader = false;
         bool hasWasm = false;
         bool hasData = false;
+        bool hasFramework = false;
         string compressionFormat = "unknown";
 
         foreach (string file in buildFiles)
@@ -163,11 +164,17 @@ public static class BuildOutputValidator
             {
                 hasData = true;
             }
+
+            if (fileName.Contains(".framework.js"))
+            {
+                hasFramework = true;
+            }
         }
 
         if (!hasLoader) errors.Add("Missing loader.js in Build/");
         if (!hasWasm) errors.Add("Missing .wasm file in Build/");
         if (!hasData) errors.Add("Missing .data file in Build/");
+        if (!hasFramework) errors.Add("Missing .framework.js file in Build/");
 
         // 9. Build/ 파일 수 검증 — 선별 복사 회귀 감지
         int expectedMaxFiles = 6; // loader, data, framework, wasm + symbols + 여유 1

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
@@ -78,4 +78,59 @@ public class BuildOutputValidatorTests
     {
         Assert.AreEqual("symbols", BuildOutputValidator.DetectFileType("notes.symbols.json.backup"));
     }
+
+    // =====================================================
+    // APPS-IN-TOSS-UNITY-SDK-11Z 회귀 가드:
+    // ValidateAll이 *.framework.js 누락을 에러로 보고해야 한다.
+    // 기존 코드는 hasLoader/hasWasm/hasData만 검증하고 hasFramework를 누락했다.
+    // 이 테스트는 framework.js가 없는 Build/ 폴더에서 ValidateAll이
+    // "Missing .framework.js" 에러를 포함한 결과를 반환하는지 고정한다.
+    // =====================================================
+
+    [Test]
+    public void ValidateAll_MissingFrameworkJs_ReturnsError()
+    {
+        // 임시 프로젝트 구조 생성
+        string tempDir = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            "ait-test-validator-" + System.Guid.NewGuid().ToString("N").Substring(0, 8));
+
+        try
+        {
+            // ait-build/dist/web/Build/ 구조 생성 (framework.js 제외)
+            string aitBuildPath = System.IO.Path.Combine(tempDir, "ait-build");
+            string distWebPath = System.IO.Path.Combine(aitBuildPath, "dist", "web");
+            string distBuildPath = System.IO.Path.Combine(distWebPath, "Build");
+            System.IO.Directory.CreateDirectory(distBuildPath);
+
+            // 필수 설정 파일
+            System.IO.File.WriteAllText(System.IO.Path.Combine(aitBuildPath, "package.json"), "{}");
+            System.IO.File.WriteAllText(System.IO.Path.Combine(aitBuildPath, "node_modules", ".keep"), "");
+            System.IO.Directory.CreateDirectory(System.IO.Path.Combine(aitBuildPath, "node_modules"));
+            System.IO.File.WriteAllText(System.IO.Path.Combine(distWebPath, "index.html"), "<html></html>");
+
+            // loader, data, wasm은 있지만 framework.js는 의도적으로 생성 안 함
+            System.IO.File.WriteAllText(System.IO.Path.Combine(distBuildPath, "build.loader.js"), "loader");
+            System.IO.File.WriteAllText(System.IO.Path.Combine(distBuildPath, "build.data"), "data");
+            System.IO.File.WriteAllText(System.IO.Path.Combine(distBuildPath, "build.wasm"), "wasm");
+            // build.framework.js 의도적으로 누락
+
+            var result = BuildOutputValidator.ValidateAll(tempDir);
+
+            Assert.IsFalse(result.passed,
+                "framework.js가 없으면 ValidateAll은 실패해야 한다");
+
+            bool hasFrameworkError = System.Array.Exists(
+                result.errors,
+                e => e.Contains("framework.js"));
+            Assert.IsTrue(hasFrameworkError,
+                "ValidateAll 에러 목록에 'framework.js' 누락 에러가 포함되어야 한다. " +
+                "실제 에러: " + string.Join(", ", result.errors));
+        }
+        finally
+        {
+            if (System.IO.Directory.Exists(tempDir))
+                System.IO.Directory.Delete(tempDir, true);
+        }
+    }
 }


### PR DESCRIPTION
**범위**: 원 이슈 \`APPS-IN-TOSS-UNITY-SDK-11Z\`의 실제 증상은 미해결 — 참조만. 별도 조사 필요

## 원 이슈 참조
- Sentry: APPS-IN-TOSS-UNITY-SDK-11Z
- 에러: \`[AIT] ✗ 치명적: WebGL 빌드 필수 파일 누락! 누락된 필수 파일: *.framework.js\`
- 원인: 실제 WebGL 빌드 환경에서 \`*.framework.js\` 파일이 생성되지 않는 빌드 파이프라인 버그로 추정
- 재현 상태: EditMode 테스트 수준에서 실제 빌드 파이프라인 실패를 재현하지 못함 (UnityEditor 빌드 과정 직접 재현 불가)

## 발견된 인접 버그 (이번 PR에서 수정)

\`BuildOutputValidator.ValidateAll()\`이 \`loader.js\`, \`wasm\`, \`data\` 세 파일의 존재만 검증하고 **\`framework.js\` 누락을 감지하지 못하는 버그**를 발견·수정했습니다.

### 문제

기존 코드에서 \`hasLoader\`, \`hasWasm\`, \`hasData\`는 체크하지만 \`hasFramework\`가 없어, \`framework.js\`가 빌드 출력에서 누락되어도 \`passed:true\`를 반환합니다.

### 수정

\`hasFramework\` 플래그와 에러 감지 로직을 추가하여 \`framework.js\` 누락 시 \`passed:false\` + 에러 메시지를 반환하도록 수정했습니다.

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| \`Tests~/E2E/SharedScripts/Editor/BuildOutputValidator.cs\` | \`hasFramework\` 체크 추가, 에러 리스트에 framework.js 누락 감지 추가 |
| \`Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs\` | \`ValidateAll_MissingFrameworkJs_ReturnsError\` 회귀 테스트 추가 |

## 검증
- \`./run-local-tests.sh --validate\` 통과