### PR TITLE
수정: apps-in-toss USER_CONFIG가 SDK brand를 덮어쓰는 2.x→3.x 마이그레이션 결함 해결 + 빌드 가드/자동 이전

### DIFF
--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -19,6 +19,18 @@ namespace AppsInToss.Editor
             "%UNITY_WEBGL_CODE_URL%"
         };
 
+        // 2.x→3.x 마이그레이션 시 USER_CONFIG로 흘러들 수 있는, 3.x에서 이동/이름변경된 키.
+        // (displayName/icon → toss 개발자센터, webViewProps → webView, outdir → webBundleDir,
+        //  bridgeColorMode → 콘솔/플랫폼 관리). USER_CONFIG에 남아 있으면 경고만 한다(빌드는 계속).
+        private static readonly string[] DeprecatedUserConfigKeys = new[]
+        {
+            "displayName",
+            "icon",
+            "webViewProps",
+            "outdir",
+            "bridgeColorMode"
+        };
+
         /// <summary>
         /// index.html에서 미치환된 플레이스홀더가 있는지 검증합니다.
         /// </summary>
@@ -96,6 +108,114 @@ namespace AppsInToss.Editor
             }
 
             return !hasError;
+        }
+
+        /// <summary>
+        /// 생성된 빌드 설정 파일(apps-in-toss.config.ts / granite.config.ts)을 검증합니다.
+        /// (① 마이그레이션 가드 — 잘못 포팅된 USER_CONFIG로 인한 bundle.json 손상을 빌드 단계에서 차단)
+        ///  • SDK_GENERATED 영역에 미치환 %AIT_*%/%UNITY_*% 플레이스홀더가 있으면 치명적 → 빌드 중단
+        ///    (실제 치환 실패. 이대로 배포하면 bundle.json에 플레이스홀더 문자열이 그대로 들어감)
+        ///  • USER_CONFIG 영역의 SDK 플레이스홀더/2.x deprecated 키는 경고만 → 빌드 계속
+        ///    (apps-in-toss.config.ts 병합에서 SDK 값이 우선하므로 결과는 정상, 정리만 권고)
+        /// 검증기 자체 예외는 빌드를 막지 않는다(보수적으로 SUCCEED 반환).
+        /// </summary>
+        /// <returns>치명적 미치환 발견 시 PLACEHOLDER_SUBSTITUTION_FAILED, 그 외 SUCCEED</returns>
+        internal static AITConvertCore.AITExportError ValidateGeneratedBuildConfigs(string buildProjectPath)
+        {
+            try
+            {
+                bool hardError = false;
+
+                foreach (var fileName in new[] { "apps-in-toss.config.ts", "granite.config.ts" })
+                {
+                    string path = Path.Combine(buildProjectPath, fileName);
+                    if (!File.Exists(path)) continue;
+
+                    string content = File.ReadAllText(path);
+
+                    // 하드 에러: SDK_GENERATED 영역의 미치환 플레이스홀더 (= 치환 실패)
+                    string sdkSection = AITTemplateManager.ExtractSdkSection(content) ?? content;
+                    var sdkPlaceholders = FindUnsubstitutedPlaceholders(sdkSection);
+                    if (sdkPlaceholders.Count > 0)
+                    {
+                        AITLog.Error(
+                            $"[AIT] ✗ 치명적: {fileName}의 SDK_GENERATED 영역에 미치환 플레이스홀더가 있습니다: "
+                            + string.Join(", ", sdkPlaceholders) + "\n"
+                            + "  이 상태로 배포하면 bundle.json에 플레이스홀더 문자열이 그대로 들어가 앱 설정이 깨집니다.\n"
+                            + "  해결: 'Clean Build' 옵션을 켜고 다시 빌드하세요.");
+                        hardError = true;
+                    }
+
+                    // 경고: USER_CONFIG 영역의 SDK 플레이스홀더/2.x deprecated 키
+                    // (병합 시 SDK 값이 우선하므로 빌드 결과는 정상 — 사용자에게 정리만 권고)
+                    // 3.x 파일(apps-in-toss.config.ts)에만 적용. granite.config.ts는 2.x 레거시라
+                    // USER_CONFIG에 webViewProps 등 2.x 키가 정상적으로 존재할 수 있어 오탐을 만든다.
+                    string userSection = fileName == "apps-in-toss.config.ts"
+                        ? AITTemplateManager.ExtractMarkerSection(content, "USER_CONFIG")
+                        : null;
+                    if (userSection != null)
+                    {
+                        var userPlaceholders = FindUnsubstitutedPlaceholders(userSection);
+                        var deprecatedKeys = FindDeprecatedUserConfigKeys(userSection);
+                        if (userPlaceholders.Count > 0 || deprecatedKeys.Count > 0)
+                        {
+                            string msg =
+                                $"[AIT]   ⚠ {fileName}의 USER_CONFIG에 SDK가 관리하는 설정이 남아 있습니다. "
+                                + "SDK 값이 우선 적용되어 빌드 결과에는 문제가 없지만, USER_CONFIG에서 제거하는 것을 권장합니다.";
+                            if (userPlaceholders.Count > 0)
+                                msg += "\n     - 미치환 플레이스홀더: " + string.Join(", ", userPlaceholders);
+                            if (deprecatedKeys.Count > 0)
+                                msg += "\n     - 3.x에서 이동/이름변경된 키: " + string.Join(", ", deprecatedKeys)
+                                     + " (표시이름·아이콘은 toss 개발자센터, 색상/권한 등은 AIT Configuration 창에서 설정)";
+
+                            // 사용자 환경(잘못 포팅된 USER_CONFIG)에 기인하므로 Sentry 전송은 억제하고 콘솔 경고만 남긴다.
+                            AITLog.Warning(msg, sentryCapture: false);
+                        }
+                    }
+                }
+
+                return hardError
+                    ? AITConvertCore.AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED
+                    : AITConvertCore.AITExportError.SUCCEED;
+            }
+            catch (Exception e)
+            {
+                // 검증기 자체 결함으로 정상 빌드를 막지 않는다.
+                AITLog.Warning($"[AIT] 빌드 설정 검증 중 예외(빌드는 계속): {e.Message}", sentryCapture: false);
+                return AITConvertCore.AITExportError.SUCCEED;
+            }
+        }
+
+        /// <summary>
+        /// 텍스트에서 미치환된 %AIT_*% / %UNITY_*% 플레이스홀더를 중복 없이 찾습니다.
+        /// </summary>
+        private static List<string> FindUnsubstitutedPlaceholders(string content)
+        {
+            var found = new HashSet<string>();
+            foreach (System.Text.RegularExpressions.Match m in
+                     System.Text.RegularExpressions.Regex.Matches(content, @"%(?:AIT|UNITY)_[A-Z0-9_]+%"))
+            {
+                found.Add(m.Value);
+            }
+            return new List<string>(found);
+        }
+
+        /// <summary>
+        /// USER_CONFIG 섹션에서 3.x deprecated/이름변경 키가 프로퍼티 키로 사용되었는지 찾습니다.
+        /// </summary>
+        private static List<string> FindDeprecatedUserConfigKeys(string userSection)
+        {
+            var found = new List<string>();
+            foreach (var key in DeprecatedUserConfigKeys)
+            {
+                // 식별자 경계 뒤에 `key:` 형태로 등장할 때만 키로 간주 (부분 문자열 오탐 방지)
+                if (System.Text.RegularExpressions.Regex.IsMatch(
+                        userSection, $@"(^|[^A-Za-z0-9_$])({System.Text.RegularExpressions.Regex.Escape(key)})\s*:"))
+                {
+                    found.Add(key);
+                }
+            }
+            return found;
         }
 
         /// <summary>

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -251,8 +251,8 @@ namespace AppsInToss
                            "2. 'Clean Build' 옵션 활성화 후 재빌드";
 
                 case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED:
