### PR TITLE
[auto-resolve] 개선: pnpm 글로벌 설치 실패 경고 Sentry 노이즈 억제 (x2)

### DIFF
--- a/Editor/AITPackageInitializer.cs
+++ b/Editor/AITPackageInitializer.cs
@@ -426,10 +426,14 @@ namespace AppsInToss.Editor
                         }
                         else
                         {
-                            Debug.LogWarning($"[AIT] pnpm 글로벌 설치 실패 (exit code: {result.ExitCode}). 첫 빌드 시 다시 시도됩니다.");
+                            // pnpm 글로벌 설치 실패 — 네트워크 차단, npm 권한 문제, AV 핸들 점유 등
+                            // 사용자 환경 원인. 메시지 자체가 "첫 빌드 시 다시 시도"라는 복구 경로를
+                            // 안내하는 정상 fallback이므로 Sentry로 전송하지 않는다.
+                            // (APPS-IN-TOSS-UNITY-SDK-11W 노이즈 방지)
+                            AITLog.Warning($"[AIT] pnpm 글로벌 설치 실패 (exit code: {result.ExitCode}). 첫 빌드 시 다시 시도됩니다.", sentryCapture: false);
                             if (!string.IsNullOrEmpty(result.Error))
                             {
-                                Debug.LogWarning($"[AIT] 오류: {result.Error}");
+                                AITLog.Warning($"[AIT] 오류: {result.Error}", sentryCapture: false);
                             }
                         }
                     },
@@ -439,7 +443,9 @@ namespace AppsInToss.Editor
             catch (Exception e)
             {
                 MarkInstallationCompleted();
-                Debug.LogWarning($"[AIT] pnpm 글로벌 설치 중 예외 발생: {e}");
+                // 프로세스 시작/IO 예외 — 사용자 환경 원인이며 AITAsyncCommandRunner가 이미
+                // 진단을 콘솔에 남기므로 여기서는 Sentry 전송 없이 Warning만 출력한다.
+                AITLog.Warning($"[AIT] pnpm 글로벌 설치 중 예외 발생: {e}", sentryCapture: false);
             }
         }
     }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs
@@ -13,6 +13,10 @@
 //     실패 → CheckAndSetupPackageManager catch가 Sentry에 전송하던 패턴.
 //     SDK-100 retry fix(#746) + sentryCapture:false(#715)로 수정됐으나 이 회귀 가드가 없어
 //     sentryCapture:false가 raw Debug.LogError로 되돌아가도 발각되지 않는 갭이 있었음.
+//   - APPS-IN-TOSS-UNITY-SDK-11W: "[AIT] pnpm 글로벌 설치 실패 (exit code: …). 첫 빌드 시 다시 시도됩니다."
+//     네트워크 차단/npm 권한/AV 핸들 점유로 백그라운드 pnpm install이 exit code 1로 실패하는
+//     사용자 환경 원인. InstallPnpmGlobal의 onComplete 콜백이 raw Debug.LogWarning으로 Sentry에
+//     전송하던 패턴을 AITLog.Warning(sentryCapture:false)로 수정.
 //
 // 진짜 빌드 실패는 다운스트림 CaptureBuildError(구조화 이벤트, errorCode fingerprint)가 별도로
 // 캡처하므로, 이 fallback warning들을 Sentry에서 억제해도 가시성을 잃지 않는다.
@@ -67,6 +71,20 @@ public class SentryNoiseSuppressionCallsiteTests
             "패키지 매니저 체크 중 예외 발생",
             "119",
             expectWarning: false);  // AITLog.Error (복구 불가 경로이므로 Error 레벨이 맞다)
