### PR TITLE
[auto-resolve] 수정: AITSentry CollectSafe WebGL undefined 접근 오류 처리

### DIFF
--- a/Runtime/Sentry/AITSentryContextEnricher.cs
+++ b/Runtime/Sentry/AITSentryContextEnricher.cs
@@ -102,8 +102,16 @@ namespace AppsInToss.Sentry
                 // IsPlatformUnavailable 예외(예: "getLocale is not a constant handler")는
                 // WebGL JS 브리지 핸들러가 없는 환경에서 발생하는 예상된 동작이므로
                 // Warning이 아닌 Info 레벨로 기록하여 Sentry 노이즈를 방지한다.
+                //
+                // "Cannot read properties of undefined" 예외는 window.AppsInToss 객체가
+                // 아직 초기화되지 않은 상태에서 jslib이 호출될 때 발생하는 JS TypeError이다.
+                // 이 역시 플랫폼 브리지 미준비 상태로서 IsPlatformUnavailable 과 동일하게
+                // Info 레벨로 기록하여 Runtime Sentry 노이즈를 방지한다.
+                // Sentry APPS-IN-TOSS-UNITY-SDK-11E.
                 var aitEx = ex as AITException;
-                if (aitEx != null && aitEx.IsPlatformUnavailable)
+                bool isUndefinedAccess = ex.Message != null &&
+                    ex.Message.IndexOf("Cannot read properties of undefined", StringComparison.Ordinal) >= 0;
+                if ((aitEx != null && aitEx.IsPlatformUnavailable) || isUndefinedAccess)
                 {
                     Debug.Log($"{Tag} {apiName} 플랫폼 미지원 (예상됨): {ex.Message}");
                 }
@@ -135,8 +143,16 @@ namespace AppsInToss.Sentry
                 // IsPlatformUnavailable 예외(예: "getLocale is not a constant handler")는
                 // WebGL JS 브리지 핸들러가 없는 환경에서 발생하는 예상된 동작이므로
                 // Warning이 아닌 Info 레벨로 기록하여 Sentry 노이즈를 방지한다.
+                //
+                // "Cannot read properties of undefined" 예외는 window.AppsInToss 객체가
+                // 아직 초기화되지 않은 상태에서 jslib이 호출될 때 발생하는 JS TypeError이다.
+                // 이 역시 플랫폼 브리지 미준비 상태로서 IsPlatformUnavailable 과 동일하게
+                // Info 레벨로 기록하여 Runtime Sentry 노이즈를 방지한다.
+                // Sentry APPS-IN-TOSS-UNITY-SDK-11E.
                 var aitEx = ex as AITException;
