### PR TITLE
리팩토링: 백그라운드 폴링 2곳 Thread.Sleep → await Task.Delay

### DIFF
--- a/Editor/AITAsyncCommandRunner.cs
+++ b/Editor/AITAsyncCommandRunner.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
@@ -87,8 +88,10 @@ namespace AppsInToss.Editor
                 OnOutputReceived = onOutputReceived
             };
 
-            // 백그라운드 스레드에서 명령 실행
-            ThreadPool.QueueUserWorkItem(_ => ExecuteCommandAsync(task, command, workingDirectory, additionalPaths, timeoutMs, additionalEnvVars));
+            // 백그라운드에서 명령 실행. Task.Run으로 ThreadPool에 올리되, 폴링 대기 중에는
+            // await Task.Delay가 스레드를 반납하므로 풀 스레드를 점유하지 않는다(ExecuteCommandAsync 내부 try/catch가
+            // 모든 예외를 흡수해 반환 Task는 fault 되지 않으므로 관찰 불필요).
+            _ = Task.Run(() => ExecuteCommandAsync(task, command, workingDirectory, additionalPaths, timeoutMs, additionalEnvVars));
 
             return task;
         }
@@ -121,9 +124,9 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// 백그라운드 스레드에서 명령 실행
+        /// 백그라운드에서 명령 실행 (await Task.Delay로 폴링 — 대기 중 풀 스레드 반납)
         /// </summary>
-        private static void ExecuteCommandAsync(
+        private static async Task ExecuteCommandAsync(
             CommandTask task,
             string command,
             string workingDirectory,
@@ -295,7 +298,8 @@ namespace AppsInToss.Editor
                             return;
                         }
 
-                        Thread.Sleep(100);
+                        // 취소는 루프 상단에서 매 100ms 감지하므로 토큰 없이 대기(취소 지연 동일·예외 경로 불변).
+                        await Task.Delay(100).ConfigureAwait(false);
                     }
 
                     process.WaitForExit(); // 출력 버퍼 플러시 대기

--- a/Editor/Package/PnpmRunner.cs
+++ b/Editor/Package/PnpmRunner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using AppsInToss.Editor.ErrorTracker;
 using UnityEngine;
 
