### PR TITLE
[auto-resolve] 수정: WebGL JS 브리지 미초기화 TypeError를 플랫폼 미지원으로 분류

### DIFF
--- a/Runtime/SDK/AITCore.cs
+++ b/Runtime/SDK/AITCore.cs
@@ -172,7 +172,10 @@ namespace AppsInToss
             if (string.IsNullOrEmpty(message)) return false;
             return message.Contains("__GRANITE_NATIVE_EMITTER") ||
                    message.Contains("ReactNativeWebView") ||
-                   message.Contains("is not a constant handler");
+                   message.Contains("is not a constant handler") ||
+                   // WebGL JS 브리지 객체(window.AppsInToss)가 아직 초기화되지 않았을 때
+                   // 발생하는 JS TypeError — 플랫폼 미지원과 동일하게 처리한다.
+                   message.Contains("Cannot read properties of undefined");
         }
     }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------
+// AITExceptionPlatformUnavailableTests.cs
+// Level 0: AITException.IsPlatformUnavailable 회귀 가드
+//
+// APPS-IN-TOSS-UNITY-SDK-11C:
+//   WebGL 환경에서 window.AppsInToss JS 브리지가 아직 초기화되지 않은 상태로
+//   AITSentryContextEnricher.EnrichAsync()가 GetPlatformOS()를 호출하면
+//   JS TypeError "Cannot read properties of undefined (reading 'getPlatformOS')"가
+//   발생하고, AITException.IsPlatformUnavailable == false로 분류되어
+//   Debug.LogWarning으로 기록 → Sentry 노이즈 유입.
+//
+//   수정: CheckPlatformUnavailable에 "Cannot read properties of undefined" 패턴을
+//         추가하여 JS 브리지 미초기화를 "플랫폼 미지원"과 동일하게 처리한다.
+//         AITSentryContextEnricher.CollectSafe에서 IsPlatformUnavailable == true이면
+//         Debug.Log (Info 레벨)로 기록하여 Sentry로 전송되지 않는다.
+// -----------------------------------------------------------------------
+
+using AppsInToss;
+using NUnit.Framework;
+
+[TestFixture]
+[Category("Unit")]
+public class AITExceptionPlatformUnavailableTests
+{
+    // =====================================================
+    // APPS-IN-TOSS-UNITY-SDK-11C 회귀 가드
+    // window.AppsInToss 미초기화 TypeError → IsPlatformUnavailable == true
+    // =====================================================
+
+    [TestCase("Cannot read properties of undefined (reading 'getPlatformOS')",
+        TestName = "getPlatformOS — SDK-11C 재현 메시지")]
+    [TestCase("Cannot read properties of undefined (reading 'getDeviceId')",
+        TestName = "getDeviceId — 동일 패턴")]
+    [TestCase("Cannot read properties of undefined (reading 'getLocale')",
+        TestName = "getLocale — 동일 패턴")]
+    [TestCase("Cannot read properties of undefined",
+        TestName = "접두 메시지만 있는 경우")]
+    public void IsPlatformUnavailable_JsBridgeUndefined_ReturnsTrue(string errorMessage)
+    {
+        var ex = new AITException(errorMessage);
+        Assert.IsTrue(ex.IsPlatformUnavailable,
+            $"window.AppsInToss 미초기화 TypeError는 플랫폼 미지원으로 분류되어야 함. " +
+            $"메시지: '{errorMessage}'. IsPlatformUnavailable이 false이면 " +
+            "AITSentryContextEnricher.CollectSafe가 Debug.LogWarning을 내보내 " +
+            "Sentry 노이즈가 발생한다 (APPS-IN-TOSS-UNITY-SDK-11C).");
+    }
+
+    // =====================================================
+    // 기존 패턴 회귀 확인
+    // =====================================================
+
+    [TestCase("__GRANITE_NATIVE_EMITTER is not defined")]
+    [TestCase("ReactNativeWebView is not available")]
+    [TestCase("getLocale is not a constant handler")]
+    public void IsPlatformUnavailable_ExistingPatterns_StillReturnTrue(string errorMessage)
+    {
+        var ex = new AITException(errorMessage);
+        Assert.IsTrue(ex.IsPlatformUnavailable,
+            $"기존 플랫폼 미지원 패턴이 여전히 true를 반환해야 함: '{errorMessage}'");
+    }
+
+    // =====================================================
+    // 실제 버그는 false여야 하는 케이스 — 오탐 방지
+    // =====================================================
+
+    [TestCase("Network request failed")]
+    [TestCase("Callback timeout")]
+    [TestCase("JSON parse error")]
+    public void IsPlatformUnavailable_RealErrors_ReturnFalse(string errorMessage)
+    {
+        var ex = new AITException(errorMessage);
+        Assert.IsFalse(ex.IsPlatformUnavailable,
+            $"실제 오류는 플랫폼 미지원으로 분류되지 않아야 함: '{errorMessage}'");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0070507feb954dddb74e620be8f1ff64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/sdk-runtime-generator~/src/templates/csharp-core.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-core.hbs
@@ -172,7 +172,10 @@ namespace AppsInToss
             if (string.IsNullOrEmpty(message)) return false;
             return message.Contains("__GRANITE_NATIVE_EMITTER") ||
                    message.Contains("ReactNativeWebView") ||
-                   message.Contains("is not a constant handler");
+                   message.Contains("is not a constant handler") ||
+                   // WebGL JS 브리지 객체(window.AppsInToss)가 아직 초기화되지 않았을 때
+                   // 발생하는 JS TypeError — 플랫폼 미지원과 동일하게 처리한다.
+                   message.Contains("Cannot read properties of undefined");
         }
     }
 