-                    return "index.html의 필수 플레이스홀더가 치환되지 않았습니다.\n\n" +
-                           "이 상태로 배포하면 'createUnityInstance is not defined' 에러가 발생합니다.\n\n" +
+                    return "빌드 산출물(index.html 또는 apps-in-toss.config.ts/granite.config.ts)의 필수 플레이스홀더가 치환되지 않았습니다.\n\n" +
+                           "이 상태로 배포하면 'createUnityInstance is not defined' 에러가 발생하거나 앱 설정(bundle.json)이 깨집니다.\n\n" +
                            "해결 방법:\n" +
                            "1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n" +
                            "2. AIT > Clean 메뉴로 빌드 폴더 삭제 후 재빌드하세요.";
@@ -337,8 +337,8 @@ namespace AppsInToss
                     return "WebGL 빌드의 index.html 이 생성되지 않았습니다.\n" +
                            "WebGL 템플릿(AITTemplate) 설정이 올바른지 확인해주세요.";
                 case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED:
-                    return "index.html 의 필수 플레이스홀더가 치환되지 않은 채 저장되었습니다.\n" +
-                           "이 상태로 배포하면 런타임에 'createUnityInstance is not defined' 오류가 발생합니다.\n" +
+                    return "빌드 산출물(index.html 또는 apps-in-toss.config.ts/granite.config.ts)의 필수 플레이스홀더가 치환되지 않은 채 저장되었습니다.\n" +
+                           "이 상태로 배포하면 런타임에 'createUnityInstance is not defined' 오류가 발생하거나 앱 설정(bundle.json)이 깨집니다.\n" +
                            "Clean Build 옵션으로 재빌드해보세요.";
                 case AITExportError.DIST_FOLDER_MISSING:
                     return "granite 빌드가 완료되었지만 dist 폴더가 생성되지 않았습니다.\n" +

--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -109,6 +109,11 @@ namespace AppsInToss.Editor
             Debug.Log("[AIT] Step 1/3: Vite 프로젝트 구조 생성 중...");
             CopyBuildConfigFromTemplate(buildProjectPath);
 
