### PR TITLE
리팩토링: AITConvertCore 빌드 취소 상태 분리 (#36 1단계)

### DIFF
--- a/Editor/AITBuildCancellation.cs
+++ b/Editor/AITBuildCancellation.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+
+namespace AppsInToss
+{
+    /// <summary>
+    /// 빌드 취소 상태 관리 (AITConvertCore에서 분리 — #36).
+    /// 백그라운드 빌드 스레드와 메인 스레드(취소 요청)가 공유하는 취소 플래그,
+    /// 진행 중인 비동기 작업 핸들, 병렬 pnpm install 컨텍스트를 한 곳에서 관리한다.
+    /// AITConvertCore의 공개 취소 API는 이 클래스로 위임하며 동작은 기존과 동일하다.
+    /// </summary>
+    internal static class AITBuildCancellation
+    {
+        // volatile: 백그라운드 빌드 스레드와 메인 스레드(취소 요청) 간 가시성 보장.
+        // 취소 플래그/핸들 참조의 stale 캐시 읽기를 막는다.
+        private static volatile bool isCancelled = false;
+        private static volatile Editor.AITAsyncCommandRunner.CommandTask currentAsyncTask = null;
+        private static volatile Editor.AITPackageBuilder.EarlyPackageContext currentEarlyContext = null;
+
+        /// <summary>
+        /// 빌드 취소 요청
+        /// </summary>
+        public static void CancelBuild()
+        {
+            isCancelled = true;
+            Debug.Log("[AIT] 빌드 취소 요청됨");
+
+            // 병렬 pnpm install 취소
+            if (currentEarlyContext != null)
+            {
+                currentEarlyContext.CancelAndDisposePnpm();
+                currentEarlyContext = null;
+            }
+
+            // 현재 실행 중인 비동기 작업이 있으면 취소
+            if (currentAsyncTask != null)
+            {
+                Editor.AITAsyncCommandRunner.CancelTask(currentAsyncTask);
+                currentAsyncTask = null;
+            }
+        }
+
+        /// <summary>
+        /// 빌드 취소 플래그 리셋
+        /// </summary>
+        public static void ResetCancellation()
+        {
+            isCancelled = false;
+            currentAsyncTask = null;
+            currentEarlyContext = null;
+        }
+
+        /// <summary>
+        /// 빌드가 취소되었는지 확인
+        /// </summary>
+        public static bool IsCancelled()
+        {
+            return isCancelled;
+        }
+
+        /// <summary>
+        /// 비동기 빌드 작업이 진행 중인지 확인
+        /// </summary>
+        public static bool HasRunningAsyncTask()
+        {
+            return currentAsyncTask != null;
+        }
+
+        /// <summary>
+        /// 현재 비동기 작업 설정 (취소용)
+        /// </summary>
+        public static void SetCurrentAsyncTask(Editor.AITAsyncCommandRunner.CommandTask task)
+        {
+            currentAsyncTask = task;
+        }
+
+        /// <summary>
+        /// 병렬 pnpm install 컨텍스트 설정 (취소 시 정리 대상). null 전달로 해제.
+        /// </summary>
+        public static void SetCurrentEarlyContext(Editor.AITPackageBuilder.EarlyPackageContext context)
+        {
+            currentEarlyContext = context;
+        }
+    }
+}

--- a/Editor/AITBuildCancellation.cs.meta
+++ b/Editor/AITBuildCancellation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5658cd61a6e48f09ec9f1a128811bbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -30,70 +30,37 @@ namespace AppsInToss
     {
         #region Build Cancellation
 
-        // volatile: 백그라운드 빌드 스레드와 메인 스레드(취소 요청) 간 가시성 보장.
-        // 취소 플래그/핸들 참조의 stale 캐시 읽기를 막는다.
-        private static volatile bool isCancelled = false;
-        private static volatile Editor.AITAsyncCommandRunner.CommandTask currentAsyncTask = null;
-        private static volatile Editor.AITPackageBuilder.EarlyPackageContext currentEarlyContext = null;
+        // 빌드 취소 상태(플래그/비동기 작업 핸들/조기 패키지 컨텍스트)는
+        // AITBuildCancellation으로 분리(#36). 아래는 기존 공개 API 호환을 위한 위임 래퍼이며
+        // 동작은 변경되지 않는다.
 
         static AITConvertCore() { }
 
         /// <summary>
         /// 빌드 취소 요청
         /// </summary>
-        public static void CancelBuild()
-        {
-            isCancelled = true;
-            Debug.Log("[AIT] 빌드 취소 요청됨");
-
-            // 병렬 pnpm install 취소
-            if (currentEarlyContext != null)
-            {
-                currentEarlyContext.CancelAndDisposePnpm();
-                currentEarlyContext = null;
-            }
-
-            // 현재 실행 중인 비동기 작업이 있으면 취소
-            if (currentAsyncTask != null)
-            {
-                Editor.AITAsyncCommandRunner.CancelTask(currentAsyncTask);
-                currentAsyncTask = null;
-            }
-        }
+        public static void CancelBuild() => AITBuildCancellation.CancelBuild();
 
         /// <summary>
         /// 빌드 취소 플래그 리셋
         /// </summary>
-        public static void ResetCancellation()
-        {
-            isCancelled = false;
-            currentAsyncTask = null;
-            currentEarlyContext = null;
-        }
+        public static void ResetCancellation() => AITBuildCancellation.ResetCancellation();
 
         /// <summary>
         /// 빌드가 취소되었는지 확인
         /// </summary>
-        public static bool IsCancelled()
-        {
-            return isCancelled;
-        }
+        public static bool IsCancelled() => AITBuildCancellation.IsCancelled();
 
         /// <summary>
         /// 비동기 빌드 작업이 진행 중인지 확인
         /// </summary>
-        public static bool HasRunningAsyncTask()
-        {
-            return currentAsyncTask != null;
-        }
+        public static bool HasRunningAsyncTask() => AITBuildCancellation.HasRunningAsyncTask();
 
         /// <summary>
         /// 현재 비동기 작업 설정 (취소용)
         /// </summary>
         internal static void SetCurrentAsyncTask(Editor.AITAsyncCommandRunner.CommandTask task)
-        {
-            currentAsyncTask = task;
-        }
+            => AITBuildCancellation.SetCurrentAsyncTask(task);
 
         #endregion
 
@@ -822,7 +789,7 @@ namespace AppsInToss
                         return;
                     }
 
-                    currentEarlyContext = earlyCtx;
+                    AITBuildCancellation.SetCurrentEarlyContext(earlyCtx);
                     Editor.AITPackageBuilder.StartPnpmInstallInBackground(earlyCtx);
 
                     // Phase 1: WebGL Build (BLOCKING - 메인 스레드)
@@ -834,7 +801,7 @@ namespace AppsInToss
                     if (webglResult != AITExportError.SUCCEED)
                     {
                         earlyCtx.CancelAndDisposePnpm();
-                        currentEarlyContext = null;
+                        AITBuildCancellation.SetCurrentEarlyContext(null);
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
                         onComplete?.Invoke(webglResult);
@@ -844,7 +811,7 @@ namespace AppsInToss
                     if (IsCancelled())
                     {
                         earlyCtx.CancelAndDisposePnpm();
-                        currentEarlyContext = null;
+                        AITBuildCancellation.SetCurrentEarlyContext(null);
                         Debug.LogWarning("[AIT] 빌드가 취소되었습니다.");
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
@@ -854,7 +821,7 @@ namespace AppsInToss
 
                     // Phase 2: WebGL 출력 복사 + pnpm install 완료 대기 + granite build
                     string webglPath = Path.Combine(projectPath, webglDir);
-                    currentEarlyContext = null;
+                    AITBuildCancellation.SetCurrentEarlyContext(null);
                     AITBuildSession.SetStage(BuildStage.Packaging);
                     Editor.AITPackageBuilder.CompletePackagingAfterWebGLBuild(
                         earlyCtx, webglPath, profile, snapshot, onComplete, onProgress, skipGraniteBuild);
@@ -958,7 +925,7 @@ namespace AppsInToss
                 profile,
                 onComplete: (result) =>
                 {
-                    currentAsyncTask = null;
+                    AITBuildCancellation.SetCurrentAsyncTask(null);
                     try { snapshot.Restore(); }
                     finally { AITBuildSession.EndBuild(); }
 


### PR DESCRIPTION
## 개요

god-class `Editor/AITConvertCore.cs`(약 1,300행) 분해(#36, TODO.md "리팩토링" P2)의 **첫 번째 동작 보존 증분**. 빌드 취소 관심사를 전용 정적 클래스 `Editor/AITBuildCancellation.cs`로 추출한다.

## 변경 내용

- **`AITBuildCancellation` 신규** (`internal static`): 3개 `volatile` 정적 필드(`isCancelled` / `currentAsyncTask` / `currentEarlyContext`)와 `CancelBuild` / `ResetCancellation` / `IsCancelled` / `HasRunningAsyncTask` / `SetCurrentAsyncTask` 본문을 그대로 이동. 더불어 파이프라인이 직접 쓰던 컨텍스트 설정을 위한 `SetCurrentEarlyContext` 접근자 추가.
- **`AITConvertCore`**: 기존 공개 취소 API(`CancelBuild`/`ResetCancellation`/`IsCancelled`/`HasRunningAsyncTask` public, `SetCurrentAsyncTask` internal)를 **위임 래퍼**로 유지 → 외부 호출자 4개 파일(`AITPackageBuilder`, `AITPackageInitializer`, `AITNpmRunner`, `Menu/AITDeployManager`)은 **변경 없음**.
- 파이프라인 내부에서 필드를 직접 쓰던 5곳(`currentEarlyContext` 4곳 + `currentAsyncTask` 1곳)을 접근자 호출로 라우팅.

## 동작 보존 근거

- `volatile` 의미(백그라운드 빌드 스레드 ↔ 메인 스레드 가시성) 유지 — 필드는 새 클래스에서도 `volatile`.
- `CancelBuild`의 `Debug.Log` 메시지·취소 순서(early context → async task) 그대로 보존.
- `AITConvertCore`의 빈 정적 생성자 유지 → 잔여 정적 필드 초기화 타이밍(beforefieldinit) 불변.
- 공개 API 시그니처 무변경 → 호출자 호환.

## 검증

- 로컬 `--validate`의 **Meta GUID Hygiene** 통과(신규 `.meta` GUID 중복 없음). SDK Generator 유닛 테스트는 로컬 미러 tarball fetch 실패(환경 이슈)로 스킵 — 본 변경은 generator/lockfile 무관(Editor C#만 수정).
- C# 컴파일·EditMode 검증은 **E2E 디스패치로 확인 예정** (10개 빌드 레그 전부에서 EditMode 컴파일).

## 비고

- #864(PR) HOT 영역(Error Handling, WebGL Build)과 **disjoint** — 동일 파일이지만 비중첩 영역만 수정.
- 리뷰 위해 **open 상태 유지**. 자동 머지하지 않음.