### PR TITLE
문서: ait-patch-cli runtimeVersion=0.84.0 deploy 수락 확인 반영

### DIFF
--- a/WebGLTemplates/AITTemplate/BuildConfig~/ait-patch-cli.mjs
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/ait-patch-cli.mjs
@@ -19,9 +19,12 @@
 // runtimeVersion 값:
 //   "0.84.0" — @apps-in-toss/cli@2.6.1의 RUNTIME_BUILD_DEFINITIONS[0].runtimeVersion.
 //   2.6.1 경로(WEB 플랫폼 포함)가 서버에 실제로 기록·수락시키는 React Native 런타임
-//   버전이다. 3.x WEB 서버가 동일 값을 수락하는지는 실제 ait deploy로 최종 확인해야
-//   하며, 거부 시 deployment 응답에서 서버가 기대하는 값을 확인해 이 상수만 갱신하면
-//   된다(beta-release.yml의 deployment GET 진단 참조).
+//   버전이다. 3.x WEB deploy 서버가 이 값을 수락함을 실제 ait deploy로 확인 완료했다
+//   (2026-06-20 베타 probe: beta-release.yml deploy_probe_only 디스패치 → 3.x ait
+//   build가 이 패치로 0.84.0을 주입한 .ait를 ait deploy가 정상 배포 생성, deploymentId
+//   019ee488-… 발급). 향후 upstream이 기대 런타임 버전을 바꿔 거부가 재발하면, deployment
+//   응답에서 서버가 기대하는 값을 확인해 이 상수만 갱신하면 된다(beta-release.yml의
+//   deployment GET 진단 참조).
 //
 // 안전 규칙 — 어떤 상황에서도 빌드를 막지 않는다(항상 정상 종료):
 //   (a) 멱등        : setMetadata에 이미 runtimeVersion이 있으면 no-op.


### PR DESCRIPTION
## 요약
3.x `ait build`가 emit하지 않는 `.ait` `runtimeVersion`을 빌드시점 cli.js 패치로 주입하는 값 **`0.84.0`이 3.x WEB deploy 서버에 실제로 수락됨**을 베타 probe로 확인했다. 이를 `ait-patch-cli.mjs` 주석에 반영(잠정 → 확인 완료). **코드/상수 변경 없음(주석만)**.

## 검증 근거 (베타 probe)
- `beta-release.yml` `deploy_probe_only=true` 디스패치 — run `27825302799` attempt#4
- macOS 2021.3 빌드 → E2E → `베타 ait deploy 검증 (게시 게이트)` 스텝 **success**
- 스텝 로그: `ait deploy`가 콘솔에 정상 배포 생성, `intoss-private://unity-sdk-sample?_deploymentId=019ee488-…` 반환
- 예전에 "ait 파일에 runtimeVersion이 없습니다"로 막던 deploy 게이트를 0.84.0 주입으로 통과 → PR #822 가설 end-to-end 입증
- `publish=skipped` (probe-only 의도대로, 베타 채널 무손상)

## 변경
- `WebGLTemplates/AITTemplate/BuildConfig~/ait-patch-cli.mjs`: `runtimeVersion 값` 주석 블록을 "실제 ait deploy로 최종 확인 필요" → "확인 완료(2026-06-20, deploymentId 019ee488-…)"로 갱신. upstream이 기대 런타임 버전을 바꿔 거부가 재발할 경우의 재검증 경로(deployment GET 진단)는 그대로 유지.

## 검증
- `./run-local-tests.sh --validate` ✓
- `ait-patch-cli.test.ts` 11 tests ✓ (RUNTIME_VERSION 상수/주입 로직 불변)
- ESM import 정상 (`RUNTIME_VERSION=0.84.0`, `injectRuntimeVersion=function`)