+
+    /// <summary>
+    /// 회귀 가드 — APPS-IN-TOSS-UNITY-SDK-11W:
+    /// InstallPnpmGlobal 의 onComplete 콜백이 pnpm 설치 exit code 1 실패를 로그할 때
+    /// raw Debug.LogWarning 으로 되돌아가지 않고 sentryCapture:false 를 유지하는지 검증.
+    /// 네트워크 차단/npm 권한/AV 핸들 점유 등 사용자 환경 원인이며, 메시지 자체가
+    /// "첫 빌드 시 다시 시도됩니다"라는 복구 경로를 안내하는 정상 fallback warning이다.
+    /// </summary>
+    [Test]
+    public void ElevenW_PnpmGlobalInstallFailure_StaysSentrySuppressed()
+        => AssertCallsiteSuppressed(
+            "AITPackageInitializer.cs",
+            "pnpm 글로벌 설치 실패 (exit code:",
+            "11W");
 
     /// <summary>
     /// fileName 소스에서 messageAnchor를 내보내는 가장 가까운 선행 로그 호출이


### PR DESCRIPTION
**범위**: 원 이슈 `APPS-IN-TOSS-UNITY-SDK-11W`의 실제 증상(pnpm 설치 환경 재현)은 미해결 — 참조만. 별도 조사 필요.
원 이슈 `APPS-IN-TOSS-UNITY-SDK-12E`(Build 폴더 미존재 치명적 오류)는 재현 실패 — 참조만. 별도 조사 필요.

## 묶음 항목

| # | Sentry ID | 제목 | 처리 |
|---|-----------|------|------|
| 1 | APPS-IN-TOSS-UNITY-SDK-11W | UnityWarning: [AIT] pnpm 글로벌 설치 실패 (exit code: 1). 첫 빌드 시 다시 시도됩니다. | 인접 callsite 수정 (Sentry 노이즈 억제) |
| 2 | APPS-IN-TOSS-UNITY-SDK-12E | UnityError: [AIT] ✗ 치명적: Build 폴더를 찾을 수 없습니다! | 재현 실패 — 조치 없음 |

## 재현 시도 결과

### APPS-IN-TOSS-UNITY-SDK-11W
- **재현 시도**: 로컬 Unity 에디터 없이는 InstallPnpmGlobal의 백그라운드 실행 흐름을 재현 불가.
- **인접 코드 이슈 발견**: AITPackageInitializer.cs의 InstallPnpmGlobal onComplete 콜백과 catch 블록에서 raw Debug.LogWarning을 사용해 Sentry로 전송됨. 동일 파일의 다른 recoverable warning이 이미 AITLog.Warning(..., sentryCapture: false) 패턴을 쓰는 것과 불일치.
- **판단**: 네트워크 차단/npm 권한 문제/AV 핸들 점유 등 사용자 환경 원인. 복구 경로가 명시된 정상 fallback warning. 수정 안전.

### APPS-IN-TOSS-UNITY-SDK-12E
- **재현 시도**: WebGLBuildCopier.CopyWebGLToPublic에서 webglPath/Build 폴더 미존재 시 발생. 로컬에서는 실제 WebGL 빌드 없이 재현 불가 (Unity 에디터 필요).
- **재현 결과**: 재현 실패 — 이 PR에서 조치하지 않음.

## 원인

InstallPnpmGlobal의 두 로그 콜사이트가 AITLog.Warning(..., sentryCapture: false) 대신 raw Debug.LogWarning을 사용해 Sentry의 [AIT] 키워드 가드를 통과, Sentry 이슈로 집계됨.

## 변경 내용

- Editor/AITPackageInitializer.cs: InstallPnpmGlobal onComplete 콜백과 catch 블록의 Debug.LogWarning → AITLog.Warning(..., sentryCapture: false) 3곳 교체
- Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs: ElevenW_PnpmGlobalInstallFailure_StaysSentrySuppressed 회귀 가드 테스트 추가

## 검증

- ./run-local-tests.sh --validate: E2E 파일 검증, Playwright 설정, Meta GUID 검사 모두 통과. SDK Generator Unit Test는 로컬 npm 미러 stale 이슈로 실패 — main 브랜치와 동일한 pre-existing 이슈임.