### PR TITLE
[auto-resolve] 테스트: SDK-11G getTossAppVersion undefined 회귀 가드 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITExceptionPlatformUnavailableTests.cs
@@ -13,6 +13,12 @@
 //         추가하여 JS 브리지 미초기화를 "플랫폼 미지원"과 동일하게 처리한다.
 //         AITSentryContextEnricher.CollectSafe에서 IsPlatformUnavailable == true이면
 //         Debug.Log (Info 레벨)로 기록하여 Sentry로 전송되지 않는다.
+//
+// APPS-IN-TOSS-UNITY-SDK-11G:
+//   동일 패턴 — GetTossAppVersion 호출 시 "Cannot read properties of undefined
+//   (reading 'getTossAppVersion')" 발생. CheckPlatformUnavailable의
+//   "Cannot read properties of undefined" 패턴이 이 케이스도 포괄하므로
+//   IsPlatformUnavailable == true가 보장됨을 명시적으로 회귀 가드한다.
 // -----------------------------------------------------------------------
 
 using AppsInToss;
@@ -33,6 +39,8 @@ public class AITExceptionPlatformUnavailableTests
         TestName = "getDeviceId — 동일 패턴")]
     [TestCase("Cannot read properties of undefined (reading 'getLocale')",
         TestName = "getLocale — 동일 패턴")]
+    [TestCase("Cannot read properties of undefined (reading 'getTossAppVersion')",
+        TestName = "getTossAppVersion — SDK-11G 재현 메시지")]
     [TestCase("Cannot read properties of undefined",
         TestName = "접두 메시지만 있는 경우")]
     public void IsPlatformUnavailable_JsBridgeUndefined_ReturnsTrue(string errorMessage)


### PR DESCRIPTION
**범위**: 원 이슈 `APPS-IN-TOSS-UNITY-SDK-11G`의 실제 증상(Runtime Sentry 노이즈)은 기존 PR #824/#826에서 이미 해결됨 — 참조만. 이 PR은 테스트 커버리지 갭 보완.

## 재현 분석

**보고된 증상**: `[AITSentry] GetTossAppVersion 호출 실패: Cannot read properties of undefined (reading 'getTossAppVersion')` 경고가 37건 Sentry에 유입.

**근본 경로**:
1. WebGL 빌드 → `AITSentryIntegration.Initialize()` → `AITSentryContextEnricher.EnrichAsync()`
2. `CollectSafe("GetTossAppVersion", ...)` → `AIT.GetTossAppVersion()` → jslib 호출
3. jslib: `window.AppsInToss.getTossAppVersion()` → `window.AppsInToss === undefined`
4. JS TypeError: `"Cannot read properties of undefined (reading 'getTossAppVersion')"`
5. `AITCore` error callback → `AITException("string", "Cannot read properties of undefined ...")`

**재현 가능 여부**: **재현 불가** — 이미 수정됨.
- PR #826: `AITCore.CheckPlatformUnavailable`에 `"Cannot read properties of undefined"` 패턴 추가 → `IsPlatformUnavailable = true`
- PR #824: `CollectSafe`의 `isUndefinedAccess` dual-check + 에디터 backstop 필터 (`IsKnownNonSdkMessageTests` 2311-2389행)

현재 코드에서 `getTossAppVersion` 경로는 `IsPlatformUnavailable == true`로 분류되어 `Debug.Log`(Info 레벨)로만 기록된다.

## 발견된 인접 갭: 테스트 커버리지

`AITExceptionPlatformUnavailableTests`가 `getPlatformOS`, `getDeviceId`, `getLocale`은 명시적으로 커버하지만 `getTossAppVersion`(SDK-11G의 정확한 API)은 누락.

## 변경 내용

`AITExceptionPlatformUnavailableTests.cs`에 `getTossAppVersion — SDK-11G 재현 메시지` TestCase 추가.

## 검증

`./run-local-tests.sh --validate`: E2E/Playwright/GUID ✓. SDK Generator ✗ (pre-existing stale npm 이슈).