### PR TITLE
수정: 자동 업데이트 봇 BuildConfig 동기화에 bridge-core 누락 보강

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -303,13 +303,18 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           BUILDCONFIG_PKG="WebGLTemplates/AITTemplate/BuildConfig~/package.json"
 
-          # BuildConfig의 web-framework 버전도 동기화
+          # BuildConfig의 @apps-in-toss 패밀리 버전 동기화
+          # web-framework/web-analytics/bridge-core는 lockstep으로 publish되므로 동일 VERSION으로 정렬한다.
+          # bridge-core는 직접 의존성으로 존재할 때만 갱신 — 향후 직접 핀이 제거되어도 phantom 키를 다시 만들지 않도록 조건부 처리.
           jq --arg v "$VERSION" '
             .dependencies["@apps-in-toss/web-framework"] = $v |
-            .dependencies["@apps-in-toss/web-analytics"] = $v
+            .dependencies["@apps-in-toss/web-analytics"] = $v |
+            (if .dependencies["@apps-in-toss/bridge-core"]
+             then .dependencies["@apps-in-toss/bridge-core"] = $v
+             else . end)
           ' "$BUILDCONFIG_PKG" > tmp.json
           mv tmp.json "$BUILDCONFIG_PKG"
-          echo "BuildConfig web-framework/web-analytics 버전: ${VERSION}"
+          echo "BuildConfig web-framework/web-analytics/bridge-core 버전: ${VERSION}"
 
           # 확인
           cat "$BUILDCONFIG_PKG" | jq '.dependencies'
@@ -358,7 +363,7 @@ jobs:
 
           - @apps-in-toss/web-framework v${VERSION} 기반 SDK 코드 재생성
           - package.json 버전 동기화
-          - BuildConfig package.json web-framework/web-analytics 버전 동기화
+          - BuildConfig package.json web-framework/web-analytics/bridge-core 버전 동기화
           - unity-bridge.ts 자동 생성
           - Docs~/GettingStarted.md 설치 가이드 업데이트
 


### PR DESCRIPTION
## 배경

자동 SDK 업데이트 봇(`.github/workflows/update.yml`)이 생성하는 `SDK 업데이트` PR에서, `WebGLTemplates/AITTemplate/BuildConfig~/package.json`의 `@apps-in-toss/bridge-core` 직접 specifier가 매 릴리즈마다 뒤처지는 재발 갭이 있었다.

- `@apps-in-toss/web-framework` / `web-analytics` / `bridge-core`는 동일 버전으로 lockstep publish됨 (jsdelivr 교차검증: 셋 다 `latest=2.10.0`, `2.9.2`/`2.9.3` 모두 존재).
- 그러나 봇의 **"BuildConfig package.json 버전 동기화"** jq 스텝은 `web-framework` / `web-analytics` 두 개만 갱신하고 `bridge-core`는 누락 → web-framework가 2.9.3으로 올라가도 `bridge-core`는 직전 버전(예: 2.9.2)에 고정.
- 결과: lockfile에 **`bridge-core` 2.9.2 직접 + 2.9.3 전이(web-framework 경유) 이중 버전 공존**. (#869 정적 검토에서 2개 독립 차원이 동일 concern으로 지적.)

## 변경

`update.yml`의 BuildConfig 동기화 jq에 `bridge-core` 정렬을 추가:

- web-framework/web-analytics와 동일 `VERSION`으로 맞춤 → lockfile 이중 버전 제거.
- **단, `bridge-core`가 직접 의존성으로 존재할 때만 갱신**하는 조건부 처리 → 향후 직접 핀이 제거되어 전이 의존성으로 전환돼도 phantom 키가 재생성되지 않음 (web-framework/web-analytics의 무조건 set보다 forward-safe).
- 이후 `BuildConfig pnpm-lock.yaml 업데이트` 스텝의 `pnpm install --no-frozen-lockfile`이 lockfile을 정합하게 재생성.

`sdk-runtime-generator~`에서 bridge-core는 전이 의존성이므로(web-framework가 끌어옴) 별도 변경 불필요.

## 검증

- jq 로직 로컬 검증: bridge-core 직접 의존성 **있음** → 셋 다 동일 버전으로 정렬 / **없음** → web-framework·web-analytics만 갱신, phantom 키 미생성.
- `update.yml` YAML 파싱 OK.

## 범위/리스크

- 미래 자동 PR에만 영향 (release 자동화 한정). 런타임/SDK 코드 변경 없음.
- bridge-core 2.x patch 정렬은 이미 web-framework가 전이로 끌어오는 버전과 동일 → 이중 버전 제거이므로 리스크를 **줄이는** 방향.
- 기존 `#869`(이미 생성된 v2.9.3 PR)의 커밋된 BuildConfig/lockfile은 이 PR로 소급 수정되지 않음. 본 PR은 **재발 근본 원인**을 막는다 (#869 자체 처리는 해당 PR에서 별도 판단).

리뷰용으로 열어둔다 (자동 머지 안 함).