### PR TITLE
수정: WebGL 템플릿 전처리기 크래시 방지 — BuildConfig~ 잔여 산출물 제거

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -20,6 +20,10 @@ namespace AppsInToss.Editor
             bool templatesChanged = AITTemplateManager.EnsureWebGLTemplatesExist();
             Debug.Log($"[AIT] 빌드 초기화: 템플릿 변경={templatesChanged}");
 
+            // Unity WebGL 템플릿 전처리기 크래시 방지 (SDK-137):
+            // BuildConfig~ 하위에 잔존하는 비-소스 산출물(node_modules 등)을 BuildPlayer 직전에 제거.
+            ScrubTemplatePreprocessorHazards();
+
             // 템플릿이 변경된 경우에만 Unity가 인식하도록 리프레시
             // Domain Reload 방지: 빌드 중 Assembly 리로드를 잠금하여
             // 비-스크립트 파일 변경으로 인한 불필요한 Domain Reload를 차단
@@ -221,6 +225,57 @@ namespace AppsInToss.Editor
                 ? editorConfig.firstInteractiveLog == 1
                 : AITDefaultSettings.GetDefaultFirstInteractiveLog();
             Debug.Log($"[AIT]   - first-interactive 계측: {firstInteractiveEnabled}{(editorConfig.firstInteractiveLog < 0 ? " (자동)" : "")}");
+        }
+
+        /// <summary>
+        /// Unity WebGL 빌드의 템플릿 전처리기(Preprocess.js)가 템플릿 폴더를 재귀 순회하다
+        /// BuildConfig~ 하위의 잔여 빌드 산출물에 들어가 크래시하는 것을 막기 위해, 빌드 직전에
+        /// 해당 산출물 폴더를 제거한다. (Sentry SDK-137)
+        ///
+        /// 배경: SDK 자신은 pnpm install을 ait-build/ 사본에서만 수행하므로
+        /// Assets/WebGLTemplates/AITTemplate/BuildConfig~/node_modules를 만들지 않는다. 그러나
+        /// 개발자가 BuildConfig~ 안에서 직접 install을 돌리면 node_modules가 남고, 그 안의 전이
+        /// 의존성(예: @react-native/codegen의 C++ 코드젠 .js)에 들어 있는 bare #endif를 Unity 템플릿
+        /// 전처리기가 "found #endif without matching #if"로 오인해 빌드가 중단된다. 폴더명 끝의 '~'는
+        /// AssetDatabase import만 가리고 WebGL 템플릿 파일 스캔은 가리지 못하기 때문이다.
+        ///
+        /// 제거 대상 세 폴더는 이미 WebGLBuildCopier.CopyAdditionalUserFiles의 excludeFolders로
+        /// 취급되는 비-소스 산출물이며 모두 gitignore + 재생성 가능하므로 빌드 직전 제거해도 안전하다.
+        /// pnpm install은 ait-build/node_modules에서 별도로 일어나므로 재설치 비용도 없다.
+        /// </summary>
+        internal static void ScrubTemplatePreprocessorHazards()
+        {
+            ScrubTemplatePreprocessorHazards(System.IO.Path.Combine(
+                Application.dataPath, "WebGLTemplates/AITTemplate/BuildConfig~"));
+        }
+
+        /// <summary>
+        /// <see cref="ScrubTemplatePreprocessorHazards()"/>의 테스트 가능한 본체.
+        /// Application.dataPath 의존 없이 임의의 BuildConfig 경로를 받아 정리한다.
+        /// </summary>
+        /// <param name="projectBuildConfigPath">프로젝트의 BuildConfig~ 절대 경로</param>
+        internal static void ScrubTemplatePreprocessorHazards(string projectBuildConfigPath)
+        {
+            if (string.IsNullOrEmpty(projectBuildConfigPath))
+                return;
+
+            // 전처리기가 들어가면 안 되는 비-소스 산출물 (WebGLBuildCopier excludeFolders와 동일 집합)
+            string[] hazardFolders = { "node_modules", ".npm-cache", "dist" };
+
+            foreach (var folder in hazardFolders)
+            {
+                string target = System.IO.Path.Combine(projectBuildConfigPath, folder);
+                if (!System.IO.Directory.Exists(target))
+                    continue;
+
+                bool removed = AITFileSystemHelper.SafeDeleteDirectory(target);
+                if (removed)
+                    Debug.Log($"[AIT] 템플릿 전처리 위험 폴더 제거: BuildConfig~/{folder} " +
+                              "(Unity WebGL 전처리기 크래시 방지 — ait-build 재설치에는 영향 없음)");
+                else
+                    Debug.LogWarning($"[AIT] BuildConfig~/{folder} 제거 실패 — " +
+                                     "Unity WebGL 빌드가 전처리 단계에서 실패할 수 있습니다. 수동 삭제를 권장합니다.");
+            }
         }
 
         /// <summary>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerScrubTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerScrubTests.cs
