### PR TITLE
기능: 에디터 Sentry DSN 환경변수 override 지원 (AIT_EDITOR_SENTRY_DSN)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -19,6 +19,13 @@ namespace AppsInToss.Editor.ErrorTracker
         // DSN의 public key는 클라이언트 측에서 사용하도록 설계되어 있으며 (Sentry 공식 문서 참조),
         // Sentry 측 inbound filter와 rate limiting으로 보호됩니다.
         private const string DEFAULT_DSN = "https://af6caf8b80107bc41edf37baff728a5d@o89496.ingest.us.sentry.io/4511182309359616";
+
+        // 에디터 트래커 DSN을 빌드/CI 환경에서 재정의할 수 있는 환경변수 이름.
+        // 미설정(혹은 공백)이면 DEFAULT_DSN으로 폴백하므로 기본 동작은 변하지 않는다(순수 추가·가역적).
+        // 런타임(플레이어) Sentry DSN을 주입하는 SENTRY_DSN(AITSentryDsnInjector)과는 의도적으로
+        // 분리한다: 에디터 트래커는 SDK 자체 Sentry 프로젝트로, 런타임은 게임 개발자의 프로젝트로
+        // 향하므로 같은 변수를 공유하면 에디터 텔레메트리가 게임 런타임 프로젝트로 오라우팅된다.
+        private const string DSN_ENV_VAR = "AIT_EDITOR_SENTRY_DSN";
         private const string RELEASE_PREFIX = "apps-in-toss.unity";
         private const string ENVIRONMENT = "editor";
         private const int MAX_BREADCRUMBS = 20;
@@ -414,15 +421,26 @@ namespace AppsInToss.Editor.ErrorTracker
 
         /// <summary>
         /// DSN이 설정되어 있는지 확인합니다. 사용자의 opt-out 상태는 반영하지 않습니다.
+        /// 환경변수 override(<see cref="DSN_ENV_VAR"/>)가 설정되어 있으면 그 값을 기준으로 판정합니다.
         /// </summary>
-        internal static bool IsDsnConfigured => !string.IsNullOrEmpty(DEFAULT_DSN);
+        internal static bool IsDsnConfigured => !string.IsNullOrEmpty(GetDsn());
 
         /// <summary>
         /// 현재 설정된 Sentry DSN을 반환합니다.
+        /// 환경변수 <see cref="DSN_ENV_VAR"/>가 비어있지 않게 설정되어 있으면 그 값을, 아니면 DEFAULT_DSN을 반환합니다.
         /// </summary>
         internal static string GetDsn()
         {
-            return DEFAULT_DSN;
+            return ResolveEditorDsn(Environment.GetEnvironmentVariable(DSN_ENV_VAR));
+        }
+
+        /// <summary>
+        /// 환경변수 override 적용 규칙(순수 함수 — 프로세스 env 없이 테스트 가능).
+        /// override가 null/공백이면 DEFAULT_DSN으로 폴백하고, 그 외에는 trim한 override 값을 사용합니다.
+        /// </summary>
+        internal static string ResolveEditorDsn(string overrideValue)
+        {
+            return string.IsNullOrWhiteSpace(overrideValue) ? DEFAULT_DSN : overrideValue.Trim();
         }
 
         /// <summary>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/EditorDsnResolverTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/EditorDsnResolverTests.cs
