### PR TITLE
[auto-resolve] 수정: ExecuteDeploy의 node_modules/.bin 경로 누락 수정 (x2)

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -733,10 +733,14 @@ namespace AppsInToss
 
                 // pnpm exec ait deploy --api-key "KEY" 형태로 직접 실행
                 string command = $"\"{pnpmPath}\" exec ait deploy --api-key \"{deploymentKey}\"";
+                // BuildAdditionalPaths: node_modules/.bin (ait CLI) + npmDir + 내장 node bin
+                // deploy는 build와 달리 additionalPaths에 npmDir만 넣어 node_modules/.bin을 누락하면
+                // Windows에서 'ait' is not recognized 오류 발생 (techchat#4138, APPS-IN-TOSS-UNITY-SDK-12J)
+                var additionalPaths = AITNpmRunner.BuildAdditionalPaths(npmPath, buildPath);
                 var result = AITPlatformHelper.ExecuteCommand(
                     command,
                     buildPath,
-                    new[] { npmDir },
+                    additionalPaths.ToArray(),
                     timeoutMs: 300000,
                     verbose: true
                 );

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/DeployPathRegressionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/DeployPathRegressionTests.cs
@@ -1,0 +1,154 @@
+// -----------------------------------------------------------------------
+// DeployPathRegressionTests.cs - ExecuteDeploy 경로 누락 회귀 검증
+// Level 0: AppsInTossMenu.cs 소스를 정적으로 읽어 ExecuteDeploy가
+//          node_modules/.bin을 PATH에 포함하도록 BuildAdditionalPaths를
+//          사용하는지 확인한다. Unity/pnpm 실행 없이 동작.
+//
+// 회귀 대상:
+//   - techchat#4138: "유니티 AIT sdk Publish 배포실패 문제"
+//   - APPS-IN-TOSS-UNITY-SDK-12J: "[Windows] AIT SDK 2.9.0 — 배포(Deploy) 메뉴가
+//     'ait' is not recognized로 실패"
+//
+// 근본 원인:
+//   AppsInTossMenu.ExecuteDeploy()가 AITPlatformHelper.ExecuteCommand에
+//   additionalPaths로 new[] { npmDir }만 전달해 node_modules/.bin을 누락.
+//   AITNpmRunner.BuildAdditionalPaths는 node_modules/.bin을 최우선으로 추가하므로
+//   deploy 경로도 동일하게 BuildAdditionalPaths를 경유해야 한다.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using AppsInToss;
+
+[TestFixture]
+public class DeployPathRegressionTests
+{
+    /// <summary>
+    /// ExecuteDeploy 본문이 additionalPaths 구성에 BuildAdditionalPaths를 사용하는지 검증.
+    ///
+    /// 핵심 가드: `new[] { npmDir }` 같은 리터럴 배열로 npmDir만 전달하면 안 된다.
+    /// BuildAdditionalPaths(npmPath, buildPath)를 통해 node_modules/.bin을 포함시켜야 한다.
+    ///
+    /// Windows에서 pnpm exec ait deploy 실행 시 PATH에 node_modules/.bin이 없으면
+    /// 'ait' is not recognized as an internal or external command 오류가 발생한다.
+    /// </summary>
+    [Test]
+    public void ExecuteDeploy_Uses_BuildAdditionalPaths_InsteadOf_NpmDirOnly()
+    {
+        string sourcePath = LocateAppsInTossMenuSource();
+        Assert.IsNotNull(sourcePath,
+            "AppsInTossMenu.cs 소스 경로를 찾을 수 없음.");
+        Assert.IsTrue(File.Exists(sourcePath),
+            $"AppsInTossMenu.cs가 존재해야 함: {sourcePath}");
+
+        string source = File.ReadAllText(sourcePath);
+        string deployBody = ExtractMethodBody(source, "private static void ExecuteDeploy()");
+        Assert.IsNotNull(deployBody,
+            "AppsInTossMenu.ExecuteDeploy() 메서드를 소스에서 찾을 수 없음.");
+
+        // 핵심 회귀 가드 #1:
+        //   `new[] { npmDir }` 패턴이 deploy 본문에 있으면 node_modules/.bin이 누락된 상태.
+        //   techchat#4138 / APPS-IN-TOSS-UNITY-SDK-12J 재발 지점.
+        Assert.IsFalse(deployBody.Contains("new[] { npmDir }"),
+            "AppsInTossMenu.ExecuteDeploy()가 new[] { npmDir }를 additionalPaths로 전달하고 있음. " +
+            "node_modules/.bin이 PATH에서 누락되어 Windows에서 'ait' is not recognized 오류가 발생한다 " +
+            "(techchat#4138, APPS-IN-TOSS-UNITY-SDK-12J). " +
+            "AITNpmRunner.BuildAdditionalPaths(npmPath, buildPath)를 사용할 것.");
+
+        // 핵심 회귀 가드 #2:
+        //   BuildAdditionalPaths 호출이 실제로 deploy 본문에 있어야 한다.
+        Assert.IsTrue(deployBody.Contains("BuildAdditionalPaths("),
+            "AppsInTossMenu.ExecuteDeploy()가 AITNpmRunner.BuildAdditionalPaths()를 호출해야 함. " +
+            "deploy 명령도 build와 동일하게 node_modules/.bin을 PATH에 포함시켜야 한다.");
+    }
+
+    /// <summary>
+    /// BuildAdditionalPaths 호출이 workingDirectory(buildPath)를 인자로 전달하는지 확인.
+    /// workingDirectory 없이 호출하면 node_modules/.bin 검색 자체가 스킵된다.
+    /// </summary>
+    [Test]
+    public void ExecuteDeploy_PassesBuildPath_To_BuildAdditionalPaths()
+    {
+        string sourcePath = LocateAppsInTossMenuSource();
+        Assert.IsNotNull(sourcePath, "AppsInTossMenu.cs 소스 경로를 찾을 수 없음.");
+
+        string source = File.ReadAllText(sourcePath);
+        string deployBody = ExtractMethodBody(source, "private static void ExecuteDeploy()");
+        Assert.IsNotNull(deployBody, "AppsInTossMenu.ExecuteDeploy() 메서드를 소스에서 찾을 수 없음.");
+
+        // BuildAdditionalPaths(npmPath, buildPath) 형태로 buildPath가 두 번째 인자로 전달되어야 한다.
+        // buildPath가 빠지면 workingDirectory=null → node_modules/.bin 스킵 → Windows 오류 재발.
+        Assert.IsTrue(
+            deployBody.Contains("BuildAdditionalPaths(npmPath, buildPath)"),
+            "AppsInTossMenu.ExecuteDeploy()에서 BuildAdditionalPaths 호출 시 " +
+            "두 번째 인자로 buildPath를 전달해야 한다. " +
+            "buildPath 없이 호출하면 node_modules/.bin이 PATH에 추가되지 않는다.");
+    }
+
+    private static string LocateAppsInTossMenuSource()
+    {
+        // 1) AssetDatabase MonoScript 경로로 탐색
+        var guids = AssetDatabase.FindAssets("AppsInTossMenu t:MonoScript");
+        foreach (var guid in guids)
+        {
+            string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+            if (string.IsNullOrEmpty(assetPath)) continue;
+            if (Path.GetFileName(assetPath) == "AppsInTossMenu.cs" && File.Exists(assetPath))
+            {
+                var ms = AssetDatabase.LoadAssetAtPath<MonoScript>(assetPath);
+                if (ms != null && ms.GetClass() == typeof(AppsInTossMenu))
+                    return assetPath;
+            }
+        }
+
+        // 2) 알려진 후보 경로 순회
+        string[] candidates = new[]
+        {
+            "Editor/AppsInTossMenu.cs",
+            "Packages/im.toss.apps-in-toss-unity-sdk/Editor/AppsInTossMenu.cs",
+        };
+        foreach (var c in candidates)
+        {
+            if (File.Exists(c)) return c;
+        }
+
+        // 3) PackageCache 패턴
+        string packageCache = "Library/PackageCache";
+        if (Directory.Exists(packageCache))
+        {
+            var dirs = Directory.GetDirectories(packageCache, "im.toss.apps-in-toss-unity-sdk*");
+            foreach (var d in dirs)
+            {
+                string p = Path.Combine(d, "Editor", "AppsInTossMenu.cs");
+                if (File.Exists(p)) return p;
+            }
+        }
+
+        return null;
+    }
+
+    private static string ExtractMethodBody(string source, string signatureSubstring)
+    {
+        int sigIdx = source.IndexOf(signatureSubstring);
+        if (sigIdx < 0) return null;
+
+        int openIdx = source.IndexOf('{', sigIdx);
+        if (openIdx < 0) return null;
+
+        int depth = 0;
+        for (int i = openIdx; i < source.Length; i++)
+        {
+            char ch = source[i];
+            if (ch == '{') depth++;
+            else if (ch == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return source.Substring(openIdx + 1, i - openIdx - 1);
+            }
+        }
+        return null;
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/DeployPathRegressionTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/DeployPathRegressionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef4483ac341f49dea5ab0f926330afee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 묶음 항목

| # | 출처 | ID | 제목 |
|---|------|----|------|
| 1 | techchat | 4138 | 유니티 AIT sdk Publish 배포실패 문제 |
| 2 | sentry-feedback | APPS-IN-TOSS-UNITY-SDK-12J | [Windows] AIT SDK 2.9.0 — 배포(Deploy) 메뉴가 'ait' is not recognized로 실패 |

## 재현 절차

Windows 11 + AIT SDK 2.9.0 환경에서 Build 후 Deploy(또는 Publish) 메뉴 실행 → stderr에서 `'ait' is not recognized as an internal or external command` 확인.

## 근본 원인

`AppsInTossMenu.ExecuteDeploy()`가 `AITPlatformHelper.ExecuteCommand`에 `additionalPaths`로 `new[] { npmDir }`만 전달해 **`node_modules/.bin`을 PATH에서 누락**시켰다.

`pnpm exec ait deploy` 실행 시 `ait` CLI는 `node_modules/.bin/ait`에 위치하므로, Windows에서는 이 경로가 PATH에 없으면 `'ait' is not recognized` 오류가 발생한다.

반면 build 경로(`AITNpmRunner.RunNpmCommandWithCache`)는 `BuildAdditionalPaths(npmPath, workingDirectory)`를 통해 `node_modules/.bin`을 최우선으로 추가하고 있었다 — deploy만 이 처리가 빠져 있었다.

## 수정 내용

`Editor/AppsInTossMenu.cs` — `ExecuteDeploy()` 메서드에서 `new[] { npmDir }`를 `AITNpmRunner.BuildAdditionalPaths(npmPath, buildPath).ToArray()`로 교체.

## 회귀 테스트

`Tests~/E2E/SharedScripts/Editor/EditModeTests/MenuTests/DeployPathRegressionTests.cs` 추가:
- `ExecuteDeploy_Uses_BuildAdditionalPaths_InsteadOf_NpmDirOnly`: `new[] { npmDir }` 리터럴 배열 사용 금지 + `BuildAdditionalPaths` 호출 보장
- `ExecuteDeploy_PassesBuildPath_To_BuildAdditionalPaths`: `buildPath`가 두 번째 인자로 전달되는지 확인

## 검증

- `./run-local-tests.sh --validate`: SDK Generator Unit Tests 1건 실패(pre-existing; stale nexus 미러의 `@apps-in-toss/web-analytics@2.9.1` E404 — origin/main에서도 동일). 나머지 3/3 통과.