### PR TITLE
기능: 3.x ait build 직전 cli.js 패치로 .ait runtimeVersion 네이티브 주입

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1973,6 +1973,7 @@ jobs:
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/package.json
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/pnpm-lock.yaml
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/pnpm-workspace.yaml
+            Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/ait-patch-cli.mjs
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/granite.config.ts
             Tests~/E2E/${{ inputs.project-dir-prefix }}-${{ inputs.unity-version }}/ait-build/build-validation.json
           if-no-files-found: error

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -458,6 +458,29 @@ namespace AppsInToss.Editor
                 Debug.Log("[AIT]   ✓ unity-bridge.ts (SDK에서 복사)");
             }
 
+            // 6.5. ait-patch-cli.mjs - 프로젝트 우선, 없으면 SDK
+            // 3.x 빌드 시 GraniteBuildRunner가 ait build 직전에 `pnpm exec node ait-patch-cli.mjs`로
+            // 이 스크립트를 실행한다. web-framework cli.js의 setMetadata 호출을 패치해 .ait
+            // 메타데이터에 runtimeVersion("0.84.0")을 직접 emit하게 만든다 (3.x deploy 게이트
+            // "runtimeVersion이 없습니다" 통과용). 빌드된 .ait는 손대지 않아 봉인이 깨지지 않는다.
+            // 스크립트는 항상 exit 0(2.x엔 setMetadata 없음/구조 변경/이미 설정됨 → graceful no-op)
+            // 이라 stable(2.x) 빌드에 무해하다. 2.x/3.x 양쪽에서 항상 복사된다(unity-build.yml
+            // 업로드 allowlist의 error-gate 충족).
+            string aitPatchName = "ait-patch-cli.mjs";
+            string aitPatchProject = Path.Combine(projectBuildConfigPath, aitPatchName);
+            string aitPatchSdk = Path.Combine(sdkBuildConfigPath, aitPatchName);
+            string aitPatchDst = Path.Combine(buildProjectPath, aitPatchName);
+            if (File.Exists(aitPatchProject))
+            {
+                File.Copy(aitPatchProject, aitPatchDst, true);
+                Debug.Log("[AIT]   ✓ ait-patch-cli.mjs (프로젝트에서 복사)");
+            }
+            else if (File.Exists(aitPatchSdk))
+            {
+                File.Copy(aitPatchSdk, aitPatchDst, true);
+                Debug.Log("[AIT]   ✓ ait-patch-cli.mjs (SDK에서 복사)");
+            }
+
             // 7. 사용자 추가 파일 복사
             Package.WebGLBuildCopier.CopyAdditionalUserFiles(projectBuildConfigPath, buildProjectPath);
 

--- a/Editor/Package/GraniteBuildRunner.cs
+++ b/Editor/Package/GraniteBuildRunner.cs
@@ -141,9 +141,36 @@ namespace AppsInToss.Editor.Package
             if (viteResult != AITConvertCore.AITExportError.SUCCEED) return viteResult;
 
             Debug.Log("[AIT] ✓ vite build 완료 (dist/web). ait build로 패키징합니다...");
+
+            // ait build 직전: cli.js를 패치해 setMetadata가 runtimeVersion을 emit하도록 만든다
+            // (3.x deploy 게이트 통과용). CANCELLED만 전파, 그 외 실패는 경고 후 계속.
+            var patchResult = RunRuntimeVersionPatchSync(ctx, label);
+            if (patchResult == AITConvertCore.AITExportError.CANCELLED) return patchResult;
+
             return AITNpmRunner.RunNpmCommandWithCache(
                 ctx.BuildProjectPath, ctx.PnpmPath, "exec ait build", ctx.LocalCachePath,
                 $"{label} (ait build)...", additionalEnvVars: ctx.UnityMetadataEnv);
