### PR TITLE
[auto-resolve] 테스트: AITSentry EnvGetDeploymentId env undefined 회귀 케이스 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2308,7 +2308,7 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
-    #region AITSentryContextEnricher CollectSafe 수집 실패 노이즈 (APPS-IN-TOSS-UNITY-SDK-11G)
+    #region AITSentryContextEnricher CollectSafe 수집 실패 노이즈 (APPS-IN-TOSS-UNITY-SDK-11F / 11G)
 
     [Test]
     public void AITSentryCollectSafe_GetTossAppVersionFailure_ReturnsTrue()
@@ -2366,6 +2366,32 @@ public class IsKnownNonSdkMessageTests
         // [AITSentry] + 호출 실패: 합성으로 이 변형도 드롭함을 검증.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "UnityWarning: [AITSentry] GetOperationalEnvironment 호출 실패: Cannot read properties of undefined (reading 'getOperationalEnvironment')"));
+    }
+
+    [Test]
+    public void AITSentryCollectSafe_EnvGetDeploymentIdUndefinedAccess_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-11F — WebGL 빌드에서 window.AppsInToss가 초기화되기 전에
+        // AITSentryContextEnricher.CollectSafe가 EnvGetDeploymentId를 호출하면 jslib에서
+        // window.AppsInToss.env.getDeploymentId() 접근 시 "Cannot read properties of undefined
+        // (reading 'env')" JS TypeError가 발생한다.
+        // 11E(GetOperationalEnvironment)와 동일한 window.AppsInToss 미초기화 타이밍 조건이지만,
+        // EnvGetDeploymentId는 window.AppsInToss.env.getDeploymentId() — 중첩 속성 접근 구조라
+        // 에러 메시지의 reading 키가 'env'로 다르다.
+        // CollectSafe의 isUndefinedAccess 가드가 이 패턴도 "unavailable"로 폴백 처리하므로
+        // SDK 동작은 중단되지 않으며, 에디터 backstop 필터가 Sentry 전송을 차단한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AITSentry] EnvGetDeploymentId 호출 실패: Cannot read properties of undefined (reading 'env')"));
+    }
+
+    [Test]
+    public void AITSentryCollectSafe_EnvGetDeploymentIdUndefinedAccess_UnityWarningPrefix_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-11F 실측 메시지 — Unity가 Debug.LogWarning을 에디터 콘솔로
+        // 보낼 때 "UnityWarning: " prefix가 붙는 변형. 중간에 "Autoconnected Player" 원격 디버거
+        // prefix가 포함된 경우에도 "[AITSentry]" + "호출 실패:" 부분 문자열 합성 조건이 매칭된다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [AITSentry] EnvGetDeploymentId 호출 실패: Cannot read properties of undefined (reading 'env')"));
     }
 
     [Test]


### PR DESCRIPTION
**범위**: 원 이슈 `APPS-IN-TOSS-UNITY-SDK-11F`의 실제 Runtime 증상은 PR #824(11E 수정)가 이미 해결 — 참조만. 별도 조사 필요 없음(동일 근본 원인).

## 묶음 항목

| # | Sentry ID | 제목 |
|---|-----------|------|
| 1 | APPS-IN-TOSS-UNITY-SDK-11F | UnityWarning: [AITSentry] EnvGetDeploymentId 호출 실패: Cannot read properties of undefined (reading 'env') |

## 재현 분석

**증상**: WebGL 빌드에서 `window.AppsInToss`가 아직 초기화되지 않은 상태에서 `AITSentryContextEnricher.EnrichAsync()`가 실행될 때 `EnvGetDeploymentId` jslib이 `window.AppsInToss.env.getDeploymentId()`를 호출하면 JS TypeError가 발생.

**11E(`GetOperationalEnvironment`)와의 차이점**:
- GetOperationalEnvironment: `window.AppsInToss.getOperationalEnvironment()` — 단일 속성 접근 → error: `"Cannot read properties of undefined (reading 'getOperationalEnvironment')"`
- EnvGetDeploymentId (11F): `window.AppsInToss.env.getDeploymentId()` — **중첩 속성 접근** → error: `"Cannot read properties of undefined (reading 'env')"`

**근본 원인**: 동일 (`window.AppsInToss` 미초기화). PR #824가 `CollectSafe`의 `isUndefinedAccess` 가드를 추가해 이미 해결됨. 11F Sentry 이벤트는 해당 Fix 배포 이전에 캡처된 것.

**에디터 backstop**: `AITEditorErrorTracker.IsKnownNonSdkMessage`의 `"[AITSentry]" + "호출 실패:"` 합성 필터가 이미 11F 메시지도 드롭하나, `reading 'env'` 변형에 대한 명시적 회귀 테스트가 없었음.

## 수정 내용

`IsKnownNonSdkMessageTests.cs`에 11F 특화 회귀 테스트 2건 추가:
- `AITSentryCollectSafe_EnvGetDeploymentIdUndefinedAccess_ReturnsTrue` — 기본 메시지 변형
- `AITSentryCollectSafe_EnvGetDeploymentIdUndefinedAccess_UnityWarningPrefix_ReturnsTrue` — `UnityWarning:` prefix 변형

## 검증

`./run-local-tests.sh --validate` — E2E 구조/Playwright/Meta GUID 검사 통과. SDK Generator 스텝은 사내 Nexus 미러 스테일 이슈로 실패하나 본 변경과 무관함.