### PR TITLE
리팩토링: AITConvertCore 빌드 취소 static 필드 volatile 적용

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -30,9 +30,11 @@ namespace AppsInToss
     {
         #region Build Cancellation
 
-        private static bool isCancelled = false;
-        private static Editor.AITAsyncCommandRunner.CommandTask currentAsyncTask = null;
-        private static Editor.AITPackageBuilder.EarlyPackageContext currentEarlyContext = null;
+        // volatile: 백그라운드 빌드 스레드와 메인 스레드(취소 요청) 간 가시성 보장.
+        // 취소 플래그/핸들 참조의 stale 캐시 읽기를 막는다.
+        private static volatile bool isCancelled = false;
+        private static volatile Editor.AITAsyncCommandRunner.CommandTask currentAsyncTask = null;
+        private static volatile Editor.AITPackageBuilder.EarlyPackageContext currentEarlyContext = null;
 
         static AITConvertCore() { }
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,6 @@
 - **P2 — `Thread.Sleep` 블로킹**: 백그라운드 ThreadPool 폴링 루프 2곳을 `await Task.Delay`로 전환 — `AITAsyncCommandRunner.cs`(프로세스 종료 폴링), `Editor/Package/PnpmRunner.cs`(pnpm install 폴링). 두 루프 모두 내부에서 메인 스레드 API를 쓰지 않아 대기 중 풀 스레드 반납이 안전. 나머지는 동기 유지가 불가피(전환 시 데드락/계약 위반):
   - 같은 루프에서 메인 스레드 진행률 UI 호출: `AITNodeJSDownloader.cs:143`, `AITNpmRunner.cs:307`, `AITPackageInitializer.cs:337` (`EditorUtility.DisplayProgressBar`).
   - 동기 종료 계약: `AITProcessTreeManager.cs:283`(`IDisposable.Dispose`의 SIGTERM→SIGKILL 유예), `AITSentryTransport.cs:268`(`EditorApplication.quitting` 동기 핸들러의 마지막 flush).
-- **P2 — 동기화 없는 static 필드**: `AITConvertCore.cs:33-34`의 `isCancelled`/`currentAsyncTask` → `Interlocked`/`volatile`로 스레드 안전성 보장. (AppsInTossMenu 서버 상태는 `AITServerStateManager`로 이전 완료)
 
 ## Sentry / 빌드 진단
 


### PR DESCRIPTION
## 요약

빌드 취소용 `AITConvertCore`의 static 필드 3개에 `volatile`을 적용해 스레드 간 가시성을 보장한다. (TODO.md 백로그 "동기화 없는 static 필드" 항목)

빌드는 백그라운드 스레드에서 진행되고 `CancelBuild()`는 UI(메인) 스레드에서 호출될 수 있어, 다음 static 필드가 동기화 없이 교차 접근됐다:

- `isCancelled` (bool)
- `currentAsyncTask` (CommandTask 참조)
- `currentEarlyContext` (EarlyPackageContext 참조 — TODO에는 미명시지만 동일 패턴이라 함께 처리)

`volatile`로 한 스레드의 쓰기가 다른 스레드의 읽기에 즉시 가시화되도록 보장해, stale 캐시 값으로 인한 취소 누락을 방지한다. 세 필드 모두 `ref`/`out`/`Interlocked` 전달 경로가 없어 CS0420 경고는 발생하지 않는다.

## 검증

CI 워크플로(lint/validate/string-check)는 Editor C#을 컴파일하지 않으므로, 로컬 Unity 2022.3 EditMode로 컴파일·테스트를 검증했다:

- ✅ 컴파일 성공 — C# 컴파일 에러 0건, EditMode **852개 통과**.
- ℹ️ 실패 1건(`BuildOutputValidatorTests.ValidateAll_MissingFrameworkJs_ReturnsError`)은 **clean main에서도 동일하게 실패**하는 기존 환경 결함(temp 디렉터리 경로 `DirectoryNotFoundException`)으로, 본 변경과 무관함을 대조 실행으로 확인.
- ℹ️ inconclusive 1건은 Windows 전용 테스트의 macOS 게이팅(예상된 동작).

## 변경 파일

- `Editor/AITConvertCore.cs` — 필드 3개에 `volatile` 추가 + 설명 주석.
- `TODO.md` — 완료된 백로그 항목 제거.
