### PR TITLE
수정: EditMode 테스트 AITConvertCore 미해결 컴파일 에러(using AppsInToss 누락)

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs
@@ -10,7 +10,8 @@ using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using AppsInToss.Editor;
+using AppsInToss;          // AITConvertCore (namespace AppsInToss)
+using AppsInToss.Editor;   // AITBuildValidator (namespace AppsInToss.Editor)
 
 [TestFixture]
 public class AITBuildValidatorConfigGuardTests


### PR DESCRIPTION
## 배경

PR #866에서 추가한 `AITBuildValidatorConfigGuardTests.cs`(글로벌 namespace)가 `using AppsInToss.Editor`만 두고 `AITConvertCore`(`namespace AppsInToss`)를 import하지 않아, EditMode 컴파일에서 `CS0103: The name 'AITConvertCore' does not exist in the current context`(L68/75/93/112/130)로 실패했다.

PR #866 시점 required check(`scan`)는 EditMode를 컴파일하지 않아 미검출되었고, 베타 릴리즈 워크플로우의 **베타 빌드(macOS)** EditMode 컴파일 단계에서 드러났다(라이선스 이슈와 무관, 라이선스는 이미 수복됨).

## 변경

- 테스트 파일 상단에 `using AppsInToss;` 추가 (`AITConvertCore` 해석)

```diff
 using UnityEngine.TestTools;
+using AppsInToss;          // AITConvertCore (namespace AppsInToss)
 using AppsInToss.Editor;   // AITBuildValidator (namespace AppsInToss.Editor)
```

## 영향

- 테스트 전용 변경. 런타임/생성기/빌드 산출물 영향 없음.
- 이 수정이 main에 들어가야 `source_ref=main` 기반 베타 5건 재빌드의 EditMode 컴파일이 통과한다.