### PR TITLE
수정: BuildOutputValidatorTests node_modules 생성 순서 — E2E 차단 회귀

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs
@@ -105,8 +105,11 @@ public class BuildOutputValidatorTests
 
             // 필수 설정 파일
             System.IO.File.WriteAllText(System.IO.Path.Combine(aitBuildPath, "package.json"), "{}");
-            System.IO.File.WriteAllText(System.IO.Path.Combine(aitBuildPath, "node_modules", ".keep"), "");
+            // node_modules/ 디렉토리를 먼저 만든 뒤 .keep을 써야 한다 —
+            // File.WriteAllText는 상위 디렉토리를 만들지 않으므로 순서가 뒤바뀌면
+            // DirectoryNotFoundException으로 테스트가 셋업 단계에서 throw된다.
             System.IO.Directory.CreateDirectory(System.IO.Path.Combine(aitBuildPath, "node_modules"));
+            System.IO.File.WriteAllText(System.IO.Path.Combine(aitBuildPath, "node_modules", ".keep"), "");
             System.IO.File.WriteAllText(System.IO.Path.Combine(distWebPath, "index.html"), "<html></html>");
 
             // loader, data, wasm은 있지만 framework.js는 의도적으로 생성 안 함


### PR DESCRIPTION
## 문제

`Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildOutputValidatorTests.cs`의 회귀 가드 테스트 `ValidateAll_MissingFrameworkJs_ReturnsError`가 셋업 단계에서 `DirectoryNotFoundException`으로 throw된다.

```
System.IO.DirectoryNotFoundException : Could not find a part of the path ".../ait-build/node_modules/.keep"
  at System.IO.File.WriteAllText(...)
```

`node_modules/.keep` 파일을 **디렉토리 생성보다 먼저** 쓰는데, `File.WriteAllText`는 상위 디렉토리를 만들지 않으므로 항상(100% 결정적) throw한다.

## 영향

- 이 테스트는 `9dcf87d` (#814, 2026-06-19)에서 도입됨. 마지막 E2E 성공이 **2026-06-18**이고 그 다음 날부터 모든 E2E가 실패한 타임라인과 정확히 일치한다.
- 모든 E2E Build 잡(macOS·Windows × Unity 6000.3/6000.2/6000.0/2022.3/2021.3, 총 10개)이 "Run EditMode Tests" 단계에서 동일하게 실패 → **2026-06-19 이후 모든 PR의 E2E가 차단**됨.
- 근거: 최근 run `28014810129` — 891개 중 정확히 1개 실패(`label="Error"`, asserts=0, 0.0018s), 위 스택트레이스.

## 수정

`Directory.CreateDirectory(node_modules)`를 `.keep` 쓰기 **이전**으로 이동(순서만 교정). 검증 대상 로직(`BuildOutputValidator.ValidateAll`)은 변경 없음.