### PR TITLE
테스트: AITPlatformHelper/AITPackageManagerHelper 특성화 유닛 테스트 추가

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,10 +22,6 @@
 
 - **P2 — `sdk-runtime-generator~/pnpm-lock.yaml` gitignored** (`.gitignore:181`): package.json은 핵심 의존성을 pin하지만 transitive dependency는 drift 가능. 재현성 목표라면 lockfile 커밋 여부 결정.
 
-## 테스트 커버리지
-
-- **P2 — 미테스트 핵심 클래스**: `AITPackageManagerHelper`, `AITPlatformHelper` 유닛 테스트 부재. (EditMode 테스트는 62→823 메서드 / 7→45 파일로 대폭 보강됨)
-
 ## 보안
 
 - **P3 — Sentry DSN 하드코딩** (`Editor/ErrorTracker/AITEditorErrorTracker.cs:21`): public key라 위험은 낮음. 환경변수/설정 주입 방식 검토.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPackageManagerHelperTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPackageManagerHelperTests.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// AITPackageManagerHelperTests.cs - 패키지 매니저 헬퍼 결정적 로직 검증
+// Level 0: PNPM 버전 핀 / Node.js 경로 설명 / ait-build 경로 등 프로세스를
+//          띄우지 않는 순수·결정적 메서드의 특성화 테스트.
+// (FindPackageManager/RunPackageCommand 등은 실제 프로세스·FS 작업이라
+//  단위 테스트 대상에서 제외 — E2E 빌드 경로에서 커버된다.)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System.IO;
+using System.Text.RegularExpressions;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITPackageManagerHelperTests
+{
+    // =====================================================
+    // PNPM_VERSION — 고정 핀
+    // =====================================================
+
+    [Test]
+    public void PnpmVersion_IsNonEmptySemver()
+    {
+        // 주의: 이 상수는 package.json 3종 + Editor 핀과 항상 동기화돼야 한다
+        // (CLAUDE.md "pnpm 버전 핀 동기화" 참조). 값 변경 시 4곳을 함께 bump할 것.
+        string v = AITPackageManagerHelper.PNPM_VERSION;
+        Assert.IsFalse(string.IsNullOrEmpty(v), "PNPM_VERSION은 비어있으면 안 된다");
+        Assert.IsTrue(Regex.IsMatch(v, @"^\d+\.\d+\.\d+$"),
+            $"PNPM_VERSION은 X.Y.Z 형식이어야 한다 (실제: '{v}')");
+    }
+
+    // =====================================================
+    // GetNodejsPathDescription — 플랫폼 의존
+    // =====================================================
+
+    [Test]
+    public void GetNodejsPathDescription_RespectsPlatform()
+    {
+        string desc = AITPackageManagerHelper.GetNodejsPathDescription();
+        Assert.IsFalse(string.IsNullOrEmpty(desc));
+        // 플랫폼 무관하게 SDK 전용 nodejs 경로를 가리켜야 한다.
+        StringAssert.Contains("ait-unity-sdk", desc);
+        StringAssert.Contains("nodejs", desc);
+
+        if (AITPlatformHelper.IsWindows)
+        {
+            StringAssert.Contains("%LOCALAPPDATA%", desc);
+        }
+        else
+        {
+            Assert.AreEqual("~/.ait-unity-sdk/nodejs/", desc);
+        }
+    }
+
+    // =====================================================
+    // GetBuildPath — ait-build 절대 경로
+    // =====================================================
+
+    [Test]
+    public void GetBuildPath_EndsWithAitBuildAndIsRooted()
+    {
+        string buildPath = AITPackageManagerHelper.GetBuildPath();
+        Assert.IsFalse(string.IsNullOrEmpty(buildPath));
+        Assert.IsTrue(Path.IsPathRooted(buildPath), "빌드 경로는 절대 경로여야 한다");
+        Assert.AreEqual("ait-build", Path.GetFileName(buildPath),
+            "빌드 경로의 마지막 세그먼트는 'ait-build'여야 한다");
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPackageManagerHelperTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPackageManagerHelperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94543746410da4b648f099ab5187d4af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPlatformHelperTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPlatformHelperTests.cs
@@ -1,0 +1,202 @@
+// -----------------------------------------------------------------------
+// AITPlatformHelperTests.cs - 크로스 플랫폼 헬퍼 순수 로직 검증
+// Level 0: ANSI 스트리핑 / 실행파일 이름 / PATH 구성 / Bash 이스케이프 등
+//          프로세스를 띄우지 않는 결정적 메서드의 특성화 테스트.
+// 플랫폼 의존 동작은 AITPlatformHelper.IsWindows로 분기해 macOS/Windows
+// CI 양쪽에서 통과하도록 작성한다.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using System.IO;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITPlatformHelperTests
+{
+    // =====================================================
+    // StripAnsiCodes — 순수(플랫폼 무관)
+    // =====================================================
+
+    [Test]
+    public void StripAnsiCodes_Null_ReturnsNull()
+    {
+        Assert.IsNull(AITPlatformHelper.StripAnsiCodes(null));
+    }
+
+    [Test]
+    public void StripAnsiCodes_Empty_ReturnsEmpty()
+    {
+        Assert.AreEqual("", AITPlatformHelper.StripAnsiCodes(""));
+    }
+
+    [Test]
+    public void StripAnsiCodes_PlainTextWithoutBrackets_Unchanged()
+    {
+        // 대괄호가 없는 평문은 그대로 유지된다.
+        const string plain = "plain build output 123 ok";
+        Assert.AreEqual(plain, AITPlatformHelper.StripAnsiCodes(plain));
+    }
+
+    [Test]
+    public void StripAnsiCodes_StandardColorSequence_Removed()
+    {
+        // ESC[31m ... ESC[0m (빨간색) → 텍스트만 남는다.
+        Assert.AreEqual("red", AITPlatformHelper.StripAnsiCodes("\u001b[31mred\u001b[0m"));
+    }
+
+    [Test]
+    public void StripAnsiCodes_MultiParamSequence_Removed()
+    {
+        // ESC[1;32m (굵게+초록) 같은 복합 파라미터 시퀀스도 제거.
+        Assert.AreEqual("green", AITPlatformHelper.StripAnsiCodes("\u001b[1;32mgreen\u001b[39m"));
+    }
+
+    [Test]
+    public void StripAnsiCodes_OscSequence_Removed()
+    {
+        // OSC 시퀀스: ESC]0;title BEL → 제거되고 본문만 남는다.
+        Assert.AreEqual("hello", AITPlatformHelper.StripAnsiCodes("\u001b]0;my-title\u0007hello"));
+    }
+
+    [Test]
+    public void StripAnsiCodes_BareBracketSequenceWithoutEsc_AlsoRemoved()
+    {
+        // 일부 터미널은 ESC 없이 "[..m"만 emit한다 — 정규식 셋째 대안이 이를 흡수한다.
+        // 의도된 공격적 스트리핑임을 특성화로 못 박는다.
+        Assert.AreEqual("textmore", AITPlatformHelper.StripAnsiCodes("text[0mmore"));
+    }
+
+    // =====================================================
+    // GetExecutableName — 플랫폼 의존
+    // =====================================================
+
+    [Test]
+    public void GetExecutableName_RespectsPlatformExtension()
+    {
+        if (AITPlatformHelper.IsWindows)
+        {
+            // npm/pnpm/npx는 .cmd, 그 외는 .exe
+            Assert.AreEqual("node.exe", AITPlatformHelper.GetExecutableName("node"));
+            Assert.AreEqual("npm.cmd", AITPlatformHelper.GetExecutableName("npm"));
+            Assert.AreEqual("pnpm.cmd", AITPlatformHelper.GetExecutableName("pnpm"));
+            Assert.AreEqual("npx.cmd", AITPlatformHelper.GetExecutableName("npx"));
+        }
+        else
+        {
+            // Unix 계열은 확장자 없이 이름 그대로.
+            Assert.AreEqual("node", AITPlatformHelper.GetExecutableName("node"));
+            Assert.AreEqual("npm", AITPlatformHelper.GetExecutableName("npm"));
+            Assert.AreEqual("pnpm", AITPlatformHelper.GetExecutableName("pnpm"));
+        }
+    }
+
+    // =====================================================
+    // 플랫폼 상수 일관성
+    // =====================================================
+
+    [Test]
+    public void PlatformConstants_MatchCurrentPlatform()
+    {
+        if (AITPlatformHelper.IsWindows)
+        {
+            Assert.AreEqual(".exe", AITPlatformHelper.ExecutableExtension);
+            Assert.AreEqual(".cmd", AITPlatformHelper.ScriptExtension);
+            Assert.AreEqual(';', AITPlatformHelper.PathSeparator);
+        }
+        else
+        {
+            Assert.AreEqual("", AITPlatformHelper.ExecutableExtension);
+            Assert.AreEqual("", AITPlatformHelper.ScriptExtension);
+            Assert.AreEqual(':', AITPlatformHelper.PathSeparator);
+        }
+    }
+
+    [Test]
+    public void IsUnix_IsConsistentWithMacOsOrLinux()
+    {
+        Assert.AreEqual(AITPlatformHelper.IsMacOS || AITPlatformHelper.IsLinux, AITPlatformHelper.IsUnix);
+    }
+
+    // =====================================================
+    // BuildPathEnv — 존재하는 경로만 통과 + 기본 경로 추가
+    // =====================================================
+
+    [Test]
+    public void BuildPathEnv_IncludesExistingDirectory()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "ait-test-pathenv-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            string result = AITPlatformHelper.BuildPathEnv(tempDir);
+            StringAssert.Contains(tempDir, result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Test]
+    public void BuildPathEnv_ExcludesNonexistentDirectory()
+    {
+        string bogus = Path.Combine(Path.GetTempPath(), "ait-does-not-exist-" + Guid.NewGuid().ToString("N"));
+        string result = AITPlatformHelper.BuildPathEnv(bogus);
+        Assert.IsFalse(result.Contains(bogus), "존재하지 않는 경로는 PATH에서 제외돼야 한다");
+    }
+
+    [Test]
+    public void BuildPathEnv_UsesPlatformSeparatorAndDefaults()
+    {
+        // 인자가 없어도 플랫폼 기본 경로가 추가돼 비어있지 않으며, 여러 경로가
+        // 플랫폼 구분자로 연결된다.
+        string result = AITPlatformHelper.BuildPathEnv();
+        Assert.IsFalse(string.IsNullOrEmpty(result));
+        StringAssert.Contains(AITPlatformHelper.PathSeparator.ToString(), result);
+        if (!AITPlatformHelper.IsWindows)
+        {
+            StringAssert.Contains("/usr/bin", result);
+        }
+    }
+
+    // =====================================================
+    // EscapeForBashDoubleQuotes — internal (InternalsVisibleTo로 접근)
+    // =====================================================
+
+    [Test]
+    public void EscapeForBashDoubleQuotes_NullOrEmpty_Unchanged()
+    {
+        Assert.IsNull(AITPlatformHelper.EscapeForBashDoubleQuotes(null));
+        Assert.AreEqual("", AITPlatformHelper.EscapeForBashDoubleQuotes(""));
+    }
+
+    [Test]
+    public void EscapeForBashDoubleQuotes_PlainText_Unchanged()
+    {
+        Assert.AreEqual("simple-text", AITPlatformHelper.EscapeForBashDoubleQuotes("simple-text"));
+    }
+
+    [Test]
+    public void EscapeForBashDoubleQuotes_EscapesSpecialChars()
+    {
+        // 백슬래시 → 두 개
+        Assert.AreEqual("a\\\\b", AITPlatformHelper.EscapeForBashDoubleQuotes("a\\b"));
+        // 큰따옴표 → \"
+        Assert.AreEqual("a\\\"b", AITPlatformHelper.EscapeForBashDoubleQuotes("a\"b"));
+        // 달러 → \$
+        Assert.AreEqual("a\\$b", AITPlatformHelper.EscapeForBashDoubleQuotes("a$b"));
+        // 백틱 → \`
+        Assert.AreEqual("a\\`b", AITPlatformHelper.EscapeForBashDoubleQuotes("a`b"));
+    }
+
+    [Test]
+    public void EscapeForBashDoubleQuotes_BackslashEscapedFirst()
+    {
+        // 백슬래시가 먼저 이스케이프되므로, 입력의 백슬래시는 더블되고
+        // 따옴표가 추가하는 백슬래시와 섞이지 않는다.
+        // 입력: \"  (백슬래시 + 큰따옴표)
+        // 기대: \\\"  (더블된 백슬래시 + 이스케이프된 따옴표)
+        Assert.AreEqual("\\\\\\\"", AITPlatformHelper.EscapeForBashDoubleQuotes("\\\""));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPlatformHelperTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITPlatformHelperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bafda3ea889664b28adf7d6fb6c9500a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 개요

TODO.md "테스트 커버리지" 백로그 항목 완료. 프로세스를 띄우지 않는 **결정적·순수 메서드**에 대한 Level 0 특성화(characterization) 유닛 테스트 20종을 추가한다.

`AITPlatformHelper`/`AITPackageManagerHelper`는 빌드 파이프라인 전반에서 쓰이는 핵심 헬퍼지만 직접 유닛 테스트가 없었다. 이 PR은 향후 리팩토링(특히 `ProcessExecutor` 추출 백로그)이 동작을 깨지 않도록 현재 동작을 못 박는다.

## 변경 내용

**`AITPlatformHelperTests.cs` (17종)**
- `StripAnsiCodes`: null/empty/평문/ESC 색상/복합 파라미터/OSC/bare-bracket(ESC 없는 공격적 스트리핑까지 특성화)
- `GetExecutableName`: 플랫폼별 확장자(npm/pnpm/npx→`.cmd`, 그 외 `.exe` on Win; Unix는 이름 그대로)
- 플랫폼 상수(`ExecutableExtension`/`ScriptExtension`/`PathSeparator`) 및 `IsUnix` 일관성
- `BuildPathEnv`: 존재하는 경로만 통과 / 비존재 경로 제외 / 구분자+기본 경로 추가
- `EscapeForBashDoubleQuotes`: null·평문 보존 / `\ " $ \`` 이스케이프 / 백슬래시 우선 이스케이프

**`AITPackageManagerHelperTests.cs` (3종)**
- `PNPM_VERSION`: 비어있지 않은 `X.Y.Z` 형식(4-file 동기화 규칙 주석으로 명시)
- `GetNodejsPathDescription`: SDK 전용 nodejs 경로 지시(Windows `%LOCALAPPDATA%` 분기)
- `GetBuildPath`: 절대 경로 + 마지막 세그먼트 `ait-build`

## 검증

로컬 Unity EditMode batchmode 실행 — **20/20 통과**. 플랫폼 의존 동작은 `IsWindows`로 분기해 macOS/Windows CI 양쪽에서 통과하도록 작성.

> 참고: PR-triggered CI는 Editor C#을 컴파일하지 않으므로(lint/validate/string-check만), 이 테스트는 로컬 Unity EditMode로 검증했다.