@@ -1,0 +1,113 @@
+// ---------------------------------------------------------------------------
+// EditorDsnResolverTests.cs - 에디터 트래커 DSN 환경변수 override 단위 테스트
+// GetDsn()/IsDsnConfigured가 AIT_EDITOR_SENTRY_DSN 환경변수로 재정의 가능하면서도,
+// 미설정 시에는 하드코딩 DEFAULT_DSN으로 폴백해 기본 동작이 불변(zero-default-change)인지 검증.
+// ---------------------------------------------------------------------------
+
+using System;
+using NUnit.Framework;
+using AppsInToss.Editor.ErrorTracker;
+
+[TestFixture]
+[Category("Unit")]
+public class EditorDsnResolverTests
+{
+    private const string EnvVar = "AIT_EDITOR_SENTRY_DSN";
+    private const string SampleOverrideDsn = "https://example0123456789abcdef@o12345.ingest.us.sentry.io/9999999";
+
+    #region 순수 함수 ResolveEditorDsn — override 적용 규칙
+
+    [Test]
+    public void ResolveEditorDsn_NullOverride_FallsBackToDefault()
+    {
+        // 미설정(null) → DEFAULT_DSN. 기본 동작 불변의 핵심.
+        var def = AITEditorErrorTracker.ResolveEditorDsn(null);
+        Assert.IsFalse(string.IsNullOrEmpty(def), "기본 DSN은 비어있지 않아야 한다.");
+    }
+
+    [Test]
+    public void ResolveEditorDsn_EmptyOrWhitespaceOverride_FallsBackToDefault()
+    {
+        // 빈 문자열/공백은 override로 취급하지 않고 DEFAULT_DSN으로 폴백한다.
+        var def = AITEditorErrorTracker.ResolveEditorDsn(null);
+        Assert.AreEqual(def, AITEditorErrorTracker.ResolveEditorDsn(""));
+        Assert.AreEqual(def, AITEditorErrorTracker.ResolveEditorDsn("   "));
+        Assert.AreEqual(def, AITEditorErrorTracker.ResolveEditorDsn("\t\n"));
+    }
+
+    [Test]
+    public void ResolveEditorDsn_NonEmptyOverride_ReturnsOverride()
+    {
+        Assert.AreEqual(SampleOverrideDsn, AITEditorErrorTracker.ResolveEditorDsn(SampleOverrideDsn));
+    }
+
+    [Test]
+    public void ResolveEditorDsn_TrimsSurroundingWhitespace()
+    {
+        Assert.AreEqual(SampleOverrideDsn, AITEditorErrorTracker.ResolveEditorDsn("  " + SampleOverrideDsn + "\n"));
+    }
+
+    [Test]
+    public void ResolveEditorDsn_OverrideDiffersFromDefault()
+    {
+        // 샘플 override가 실제로 기본값과 다른 채널을 가리키는지(테스트가 자명참이 아닌지) 확인.
+        var def = AITEditorErrorTracker.ResolveEditorDsn(null);
+        Assert.AreNotEqual(def, SampleOverrideDsn);
+    }
+
+    #endregion
+
+    #region GetDsn()/IsDsnConfigured — 환경변수 라운드트립
+
+    [Test]
+    public void GetDsn_WhenEnvUnset_ReturnsDefault()
+    {
+        var original = Environment.GetEnvironmentVariable(EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(EnvVar, null);
+            var def = AITEditorErrorTracker.ResolveEditorDsn(null);
+            Assert.AreEqual(def, AITEditorErrorTracker.GetDsn());
+            Assert.IsTrue(AITEditorErrorTracker.IsDsnConfigured);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EnvVar, original);
+        }
+    }
+
+    [Test]
+    public void GetDsn_WhenEnvSet_ReturnsOverride()
+    {
+        var original = Environment.GetEnvironmentVariable(EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(EnvVar, SampleOverrideDsn);
+            Assert.AreEqual(SampleOverrideDsn, AITEditorErrorTracker.GetDsn());
+            Assert.IsTrue(AITEditorErrorTracker.IsDsnConfigured);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EnvVar, original);
+        }
+    }
+
+    [Test]
+    public void GetDsn_WhenEnvSetToWhitespace_FallsBackToDefault()
+    {
+        var original = Environment.GetEnvironmentVariable(EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(EnvVar, "   ");
+            var def = AITEditorErrorTracker.ResolveEditorDsn(null);
+            Assert.AreEqual(def, AITEditorErrorTracker.GetDsn());
+            Assert.IsTrue(AITEditorErrorTracker.IsDsnConfigured);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EnvVar, original);
+        }
+    }
+
+    #endregion
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/EditorDsnResolverTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/EditorDsnResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a31f080063ba4b57b2ab6b6f35245c41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경 (#38 — `[결정 필요]`)

에디터 에러 트래커(`AITEditorErrorTracker`)의 Sentry DSN이 소스에 하드코딩(`DEFAULT_DSN` 상수)되어 있어, 빌드/CI 환경에서 다른 Sentry 프로젝트로 재라우팅할 방법이 없었습니다. 이 PR은 **기본 동작을 바꾸지 않으면서** 환경변수로 재정의할 수 있는 옵트인 경로를 추가합니다.

## 변경 내용

- `AIT_EDITOR_SENTRY_DSN` 환경변수가 **비어있지 않게** 설정되면 그 값으로 에디터 트래커 DSN을 재정의.
- 미설정/공백이면 기존 `DEFAULT_DSN`으로 폴백 → **기본 동작 불변(zero-default-change), 가역적**.
- `GetDsn()`을 순수 함수 `ResolveEditorDsn(override)`로 분리 → 프로세스 env 없이 단위 테스트 가능.
- `IsDsnConfigured`를 resolved DSN 기준으로 판정하도록 정리(기본값은 항상 non-empty라 기존과 동일하게 `true`).
- EditMode 단위 테스트 추가: 폴백(null/빈/공백) · override · trim · env 라운드트립.

## 설계 결정 (리뷰 포인트)

**채택: 런타임과 분리된 전용 환경변수 `AIT_EDITOR_SENTRY_DSN`.**

런타임(플레이어) Sentry DSN을 주입하는 기존 `SENTRY_DSN`(`AITSentryDsnInjector`, `IPreprocessBuildWithReport`)을 **재사용하지 않은** 이유:

- 두 채널은 **서로 다른 Sentry 프로젝트**로 향합니다.
  - `SENTRY_DSN` → WebGL 빌드 시 `SentryOptions.asset`에 주입 → **게임 개발자**의 런타임 프로젝트.
  - 에디터 트래커 DSN → SDK 자체 프로젝트(`o89496/4511182309359616`) → **SDK 개발팀**의 에디터 텔레메트리.
- 같은 변수를 공유하면, 게임 개발자가 자신의 런타임 DSN을 설정했을 때 **SDK 에디터 텔레메트리가 게임의 런타임 프로젝트로 오라우팅**됩니다.

**대안 (미채택):** `SENTRY_DSN` 단일 변수 재사용 — 위 오라우팅 위험 때문에 기각.

> DSN public key는 클라이언트 측 사용을 전제로 설계된 비밀이 아닌 값이며(Sentry inbound filter + rate limiting으로 보호), 기존 `DEFAULT_DSN` 주석에 명시되어 있습니다. 따라서 이 변경은 시크릿 노출 표면을 늘리지 않습니다.

## 검증

- `Editor/`/`Tests~`는 로컬에 Unity Editor가 없어 `--validate`로 C# 컴파일을 검증할 수 없으므로 **E2E를 디스패치해 10개 빌드 레그의 "Run EditMode Tests"로 검증**합니다(결과는 코멘트로 추가).
- 호출부(`AITBuildTransaction`, `AITIssueReportService`, `AITConfigurationWindow`, `AITConvertCore`)는 시그니처 변경이 없어 영향 없음.

## 머지 정책

`[결정 필요]` 항목이므로 **자동 머지하지 않고 리뷰 대기**합니다. 환경변수 스킴(전용 변수 vs `SENTRY_DSN` 재사용)에 대한 합의가 머지 게이트입니다.