+        }
+
+        /// <summary>
+        /// ait build 직전에 web-framework cli.js를 패치해 setMetadata가 runtimeVersion을
+        /// 직접 emit하도록 만든다 (3.x deploy 게이트 "runtimeVersion이 없습니다" 통과용).
+        /// 빌드된 .ait 자체는 손대지 않으므로 봉인이 깨지지 않는다.
+        ///
+        /// ait-patch-cli.mjs는 항상 exit 0이며 (2.x cli.js엔 setMetadata 없음/구조 변경/
+        /// 이미 설정됨 → graceful no-op), 패치 자체는 빌드를 막지 않는다. 따라서 사용자
+        /// 취소(CANCELLED)만 상위로 전파하고, 그 외 비정상 종료는 경고만 남기고 ait build를
+        /// 계속 진행한다 (패치 실패가 빌드 실패로 번지지 않게 — stable 무회귀).
+        /// </summary>
+        internal static AITConvertCore.AITExportError RunRuntimeVersionPatchSync(AITPackageBuilder.PackageContext ctx, string label)
+        {
+            var result = AITNpmRunner.RunNpmCommandWithCache(
+                ctx.BuildProjectPath, ctx.PnpmPath, "exec node ait-patch-cli.mjs", ctx.LocalCachePath,
+                $"{label} (runtimeVersion 패치)...", additionalEnvVars: ctx.UnityMetadataEnv);
+            if (result == AITConvertCore.AITExportError.CANCELLED) return result;
+            if (result != AITConvertCore.AITExportError.SUCCEED)
+                Debug.LogWarning($"[AIT] runtimeVersion 패치 스크립트 비정상 종료 (결과: {result}) — 무시하고 ait build를 계속합니다.");
+            return AITConvertCore.AITExportError.SUCCEED;
         }
 
         /// <summary>
@@ -289,24 +316,66 @@ namespace AppsInToss.Editor.Package
                     }
 
                     Debug.Log("[AIT] ✓ vite build 완료 (dist/web). ait build로 패키징합니다...");
-                    AITNpmRunner.RunNpmCommandWithCacheAsync(
-                        ctx.BuildProjectPath, ctx.PnpmPath, "exec ait build", ctx.LocalCachePath,
-                        onComplete: (aitResult) =>
+
+                    // ait build 직전: cli.js 패치(runtimeVersion 주입) → 그 다음 ait build.
+                    // 패치 자체 실패는 빌드를 막지 않고, 사용자 취소(CANCELLED)만 전파한다.
+                    RunRuntimeVersionPatchAsync(ctx, (patchResult) =>
+                    {
+                        if (patchResult == AITConvertCore.AITExportError.CANCELLED)
                         {
-                            if (aitResult == AITConvertCore.AITExportError.SUCCEED)
-                                Debug.Log("[AIT] ✓ ait build 패키징 성공 (3.x)");
-                            onComplete?.Invoke(aitResult);
-                        },
-                        onOutputReceived: (line) =>
-                        {
-                            onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.85f, line);
-                        },
-                        additionalEnvVars: ctx.UnityMetadataEnv
-                    );
+                            onComplete?.Invoke(patchResult);
+                            return;
+                        }
+                        AITNpmRunner.RunNpmCommandWithCacheAsync(
+                            ctx.BuildProjectPath, ctx.PnpmPath, "exec ait build", ctx.LocalCachePath,
+                            onComplete: (aitResult) =>
+                            {
+                                if (aitResult == AITConvertCore.AITExportError.SUCCEED)
+                                    Debug.Log("[AIT] ✓ ait build 패키징 성공 (3.x)");
+                                onComplete?.Invoke(aitResult);
+                            },
+                            onOutputReceived: (line) =>
+                            {
+                                onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.85f, line);
+                            },
+                            additionalEnvVars: ctx.UnityMetadataEnv
+                        );
+                    });
                 },
                 onOutputReceived: (line) =>
                 {
                     onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.7f, line);
