### PR TITLE
수정: EditMode 테스트 컴파일 실패(main RED) — AITBuildValidatorConfigGuardTests using AppsInToss 누락 해소

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using AppsInToss.Editor;
+using AppsInToss; // AITConvertCore(=AppsInToss.AITConvertCore) 해소 — using AppsInToss.Editor는 부모 네임스페이스를 가져오지 않음
 
 [TestFixture]
 public class AITBuildValidatorConfigGuardTests


### PR DESCRIPTION
## 요약 — main HEAD RED 해소 (1라인)

`#866`(머지 커밋 `d7a51d4`, 현재 main HEAD)에서 추가된 `AITBuildValidatorConfigGuardTests.cs`가 `AITConvertCore`(네임스페이스 `AppsInToss`)를 참조하면서 `using AppsInToss.Editor`만 두고 **`using AppsInToss`를 누락**했습니다. C#에서 `using AppsInToss.Editor`는 부모 네임스페이스 `AppsInToss`를 가져오지 않으므로, bare `AITConvertCore`가 **CS0103("does not exist in the current context")** 으로 해소 실패합니다.

## 영향

- `AppsInTossEditModeTests` 어셈블리 **전체가 전 플랫폼에서 컴파일 실패** → main HEAD(`d7a51d4`) 기반 **모든 PR의 E2E `Run EditMode Tests` 단계가 RED**.
- `#870`은 `#866` 머지 **전** 분기되어 이 테스트 파일이 없었기에 통과했고, `#866` 머지 **이후 main HEAD를 직접 검증한 E2E가 없어** 회귀가 가려져 있었습니다. 최근 E2E #874(main + 무관 파일)에서 Windows 5개 버전 빌드가 동일 시그니처(`AITConvertCore CS0103 ×5`)로 실패하며 표면화되었습니다.

## 수정

동일 어셈블리의 다른 `AITConvertCore` 소비자들(`BuildMarkerTests`, `ValidateDistOutputTests` 등 10여 개)과 동일하게 **`using AppsInToss;` 한 줄 추가**. 동작 변경 없음, 컴파일 해소만.

## 검증

- 정적 분석: 실패 파일만이 유일하게 `using AppsInToss` 누락(CI도 이 파일에서만 CS0103 5건 보고). 단일 파일 수정으로 완결.
- E2E `clean_library=true`로 디스패치하여 EditMode 컴파일 복구 확인 예정.

> 우선 머지 대상: main이 RED라 본 머지 전까지 다른 PR들의 E2E EditMode가 통과 불가합니다. (squash merge)