### PR TITLE
테스트: AITBuildValidatorConfigGuardTests FormatException 해소 (main E2E RED 복구)

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildValidatorConfigGuardTests.cs
@@ -29,6 +29,8 @@ public class AITBuildValidatorConfigGuardTests
         "  webBundleDir: 'dist/web',\n" +
         "};\n" +
         "//// SDK_GENERATED_END ////\n" +
+        // USER_CONFIG 블록이 삽입되는 자리(sentinel). 반드시 string.Replace로 치환할 것 —
+        // string.Format을 쓰면 위 TS 리터럴 중괄호({ ... })를 서식 placeholder로 오인해 FormatException이 발생한다.
         "{0}" +
         "const _userConfig = userConfig as Record<string, any>;\n" +
         "export default defineConfig({ ..._userConfig, ...sdkConfig });\n";
@@ -62,7 +64,7 @@ public class AITBuildValidatorConfigGuardTests
     [Test]
     public void Validate_CleanConfig_ReturnsSucceed()
     {
-        WriteAppsInToss(string.Format(Substituted, EmptyUserConfig));
+        WriteAppsInToss(Substituted.Replace("{0}", EmptyUserConfig));
 
         var result = AITBuildValidator.ValidateGeneratedBuildConfigs(_buildDir);
 
@@ -105,7 +107,7 @@ public class AITBuildValidatorConfigGuardTests
             "  brand: { primaryColor: '%AIT_PRIMARY_COLOR%', displayName: '%AIT_DISPLAY_NAME%' },\n" +
             "};\n" +
             "//// USER_CONFIG_END ////\n";
-        WriteAppsInToss(string.Format(Substituted, userConfig));
+        WriteAppsInToss(Substituted.Replace("{0}", userConfig));
 
         LogAssert.Expect(LogType.Warning, new Regex(@"USER_CONFIG에 SDK가 관리하는 설정이 남아"));
         var result = AITBuildValidator.ValidateGeneratedBuildConfigs(_buildDir);
@@ -123,7 +125,7 @@ public class AITBuildValidatorConfigGuardTests
             "  webViewProps: { bounces: false },\n" +
             "};\n" +
             "//// USER_CONFIG_END ////\n";
-        WriteAppsInToss(string.Format(Substituted, userConfig));
+        WriteAppsInToss(Substituted.Replace("{0}", userConfig));
 
         LogAssert.Expect(LogType.Warning, new Regex(@"이동/이름변경된 키"));
         var result = AITBuildValidator.ValidateGeneratedBuildConfigs(_buildDir);


### PR DESCRIPTION
## 무엇을 / 왜

`origin/main`(#876 머지 시점)의 EditMode 테스트 `AITBuildValidatorConfigGuardTests`가 **3개 테스트에서 `System.FormatException`으로 RED** 상태였습니다.

### 원인
`Substituted` 상수는 생성된 `apps-in-toss.config.ts` 골격을 그대로 담고 있어 TypeScript 리터럴 중괄호를 포함합니다:

- `import { defineConfig } from ...`
- `brand: { primaryColor: '#3182f6' }`
- `webView: { allowsInlineMediaPlayback: true, ... }`
- `export default defineConfig({ ..._userConfig, ...sdkConfig })`

여기에 `string.Format(Substituted, userConfig)`를 호출하면 `string.Format`이 위 리터럴 `{ ... }`들을 **서식 placeholder로 오인**해 `FormatException`을 던졌습니다(미처리 예외 → NUnit `label=Error`). USER_CONFIG 삽입 자리는 단일 `"{0}"` sentinel입니다.

### 수정
3개 호출부(`Validate_CleanConfig_ReturnsSucceed`, `Validate_PlaceholderOnlyInUserConfig_ReturnsSucceed_WithWarning`, `Validate_DeprecatedKeyInUserConfig_ReturnsSucceed_WithWarning`)를 `string.Format(Substituted, X)` → `Substituted.Replace("{0}", X)`로 교체. 리터럴 중괄호를 건드리지 않습니다. 회귀 방지를 위해 sentinel 위에 한국어 주석 추가.

**프로덕션 코드 변경 없음 — 테스트 전용.** `AITBuildValidator` / `AITConvertCore` 동작 불변.

### 배경
- #866이 이 테스트를 추가했으나 CS0103(`using AppsInToss;` 누락)으로 컴파일이 막혀 한 번도 green으로 실행된 적이 없었습니다.
- #876이 CS0103을 고쳐 컴파일은 통과시켰지만, 컴파일이 풀리자 그 아래 잠복해 있던 `FormatException`이 드러났습니다.
- 본 PR이 그 잔여 결함을 해소합니다.

## 검증
- 변경 후 3개 테스트는 sentinel만 치환하므로 `FormatException` 없이 의도한 경고/성공 경로를 그대로 탑니다.
- E2E(EditMode 포함)를 디스패치해 10/10 빌드 green 확인 예정.