--- a/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs
+++ b/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs
@@ -172,7 +172,10 @@ namespace AppsInToss
             if (string.IsNullOrEmpty(message)) return false;
             return message.Contains("__GRANITE_NATIVE_EMITTER") ||
                    message.Contains("ReactNativeWebView") ||
-                   message.Contains("is not a constant handler");
+                   message.Contains("is not a constant handler") ||
+                   // WebGL JS 브리지 객체(window.AppsInToss)가 아직 초기화되지 않았을 때
+                   // 발생하는 JS TypeError — 플랫폼 미지원과 동일하게 처리한다.
+                   message.Contains("Cannot read properties of undefined");
         }
     }
 

--- a/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
+++ b/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
@@ -172,7 +172,10 @@ namespace AppsInToss
             if (string.IsNullOrEmpty(message)) return false;
             return message.Contains("__GRANITE_NATIVE_EMITTER") ||
                    message.Contains("ReactNativeWebView") ||
-                   message.Contains("is not a constant handler");
+                   message.Contains("is not a constant handler") ||
+                   // WebGL JS 브리지 객체(window.AppsInToss)가 아직 초기화되지 않았을 때
+                   // 발생하는 JS TypeError — 플랫폼 미지원과 동일하게 처리한다.
+                   message.Contains("Cannot read properties of undefined");
         }
     }
 


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-11C

## 요약

WebGL 빌드에서 \`window.AppsInToss\` JS 브리지가 초기화되기 전에 \`GetPlatformOS()\`가 호출될 때 발생하는 JS TypeError를 \`IsPlatformUnavailable == true\`로 올바르게 분류하여 Sentry 노이즈를 제거한다.

## 재현 경로

1. WebGL 빌드 → \`AITSentryIntegration.Initialize()\` → \`AITSentryContextEnricher.EnrichAsync()\`
2. \`GetPlatformOS()\` → jslib \`window.AppsInToss.getPlatformOS()\` → \`window.AppsInToss === undefined\`
3. JS TypeError: \`"Cannot read properties of undefined (reading 'getPlatformOS')"\`
4. \`CheckPlatformUnavailable()\` → false (기존 패턴 불일치)
5. \`CollectSafe\` → \`Debug.LogWarning(...)\` → Sentry 노이즈

## 수정

\`CheckPlatformUnavailable()\`에 \`"Cannot read properties of undefined"\` 패턴 추가.

generator 템플릿 + 생성 파일(Runtime/SDK/AITCore.cs) + golden 파일 동기화.

수동 동기화 이유: 사내 Nexus npm 미러가 stale하여 worktree에서 pnpm generate 불가 (pre-existing 인프라 이슈). 템플릿이 소스 of truth이며, 동일 diff로 수동 동기화.

## 회귀 가드

AITExceptionPlatformUnavailableTests.cs (EditMode) 추가:
- SDK-11C 재현 메시지가 IsPlatformUnavailable == true 반환 검증
- 동일 패턴의 다른 API(getDeviceId, getLocale) 커버
- 기존 패턴 3개 회귀 확인
- 실제 오류는 false 분류 (오탐 방지)

## 검증

./run-local-tests.sh --validate 통과 (Generator Unit Tests는 stale npm 미러 이슈 pre-existing)