@@ -32,11 +33,13 @@ namespace AppsInToss.Editor.Package
         {
             Debug.Log("[AIT] [병렬] pnpm install을 백그라운드에서 시작합니다...");
 
-            ThreadPool.QueueUserWorkItem(_ =>
+            // Task.Run으로 백그라운드 실행. 폴링 대기(await Task.Delay) 중에는 풀 스레드를 반납한다.
+            // 람다 내부 try/catch가 모든 예외를 흡수하므로 반환 Task는 fault 되지 않아 관찰 불필요.
+            _ = Task.Run(async () =>
             {
                 try
                 {
-                    var result = RunPnpmInstallInThread(earlyCtx);
+                    var result = await RunPnpmInstallInThread(earlyCtx).ConfigureAwait(false);
 
                     if (result == AITConvertCore.AITExportError.SUCCEED)
                         Debug.Log("[AIT] [병렬] ✓ 백그라운드 pnpm install 완료");
@@ -61,7 +64,7 @@ namespace AppsInToss.Editor.Package
         /// 메인 스레드 전용 API(EditorUtility 등)를 사용하지 않으며,
         /// Process.HasExited 폴링 + CancellationToken으로 취소를 지원합니다.
         /// </summary>
-        private static AITConvertCore.AITExportError RunPnpmInstallInThread(AITPackageBuilder.EarlyPackageContext earlyCtx)
+        private static async Task<AITConvertCore.AITExportError> RunPnpmInstallInThread(AITPackageBuilder.EarlyPackageContext earlyCtx)
         {
             var ct = earlyCtx.PnpmCancellationToken;
             var additionalPaths = AITNpmRunner.BuildAdditionalPaths(earlyCtx.PnpmPath);
@@ -145,7 +148,8 @@ namespace AppsInToss.Editor.Package
                                         break; // 다음 단계로
                                     }
 
-                                    Thread.Sleep(200);
+                                    // 취소·타임아웃은 루프 상단에서 매 200ms 감지(대기 중 풀 스레드 반납).
+                                    await Task.Delay(200).ConfigureAwait(false);
                                 }
 
                                 // 타임아웃으로 Kill한 경우 process.HasExited가 true가 되어 아래 exit-code 경로로

--- a/TODO.md
+++ b/TODO.md
@@ -9,9 +9,9 @@
 
 ## 비동기 / 스레드 안전성
 
-- **P2 — `Thread.Sleep` 블로킹**: 가능한 곳부터 `Task.Delay`/async 전환.
-  - `AITNodeJSDownloader.cs:143` (최대 3초) — 우선 검토
-  - `AITProcessTreeManager.cs:283`, `AITNpmRunner.cs:307`, `AITAsyncCommandRunner.cs:298`, `AITSentryTransport.cs:268`, `AITPackageInitializer.cs:337`, `Editor/Package/PnpmRunner.cs:148`
+- **P2 — `Thread.Sleep` 블로킹**: 백그라운드 ThreadPool 폴링 루프 2곳을 `await Task.Delay`로 전환 — `AITAsyncCommandRunner.cs`(프로세스 종료 폴링), `Editor/Package/PnpmRunner.cs`(pnpm install 폴링). 두 루프 모두 내부에서 메인 스레드 API를 쓰지 않아 대기 중 풀 스레드 반납이 안전. 나머지는 동기 유지가 불가피(전환 시 데드락/계약 위반):
+  - 같은 루프에서 메인 스레드 진행률 UI 호출: `AITNodeJSDownloader.cs:143`, `AITNpmRunner.cs:307`, `AITPackageInitializer.cs:337` (`EditorUtility.DisplayProgressBar`).
+  - 동기 종료 계약: `AITProcessTreeManager.cs:283`(`IDisposable.Dispose`의 SIGTERM→SIGKILL 유예), `AITSentryTransport.cs:268`(`EditorApplication.quitting` 동기 핸들러의 마지막 flush).
 - **P2 — 동기화 없는 static 필드**: `AITConvertCore.cs:33-34`의 `isCancelled`/`currentAsyncTask` → `Interlocked`/`volatile`로 스레드 안전성 보장. (AppsInTossMenu 서버 상태는 `AITServerStateManager`로 이전 완료)
 
 ## 의존성


### PR DESCRIPTION
## 요약
ThreadPool 백그라운드 워커에서 자식 프로세스 종료를 폴링하는 **두 루프**를 동기 `Thread.Sleep` → `await Task.Delay`로 전환합니다. 대기 구간 동안 풀 스레드를 반납해 점유를 줄입니다. (#31)

## 변경
| 파일 | 메서드 | 변경 |
|------|--------|------|
| `Editor/AITAsyncCommandRunner.cs` | `ExecuteCommandAsync` | `QueueUserWorkItem`→`Task.Run`, `Thread.Sleep(100)`→`await Task.Delay(100)` |
| `Editor/Package/PnpmRunner.cs` | `RunPnpmInstallInThread` | `QueueUserWorkItem`→`Task.Run`, `Thread.Sleep(200)`→`await Task.Delay(200)` |

## 안전성 근거
- 두 폴링 루프 모두 **내부에서 메인 스레드 Unity API를 호출하지 않음** — 결과 콜백/로그는 `EnqueueMainThread`(AITAsyncCommandRunner) 또는 `Debug.Log`/필드 대입(PnpmRunner)으로 처리. continuation이 풀 스레드에서 재개돼도 안전(`ConfigureAwait(false)`).
- **취소 지연 불변**: `Task.Delay`에 토큰을 넘기지 않아 취소는 기존과 동일하게 루프 상단(100/200ms 주기)에서 감지. 예외 경로도 그대로.
- **예외 관찰**: 두 메서드 모두 최상위 `try/catch`로 전 예외를 흡수하고 결과로 신호하므로 반환 Task는 fault되지 않음 → `_ =`로 폐기해도 unobserved exception 위험 없음.
- **로그 억제 카운터**: `AITEditorErrorTracker._suppressLogCaptureCount`는 `[ThreadStatic]`이 아닌 process-wide `volatile int` + `Interlocked`라, await로 스레드가 바뀌어도 `Begin`/`End` 짝이 유지됨.
- 각 메서드는 호출부가 1곳뿐(동기 호출자 없음) — 시그니처 변경 파급 없음.

## 전환하지 않은 곳 (동기 유지가 불가피)
- **같은 루프에서 메인 스레드 진행률 UI 호출**: `AITNodeJSDownloader`/`AITNpmRunner`/`AITPackageInitializer` (`EditorUtility.DisplayProgressBar`는 메인 스레드 전용).
- **Unity 동기 빌드 파이프라인**: `AITFileSystemHelper`(디렉토리 삭제/이동 재시도).
- **동기 종료 계약**: `AITProcessTreeManager`(`IDisposable.Dispose`의 SIGTERM→SIGKILL 유예), `AITSentryTransport`(`EditorApplication.quitting` 동기 핸들러의 마지막 flush — `UnityWebRequest`가 메인 루프 펌프를 요구해 await 시 데드락 위험).

## 가치 / 리스크 (정직한 평가)
- **가치**: Editor에서 보통 동시 실행이 1건이라 실효 이득은 작음(풀 스레드 1~2개 반납). 기능 버그 수정이 아니라 async 위생 개선에 가까움.
- **리스크**: 빌드 크리티컬 백그라운드 경로지만 동작 보존 전환(위 근거). C# 컴파일은 로컬 `--validate`로 검증 불가(SDK/구조만 검사) → **CI 빌드에서 최종 확인 필요**.
- 머지 여부는 리뷰 판단에 맡깁니다 — 자동 머지하지 않습니다.