+                },
+                additionalEnvVars: ctx.UnityMetadataEnv
+            );
+        }
+
+        /// <summary>
+        /// <see cref="RunRuntimeVersionPatchSync"/>의 비동기 버전.
+        /// CANCELLED만 onComplete로 전파하고, 그 외 비정상 종료는 경고 후 SUCCEED로 흘려
+        /// 호출부가 ait build를 계속 진행하게 한다.
+        /// </summary>
+        internal static void RunRuntimeVersionPatchAsync(
+            AITPackageBuilder.PackageContext ctx,
+            Action<AITConvertCore.AITExportError> onComplete)
+        {
+            Debug.Log("[AIT] runtimeVersion 패치: cli.js setMetadata에 runtimeVersion 주입 시도...");
+            AITNpmRunner.RunNpmCommandWithCacheAsync(
+                ctx.BuildProjectPath, ctx.PnpmPath, "exec node ait-patch-cli.mjs", ctx.LocalCachePath,
+                onComplete: (result) =>
+                {
+                    if (result == AITConvertCore.AITExportError.CANCELLED)
+                    {
+                        onComplete?.Invoke(result);
+                        return;
+                    }
+                    if (result != AITConvertCore.AITExportError.SUCCEED)
+                        Debug.LogWarning($"[AIT] runtimeVersion 패치 스크립트 비정상 종료 (결과: {result}) — 무시하고 ait build를 계속합니다.");
+                    onComplete?.Invoke(AITConvertCore.AITExportError.SUCCEED);
+                },
+                onOutputReceived: (line) =>
+                {
+                    Debug.Log($"[AIT] [patch] {line}");
                 },
                 additionalEnvVars: ctx.UnityMetadataEnv
             );

--- a/WebGLTemplates/AITTemplate/BuildConfig~/ait-patch-cli.mjs
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/ait-patch-cli.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// ait-patch-cli.mjs
+//
+// 빌드시점 CLI 패치 — @apps-in-toss/web-framework 3.x의 `ait build`가 .ait
+// 메타데이터에 runtimeVersion을 emit하지 않는 upstream gap을 브릿지한다.
+//
+// 배경:
+//   - 3.x `ait deploy`는 .ait 메타데이터의 runtimeVersion(non-empty)을 요구한다.
+//   - 그러나 3.x `ait build`의 setMetadata 호출에는 runtimeVersion 키가 없어
+//     항상 빈 문자열이 기록되고, deploy 게이트("ait 파일에 runtimeVersion이
+//     없습니다")에 걸려 배포가 불가능하다.
+//   - 사후에 .ait를 ait-format으로 재저장해 주입하면 zip 재압축/createdAtMs
+//     재스탬프로 바이트가 달라져 서버가 "잘못된 앱 정보"로 거부함이 확인됐다
+//     (폐기된 ait-inject-runtime-version.mjs 방식).
+//   => 유일한 네이티브 경로: ait build를 호출하기 "직전"에 cwd의 web-framework
+//      cli.js를 패치해 setMetadata가 runtimeVersion을 직접 emit하게 만든다.
+//      빌드된 .ait 자체는 손대지 않으므로 봉인이 깨지지 않는다.
+//
+// runtimeVersion 값:
+//   "0.84.0" — @apps-in-toss/cli@2.6.1의 RUNTIME_BUILD_DEFINITIONS[0].runtimeVersion.
+//   2.6.1 경로(WEB 플랫폼 포함)가 서버에 실제로 기록·수락시키는 React Native 런타임
+//   버전이다. 3.x WEB 서버가 동일 값을 수락하는지는 실제 ait deploy로 최종 확인해야
+//   하며, 거부 시 deployment 응답에서 서버가 기대하는 값을 확인해 이 상수만 갱신하면
+//   된다(beta-release.yml의 deployment GET 진단 참조).
+//
+// 안전 규칙 — 어떤 상황에서도 빌드를 막지 않는다(항상 정상 종료):
+//   (a) 멱등        : setMetadata에 이미 runtimeVersion이 있으면 no-op.
+//   (b) 버전 게이팅 : setMetadata 객체 리터럴을 못 찾으면(2.x 등) no-op.
+//   (c) 구조 변화   : 패턴이 안 맞으면 경고만 남기고 no-op(빌드 진행).
+//   (d) upstream 수정: upstream이 네이티브로 emit하면 (a)에 의해 자동 no-op.
+//   (e) 스토어 보호 : pnpm 하드링크로 공유 store가 오염되지 않도록, 쓰기 전에
+//                     하드링크를 끊고(unlink) 새 inode로 기록한다(Linux CI 필수).
+
+import { readFileSync, writeFileSync, unlinkSync, realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const RUNTIME_VERSION = '0.84.0';
+const TAG = '[ait-patch-cli]';
+const CLI_REL_PATH = 'node_modules/@apps-in-toss/web-framework/dist/cli.js';
+
+/**
+ * web-framework cli.js 소스에서 setMetadata({...}) 객체 리터럴을 찾아
+ * runtimeVersion 한 줄을 여는 `{` 직후에 주입한 새 소스를 반환한다.
+ *
+ * 삽입 지점은 항상 "여는 `{` 직후"이므로, 객체 본문의 brace 카운팅이 다소
+ * 어긋나더라도 구문상 안전하다. brace 파서는 문자열/템플릿/주석 내부의 괄호를
+ * 무시하므로 setMetadata 인자 안에 nested `})` 또는 `}` 문자가 있어도 오삽입하지
+ * 않는다.
+ *
+ * @param {string} src
+ * @param {string} runtimeVersion
+ * @returns {{ changed: boolean, source: string, reason: string }}
+ */
+export function injectRuntimeVersion(src, runtimeVersion = RUNTIME_VERSION) {
+  const obj = findSetMetadataObject(src);
+  if (!obj) {
+    return { changed: false, source: src, reason: 'setMetadata 객체 리터럴 없음 (2.x이거나 구조 변경)' };
+  }
+  const objText = src.slice(obj.start, obj.end + 1);
+  if (/\bruntimeVersion\s*:/.test(objText)) {
+    return { changed: false, source: src, reason: 'runtimeVersion 이미 존재 (멱등/upstream emit)' };
+  }
+  // 여는 `{`(obj.start) 직후에 runtimeVersion 한 줄 삽입 (다른 필드 보존).
+  const insertAt = obj.start + 1;
+  const injected = `\n    runtimeVersion: ${JSON.stringify(runtimeVersion)},`;
+  const out = src.slice(0, insertAt) + injected + src.slice(insertAt);
+  return { changed: true, source: out, reason: `runtimeVersion=${JSON.stringify(runtimeVersion)} 삽입` };
+}
+
+/**
+ * `setMetadata(` 다음의 첫 객체 리터럴 `{...}`의 시작/끝 인덱스를 brace-depth로 찾는다.
+ * 문자열/템플릿/주석 내부의 괄호는 무시한다.
+ * @returns {{ start: number, end: number } | null}
+ */
+function findSetMetadataObject(src) {
+  const call = /\bsetMetadata\s*\(/.exec(src);
+  if (!call) return null;
+
+  // `(` 다음 첫 비공백(주석 제외)이 `{` 인지 확인 — 객체 리터럴 인자가 아니면
+  // (예: setMetadata(meta)) 안전하게 패치 불가로 처리한다.
+  let i = skipTrivia(src, call.index + call[0].length);
+  if (src[i] !== '{') return null;
+
+  const start = i;
+  let depth = 0;
+  for (let j = start; j < src.length; j++) {
+    const skipped = skipStringOrComment(src, j);
+    if (skipped > j) { j = skipped - 1; continue; }
+    const ch = src[j];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return { start, end: j };
+    }
+  }
+  return null; // 괄호 불균형 — 안전 no-op
+}
+
+/** 공백 + 주석을 건너뛴 다음 인덱스를 반환. */
+function skipTrivia(src, i) {
+  for (;;) {
+    while (i < src.length && /\s/.test(src[i])) i++;
+    const next = skipComment(src, i);
+    if (next === i) return i;
+    i = next;
+  }
+}
+
+/** i가 문자열/템플릿/주석 시작이면 그 끝 다음 인덱스를, 아니면 i를 반환. */
+function skipStringOrComment(src, i) {
+  const c = src[i];
+  if (c === '"' || c === "'" || c === '`') return skipString(src, i);
+  return skipComment(src, i);
+}
+
+function skipString(src, i) {
+  const quote = src[i];
+  let j = i + 1;
+  while (j < src.length) {
+    if (src[j] === '\\') { j += 2; continue; }
+    if (src[j] === quote) return j + 1;
+    j++;
+  }
+  return j; // 닫히지 않은 문자열 — 소스 끝까지
+}
+
+function skipComment(src, i) {
+  if (src[i] === '/' && src[i + 1] === '/') {
+    let j = i + 2;
+    while (j < src.length && src[j] !== '\n') j++;
+    return j;
+  }
+  if (src[i] === '/' && src[i + 1] === '*') {
+    let j = i + 2;
+    while (j < src.length && !(src[j] === '*' && src[j + 1] === '/')) j++;
+    return Math.min(src.length, j + 2);
+  }
+  return i;
+}
+
+function main() {
+  const cliPath = resolve(process.cwd(), CLI_REL_PATH);
+  let realPath = cliPath;
+  let src;
+  try {
+    // pnpm은 node_modules/@apps-in-toss/web-framework를 .pnpm 가상 스토어로
+    // symlink하므로, 실제 파일 경로를 얻기 위해 realpath로 해석한다.
+    realPath = realpathSync(cliPath);
+    src = readFileSync(realPath, 'utf8');
+  } catch (e) {
+    // (b) cli.js 없음 — 2.x(granite) 경로이거나 미설치. no-op.
+    console.warn(`${TAG} cli.js를 읽지 못함 — 패치 건너뜀(2.x이거나 미설치): ${e?.message ?? e}`);
+    return;
+  }
+
+  const { changed, source, reason } = injectRuntimeVersion(src, RUNTIME_VERSION);
+  if (!changed) {
+    console.log(`${TAG} 패치 불필요 — ${reason}.`);
+    return;
+  }
+
+  try {
+    // (e) pnpm 하드링크로 연결된 공유 store 오염 방지: 하드링크를 끊고 새 inode로 기록.
+    //     Linux CI에서 store(content-addressable)와 node_modules가 하드링크로 묶이므로,
+    //     in-place 덮어쓰기는 다른 빌드가 공유하는 store 파일을 변조한다. unlink 후
+    //     writeFile은 새 inode를 만들어 store와의 연결을 끊는다(macOS APFS는 reflink라 무관).
+    try { unlinkSync(realPath); } catch { /* 링크가 없으면 그대로 덮어쓴다 */ }
+    writeFileSync(realPath, source, 'utf8');
+    console.log(`${TAG} ✓ cli.js setMetadata에 ${reason} 완료.`);
+  } catch (e) {
+    console.warn(`${TAG} cli.js 쓰기 실패 — 패치 건너뜀(빌드는 계속): ${e?.message ?? e}`);
+  }
+}
+
+// 직접 실행될 때만 main()을 돌린다. import(단위 테스트) 시에는 실행하지 않는다.
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  try {
+    main();
+  } catch (e) {
+    // 최후의 안전망: 어떤 예외도 빌드를 막지 않는다.
+    console.warn(`${TAG} 예기치 못한 오류 — 패치 건너뜀: ${e?.message ?? e}`);
+  }
+}

--- a/sdk-runtime-generator~/tests/unit/ait-patch-cli.test.ts
+++ b/sdk-runtime-generator~/tests/unit/ait-patch-cli.test.ts
@@ -1,0 +1,143 @@
+/**
+ * ait-patch-cli.mjs 단위 테스트
+ *
+ * 빌드시점 cli.js 패치의 핵심 순수 함수 `injectRuntimeVersion`을 검증한다.
+ * 이 패치는 web-framework 3.x `ait build`가 emit하지 않는 .ait 메타데이터의
+ * runtimeVersion을 setMetadata 호출에 주입해 3.x deploy 게이트를 통과시킨다.
+ *
+ * Unity E2E는 3.x 빌드를 실제로 돌리지 않으므로(비용·fixture 제약), 패치 변환의
+ * 정확성(삽입 위치·중첩 brace/문자열 안전·멱등·2.x no-op)을 여기서 단위로 못 박는다.
+ *
+ * 대상 파일은 SDK 패키지 밖(WebGLTemplates/.../BuildConfig~)에 있으므로 상대경로로
+ * 직접 import한다. 스크립트는 `import.meta.url === argv[1]`일 때만 main()을 돌리므로
+ * import 시 부작용이 없다.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  injectRuntimeVersion,
+  RUNTIME_VERSION,
+} from '../../../WebGLTemplates/AITTemplate/BuildConfig~/ait-patch-cli.mjs';
+
+/**
+ * 주입된 `setMetadata({...})` 단일 표현식을 실제로 평가해 결과 객체를 돌려준다.
+ * 삽입이 구문상 유효한지 + 올바른(최상위) 위치에 들어갔는지 실증한다.
+ */
+function evalObject(injectedExpr: string): any {
+  // setMetadata는 인자를 그대로 돌려주는 stub.
+  const fn = new Function('setMetadata', `return ${injectedExpr};`);
+  return fn((o: any) => o);
+}
+
+describe('RUNTIME_VERSION 상수', () => {
+  test('@apps-in-toss/cli@2.6.1 RUNTIME_BUILD_DEFINITIONS[0]과 일치하는 0.84.0', () => {
+    expect(RUNTIME_VERSION).toBe('0.84.0');
+  });
+});
+
+describe('injectRuntimeVersion — 정상 주입', () => {
+  test('현실적인 3.x cli.js setMetadata 블록에 runtimeVersion을 여는 { 직후로 삽입', () => {
+    const src = [
+      'async function buildCommand() {',
+      '  const writer = new BundleWriter();',
+      '  writer.setMetadata({',
+      '    platform: PlatformType.WEB,',
+      '    sdkVersion: sdkPackageJson.version,',
+      '    packageJson: appPackageJson,',
+      '  });',
+      '  await writer.write(outPath);',
+      '}',
+    ].join('\n');
+
+    const { changed, source, reason } = injectRuntimeVersion(src);
+    expect(changed).toBe(true);
+    expect(reason).toContain('0.84.0');
+    // 여는 `{` 바로 다음에 삽입.
+    expect(source).toContain('writer.setMetadata({\n    runtimeVersion: "0.84.0",');
+    // 기존 필드 보존.
+    expect(source).toContain('platform: PlatformType.WEB,');
+    expect(source).toContain('sdkVersion: sdkPackageJson.version,');
+    expect(source).toContain('packageJson: appPackageJson,');
+  });
+
+  test('minified 단일 라인 setMetadata도 주입하고 구문이 유효', () => {
+    const expr = 'setMetadata({platform:"WEB",sdkVersion:"3.0.0"})';
+    const { changed, source } = injectRuntimeVersion(expr);
+    expect(changed).toBe(true);
+    const meta = evalObject(source);
+    expect(meta.runtimeVersion).toBe('0.84.0');
+    expect(meta.platform).toBe('WEB');
+    expect(meta.sdkVersion).toBe('3.0.0');
+  });
+
+  test('runtimeVersion 인자를 명시하면 그 값이 들어간다', () => {
+    const { changed, source } = injectRuntimeVersion('setMetadata({a:1})', '9.9.9');
+    expect(changed).toBe(true);
+    expect(evalObject(source).runtimeVersion).toBe('9.9.9');
+  });
+});
+
+describe('injectRuntimeVersion — brace 파서 견고성', () => {
+  test('중첩 객체 + 문자열 내부 중괄호에 속지 않고 최상위 키로 삽입', () => {
+    const expr =
+      'setMetadata({ platform: "WEB", extra: { tag: "a}b{c", deep: { y: 2 } }, sdkVersion: "3.0.0" })';
+    const { changed, source } = injectRuntimeVersion(expr);
+    expect(changed).toBe(true);
+
+    const meta = evalObject(source);
+    // runtimeVersion이 최상위 키여야 한다(중첩 객체 안이 아니라).
+    expect(meta.runtimeVersion).toBe('0.84.0');
+    expect(meta.platform).toBe('WEB');
+    expect(meta.extra.tag).toBe('a}b{c');
+    expect(meta.extra.deep.y).toBe(2);
+    expect(meta.sdkVersion).toBe('3.0.0');
+  });
+
+  test('객체 끝보다 앞서 등장하는 문자열 } 들에 종료를 오인하지 않는다(멱등 스캔 검증)', () => {
+    const expr = 'setMetadata({ a: "}}}", b: 1 })';
+    const once = injectRuntimeVersion(expr);
+    expect(once.changed).toBe(true);
+    expect(evalObject(once.source).a).toBe('}}}');
+
+    // 두 번째 주입은 no-op이어야 한다 — findSetMetadataObject가 문자열 } 너머
+    // 진짜 객체 끝까지 스캔해 runtimeVersion 존재를 정확히 감지함을 의미.
+    const twice = injectRuntimeVersion(once.source);
+    expect(twice.changed).toBe(false);
+  });
+});
+
+describe('injectRuntimeVersion — 멱등 / no-op (안전 규칙)', () => {
+  test('이미 runtimeVersion이 있으면 no-op (멱등 / upstream emit)', () => {
+    const expr = 'setMetadata({ runtimeVersion: "0.84.0", platform: "WEB" })';
+    const { changed } = injectRuntimeVersion(expr);
+    expect(changed).toBe(false);
+  });
+
+  test('한 번 주입한 결과를 다시 넣어도 no-op', () => {
+    const src = 'writer.setMetadata({\n    platform: "WEB",\n  })';
+    const first = injectRuntimeVersion(src);
+    expect(first.changed).toBe(true);
+    const second = injectRuntimeVersion(first.source);
+    expect(second.changed).toBe(false);
+    expect(second.source).toBe(first.source);
+  });
+
+  test('setMetadata 호출이 없으면 no-op (2.x cli.js 안전)', () => {
+    const src = 'function build() { return granite.build(); }';
+    const { changed, source } = injectRuntimeVersion(src);
+    expect(changed).toBe(false);
+    expect(source).toBe(src);
+  });
+
+  test('setMetadata 인자가 객체 리터럴이 아니면 패치하지 않는다', () => {
+    const src = 'const meta = buildMeta(); writer.setMetadata(meta);';
+    const { changed } = injectRuntimeVersion(src);
+    expect(changed).toBe(false);
+  });
+
+  test('괄호가 닫히지 않은 깨진 입력에도 안전하게 no-op', () => {
+    const src = 'writer.setMetadata({ platform: "WEB",';
+    const { changed } = injectRuntimeVersion(src);
+    expect(changed).toBe(false);
+  });
+});


### PR DESCRIPTION
## 배경

web-framework **3.x**의 `ait build`는 `.ait` 메타데이터에 `runtimeVersion`을 emit하지 않아, `ait deploy` 게이트("ait 파일에 runtimeVersion이 없습니다")에 걸려 배포가 불가능하다.

사후에 `.ait`를 재저장해 주입하는 방식은 zip 재압축/`createdAtMs` 재스탬프로 바이트가 달라져 서버가 "잘못된 앱 정보"로 거부함이 확인됐다(폐기). 봉인을 깨지 않는 유일한 네이티브 경로는 **`ait build` 호출 직전에 web-framework `cli.js`를 패치**해 `setMetadata`가 `runtimeVersion`을 직접 emit하게 만드는 것이다. 빌드된 `.ait` 자체는 손대지 않는다.

## 변경 내용

- **`WebGLTemplates/AITTemplate/BuildConfig~/ait-patch-cli.mjs`** (신규)
  - brace-aware 파서로 `setMetadata({...})` 객체 리터럴을 찾아 여는 `{` 직후에 `runtimeVersion: "0.84.0"`을 주입(문자열/주석 내부 중괄호 무시).
  - 안전 규칙 — 어떤 상황에서도 빌드를 막지 않음(항상 exit 0): 멱등 / 2.x(`setMetadata` 없음) no-op / 구조 변경 no-op / pnpm 하드링크 store 오염 방지(unlink 후 새 inode 기록).
- **`Editor/Package/GraniteBuildRunner.cs`**
  - 3.x sync/async 빌드 경로(`Run3xBuildSync`/`Run3xBuildAsync`)에서 `ait build` 직전 `pnpm exec node ait-patch-cli.mjs` 실행.
  - 사용자 취소(`CANCELLED`)만 상위로 전파하고, 그 외 비정상 종료는 경고 후 `ait build`를 계속 진행(패치 실패가 빌드 실패로 번지지 않게 — **stable 무회귀**).
  - 2.x 경로(`RunAitOrGraniteBuild*`)는 패치 미적용(불필요 + `cli.js`에 `setMetadata`가 없어 어차피 no-op).
- **`Editor/AITPackageBuilder.cs`**: `ait-patch-cli.mjs`를 빌드 프로젝트로 복사(프로젝트 우선, 없으면 SDK 폴백). 2.x/3.x 양쪽 항상 복사.
- **`.github/workflows/unity-build.yml`**: E2E AIT 빌드 업로드 allowlist에 `ait-patch-cli.mjs` 추가.
- **`sdk-runtime-generator~/tests/unit/ait-patch-cli.test.ts`** (신규): `injectRuntimeVersion` 단위 테스트 11종(주입 위치 / minified / 중첩 brace·문자열 안전 / 멱등 / 2.x no-op / 깨진 입력 안전).

## 스코프 메모

이 작업의 원본 WIP에는 베타 deploy **검증 워크플로**(`beta-release.yml`) 변경도 포함돼 있었으나, 해당 기능은 이미 `main`에 **더 정제된 형태**(first-leg 게이팅, timeout→경고 통과, `deploy_probe_only` 입력, dist-tag resolution 등)로 반영돼 있어 **중복/회귀 방지를 위해 이번 PR에서 제외**했다. 이 PR의 고유 기여는 **`runtimeVersion` 네이티브 주입**에 한정한다.

## 검증

- `ait-patch-cli.test.ts` — **11/11 통과**(`vitest run`).
- C# 통합 검토: 모든 **3.x** `ait build` 호출 지점이 패치 게이트를 거침, 2.x 경로는 의도적으로 미적용. 참조 심볼(`RunNpmCommandWithCache(Async)`, `PackageContext`, `AITExportError`)은 현행 `main`에 존재.
- 머지 스코프: `main` 대비 5개 파일(+434), 충돌 마커 없음, `package.json`/lockfile 불변.

> 참고: 로컬 `./run-local-tests.sh --validate`의 SDK generator 단위 테스트(C# ↔ jslib invariants)는 본 변경과 무관하며(SDK 생성 표면 미변경), 사내 npm 미러가 아직 `web-analytics@2.9.0`을 미러링하지 못해 로컬 install이 막힌 환경 이슈로만 실행 불가하다(공개 npm에는 존재, jsdelivr로 교차확인). CI(공개 npm)에서는 `main`과 동일하게 통과한다.
