### PR TITLE
수정: update.yml public npm resolvability 가드 — phantom 버전 PR 차단

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -63,8 +63,10 @@ jobs:
           fi
 
           # npm에서 모든 버전 가져오기 (정식 릴리즈만, dev/alpha/beta 제외)
+          # --prefer-online: self-hosted runner의 stale npm 메타데이터 캐시가 unpublish된
+          # phantom 버전(설치 시 E404나 목록에는 잔존)을 노출하지 않도록 매번 레지스트리 재검증.
           echo "=== npm에서 버전 목록 가져오기 ==="
-          ALL_NPM_VERSIONS=$(npm view @apps-in-toss/web-framework versions --json | jq -r '.[]' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
+          ALL_NPM_VERSIONS=$(npm view @apps-in-toss/web-framework versions --json --prefer-online | jq -r '.[]' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
           echo "npm 버전 목록:"
           echo "$ALL_NPM_VERSIONS"
 
@@ -123,6 +125,20 @@ jobs:
             # 이미 열린 PR이 있으면 스킵
             if echo "$OPEN_PR_VERSIONS" | grep -qx "$VERSION"; then
               echo "  ${VERSION}: 열린 PR 존재 (스킵)"
+              continue
+            fi
+
+            # public npm resolvability 가드: 후보 버전이 실제로 public npm에 존재하는지 최종 검증.
+            # 감지 목록(npm view versions)이 stale 캐시로 phantom 버전을 포함할 수 있고,
+            # 외부 개발자는 public npm 기준으로 BuildConfig~를 clean install하므로
+            # web-framework·web-analytics 둘 중 하나라도 없으면 release/vX.Y.Z가 깨진다.
+            # --prefer-online으로 캐시 우회 재검증하여 unpublish/미존재 버전 PR을 차단한다.
+            if ! npm view "@apps-in-toss/web-framework@${VERSION}" version --prefer-online >/dev/null 2>&1; then
+              echo "  ${VERSION}: web-framework@${VERSION} public npm 미존재(E404/unpublished) — PR 생성 스킵"
+              continue
+            fi
+            if ! npm view "@apps-in-toss/web-analytics@${VERSION}" version --prefer-online >/dev/null 2>&1; then
+              echo "  ${VERSION}: web-analytics@${VERSION} public npm 미존재(E404/unpublished) — PR 생성 스킵"
               continue
             fi
 


### PR DESCRIPTION
## 문제

SDK 업데이트 cron(`update.yml`)이 **public npm에 실제로 존재하지 않는 버전**에 대해 SDK 업데이트 PR을 반복 생성하고 있었습니다.

- public npm `latest` = `2.7.0` (= 현재 main). `2.7.1`/`2.8.0`/`2.9.0`은 public npm에서 **E404**(미존재).
- 그럼에도 cron이 이 phantom 버전들을 감지해 PR 생성 — #806, #807에 이어 #815/#816/#817로 재생성됨.
- 원인: self-hosted runner의 **stale npm 메타데이터 캐시**가 unpublish된 버전을 `npm view ... versions` 목록에 잔존시킴. warm pnpm store 때문에 E2E도 통과하여 미설치성을 가림.
- 영향: 머지 시 `release/vX.Y.Z`가 생성되고, 외부 개발자가 public npm 기준으로 `BuildConfig~`를 clean install하면 **E404로 빌드 실패**.

## 변경

`누락된 버전 감지` 단계에 2중 가드 추가:

1. 감지 쿼리 `npm view ... versions`에 `--prefer-online` → stale 캐시 우회. phantom 버전이 애초에 목록에 진입하지 않음.
2. PR 생성 직전 후보 버전마다 `@apps-in-toss/web-framework@VERSION`·`@apps-in-toss/web-analytics@VERSION` **둘 다** public npm resolvable 여부를 `--prefer-online`으로 최종 검증. 하나라도 미존재면 해당 버전 스킵.

## 검증

가드 술어 라이브 테스트(public npm 대상):

| 버전 | 결과 |
|------|------|
| 2.6.2 | RESOLVABLE (PR 허용) |
| 2.7.0 | RESOLVABLE (PR 허용) |
| 2.7.1 | E404 (가드 스킵) |
| 2.8.0 | E404 (가드 스킵) |
| 2.9.0 | E404 (가드 스킵) |

- YAML 파싱 OK.
- 실제 존재 버전은 통과, phantom 버전만 차단됨 확인.

## 관련

phantom 버전 PR #815(v2.7.1)/#816(v2.8.0)/#817(v2.9.0)는 본 가드와 별개로 close 처리. 이 가드가 머지되면 향후 cron이 동일 phantom 버전 PR을 재생성하지 않습니다.