@@ -1,0 +1,87 @@
+// -----------------------------------------------------------------------
+// AITBuildInitializerScrubTests.cs - ScrubTemplatePreprocessorHazards 단위 테스트
+// Level 0: BuildConfig~ 하위 비-소스 산출물(node_modules/.npm-cache/dist) 제거 검증
+//   - Unity WebGL 템플릿 전처리기(Preprocess.js) 크래시 방지 (Sentry SDK-137)
+//   - 소스 파일/폴더는 보존, 위험 폴더만 제거, 부재 시 무해(no-op)
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+using AppsInToss.Editor; // AITBuildInitializer (internal — AssemblyInfo InternalsVisibleTo 경유)
+
+[TestFixture]
+public class AITBuildInitializerScrubTests
+{
+    private string _buildConfigDir;
+
+    [SetUp]
+    public void Setup()
+    {
+        _buildConfigDir = Path.Combine(Path.GetTempPath(), "ait-scrub-tests-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_buildConfigDir);
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        if (_buildConfigDir != null && Directory.Exists(_buildConfigDir))
+            Directory.Delete(_buildConfigDir, recursive: true);
+    }
+
+    private void MakeDir(string name)
+    {
+        Directory.CreateDirectory(Path.Combine(_buildConfigDir, name));
+    }
+
+    private void MakeFile(string relativePath, string content = "x")
+    {
+        string full = Path.Combine(_buildConfigDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full));
+        File.WriteAllText(full, content);
+    }
+
+    [Test]
+    public void Scrub_RemovesHazardFolders_PreservesSourceFiles()
+    {
+        // 위험 폴더(전처리기가 들어가면 크래시) + 그 안의 파일
+        MakeFile("node_modules/.pnpm/pkg/lib/Generate.js", "#endif");
+        MakeFile(".npm-cache/tarball.tgz");
+        MakeFile("dist/web/index.js", "console.log(1)");
+        // 보존되어야 하는 소스
+        MakeFile("package.json", "{}");
+        MakeFile("vite.config.ts", "export default {}");
+
+        AITBuildInitializer.ScrubTemplatePreprocessorHazards(_buildConfigDir);
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(_buildConfigDir, "node_modules")), "node_modules는 제거되어야 한다");
+        Assert.IsFalse(Directory.Exists(Path.Combine(_buildConfigDir, ".npm-cache")), ".npm-cache는 제거되어야 한다");
+        Assert.IsFalse(Directory.Exists(Path.Combine(_buildConfigDir, "dist")), "dist는 제거되어야 한다");
+
+        Assert.IsTrue(File.Exists(Path.Combine(_buildConfigDir, "package.json")), "소스 package.json은 보존되어야 한다");
+        Assert.IsTrue(File.Exists(Path.Combine(_buildConfigDir, "vite.config.ts")), "소스 vite.config.ts는 보존되어야 한다");
+    }
+
+    [Test]
+    public void Scrub_NoHazardFolders_IsNoOp()
+    {
+        MakeFile("package.json", "{}");
+
+        // 위험 폴더가 없을 때 예외 없이 통과해야 한다
+        Assert.DoesNotThrow(() => AITBuildInitializer.ScrubTemplatePreprocessorHazards(_buildConfigDir));
+        Assert.IsTrue(File.Exists(Path.Combine(_buildConfigDir, "package.json")));
+    }
+
+    [Test]
+    public void Scrub_NonexistentPath_IsNoOp()
+    {
+        string missing = Path.Combine(_buildConfigDir, "does-not-exist");
+        Assert.DoesNotThrow(() => AITBuildInitializer.ScrubTemplatePreprocessorHazards(missing));
+    }
+
+    [Test]
+    public void Scrub_NullOrEmptyPath_IsNoOp()
+    {
+        Assert.DoesNotThrow(() => AITBuildInitializer.ScrubTemplatePreprocessorHazards(null));
+        Assert.DoesNotThrow(() => AITBuildInitializer.ScrubTemplatePreprocessorHazards(string.Empty));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerScrubTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerScrubTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 205b06f402a44efe945521dab64ff7dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 문제 (Sentry SDK-137)

Unity WebGL 빌드는 `Assets/WebGLTemplates/AITTemplate/` 폴더의 모든 파일을 `Preprocess.js`로 재귀 순회한다. 개발자가 `BuildConfig~` 안에서 직접 `pnpm/npm install`을 돌린 적이 있으면 `BuildConfig~/node_modules`가 남고, 그 안의 전이 의존성(`@react-native/codegen`의 C++ 코드젠 `.js` 등)에 들어 있는 bare `#endif`를 Unity 전처리기가 `found #endif without matching #if`로 오인해 **빌드가 중단**된다.

- 폴더명 끝의 `~`는 Unity **AssetDatabase import**만 가린다. WebGL 템플릿 파일 스캔/전처리는 디스크를 직접 읽으므로 `~` 폴더에도 들어간다.
- SDK 자신은 `pnpm install`을 `ait-build/` 사본에서만 수행하므로 `BuildConfig~/node_modules`를 만들지 않는다 → 이 잔여물은 **개발자의 수동 install**로만 생긴다.

## 수정

`AITBuildInitializer.Init`에서 `BuildPipeline.BuildPlayer` 직전(템플릿 ensure 직후)에 프로젝트 `BuildConfig~` 하위의 비-소스 산출물 `node_modules` / `.npm-cache` / `dist`를 제거한다.

- 이 세 폴더는 이미 `WebGLBuildCopier.CopyAdditionalUserFiles`의 `excludeFolders`로 취급되는 비-소스 산출물이며, 모두 gitignore + 재생성 가능 → 빌드 직전 제거해도 안전.
- `pnpm install`은 `ait-build/node_modules`에서 별도로 일어나므로 **재설치 비용 0**.
- 잔여물이 없으면 완전 no-op(로그도 없음) → 일반 빌드 경로에 영향 없음.
- `AITFileSystemHelper.SafeDeleteDirectory`(retry-backoff, Windows read-only 처리, 예외 흡수) 재사용.

## 테스트

`AITBuildInitializerScrubTests` (EditMode) 추가:
- 위험 폴더 3종 제거 + 소스 파일(package.json/vite.config.ts) 보존
- 위험 폴더 부재 시 no-op
- 존재하지 않는 경로 / null·empty 경로 무해

로컬 `--validate`: Meta GUID Hygiene 통과(신규 테스트 meta 포함). SDK Generator 유닛 테스트의 pnpm install 단계는 로컬 nexus 미러 stale로 실패하나 **본 변경과 무관**(C#만 수정, lockfile/package.json 미변경). C# 컴파일·EditMode 검증은 CI E2E에서 수행.

Fixes APPS-IN-TOSS-UNITY-SDK-137