### PR TITLE
리팩토링: AITConvertCore 빌드 결과 진단 분리 — AITWebGLBuildDiagnostics (#36 증분 2)

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -129,154 +129,6 @@ namespace AppsInToss
         }
 
         /// <summary>
-        /// Unity의 BuildResult를 AIT 내부 에러 코드로 매핑합니다.
-        /// Cancelled는 사용자 의사이므로 SDK 결함 보고 대상이 아니며 CANCELLED로 매핑됩니다.
-        /// </summary>
-        internal static AITExportError MapBuildResultToExportError(
-            UnityEditor.Build.Reporting.BuildResult result)
-        {
-            switch (result)
-            {
-                case UnityEditor.Build.Reporting.BuildResult.Succeeded:
-                    return AITExportError.SUCCEED;
-                case UnityEditor.Build.Reporting.BuildResult.Cancelled:
-                    return AITExportError.CANCELLED;
-                default:
-                    return AITExportError.BUILD_WEBGL_FAILED;
-            }
-        }
-
-        // WebGL 빌드 실패 진단에서 에러/경고에 부여하는 '개별' 캡(슬롯).
-        // 과거에는 단일 maxMessages(10)를 에러·경고가 공유해, 에러가 10개를 채우면 경고가
-        // 한 줄도 안 보이고 생략 카운트도 심각도 구분 없이 합산돼 모호했다(이 PR이 해소하는 갭).
-        // 캡을 분리해 에러를 우선 보장하고 경고에도 별도 예산을 준다.
-        internal const int FailureSummaryMaxErrors = 10;
-        internal const int FailureSummaryMaxWarnings = 5;
-
-        /// <summary>
-        /// WebGL 빌드 실패 진단 요약 문자열을 구성합니다. 에러/경고 캡을 분리(에러 우선)하여
-        /// 한쪽이 다른 쪽의 슬롯을 잠식하지 않게 하고, 생략 개수를 심각도별로 분리 표기합니다.
-        /// <paramref name="messages"/>에 에러/경고가 하나도 없을 때(예: Bee/IL2CPP의 .o 컴파일
-        /// 실패가 BuildReport.steps 메시지로 잡히지 않는 무진단 실패)에 한해
-        /// <paramref name="logTail"/>(에디터 로그 꼬리)을 첨부해 단서를 남깁니다.
-        /// 순수 함수로 분리되어 EditMode에서 BuildReport 없이 검증 가능합니다.
-        /// </summary>
-        internal static string BuildFailureSummary(
-            string resultLabel,
-            int summaryTotalErrors,
-            int summaryTotalWarnings,
-            List<(LogType type, string content)> messages,
-            string logTail,
-            int maxErrors = FailureSummaryMaxErrors,
-            int maxWarnings = FailureSummaryMaxWarnings)
-        {
-            var sb = new System.Text.StringBuilder();
-            sb.AppendLine("[AIT] WebGL 빌드가 실패했습니다.");
-            sb.AppendLine($"  결과: {resultLabel}");
-            sb.AppendLine($"  총 에러: {summaryTotalErrors}, 총 경고: {summaryTotalWarnings}");
-
-            int shownErrors = 0, omittedErrors = 0;
-            int shownWarnings = 0, omittedWarnings = 0;
-
-            if (messages != null)
-            {
-                // 에러(Error/Exception/Assert) 먼저 출력 — 실패 원인 우선.
-                foreach (var m in messages)
-                {
-                    if (m.type == LogType.Error || m.type == LogType.Exception || m.type == LogType.Assert)
-                    {
-                        if (shownErrors < maxErrors)
-                        {
-                            sb.AppendLine($"  [{m.type}] {m.content}");
-                            shownErrors++;
-                        }
-                        else
-                        {
-                            omittedErrors++;
-                        }
-                    }
-                }
-
-                // 경고는 에러 캡과 무관한 별도 예산으로 출력(에러가 경고 슬롯을 잠식하지 않음).
-                foreach (var m in messages)
-                {
-                    if (m.type == LogType.Warning)
-                    {
-                        if (shownWarnings < maxWarnings)
-                        {
-                            sb.AppendLine($"  [{m.type}] {m.content}");
-                            shownWarnings++;
-                        }
-                        else
-                        {
-                            omittedWarnings++;
-                        }
-                    }
-                }
-            }
-
-            if (omittedErrors > 0 || omittedWarnings > 0)
-            {
-                sb.AppendLine($"  ... 생략: 에러 {omittedErrors}개, 경고 {omittedWarnings}개");
-            }
-
-            // step 메시지가 하나도 없을 때만 로그 꼬리를 첨부(Bee/IL2CPP .o 무진단 실패 대비).
-            bool hadAnyStepMessage =
-                shownErrors > 0 || shownWarnings > 0 || omittedErrors > 0 || omittedWarnings > 0;
-            if (!hadAnyStepMessage && !string.IsNullOrEmpty(logTail))
-            {
-                sb.AppendLine("  [진단] BuildReport.steps에 메시지가 없습니다. 에디터 로그 꼬리:");
-                sb.Append(logTail);
-            }
-
-            return sb.ToString().TrimEnd();
-        }
-
-        /// <summary>
-        /// 에디터 로그 파일의 마지막 <paramref name="maxBytes"/>바이트(꼬리)를 읽어 반환합니다.
-        /// Bee/IL2CPP의 .o 컴파일 실패처럼 BuildReport.steps에 잡히지 않는 무진단 실패의 단서를
-        /// 남기기 위한 보조 진단 경로입니다. 파일이 에디터에 의해 열려 있을 수 있으므로 공유 읽기
-        /// 모드로 접근하고, 어떤 예외도 삼켜 <c>null</c>을 반환합니다(진단 보조라 실패가 빌드 흐름을
-        /// 막으면 안 됨). UTF-8 다바이트 경계가 잘릴 수 있으나 진단용으로 허용합니다.
-        /// </summary>
-        internal static string ReadEditorLogTail(string logPath, int maxBytes = 4000)
-        {
-            try
-            {
-                if (string.IsNullOrEmpty(logPath) || !File.Exists(logPath))
-                    return null;
-
-                using (var fs = new FileStream(logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                {
-                    long len = fs.Length;
-                    if (len <= 0)
-                        return null;
-
-                    int toRead = (int)Math.Min(len, (long)Math.Max(0, maxBytes));
-                    if (toRead <= 0)
-                        return null;
-
-                    fs.Seek(-toRead, SeekOrigin.End);
-                    var buffer = new byte[toRead];
-                    int offset = 0;
-                    while (offset < toRead)
-                    {
-                        int read = fs.Read(buffer, offset, toRead - offset);
-                        if (read <= 0)
-                            break;
-                        offset += read;
-                    }
-
-                    return System.Text.Encoding.UTF8.GetString(buffer, 0, offset);
-                }
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
         /// 에러 코드를 사용자 친화적 메시지로 변환
         /// </summary>
         public static string GetErrorMessage(AITExportError error)
@@ -1141,11 +993,11 @@ namespace AppsInToss
                         break;
                     }
                 }
-                string logTail = hasDiagnosticMessage ? null : ReadEditorLogTail(Application.consoleLogPath);
+                string logTail = hasDiagnosticMessage ? null : AITWebGLBuildDiagnostics.ReadEditorLogTail(Application.consoleLogPath);
 
                 // BuildSummary.totalErrors/totalWarnings는 uint이므로 int 시그니처로 명시 캐스트
                 // (실패 빌드의 카운트는 항상 int 범위 — overflow 우려 없음).
-                string failureSummary = BuildFailureSummary(
+                string failureSummary = AITWebGLBuildDiagnostics.BuildFailureSummary(
                     result.summary.result.ToString(),
                     (int)result.summary.totalErrors,
                     (int)result.summary.totalWarnings,

--- a/Editor/AITWebGLBuildDiagnostics.cs
+++ b/Editor/AITWebGLBuildDiagnostics.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+namespace AppsInToss
+{
+    /// <summary>
+    /// Unity WebGL 빌드 결과 해석 헬퍼(#36으로 AITConvertCore에서 분리). BuildResult→AIT 에러 코드
+    /// 매핑, 빌드 실패 요약 문자열 구성, 무진단 실패 대비 에디터 로그 꼬리 읽기를 담당하는 순수/준순수
+    /// 유틸리티입니다. 동작은 분리 전과 동일합니다(behavior-preserving).
+    ///
+    /// 주의: 이름이 비슷한 <see cref="Editor.AITBuildDiagnostics"/>(AppsInToss.Editor)와는 별개입니다 —
+    /// 그쪽은 외부 명령 실패의 exit code/stderr를 Sentry extra로 싣는 상태 버퍼이고, 이 클래스는
+    /// 무상태 결과 해석/요약 함수 모음입니다. 공개 에러 메시지 변환(GetErrorMessage 등)과
+    /// AITExportError 열거형은 공개 계약이라 AITConvertCore에 남습니다.
+    /// </summary>
+    internal static class AITWebGLBuildDiagnostics
+    {
+        /// <summary>
+        /// Unity의 BuildResult를 AIT 내부 에러 코드로 매핑합니다.
+        /// Cancelled는 사용자 의사이므로 SDK 결함 보고 대상이 아니며 CANCELLED로 매핑됩니다.
+        /// </summary>
+        internal static AITConvertCore.AITExportError MapBuildResultToExportError(
+            UnityEditor.Build.Reporting.BuildResult result)
+        {
+            switch (result)
+            {
+                case UnityEditor.Build.Reporting.BuildResult.Succeeded:
+                    return AITConvertCore.AITExportError.SUCCEED;
+                case UnityEditor.Build.Reporting.BuildResult.Cancelled:
+                    return AITConvertCore.AITExportError.CANCELLED;
+                default:
+                    return AITConvertCore.AITExportError.BUILD_WEBGL_FAILED;
+            }
+        }
+
+        // WebGL 빌드 실패 진단에서 에러/경고에 부여하는 '개별' 캡(슬롯).
+        // 과거에는 단일 maxMessages(10)를 에러·경고가 공유해, 에러가 10개를 채우면 경고가
+        // 한 줄도 안 보이고 생략 카운트도 심각도 구분 없이 합산돼 모호했다(이 PR이 해소하는 갭).
+        // 캡을 분리해 에러를 우선 보장하고 경고에도 별도 예산을 준다.
+        internal const int FailureSummaryMaxErrors = 10;
+        internal const int FailureSummaryMaxWarnings = 5;
+
+        /// <summary>
+        /// WebGL 빌드 실패 진단 요약 문자열을 구성합니다. 에러/경고 캡을 분리(에러 우선)하여
+        /// 한쪽이 다른 쪽의 슬롯을 잠식하지 않게 하고, 생략 개수를 심각도별로 분리 표기합니다.
+        /// <paramref name="messages"/>에 에러/경고가 하나도 없을 때(예: Bee/IL2CPP의 .o 컴파일
+        /// 실패가 BuildReport.steps 메시지로 잡히지 않는 무진단 실패)에 한해
+        /// <paramref name="logTail"/>(에디터 로그 꼬리)을 첨부해 단서를 남깁니다.
+        /// 순수 함수로 분리되어 EditMode에서 BuildReport 없이 검증 가능합니다.
+        /// </summary>
+        internal static string BuildFailureSummary(
+            string resultLabel,
+            int summaryTotalErrors,
+            int summaryTotalWarnings,
+            List<(LogType type, string content)> messages,
+            string logTail,
+            int maxErrors = FailureSummaryMaxErrors,
+            int maxWarnings = FailureSummaryMaxWarnings)
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("[AIT] WebGL 빌드가 실패했습니다.");
+            sb.AppendLine($"  결과: {resultLabel}");
+            sb.AppendLine($"  총 에러: {summaryTotalErrors}, 총 경고: {summaryTotalWarnings}");
+
+            int shownErrors = 0, omittedErrors = 0;
+            int shownWarnings = 0, omittedWarnings = 0;
+
+            if (messages != null)
+            {
+                // 에러(Error/Exception/Assert) 먼저 출력 — 실패 원인 우선.
+                foreach (var m in messages)
+                {
+                    if (m.type == LogType.Error || m.type == LogType.Exception || m.type == LogType.Assert)
+                    {
+                        if (shownErrors < maxErrors)
+                        {
+                            sb.AppendLine($"  [{m.type}] {m.content}");
+                            shownErrors++;
+                        }
+                        else
+                        {
+                            omittedErrors++;
+                        }
+                    }
+                }
+
+                // 경고는 에러 캡과 무관한 별도 예산으로 출력(에러가 경고 슬롯을 잠식하지 않음).
+                foreach (var m in messages)
+                {
+                    if (m.type == LogType.Warning)
+                    {
+                        if (shownWarnings < maxWarnings)
+                        {
+                            sb.AppendLine($"  [{m.type}] {m.content}");
+                            shownWarnings++;
+                        }
+                        else
+                        {
+                            omittedWarnings++;
+                        }
+                    }
+                }
+            }
+
+            if (omittedErrors > 0 || omittedWarnings > 0)
+            {
+                sb.AppendLine($"  ... 생략: 에러 {omittedErrors}개, 경고 {omittedWarnings}개");
+            }
+
+            // step 메시지가 하나도 없을 때만 로그 꼬리를 첨부(Bee/IL2CPP .o 무진단 실패 대비).
+            bool hadAnyStepMessage =
+                shownErrors > 0 || shownWarnings > 0 || omittedErrors > 0 || omittedWarnings > 0;
+            if (!hadAnyStepMessage && !string.IsNullOrEmpty(logTail))
+            {
+                sb.AppendLine("  [진단] BuildReport.steps에 메시지가 없습니다. 에디터 로그 꼬리:");
+                sb.Append(logTail);
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        /// <summary>
+        /// 에디터 로그 파일의 마지막 <paramref name="maxBytes"/>바이트(꼬리)를 읽어 반환합니다.
+        /// Bee/IL2CPP의 .o 컴파일 실패처럼 BuildReport.steps에 잡히지 않는 무진단 실패의 단서를
+        /// 남기기 위한 보조 진단 경로입니다. 파일이 에디터에 의해 열려 있을 수 있으므로 공유 읽기
+        /// 모드로 접근하고, 어떤 예외도 삼켜 <c>null</c>을 반환합니다(진단 보조라 실패가 빌드 흐름을
+        /// 막으면 안 됨). UTF-8 다바이트 경계가 잘릴 수 있으나 진단용으로 허용합니다.
+        /// </summary>
+        internal static string ReadEditorLogTail(string logPath, int maxBytes = 4000)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(logPath) || !File.Exists(logPath))
+                    return null;
+
+                using (var fs = new FileStream(logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    long len = fs.Length;
+                    if (len <= 0)
+                        return null;
+
+                    int toRead = (int)Math.Min(len, (long)Math.Max(0, maxBytes));
+                    if (toRead <= 0)
+                        return null;
+
+                    fs.Seek(-toRead, SeekOrigin.End);
+                    var buffer = new byte[toRead];
+                    int offset = 0;
+                    while (offset < toRead)
+                    {
+                        int read = fs.Read(buffer, offset, toRead - offset);
+                        if (read <= 0)
+                            break;
+                        offset += read;
+                    }
+
+                    return System.Text.Encoding.UTF8.GetString(buffer, 0, offset);
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Editor/AITWebGLBuildDiagnostics.cs.meta
+++ b/Editor/AITWebGLBuildDiagnostics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2c30a01cec84441b3066b74e4ff5271
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFailureSummaryTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFailureSummaryTests.cs
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------
-// BuildFailureSummaryTests.cs - AITConvertCore.BuildFailureSummary / ReadEditorLogTail 단위 테스트
+// BuildFailureSummaryTests.cs - AITWebGLBuildDiagnostics.BuildFailureSummary / ReadEditorLogTail 단위 테스트
 // 에러/경고 캡 분리(에러 우선, 상호 비잠식)·심각도별 생략 표기·무진단 실패 시 에디터 로그 꼬리
 // 첨부를 검증한다. BuildReport 없이 순수 함수로 검증 가능(Level 0, Unity/빌드 실행 불필요).
 // ---------------------------------------------------------------------------
@@ -22,7 +22,7 @@ public class BuildFailureSummaryTests
     [Test]
     public void Header_AlwaysIncludesResultAndTotals()
     {
-        string s = AITConvertCore.BuildFailureSummary("Failed", 3, 7, null, null);
+        string s = AITWebGLBuildDiagnostics.BuildFailureSummary("Failed", 3, 7, null, null);
         StringAssert.Contains("[AIT] WebGL 빌드가 실패했습니다.", s);
         StringAssert.Contains("결과: Failed", s);
         StringAssert.Contains("총 에러: 3, 총 경고: 7", s);
@@ -31,7 +31,7 @@ public class BuildFailureSummaryTests
     [Test]
     public void ErrorsShownBeforeWarnings()
     {
-        string s = AITConvertCore.BuildFailureSummary("Failed", 1, 1,
+        string s = AITWebGLBuildDiagnostics.BuildFailureSummary("Failed", 1, 1,
             Msgs((LogType.Warning, "W1"), (LogType.Error, "E1")), null);
         int eIdx = s.IndexOf("E1");
         int wIdx = s.IndexOf("W1");
@@ -49,7 +49,7 @@ public class BuildFailureSummaryTests
         for (int i = 0; i < 20; i++) msgs.Add((LogType.Error, "E" + i));
         msgs.Add((LogType.Warning, "WKEEP"));
 
-        string s = AITConvertCore.BuildFailureSummary("Failed", 20, 1, msgs, null,
+        string s = AITWebGLBuildDiagnostics.BuildFailureSummary("Failed", 20, 1, msgs, null,
             maxErrors: 10, maxWarnings: 5);
 
         StringAssert.Contains("WKEEP", s);
@@ -63,7 +63,7 @@ public class BuildFailureSummaryTests
         for (int i = 0; i < 12; i++) msgs.Add((LogType.Error, "E" + i));
         for (int i = 0; i < 8; i++) msgs.Add((LogType.Warning, "W" + i));
 
-        string s = AITConvertCore.BuildFailureSummary("Failed", 12, 8, msgs, null,
+        string s = AITWebGLBuildDiagnostics.BuildFailureSummary("Failed", 12, 8, msgs, null,
             maxErrors: 10, maxWarnings: 5);
 
         // 에러 12개 중 10개 표시 → 2개 생략, 경고 8개 중 5개 표시 → 3개 생략
@@ -73,7 +73,7 @@ public class BuildFailureSummaryTests
     [Test]
     public void NoOmissionLine_WhenWithinCaps()
     {
-        string s = AITConvertCore.BuildFailureSummary("Failed", 1, 1,
+        string s = AITWebGLBuildDiagnostics.BuildFailureSummary("Failed", 1, 1,
             Msgs((LogType.Error, "E1"), (LogType.Warning, "W1")), null);
         StringAssert.DoesNotContain("생략", s);
     }
@@ -81,7 +81,7 @@ public class BuildFailureSummaryTests
     [Test]
     public void AssertAndExceptionCountAsErrors()
     {
-        string s = AITConvertCore.BuildFailureSummary("Failed", 2, 0,
+        string s = AITWebGLBuildDiagnostics.BuildFailureSummary("Failed", 2, 0,
             Msgs((LogType.Exception, "EX1"), (LogType.Assert, "AS1")), null);
         StringAssert.Contains("EX1", s);
         StringAssert.Contains("AS1", s);
@@ -90,7 +90,7 @@ public class BuildFailureSummaryTests
     [Test]
     public void LogTailAttached_OnlyWhenNoStepMessages()
     {
-        string s = AITConvertCore.BuildFailureSummary("Failed", 0, 0,
+        string s = AITWebGLBuildDiagnostics.BuildFailureSummary("Failed", 0, 0,
             new List<(LogType type, string content)>(), "TAIL-CONTENT-XYZ");
         StringAssert.Contains("에디터 로그 꼬리", s);
         StringAssert.Contains("TAIL-CONTENT-XYZ", s);
@@ -99,7 +99,7 @@ public class BuildFailureSummaryTests
     [Test]
     public void LogTailNotAttached_WhenStepMessagesPresent()
     {
-        string s = AITConvertCore.BuildFailureSummary("Failed", 1, 0,
+        string s = AITWebGLBuildDiagnostics.BuildFailureSummary("Failed", 1, 0,
             Msgs((LogType.Error, "E1")), "TAIL-CONTENT-XYZ");
         StringAssert.DoesNotContain("TAIL-CONTENT-XYZ", s);
     }
@@ -113,7 +113,7 @@ public class BuildFailureSummaryTests
         try
         {
             File.WriteAllText(path, "HEAD-0123456789-TAILSEGMENT");
-            string tail = AITConvertCore.ReadEditorLogTail(path, maxBytes: 11);
+            string tail = AITWebGLBuildDiagnostics.ReadEditorLogTail(path, maxBytes: 11);
             Assert.AreEqual("TAILSEGMENT", tail);
         }
         finally
@@ -129,7 +129,7 @@ public class BuildFailureSummaryTests
         try
         {
             File.WriteAllText(path, "short");
-            Assert.AreEqual("short", AITConvertCore.ReadEditorLogTail(path, maxBytes: 1000));
+            Assert.AreEqual("short", AITWebGLBuildDiagnostics.ReadEditorLogTail(path, maxBytes: 1000));
         }
         finally
         {
@@ -140,14 +140,14 @@ public class BuildFailureSummaryTests
     [Test]
     public void ReadEditorLogTail_MissingFile_ReturnsNull()
     {
-        Assert.IsNull(AITConvertCore.ReadEditorLogTail(
+        Assert.IsNull(AITWebGLBuildDiagnostics.ReadEditorLogTail(
             Path.Combine(Path.GetTempPath(), "ait-nonexistent-" + System.Guid.NewGuid().ToString("N") + ".log")));
     }
 
     [Test]
     public void ReadEditorLogTail_NullPath_ReturnsNull()
     {
-        Assert.IsNull(AITConvertCore.ReadEditorLogTail(null));
+        Assert.IsNull(AITWebGLBuildDiagnostics.ReadEditorLogTail(null));
     }
 
     private static string TempLogPath()

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildResultMappingTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildResultMappingTests.cs
@@ -18,7 +18,7 @@ public class BuildResultMappingTests
         // BUILD_WEBGL_FAILED로 매핑되어 Sentry 노이즈를 만들면 안 된다.
         Assert.AreEqual(
             AITConvertCore.AITExportError.CANCELLED,
-            AITConvertCore.MapBuildResultToExportError(BuildResult.Cancelled));
+            AITWebGLBuildDiagnostics.MapBuildResultToExportError(BuildResult.Cancelled));
     }
 
     [Test]
@@ -26,7 +26,7 @@ public class BuildResultMappingTests
     {
         Assert.AreEqual(
             AITConvertCore.AITExportError.SUCCEED,
-            AITConvertCore.MapBuildResultToExportError(BuildResult.Succeeded));
+            AITWebGLBuildDiagnostics.MapBuildResultToExportError(BuildResult.Succeeded));
     }
 
     [Test]
@@ -34,7 +34,7 @@ public class BuildResultMappingTests
     {
         Assert.AreEqual(
             AITConvertCore.AITExportError.BUILD_WEBGL_FAILED,
-            AITConvertCore.MapBuildResultToExportError(BuildResult.Failed));
+            AITWebGLBuildDiagnostics.MapBuildResultToExportError(BuildResult.Failed));
     }
 
     [Test]
@@ -44,6 +44,6 @@ public class BuildResultMappingTests
         // SDK가 진단할 수 있는 추가 정보가 없으므로 일반 빌드 실패로 매핑한다.
         Assert.AreEqual(
             AITConvertCore.AITExportError.BUILD_WEBGL_FAILED,
-            AITConvertCore.MapBuildResultToExportError(BuildResult.Unknown));
+            AITWebGLBuildDiagnostics.MapBuildResultToExportError(BuildResult.Unknown));
     }
 }


### PR DESCRIPTION
## 개요
[#36] god-class `Editor/AITConvertCore.cs` 분리의 두 번째 증분. WebGL 빌드 **결과 해석/실패 진단** 헬퍼를 무상태 유틸리티 클래스 `AITWebGLBuildDiagnostics`로 추출한다.

(첫 증분 = #867 Build Cancellation → `AITBuildCancellation`. 본 PR은 그와 **겹치지 않는** Error Handling 영역만 건드린다.)

## 변경
새 파일 `Editor/AITWebGLBuildDiagnostics.cs` (`namespace AppsInToss`, `internal static`):
- `MapBuildResultToExportError` — Unity `BuildResult` → `AITExportError` 매핑
- `BuildFailureSummary` — 에러/경고 캡 분리 실패 요약 문자열 (순수 함수)
- `ReadEditorLogTail` — 무진단(Bee/IL2CPP `.o`) 실패 대비 에디터 로그 꼬리
- `FailureSummaryMaxErrors` / `FailureSummaryMaxWarnings` 상수

호출부 갱신: `AITConvertCore`의 WebGL 빌드 경로 2곳, EditMode 테스트 2개(`BuildFailureSummaryTests`, `BuildResultMappingTests`).

`AITConvertCore.cs`: **1,416 → 1,268행 (-148)**

## behavior-preserving
- 메서드 본문은 그대로 이동(로직 변경 0). 이동한 블록 내 `AITExportError` 참조만 `AITConvertCore.AITExportError`로 정규화.
- **공개 계약 유지**: `AITExportError` 열거형(221곳 참조)과 `GetErrorMessage`/`GetErrorShortReason`/`GetErrorCause`는 공개 API라 `AITConvertCore`에 남김.

## 네이밍
기존 `AppsInToss.Editor.AITBuildDiagnostics`(외부 명령 exit code/stderr를 Sentry extra로 싣는 **상태 버퍼**, #723)와 책임이 다르고 이름이 겹치므로 **`WebGL` 접두사**로 명명하고 클래스 doc에 차이를 명시했다.

## 검증
- 정적 검증: 브레이스 균형, 잔여 구참조 0, 새 클래스 19개 호출부 네임스페이스 해석 확인, `.meta` GUID 유니크, 기존 #723 파일 무변경 확인.
- C# 컴파일/회귀(EditMode `BuildFailureSummaryTests`·`BuildResultMappingTests` 포함)는 E2E로 검증 — dispatch 예정.

> 리뷰 후 머지 대상(자동 머지 안 함). #867과 라인 영역이 disjoint하여 머지 순서 무관.