+            // 생성된 빌드 설정 검증 (① 마이그레이션 가드): SDK_GENERATED 미치환 시 빌드 중단
+            var configValidation = AITBuildValidator.ValidateGeneratedBuildConfigs(buildProjectPath);
+            if (configValidation != AITConvertCore.AITExportError.SUCCEED)
+                return (null, configValidation);
+
             Debug.Log("[AIT] Step 2/3: Unity WebGL 빌드 복사 중...");
             var copyResult = Package.WebGLBuildCopier.CopyWebGLToPublic(webglPath, buildProjectPath, profile);
             if (copyResult != AITConvertCore.AITExportError.SUCCEED)
@@ -171,6 +176,11 @@ namespace AppsInToss.Editor
             // BuildConfig 복사 (WebGL 출력 불필요 — package.json, lockfile 등만)
             Debug.Log("[AIT] [병렬] BuildConfig 파일 복사 중...");
             CopyBuildConfigFromTemplate(buildProjectPath);
+
+            // 생성된 빌드 설정 검증 (① 마이그레이션 가드): SDK_GENERATED 미치환 시 빌드 중단
+            var configValidation = AITBuildValidator.ValidateGeneratedBuildConfigs(buildProjectPath);
+            if (configValidation != AITConvertCore.AITExportError.SUCCEED)
+                return (null, configValidation);
 
             // pnpm 경로 확인
             string pnpmPath = AITNpmRunner.FindPnpmPath();

