### PR TITLE
문서: CLAUDE.md 라이선스 플레이크 노트 정정 — 라벨 핀 러너 라이선스 결함은 transient 아님

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,9 @@
   ```bash
   gh api repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs -X POST
   ```
-- **알려진 flaky 패턴** (모두 인프라 기인, 코드 변경 없이 재실행으로 해결):
-  - **Unity 라이선스 충돌** — `Code 10 while verifying Licensing Client signature` / handshake / IPC 에러. self-hosted runner는 현재 `unity-<version>` 라벨로 1:1 핀 고정되어 차단 중. 재발 시 라벨이 빠진 머신이 있는지 확인 (`docs/claude/github-actions.md`)
+- **알려진 flaky 패턴** (대부분 인프라 기인, 코드 변경 없이 재실행으로 해결 — Unity 라이선스 결함은 예외, 아래 참조):
+  - **Unity 라이선스 충돌** — `Code 8 (또는 Code 10) while verifying Licensing Client signature` / `No ULF license found` / `Token not found in cache` / handshake / IPC 에러 (exit code 42). self-hosted runner는 현재 `unity-<version>` 라벨로 1:1 핀 고정되어 차단 중. 재발 시 라벨이 빠진 머신이 있는지 확인 (`docs/claude/github-actions.md`).
+    - ⚠️ **단, 라벨 핀된 단일 러너(예: `macos-1-1`=2021.3)의 라이선스가 실제로 깨진 경우는 transient가 아니다** — `rerun-failed-jobs`를 반복해도 인프라/사람이 라이선스를 고치기 전까지 매번 동일 시그니처로 실패한다. (2026-06 베타 deploy probe에서 attempt #1~#3이 모두 macos-1-1의 동일 라이선스 시그니처로 실패했고, **시간 경과가 아니라 수동 라이선스 수복 후에야** attempt #4가 통과했다 — 자연 복구 아님.) 동일 라이선스 시그니처가 **2회 연속**이면 transient로 보지 말고 러너 라이선스 수복 필요로 **에스컬레이션**(반복 rerun으로 시간 낭비 금지).
   - **Windows artifact upload finalize transient** — `actions/upload-artifact@v7`가 `successfully finalized` 메시지 없이 종료 (~1.3% 빈도). 진단 step + `continue-on-error`가 적용되어 있고 재실행으로 해결됨
   - **Unity WebGL Brotli/Gzip 크래시** — `[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`. self-hosted runner 동시 빌드 시 리소스 경합. **현재 E2E CI는 압축 비활성화(`AIT_COMPRESSION_FORMAT="0"`)** 로 압축 단계 자체를 건너뛰므로 신규 발생 없음 (E2E는 vite preview에서만 로드되며 배포되지 않아 압축 불필요). 로컬 재현은 아래 "로컬 CI 재현" 가이드 참조
 - **Sentry 노이즈 패턴 추가**는 자동화(`auto-resolve`)가 처리하므로 수동 PR 불필요 — `Editor/ErrorTracker/AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 자동 흡수됨


### PR DESCRIPTION
## 요약
self-hosted Unity 라이선스 플레이크에 대한 CLAUDE.md 노트를 **사실 정정**한다. 기존 노트는 라이선스 충돌을 "코드 변경 없이 재실행으로 해결"되는 transient로 일반화했으나, **라벨 핀된 단일 러너(`macos-1-1`=2021.3)의 라이선스가 실제로 깨진 경우는 transient가 아니다** — `rerun-failed-jobs`를 반복해도 인프라/사람이 라이선스를 수복하기 전까지 매번 동일 시그니처로 실패한다.

## 근거 (2026-06 베타 deploy probe)
- `beta-release.yml` `deploy_probe_only` 디스패치에서 attempt #1~#3이 **모두 macos-1-1의 동일 라이선스 시그니처**(`No ULF license found` / `Token not found in cache` / `Code 8 while verifying Licensing Client signature`, exit 42)로 실패.
- attempt #4는 **시간 경과로 자연 복구된 것이 아니라 수동 라이선스 수복 직후** 통과 — 즉 rerun 반복은 무의미했고 사람의 개입이 필요했다.

## 변경 (`CLAUDE.md` 문서만, 코드 영향 없음)
- "알려진 flaky 패턴" 헤더의 "모두 … 재실행으로 해결" → "대부분 … 재실행으로 해결 — Unity 라이선스 결함은 예외".
- Unity 라이선스 충돌 bullet에 실제 시그니처(`No ULF license found` / `Token not found in cache` / Code 8/10, exit 42) 보강.
- ⚠️ 서브노트 추가: 라벨 핀 단일 러너의 라이선스 결함은 transient 아님 → 동일 시그니처 **2회 연속**이면 transient로 보지 말고 러너 라이선스 수복 필요로 **에스컬레이션**(반복 rerun 시간 낭비 금지).

## 검증
- 문서 전용 변경(`*.md`) — 빌드/테스트/SDK 생성에 영향 없음.