-                if (aitEx != null && aitEx.IsPlatformUnavailable)
+                bool isUndefinedAccess = ex.Message != null &&
+                    ex.Message.IndexOf("Cannot read properties of undefined", StringComparison.Ordinal) >= 0;
+                if ((aitEx != null && aitEx.IsPlatformUnavailable) || isUndefinedAccess)
                 {
                     Debug.Log($"{Tag} {apiName} 플랫폼 미지원 (예상됨): {ex.Message}");
                 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2347,6 +2347,28 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void AITSentryCollectSafe_GetOperationalEnvironmentUndefinedAccess_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-11E — WebGL 빌드에서 window.AppsInToss가 초기화되기 전에
+        // AITSentryContextEnricher.CollectSafe가 GetOperationalEnvironment를 호출하면 jslib에서
+        // "Cannot read properties of undefined (reading 'getOperationalEnvironment')" JS TypeError가 발생한다.
+        // CollectSafe는 이 예외를 잡아 "unavailable"를 반환하므로 SDK 동작은 중단되지 않는다.
+        // 에디터 Sentry로 전송하면 조치 불가한 노이즈가 되므로 차단한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentry] GetOperationalEnvironment 호출 실패: Cannot read properties of undefined (reading 'getOperationalEnvironment')"));
+    }
+
+    [Test]
+    public void AITSentryCollectSafe_GetOperationalEnvironmentUndefinedAccess_UnityWarningPrefix_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-11E 실측 메시지 — Unity가 Debug.LogWarning을 에디터 콘솔로
+        // 보낼 때 "UnityWarning: " prefix가 붙는 변형. 에디터 backstop 필터(IsKnownNonSdkMessage)가
+        // [AITSentry] + 호출 실패: 합성으로 이 변형도 드롭함을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [AITSentry] GetOperationalEnvironment 호출 실패: Cannot read properties of undefined (reading 'getOperationalEnvironment')"));
+    }
+
+    [Test]
     public void AITSentryCollectSafe_OtherDiagnostic_NotFiltered()
     {
         // "[AITSentry]" prefix라도 "호출 실패:" 패턴이 없는 다른 진단 메시지는 통과해야 한다.


### PR DESCRIPTION

**범위**: 원 이슈 APPS-IN-TOSS-UNITY-SDK-11E의 Runtime Sentry 노이즈 제거 — window.AppsInToss undefined 접근을 플랫폼 미지원으로 재분류

## 묶음 항목

| # | Sentry ID | 제목 |
|---|-----------|------|
| 1 | APPS-IN-TOSS-UNITY-SDK-11E | UnityWarning: [AITSentry] GetOperationalEnvironment 호출 실패: Cannot read properties of undefined (reading 'getOperationalEnvironment') |

## 재현 분석

**증상**: WebGL 빌드에서 `AITSentryContextEnricher.EnrichAsync()`가 `AfterSceneLoad`에 실행될 때, `window.AppsInToss` JS 객체가 아직 초기화되지 않은 경우 `getOperationalEnvironment` jslib 호출이 JS TypeError를 발생시킨다.

**오류 메시지 흐름**:
1. `AITSentryContextEnricher.CollectSafe("GetOperationalEnvironment", ...)` 호출
2. `AIT.GetOperationalEnvironment()` → `__getOperationalEnvironment_Internal()` jslib 호출
3. jslib: `window.AppsInToss.getOperationalEnvironment()` → `window.AppsInToss`가 `undefined`
4. jslib catch: error.message = "Cannot read properties of undefined" → success: false 응답 반환
5. `AITCore` error callback → `AITException("Cannot read properties of undefined ...")`
6. `CollectSafe` catch: `IsPlatformUnavailable` = false (`CheckPlatformUnavailable`가 이 패턴 미인식)
7. `Debug.LogWarning("[AITSentry] GetOperationalEnvironment 호출 실패: ...")` 출력
8. Runtime Sentry SDK가 `LogType.Warning` 캡처 → Sentry 이슈 생성

**근본 원인**: `AITCore.CheckPlatformUnavailable`은 `"__GRANITE_NATIVE_EMITTER"`, `"ReactNativeWebView"`, `"is not a constant handler"` 세 패턴만 인식한다. `window.AppsInToss` 미초기화로 인한 `"Cannot read properties of undefined"` JS TypeError는 인식하지 못해 `IsPlatformUnavailable = false` → `Debug.LogWarning` 경로로 흐른다.

## 수정 내용

`Runtime/Sentry/AITSentryContextEnricher.cs`의 `CollectSafe` 메서드에서 예외 메시지에 `"Cannot read properties of undefined"`가 포함된 경우를 플랫폼 미지원 시나리오와 동일하게 처리:
- 기존: `Debug.LogWarning` → Runtime Sentry 캡처
- 수정: `Debug.Log` → 조용히 "unavailable" 반환 (SDK 동작 계속)

이 패턴은 `"is not a constant handler"` 오류(SDK-11J)와 동일한 원인(브리지 미준비)이며, 두 경우 모두 `CollectSafe`가 "unavailable"로 폴백하여 SDK 동작은 중단되지 않는다.

## 테스트

`IsKnownNonSdkMessageTests.cs`에 에디터 backstop 필터 회귀 테스트 2건 추가:
- `AITSentryCollectSafe_GetOperationalEnvironmentUndefinedAccess_ReturnsTrue`
- `AITSentryCollectSafe_GetOperationalEnvironmentUndefinedAccess_UnityWarningPrefix_ReturnsTrue`

검증: `./run-local-tests.sh --validate` — SDK Generator 스텝은 사내 Nexus 미러 스테일 이슈로 실패하나 본 변경과 무관함. E2E/Playwright/Meta GUID 검사 통과.