--- a/Editor/Package/BuildConfigMerger.cs
+++ b/Editor/Package/BuildConfigMerger.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace AppsInToss.Editor.Package
@@ -383,7 +384,6 @@ namespace AppsInToss.Editor.Package
         /// </summary>
         internal static void UpdateAppsInTossConfig(string projectBuildConfigPath, string sdkBuildConfigPath, string destPath, AITEditorScriptObject config)
         {
-            string projectFile = Path.Combine(projectBuildConfigPath, "apps-in-toss.config.ts");
             string sdkFile = Path.Combine(sdkBuildConfigPath, "apps-in-toss.config.ts");
             string destFile = Path.Combine(destPath, "apps-in-toss.config.ts");
 
@@ -405,21 +405,16 @@ namespace AppsInToss.Editor.Package
                 .Replace("%AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%", config.mediaPlaybackRequiresUserAction.ToString().ToLower())
                 .Replace("%AIT_PERMISSIONS%", config.GetPermissionsJson());
 
-            // 프로젝트 파일이 있으면 USER_CONFIG 영역만 보존
-            if (File.Exists(projectFile))
+            // USER_CONFIG 결정:
+            //  1) 프로젝트 apps-in-toss.config.ts의 USER_CONFIG에 실제 내용이 있으면 그대로 보존
+            //  2) 비어 있으면 granite.config.ts의 USER_CONFIG를 자동 이전 (2.x→3.x 마이그레이션, 수동 포팅 제거)
+            //  3) 둘 다 비어 있으면 SDK 템플릿 기본값(빈 USER_CONFIG) 유지
+            // SDK 관리 필드(brand/appName/permissions/webView 등)는 apps-in-toss.config.ts의 병합 로직에서
+            // 항상 SDK 값이 우선하므로, granite USER_CONFIG를 그대로 가져와도 안전하다.
+            string resolvedUserConfig = ResolveUserConfigForAppsInToss(projectBuildConfigPath);
+            if (resolvedUserConfig != null)
             {
-                string projectContent = File.ReadAllText(projectFile);
-
-                string projectUserConfig = AITTemplateManager.ExtractMarkerSection(projectContent, "USER_CONFIG");
-                if (projectUserConfig != null)
-                {
-                    finalContent = AITTemplateManager.ReplaceMarkerSection(finalContent, "USER_CONFIG", projectUserConfig);
-                    Debug.Log("[AIT]   ✓ apps-in-toss.config.ts (SDK 최신 버전 + USER_CONFIG 보존)");
-                }
-                else
-                {
-                    Debug.Log("[AIT]   ✓ apps-in-toss.config.ts (SDK 최신 버전으로 갱신)");
-                }
+                finalContent = AITTemplateManager.ReplaceMarkerSection(finalContent, "USER_CONFIG", resolvedUserConfig);
             }
             else
             {
@@ -427,6 +422,61 @@ namespace AppsInToss.Editor.Package
             }
 
             File.WriteAllText(destFile, finalContent, new System.Text.UTF8Encoding(false));
+        }
+
+        /// <summary>
+        /// apps-in-toss.config.ts에 주입할 USER_CONFIG 섹션을 결정합니다.
+        /// 프로젝트 apps-in-toss.config.ts의 USER_CONFIG가 비어 있으면 granite.config.ts의 USER_CONFIG를
+        /// 자동 이전합니다(2.x→3.x 마이그레이션). 둘 다 비어 있으면 null(SDK 템플릿 기본값 유지)을 반환합니다.
+        /// </summary>
+        internal static string ResolveUserConfigForAppsInToss(string projectBuildConfigPath)
+        {
+            // 1) apps-in-toss.config.ts의 USER_CONFIG 우선
+            string appsInTossFile = Path.Combine(projectBuildConfigPath, "apps-in-toss.config.ts");
+            if (File.Exists(appsInTossFile))
+            {
+                string section = AITTemplateManager.ExtractMarkerSection(File.ReadAllText(appsInTossFile), "USER_CONFIG");
+                if (section != null && !IsEffectivelyEmptyUserConfig(section))
+                {
+                    Debug.Log("[AIT]   ✓ apps-in-toss.config.ts (SDK 최신 버전 + USER_CONFIG 보존)");
+                    return section;
+                }
+            }
+
+            // 2) 비어 있으면 granite.config.ts의 USER_CONFIG를 자동 이전
+            string graniteFile = Path.Combine(projectBuildConfigPath, "granite.config.ts");
+            if (File.Exists(graniteFile))
+            {
+                string section = AITTemplateManager.ExtractMarkerSection(File.ReadAllText(graniteFile), "USER_CONFIG");
+                if (section != null && !IsEffectivelyEmptyUserConfig(section))
+                {
+                    Debug.Log(
+                        "[AIT]   ✓ apps-in-toss.config.ts (granite.config.ts의 USER_CONFIG 자동 이전 — 2.x→3.x 마이그레이션). " +
+                        "SDK 관리 필드는 SDK 값이 우선하므로 안전합니다.");
+                    return section;
+                }
+            }
+
+            // 3) 둘 다 비어 있음 → SDK 템플릿 기본값 유지
+            return null;
+        }
+
+        /// <summary>
+        /// USER_CONFIG 마커 섹션이 실질적으로 비어 있는지(실제 프로퍼티 없이 주석/공백만 있는지) 판별합니다.
+        /// 구조를 확신할 수 없으면(중괄호 미발견 등) 보수적으로 "내용 있음"으로 간주해 보존합니다.
+        /// </summary>
+        internal static bool IsEffectivelyEmptyUserConfig(string section)
+        {
+            if (string.IsNullOrEmpty(section)) return true;
+
+            int open = section.IndexOf('{');
+            int close = section.LastIndexOf('}');
+            if (open == -1 || close == -1 || close <= open) return false; // 구조 불명 → 보존
+
+            string body = section.Substring(open + 1, close - open - 1);
+            body = Regex.Replace(body, @"/\*.*?\*/", "", RegexOptions.Singleline); // 블록 주석 제거
+            body = Regex.Replace(body, @"//[^\n]*", "");                           // 줄 주석 제거
+            return body.Trim().Length == 0;
         }
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs
@@ -1,0 +1,132 @@
+// -----------------------------------------------------------------------
+// AITBuildValidatorConfigGuardTests.cs - ValidateGeneratedBuildConfigs(①) 단위 테스트
+// Level 0: 생성된 apps-in-toss.config.ts/granite.config.ts의 미치환 플레이스홀더 가드 검증
+//   - SDK_GENERATED 미치환 → 치명적(PLACEHOLDER_SUBSTITUTION_FAILED)
+//   - USER_CONFIG 미치환/2.x deprecated 키 → 경고만(SUCCEED)
+// -----------------------------------------------------------------------
+
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITBuildValidatorConfigGuardTests
+{
+    private string _buildDir;
+
+    private const string Substituted =
+        "import { defineConfig } from '@apps-in-toss/web-framework/config';\n" +
+        "//// SDK_GENERATED_START - DO NOT EDIT THIS SECTION ////\n" +
+        "const sdkConfig = {\n" +
+        "  appName: 'guard-app',\n" +
+        "  brand: { primaryColor: '#3182f6' },\n" +
+        "  permissions: [],\n" +
+        "  webView: { allowsInlineMediaPlayback: true, mediaPlaybackRequiresUserAction: false },\n" +
+        "  webBundleDir: 'dist/web',\n" +
+        "};\n" +
+        "//// SDK_GENERATED_END ////\n" +
+        "{0}" +
+        "const _userConfig = userConfig as Record<string, any>;\n" +
+        "export default defineConfig({ ..._userConfig, ...sdkConfig });\n";
+
+    private const string EmptyUserConfig =
+        "//// USER_CONFIG_START ////\n" +
+        "const userConfig = {\n" +
+        "  // 여기에 사용자 커스텀 설정을 추가하세요\n" +
+        "};\n" +
+        "//// USER_CONFIG_END ////\n";
+
+    [SetUp]
+    public void Setup()
+    {
+        _buildDir = Path.Combine(Path.GetTempPath(), "ait-guard-tests-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_buildDir);
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        if (_buildDir != null && Directory.Exists(_buildDir))
+            Directory.Delete(_buildDir, recursive: true);
+    }
+
+    private void WriteAppsInToss(string content)
+    {
+        File.WriteAllText(Path.Combine(_buildDir, "apps-in-toss.config.ts"), content);
+    }
+
+    [Test]
+    public void Validate_CleanConfig_ReturnsSucceed()
+    {
+        WriteAppsInToss(string.Format(Substituted, EmptyUserConfig));
+
+        var result = AITBuildValidator.ValidateGeneratedBuildConfigs(_buildDir);
+
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result);
+    }
+
+    [Test]
+    public void Validate_NoConfigFiles_ReturnsSucceed()
+    {
+        var result = AITBuildValidator.ValidateGeneratedBuildConfigs(_buildDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result);
+    }
+
+    [Test]
+    public void Validate_PlaceholderInSdkGenerated_ReturnsPlaceholderFailure()
+    {
+        // SDK_GENERATED 영역에 미치환 %AIT_PRIMARY_COLOR% 가 남은 상태
+        string bad =
+            "//// SDK_GENERATED_START ////\n" +
+            "const sdkConfig = { appName: 'x', brand: { primaryColor: '%AIT_PRIMARY_COLOR%' } };\n" +
+            "//// SDK_GENERATED_END ////\n" +
+            EmptyUserConfig +
+            "export default sdkConfig;\n";
+        WriteAppsInToss(bad);
+
+        LogAssert.Expect(LogType.Error, new Regex(@"미치환 플레이스홀더"));
+        var result = AITBuildValidator.ValidateGeneratedBuildConfigs(_buildDir);
+
+        Assert.AreEqual(AITConvertCore.AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED, result);
+    }
+
+    [Test]
+    public void Validate_PlaceholderOnlyInUserConfig_ReturnsSucceed_WithWarning()
+    {
+        // 잘못 포팅된 USER_CONFIG: brand 블록을 통째로 복사 → 미치환 플레이스홀더 포함
+        // 병합에서 SDK 값이 우선하므로 치명적이지 않음(경고만, 빌드 계속)
+        string userConfig =
+            "//// USER_CONFIG_START ////\n" +
+            "const userConfig = {\n" +
+            "  brand: { primaryColor: '%AIT_PRIMARY_COLOR%', displayName: '%AIT_DISPLAY_NAME%' },\n" +
+            "};\n" +
+            "//// USER_CONFIG_END ////\n";
+        WriteAppsInToss(string.Format(Substituted, userConfig));
+
+        LogAssert.Expect(LogType.Warning, new Regex(@"USER_CONFIG에 SDK가 관리하는 설정이 남아"));
+        var result = AITBuildValidator.ValidateGeneratedBuildConfigs(_buildDir);
+
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result);
+    }
+
+    [Test]
+    public void Validate_DeprecatedKeyInUserConfig_ReturnsSucceed_WithWarning()
+    {
+        // 2.x 키(webViewProps)가 USER_CONFIG에 남은 경우 → 경고만
+        string userConfig =
+            "//// USER_CONFIG_START ////\n" +
+            "const userConfig = {\n" +
+            "  webViewProps: { bounces: false },\n" +
+            "};\n" +
+            "//// USER_CONFIG_END ////\n";
+        WriteAppsInToss(string.Format(Substituted, userConfig));
+
+        LogAssert.Expect(LogType.Warning, new Regex(@"이동/이름변경된 키"));
+        var result = AITBuildValidator.ValidateGeneratedBuildConfigs(_buildDir);
+
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03d3381bf16641648f668c9ccc0ba207
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerMigrationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerMigrationTests.cs
@@ -1,0 +1,217 @@
+// -----------------------------------------------------------------------
+// BuildConfigMergerMigrationTests.cs - UpdateAppsInTossConfig USER_CONFIG 자동 이전(②) 단위 테스트
+// Level 0: granite.config.ts → apps-in-toss.config.ts 마이그레이션 + 빈/내용 판별 검증
+// -----------------------------------------------------------------------
+
+using System.IO;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace AppsInToss.Editor.Package.Tests
+{
+    [TestFixture]
+    public class BuildConfigMergerMigrationTests
+    {
+        private string _projectDir;
+        private string _sdkDir;
+        private string _destDir;
+        private AITEditorScriptObject _config;
+
+        private const string SdkAppsInTossTemplate =
+            "import { defineConfig } from '@apps-in-toss/web-framework/config';\n" +
+            "//// SDK_GENERATED_START - DO NOT EDIT THIS SECTION ////\n" +
+            "const sdkConfig = {\n" +
+            "  appName: '%AIT_APP_NAME%',\n" +
+            "  brand: { primaryColor: '%AIT_PRIMARY_COLOR%' },\n" +
+            "  permissions: %AIT_PERMISSIONS%,\n" +
+            "  webView: {\n" +
+            "    allowsInlineMediaPlayback: %AIT_ALLOWS_INLINE_MEDIA_PLAYBACK%,\n" +
+            "    mediaPlaybackRequiresUserAction: %AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%,\n" +
+            "  },\n" +
+            "  webBundleDir: 'dist/web',\n" +
+            "};\n" +
+            "//// SDK_GENERATED_END ////\n" +
+            "//// USER_CONFIG_START ////\n" +
+            "const userConfig = {\n" +
+            "  // 여기에 사용자 커스텀 설정을 추가하세요\n" +
+            "};\n" +
+            "//// USER_CONFIG_END ////\n" +
+            "const _userConfig = userConfig as Record<string, any>;\n" +
+            "export default defineConfig({ ..._userConfig, ...sdkConfig });\n";
+
+        [SetUp]
+        public void Setup()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "ait-bcm-mig-tests-" + System.Guid.NewGuid().ToString("N"));
+            _projectDir = Path.Combine(root, "project");
+            _sdkDir = Path.Combine(root, "sdk");
+            _destDir = Path.Combine(root, "dest");
+            Directory.CreateDirectory(_projectDir);
+            Directory.CreateDirectory(_sdkDir);
+            Directory.CreateDirectory(_destDir);
+
+            _config = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+            _config.appName = "mig-app";
+            _config.primaryColor = "#123456";
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            if (_projectDir != null)
+            {
+                string root = Path.GetDirectoryName(_projectDir);
+                if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+            }
+            if (_config != null) Object.DestroyImmediate(_config);
+        }
+
+        private static string GraniteWithUserConfig(string userConfigBody)
+        {
+            return
+                "import { defineConfig } from '@granite-js/react-native/config';\n" +
+                "//// SDK_GENERATED_START ////\n" +
+                "const sdkConfig = { appName: '%AIT_APP_NAME%' };\n" +
+                "//// SDK_GENERATED_END ////\n" +
+                "//// USER_CONFIG_START ////\n" +
+                "const userConfig = {\n" +
+                userConfigBody +
+                "};\n" +
+                "//// USER_CONFIG_END ////\n" +
+                "export default defineConfig({ ...sdkConfig, ...userConfig });\n";
+        }
+
+        // ----- IsEffectivelyEmptyUserConfig -----
+
+        [Test]
+        public void IsEffectivelyEmptyUserConfig_DefaultCommentOnly_ReturnsTrue()
+        {
+            string section =
+                "//// USER_CONFIG_START ////\n" +
+                "const userConfig = {\n" +
+                "  // 여기에 사용자 커스텀 설정을 추가하세요\n" +
+                "};\n" +
+                "//// USER_CONFIG_END ////";
+            Assert.IsTrue(BuildConfigMerger.IsEffectivelyEmptyUserConfig(section));
+        }
+
+        [Test]
+        public void IsEffectivelyEmptyUserConfig_WithRealProperty_ReturnsFalse()
+        {
+            string section =
+                "//// USER_CONFIG_START ////\n" +
+                "const userConfig = {\n" +
+                "  myCustomPlugin: true,\n" +
+                "};\n" +
+                "//// USER_CONFIG_END ////";
+            Assert.IsFalse(BuildConfigMerger.IsEffectivelyEmptyUserConfig(section));
+        }
+
+        [Test]
+        public void IsEffectivelyEmptyUserConfig_BlockCommentOnly_ReturnsTrue()
+        {
+            string section =
+                "//// USER_CONFIG_START ////\n" +
+                "const userConfig = {\n" +
+                "  /* nothing here yet */\n" +
+                "};\n" +
+                "//// USER_CONFIG_END ////";
+            Assert.IsTrue(BuildConfigMerger.IsEffectivelyEmptyUserConfig(section));
+        }
+
+        // ----- ResolveUserConfigForAppsInToss -----
+
+        [Test]
+        public void Resolve_PrefersAppsInTossUserConfig_WhenNonEmpty()
+        {
+            File.WriteAllText(Path.Combine(_projectDir, "apps-in-toss.config.ts"),
+                SdkAppsInTossTemplate.Replace(
+                    "  // 여기에 사용자 커스텀 설정을 추가하세요\n",
+                    "  fromAppsInToss: 1,\n"));
+            File.WriteAllText(Path.Combine(_projectDir, "granite.config.ts"),
+                GraniteWithUserConfig("  fromGranite: 2,\n"));
+
+            string section = BuildConfigMerger.ResolveUserConfigForAppsInToss(_projectDir);
+
+            StringAssert.Contains("fromAppsInToss", section);
+            Assert.IsFalse(section.Contains("fromGranite"), "apps-in-toss USER_CONFIG가 우선되어야 함");
+        }
+
+        [Test]
+        public void Resolve_MigratesGraniteUserConfig_WhenAppsInTossEmpty()
+        {
+            // apps-in-toss.config.ts는 비어 있고(기본 주석만), granite에는 커스텀 설정 존재
+            File.WriteAllText(Path.Combine(_projectDir, "apps-in-toss.config.ts"), SdkAppsInTossTemplate);
+            File.WriteAllText(Path.Combine(_projectDir, "granite.config.ts"),
+                GraniteWithUserConfig("  fromGranite: 2,\n"));
+
+            string section = BuildConfigMerger.ResolveUserConfigForAppsInToss(_projectDir);
+
+            Assert.IsNotNull(section);
+            StringAssert.Contains("fromGranite", section);
+        }
+
+        [Test]
+        public void Resolve_MigratesGraniteUserConfig_WhenNoAppsInTossFile()
+        {
+            // apps-in-toss.config.ts 자체가 없는 2.x 프로젝트
+            File.WriteAllText(Path.Combine(_projectDir, "granite.config.ts"),
+                GraniteWithUserConfig("  fromGranite: 3,\n"));
+
+            string section = BuildConfigMerger.ResolveUserConfigForAppsInToss(_projectDir);
+
+            Assert.IsNotNull(section);
+            StringAssert.Contains("fromGranite", section);
+        }
+
+        [Test]
+        public void Resolve_ReturnsNull_WhenBothEmpty()
+        {
+            File.WriteAllText(Path.Combine(_projectDir, "apps-in-toss.config.ts"), SdkAppsInTossTemplate);
+            File.WriteAllText(Path.Combine(_projectDir, "granite.config.ts"),
+                GraniteWithUserConfig("  // 여기에 사용자 커스텀 설정을 추가하세요\n"));
+
+            string section = BuildConfigMerger.ResolveUserConfigForAppsInToss(_projectDir);
+
+            Assert.IsNull(section, "둘 다 비어 있으면 SDK 템플릿 기본값(null) 유지");
+        }
+
+        [Test]
+        public void Resolve_ReturnsNull_WhenNoFiles()
+        {
+            Assert.IsNull(BuildConfigMerger.ResolveUserConfigForAppsInToss(_projectDir));
+        }
+
+        // ----- UpdateAppsInTossConfig end-to-end (마이그레이션 경로) -----
+
+        [Test]
+        public void UpdateAppsInTossConfig_MigratesGraniteUserConfig_AndSubstitutesSdkPlaceholders()
+        {
+            // SDK 템플릿
+            File.WriteAllText(Path.Combine(_sdkDir, "apps-in-toss.config.ts"), SdkAppsInTossTemplate);
+            // 프로젝트: apps-in-toss 없음, granite에 커스텀 USER_CONFIG
+            File.WriteAllText(Path.Combine(_projectDir, "granite.config.ts"),
+                GraniteWithUserConfig("  myCustomPlugin: true,\n"));
+
+            BuildConfigMerger.UpdateAppsInTossConfig(_projectDir, _sdkDir, _destDir, _config);
+
+            string merged = File.ReadAllText(Path.Combine(_destDir, "apps-in-toss.config.ts"));
+            // granite USER_CONFIG가 이전됨
+            StringAssert.Contains("myCustomPlugin", merged);
+            // SDK_GENERATED 플레이스홀더는 치환됨
+            StringAssert.Contains("mig-app", merged);
+            StringAssert.Contains("#123456", merged);
+            Assert.IsFalse(Regex.IsMatch(merged, "%AIT_(APP_NAME|PRIMARY_COLOR)%"),
+                "SDK_GENERATED 플레이스홀더가 남아있음:\n" + merged);
+        }
+
+        [Test]
+        public void UpdateAppsInTossConfig_NoOp_WhenSdkTemplateMissing()
+        {
+            // SDK 템플릿이 없으면(구버전 SDK) dest 파일을 만들지 않는다
+            BuildConfigMerger.UpdateAppsInTossConfig(_projectDir, _sdkDir, _destDir, _config);
+            Assert.IsFalse(File.Exists(Path.Combine(_destDir, "apps-in-toss.config.ts")));
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerMigrationTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerMigrationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5624b21deac44376b3098538e8f2ea9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/WebGLTemplates/AITTemplate/BuildConfig~/apps-in-toss.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/apps-in-toss.config.ts
@@ -25,4 +25,15 @@ const userConfig = {
 };
 //// USER_CONFIG_END ////
 
-export default defineConfig({ ...sdkConfig, ...userConfig });
+// SDK_GENERATED가 관리하는 필드(appName/brand/permissions/webBundleDir/webView 플래그)는
+// AIT Configuration 창에서 설정합니다. userConfig에서 이 필드들을 덮어쓰면 2.x의
+// brand.displayName/icon(3.x에서 toss 개발자센터로 이동)이나 미치환 %AIT_*% 플레이스홀더가
+// bundle.json으로 새어 들어가는 마이그레이션 결함이 있었습니다. 그래서 SDK 관리 필드는 항상
+// SDK 값이 이기도록 병합하고, userConfig에는 3.x 신규 필드 추가(navigationBar 등)와
+// webView 옵션 확장(bounces 등)만 허용합니다.
+const _userConfig = userConfig as Record<string, any>;
+export default defineConfig({
+  ..._userConfig,
+  ...sdkConfig,
+  webView: { ..._userConfig.webView, ...sdkConfig.webView },
+});

--- a/WebGLTemplates/AITTemplate/BuildConfig~/granite.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/granite.config.ts
@@ -34,4 +34,15 @@ const userConfig = {
 };
 //// USER_CONFIG_END ////
 
-export default defineConfig({ ...sdkConfig, ...userConfig });
+// SDK_GENERATED가 관리하는 필드(appName/brand/permissions/outdir/webViewProps 플래그)는
+// AIT Configuration 창에서 설정합니다. userConfig에서 이 필드들을 덮어쓰면 brand의
+// 미치환 %AIT_*% 플레이스홀더(특히 마이그레이션 중 복사된 brand 블록)가 빌드 산출물로
+// 새어 들어가는 결함이 있었습니다(apps-in-toss.config.ts와 동일 클래스). 그래서 SDK 관리
+// 필드는 항상 SDK 값이 이기도록 병합하고, userConfig에는 신규 필드 추가와 webViewProps
+// 옵션 확장만 허용합니다.
+const _userConfig = userConfig as Record<string, any>;
+export default defineConfig({
+  ..._userConfig,
+  ...sdkConfig,
+  webViewProps: { ..._userConfig.webViewProps, ...sdkConfig.webViewProps },
+});


### PR DESCRIPTION
## 배경

2.x→3.x 마이그레이션에서 사용자가 `granite.config.ts`의 `brand` 블록(또는 SDK_GENERATED 영역 일부)을 `apps-in-toss.config.ts`의 USER_CONFIG로 그대로 복사해 두는 경우가 있었습니다. 기존 병합 라인이 얕은 스프레드였기 때문에:

```ts
export default defineConfig({ ...sdkConfig, ...userConfig });
```

`userConfig.brand`가 SDK가 치환해 둔 `sdkConfig.brand`를 **덮어써서**, 미치환 `%AIT_*%` 플레이스홀더와 3.x에서 제거된 `displayName`/`icon`이 `bundle.json`으로 새어 들어가 앱 설정이 깨졌습니다. 증상이 빌드 성공 후 런타임/배포 단계에서야 드러나 원인 파악이 어려웠습니다.

## 변경 사항

승인된 범위(**① 가드 + ② 자동 마이그레이션**)를 구현합니다. 3개 축으로 방어합니다.

### ②a 템플릿 병합 강화 (근본 해결)
`WebGLTemplates/AITTemplate/BuildConfig~/apps-in-toss.config.ts`의 병합 라인을 SDK 관리 필드가 항상 이기도록 변경:

```ts
const _userConfig = userConfig as Record<string, any>;
export default defineConfig({
  ..._userConfig,
  ...sdkConfig,
  webView: { ..._userConfig.webView, ...sdkConfig.webView },
});
```

- 이 라인은 마커(USER_CONFIG/SDK_GENERATED) **밖**에 있어 SDK 템플릿이 항상 제어 → 다음 빌드부터 **모든 프로젝트에 자동 적용**.
- `..._userConfig`를 베이스로 두되 `...sdkConfig`로 SDK 소유 키 전부를 덮어써 USER_CONFIG가 brand/appName/permissions/webBundleDir/webView 플래그를 더 이상 침범하지 못함.
- `webView`는 딥머지로 사용자 확장 옵션(bounces 등)은 보존하면서 SDK 플래그가 이기도록 함.

### ② 자동 이전 (수동 포팅 제거)
`Editor/Package/BuildConfigMerger.cs` — `apps-in-toss.config.ts`의 USER_CONFIG가 실질적으로 비어 있으면 `granite.config.ts`의 USER_CONFIG를 빌드 산출물로 **자동 이전**(`ResolveUserConfigForAppsInToss`/`IsEffectivelyEmptyUserConfig`). 마커 단위 verbatim 복사라 TS 파싱 없이 안전하며, 병합에서 SDK 필드가 우선하므로 granite USER_CONFIG를 그대로 가져와도 안전합니다. 빌드 산출물에만 적용(비파괴적).

### ① 빌드 가드 (조용한 손상 → 명확한 빌드 에러)
`Editor/AITBuildValidator.cs` — `ValidateGeneratedBuildConfigs`:
- 생성된 설정의 **SDK_GENERATED** 영역에 미치환 플레이스홀더가 있으면 치명적 → 빌드 중단(`PLACEHOLDER_SUBSTITUTION_FAILED`). 실제 치환 실패이므로 배포 차단.
- **USER_CONFIG**의 잔여 SDK 플레이스홀더/2.x deprecated 키(displayName/icon/webViewProps 등)는 **경고만** — ②a 병합이 런타임을 보호하므로 빌드는 계속하고 정리만 권고. 이 경고는 3.x 파일(`apps-in-toss.config.ts`)에만 적용(granite는 2.x 키가 정상이라 오탐 방지).
- `AITPackageBuilder`의 실제 빌드 경로 2곳(`PreparePackaging`/`PrepareEarlyPackaging`)에 배선. 검증기 자체 예외는 빌드를 막지 않음(보수적 SUCCEED).

### 기타
- `AITConvertCore`의 `PLACEHOLDER_SUBSTITUTION_FAILED` 에러 메시지를 index.html 한정에서 빌드 산출물 일반(config 포함)으로 확장.
- EditMode 테스트 추가: 가드/자동 이전/병합 동작 검증.

## 테스트
- 신규 EditMode 단위 테스트 2종 추가 (`AITBuildValidatorConfigGuardTests`, `BuildConfigMergerMigrationTests`). Unity EditMode는 CI에서 실행됩니다.
- 로컬 `./run-local-tests.sh --validate`는 사내 nexus 미러 stale 이슈로 `pnpm install` 단계가 막혀 전체 실행이 불가했습니다(코드 무관 환경 이슈). 변경은 `Runtime/SDK`/jslib를 건드리지 않아 해당 invariants에 영향 없음.

## 호환성
- 기존 USER_CONFIG에 정상 커스텀 설정만 둔 프로젝트는 동작 변화 없음(USER_CONFIG 보존 우선).
- 기본 빈 USER_CONFIG + 치환된 SDK_GENERATED + 새 병합 라인 → 플레이스홀더 무검출. E2E의 placeholder-free 단언과 충돌 없음.
