### PR TITLE
수정: Regenerate Lockfiles git add 실패 해소 (sdk-runtime-generator~ lockfile .gitignore 예외)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,7 +190,10 @@ yarn.lock.meta
 # Tests~/E2E/tests의 pnpm-lock.yaml은 커밋 (E2E 잡이 --frozen-lockfile 사용)
 !**/Tests~/E2E/tests/pnpm-lock.yaml
 
-# Lockfile은 일반적으로 커밋하지 않음 (BuildConfig~, Tests~/E2E/tests 제외)
+# sdk-runtime-generator~의 pnpm-lock.yaml은 커밋 (Regenerate Lockfiles 워크플로가 재생성·커밋)
+!sdk-runtime-generator~/pnpm-lock.yaml
+
+# Lockfile은 일반적으로 커밋하지 않음 (BuildConfig~, Tests~/E2E/tests, sdk-runtime-generator~ 제외)
 
 # Superpowers 플랜 문서 (Claude Code 작업용, 커밋 불필요)
 docs/superpowers/


### PR DESCRIPTION
## 배경

`Regenerate Lockfiles` 워크플로가 **2026-06-17 / 06-18 반복 실패**했다 (run `27712462687`, `27782232360`, `Open PR if changed` 스텝, exit code 1).

## 원인

루트 `.gitignore`의 전역 `pnpm-lock.yaml` 규칙(line 181)이 `sdk-runtime-generator~/pnpm-lock.yaml`을 ignore한다. `BuildConfig~`(line 188)와 `Tests~/E2E/tests`(line 191)는 `!` negation 예외가 있지만 `sdk-runtime-generator~`에는 누락되어 있었다. 워크플로가 lockfile을 재생성한 뒤 `git add` 할 때 다음 에러로 스텝 전체가 실패한다:

```
The following paths are ignored by one of your .gitignore files:
sdk-runtime-generator~/pnpm-lock.yaml
hint: Use -f if you really want to add them.
##[error]Process completed with exit code 1.
```

(히스토리: f8830f1에서 예외 규칙이 제거됐고, 이후 #545가 워크플로에 sdk-gen lockfile 재생성 스텝을 추가했지만 `.gitignore` 예외는 복원되지 않아 불일치 발생.)

## 변경

`.gitignore`에 예외 1줄 추가:

```gitignore
!sdk-runtime-generator~/pnpm-lock.yaml
```

이 lockfile 자체는 본 PR에서 커밋하지 않는다 — `Regenerate Lockfiles` 워크플로가 재생성·커밋하는 것이 의도된 동작이며, 본 PR은 그 `git add`를 가능하게만 한다.

🤖 read-only 멀티에이전트 분석으로 root-cause 규명 후 적대적 검증(refuted=false, high)으로 확인.