### PR TITLE
[auto-resolve] 개선: AITSentryContextEnricher undefined 브리지 Sentry 노이즈 억제

### DIFF
--- a/Runtime/Sentry/AITSentryContextEnricher.cs
+++ b/Runtime/Sentry/AITSentryContextEnricher.cs
@@ -107,6 +107,14 @@ namespace AppsInToss.Sentry
                 {
                     Debug.Log($"{Tag} {apiName} 플랫폼 미지원 (예상됨): {ex.Message}");
                 }
+                else if (ex.Message != null && ex.Message.Contains("Cannot read properties of undefined"))
+                {
+                    // window.AppsInToss 브리지가 주입되지 않은 환경(Toss 앱 WebView 외부)에서
+                    // jslib 내 window.AppsInToss.xxx() 호출 시 발생하는 JS TypeError.
+                    // 이는 플랫폼 미지원 상황의 예상된 동작이므로 Info 레벨로 기록한다.
+                    // (APPS-IN-TOSS-UNITY-SDK-11D)
+                    Debug.Log($"{Tag} {apiName} 플랫폼 브리지 미초기화 (예상됨): {ex.Message}");
+                }
                 else
                 {
                     Debug.LogWarning($"{Tag} {apiName} 호출 실패: {ex.Message}");
@@ -139,6 +147,14 @@ namespace AppsInToss.Sentry
                 if (aitEx != null && aitEx.IsPlatformUnavailable)
                 {
                     Debug.Log($"{Tag} {apiName} 플랫폼 미지원 (예상됨): {ex.Message}");
+                }
+                else if (ex.Message != null && ex.Message.Contains("Cannot read properties of undefined"))
+                {
+                    // window.AppsInToss 브리지가 주입되지 않은 환경(Toss 앱 WebView 외부)에서
+                    // jslib 내 window.AppsInToss.xxx() 호출 시 발생하는 JS TypeError.
+                    // 이는 플랫폼 미지원 상황의 예상된 동작이므로 Info 레벨로 기록한다.
+                    // (APPS-IN-TOSS-UNITY-SDK-11D)
+                    Debug.Log($"{Tag} {apiName} 플랫폼 브리지 미초기화 (예상됨): {ex.Message}");
                 }
                 else
                 {

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs
@@ -1,0 +1,145 @@
+// -----------------------------------------------------------------------
+// AITExceptionPlatformUnavailableTests.cs - AITSentryContextEnricher undefined 브리지 처리 회귀 가드
+// Level 0: APPS-IN-TOSS-UNITY-SDK-11D 재현 — WebGL 환경에서 window.AppsInToss 가
+//           undefined일 때 발생하는 JS TypeError가 Debug.LogWarning → Sentry 노이즈로
+//           보고되지 않도록 CollectSafe()가 올바르게 처리하는지 정적 소스 스캔으로 검증.
+//
+// 배경:
+//   - AITSentryContextEnricher.CollectSafe()는 AITException.IsPlatformUnavailable이
+//     true이면 Debug.Log(info), false이면 Debug.LogWarning을 내보낸다.
+//   - WebGL 빌드에서 Toss 앱 WebView 외부(브리지 미주입)로 실행될 때,
+//     AppsInToss-GetDeviceId.jslib 안의 window.AppsInToss.getDeviceId() 호출이
+//     TypeError: "Cannot read properties of undefined (reading 'getDeviceId')"를 던진다.
+//   - AITException.CheckPlatformUnavailable()의 기존 패턴
+//     (__GRANITE_NATIVE_EMITTER / ReactNativeWebView / is not a constant handler)에
+//     일치하지 않아, CollectSafe()가 이를 명시적으로 처리하지 않으면
+//     IsPlatformUnavailable=false → LogWarning → Sentry 전송됨.
+//   - 이 테스트는 CollectSafe()가 "Cannot read properties of undefined" 패턴을
+//     Info 레벨로 처리하는 코드를 유지하도록 정적 스캔으로 보장한다.
+//   - 정적 소스 스캔을 쓰는 이유: CollectSafe는 async/delegate 구조라 EditMode에서
+//     직접 호출이 불가능하고, WebGL 런타임 없이 동등한 검증이 가능하기 때문
+//     (SentryNoiseSuppressionCallsiteTests, CleanMenuSafetyTests와 동일한 접근법).
+// -----------------------------------------------------------------------
+
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEditor;
+
+[TestFixture]
+[Category("Unit")]
+public class AITExceptionPlatformUnavailableTests
+{
+    private const string FileName = "AITSentryContextEnricher.cs";
+    // 수정한 패턴 (이 리터럴이 소스에 있어야 함)
+    private const string UndefinedBridgeAnchor = "Cannot read properties of undefined";
+
+    /// <summary>
+    /// 회귀 가드: CollectSafe()가 "Cannot read properties of undefined" 패턴(window.AppsInToss
+    /// 브리지 미주입 에러)을 Debug.Log (Info 레벨)로 처리하는지 정적 소스 스캔으로 검증.
+    ///
+    /// 이 테스트가 실패하면:
+    ///   1) 앵커 문자열이 소스에서 삭제됨 → 회귀 (Sentry 노이즈 재발)
+    ///   2) 해당 패턴 처리가 Debug.LogWarning으로 되돌아감 → 노이즈 회귀
+    ///   (APPS-IN-TOSS-UNITY-SDK-11D)
+    /// </summary>
+    [Test]
+    public void CollectSafe_UndefinedBridgePattern_HandledAsInfoNotWarning()
+    {
+        string path = LocateSentrySource(FileName);
+        Assert.IsNotNull(path,
+            $"{FileName} 소스 경로를 찾을 수 없음 (AssetDatabase 및 알려진 후보 경로 모두 실패).");
+        Assert.IsTrue(File.Exists(path), $"{FileName}가 존재해야 함: {path}");
+
+        string source = File.ReadAllText(path);
+
+        // (1) 패턴 존재 검증 — 없으면 fix가 삭제된 것
+        int anchorIdx = source.IndexOf(UndefinedBridgeAnchor, System.StringComparison.Ordinal);
+        Assert.GreaterOrEqual(anchorIdx, 0,
+            $"[SDK-11D] {FileName}에서 undefined 브리지 처리 패턴을 찾을 수 없음: \"{UndefinedBridgeAnchor}\". " +
+            "이 패턴이 없으면 window.AppsInToss 미주입 에러가 Debug.LogWarning으로 전송되어 Sentry 노이즈가 발생한다.");
+
+        // (2) 앵커 앞 가장 가까운 로그 호출 확인 — Debug.Log (Info)여야 하고 Debug.LogWarning이 아니어야 함
+        //     패턴 앞 2000자를 스캔해 nearest 로그 호출을 찾는다.
+        int scanStart = System.Math.Max(0, anchorIdx - 2000);
+        string region = source.Substring(scanStart, anchorIdx - scanStart);
+
+        // 로그 호출 토큰 (LogWarning이 Log보다 구체적이므로 먼저 검사)
+        string[] logTokens = { "Debug.LogWarning(", "Debug.LogError(", "Debug.Log(" };
+        int bestIdx = -1;
+        string bestTok = null;
+        foreach (var tok in logTokens)
+        {
+            int idx = region.LastIndexOf(tok, System.StringComparison.Ordinal);
+            if (idx > bestIdx) { bestIdx = idx; bestTok = tok; }
+        }
+
+        Assert.AreEqual("Debug.Log(",  bestTok,
+            $"[SDK-11D] \"{UndefinedBridgeAnchor}\" 앞의 로그 호출이 'Debug.Log('여야 하는데 '{bestTok ?? "(없음)"}'임. " +
+            "이 패턴은 플랫폼 브리지 미주입(예상된 동작)이므로 Info 레벨로 기록해야 합니다. " +
+            "LogWarning이면 Sentry 노이즈(APPS-IN-TOSS-UNITY-SDK-11D)가 재발합니다.");
+    }
+
+    // =====================================================
+    // 기존 IsPlatformUnavailable 패턴 회귀 가드
+    // (AITException.CheckPlatformUnavailable이 기존 패턴을 유지하는지)
+    // =====================================================
+
+    [TestCase("__GRANITE_NATIVE_EMITTER is not defined")]
+    [TestCase("ReactNativeWebView is not defined")]
+    [TestCase("getLocale is not a constant handler")]
+    [TestCase("getDeviceId is not a constant handler")]
+    public void KnownPlatformUnavailableMessages_ReturnTrue(string message)
+    {
+        var ex = new AppsInToss.AITException(message);
+        Assert.IsTrue(ex.IsPlatformUnavailable,
+            $"'{message}' 는 플랫폼 미지원으로 분류되어야 합니다.");
+    }
+
+    [TestCase("NullReferenceException: Object reference not set to an instance of an object")]
+    [TestCase("IndexOutOfRangeException: Index was outside the bounds of the array")]
+    [TestCase("Network request failed")]
+    [TestCase("Unauthorized")]
+    public void RealSdkErrors_ReturnFalse(string message)
+    {
+        var ex = new AppsInToss.AITException(message);
+        Assert.IsFalse(ex.IsPlatformUnavailable,
+            $"'{message}' 는 실제 SDK 버그이므로 IsPlatformUnavailable=false여야 합니다.");
+    }
+
+    // ===================================================================
+    // 헬퍼: AITSentryContextEnricher.cs 소스 경로 해석
+    // ===================================================================
+
+    private static string LocateSentrySource(string fileName)
+    {
+        string nameNoExt = Path.GetFileNameWithoutExtension(fileName);
+        foreach (var guid in AssetDatabase.FindAssets(nameNoExt + " t:MonoScript"))
+        {
+            string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+            if (string.IsNullOrEmpty(assetPath)) continue;
+            if (Path.GetFileName(assetPath) == fileName && File.Exists(assetPath))
+                return assetPath;
+        }
+
+        string[] candidates =
+        {
+            "Runtime/Sentry/" + fileName,
+            "Packages/im.toss.apps-in-toss-unity-sdk/Runtime/Sentry/" + fileName,
+        };
+        foreach (var c in candidates)
+            if (File.Exists(c)) return c;
+
+        const string packageCache = "Library/PackageCache";
+        if (Directory.Exists(packageCache))
+        {
+            foreach (var d in Directory.GetDirectories(packageCache, "im.toss.apps-in-toss-unity-sdk*"))
+            {
+                string p = Path.Combine(d, "Runtime", "Sentry", fileName);
+                if (File.Exists(p)) return p;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef4cf3db127d436ca6b803af8df23c28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
**범위**: 원 이슈 \`APPS-IN-TOSS-UNITY-SDK-11D\`의 네이티브 바인딩 초기화 타이밍 문제 여부는 미해결 — 참조만. 별도 조사 필요.

## 묶음 항목

| # | 이슈 ID | 제목 | 비고 |
|---|---------|------|------|
| 1 | APPS-IN-TOSS-UNITY-SDK-11D | \`[AITSentry] GetDeviceId 호출 실패: Cannot read properties of undefined (reading 'getDeviceId')\` | auto 금지 — Sentry 노이즈만 억제 |

## 재현 결과

\`AITSentryContextEnricher.CollectSafe()\`에서 \`AITException.IsPlatformUnavailable\` 체크가 \`false\`를 반환하는 케이스:

- 에러 메시지: \`"Cannot read properties of undefined (reading 'getDeviceId')"\`
- 이 메시지는 \`AITException.CheckPlatformUnavailable()\`의 기존 패턴(\`__GRANITE_NATIVE_EMITTER\`, \`ReactNativeWebView\`, \`is not a constant handler\`)에 일치하지 않음
- 결과: \`CollectSafe()\`가 \`Debug.LogWarning\`으로 기록 → Sentry 전송 (노이즈)

재현 방법: WebGL 빌드를 Toss 앱 WebView 외부에서 실행하면 \`window.AppsInToss\`가 \`undefined\`이고, \`AppsInToss-GetDeviceId.jslib\`의 \`window.AppsInToss.getDeviceId()\` 호출이 \`TypeError\`를 던짐. 이 에러가 C# callback으로 전달되어 \`AITSentryContextEnricher\`에서 Sentry Warning으로 보고됨.

## 원인 및 변경 내용

**원인**: \`CollectSafe()\`가 \`window.AppsInToss\`(JS bridge) 미주입 환경에서 발생하는 \`"Cannot read properties of undefined"\` TypeError를 플랫폼 미지원 케이스로 처리하지 않아 \`Debug.LogWarning\` → Sentry로 전송됨.

**변경**:
- \`Runtime/Sentry/AITSentryContextEnricher.cs\`: \`CollectSafe()\`의 catch 블록에 \`"Cannot read properties of undefined"\` 패턴 처리 추가 — \`Debug.Log\` (Info 레벨)로 기록하여 Sentry 전송 방지 (UNITY 6+ / 구버전 양쪽 모두)
- \`Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs\`: 정적 소스 스캔 회귀 테스트 추가 (패턴이 \`Debug.Log\`로 처리됨을 보장)

## 미해결 사항

- \`window.AppsInToss\`가 undefined인 원인이 순수 환경 문제(Toss 앱 외부 실행)인지, 아니면 초기화 타이밍 버그(native 바인딩 미초기화)인지는 WebGL E2E 없이는 확인 불가
- 타이밍 버그라면 \`AITSentryIntegration.Initialize()\`의 \`AfterSceneLoad\` 호출 시점과 native bridge 주입 시점의 경쟁 조건 가능성 있음 → 별도 조사 필요

## 검증

- \`./run-local-tests.sh --validate\` 통과 (pre-existing pnpm mirror stale 에러 제외 — main 브랜치와 동일한 1개 실패)
- 새로 추가된 \`AITExceptionPlatformUnavailableTests\` 는 Unity EditMode(\`--editmode\`)에서 실행 가능