### PR TITLE
수정: 베타 release notes commit 표기를 실제 게시 orphan 해시로 정정

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -770,7 +770,11 @@ jobs:
           CHANNEL_REF="${{ needs.beta-prepare.outputs.channel_ref }}"
           BETA_TAG="${{ needs.beta-prepare.outputs.beta_tag }}"
           RELEASE_DATETIME="${{ steps.release-info.outputs.release_datetime }}"
-          COMMIT_HASH="${{ steps.release-info.outputs.commit_hash }}"
+          # release notes의 commit 표기는 실제 게시된 orphan(publish step) 단축 해시를 사용한다.
+          # release-info.commit_hash는 UPM 정리(rm) 이전 staging HEAD라 force-push된 게시 커밋과
+          # 어긋난다(예: staging 1600e8c ≠ 게시 9c74bb0). publish.outputs.sha가 실제 게시 커밋이다.
+          COMMIT_HASH="${{ steps.publish.outputs.sha }}"
+          COMMIT_HASH="${COMMIT_HASH:0:7}"
 
           RELEASE_BODY=$(cat <<EOF
           ## Apps in Toss Unity SDK — 베타 (v${PKG_VERSION})


### PR DESCRIPTION
## 문제

`beta-release.yml`의 GitHub Release notes `🔗 **Commit**` 표기가 **실제 게시된 orphan 커밋과 어긋난다.**

원인은 release body 생성 순서:
1. `릴리즈 정보 주입`(L676) → `COMMIT_HASH=$(git rev-parse --short=7 HEAD)` — 이 시점 HEAD는 **UPM 정리(rm) 이전 staging orphan**
2. `UPM 패키지 정리`(L703) → `rm -rf .github/ Tests~/ CLAUDE.md …` 로 트리 변경
3. `Orphan Commit 생성`(L727) → `git commit-tree`로 **정리 후 최종 게시 orphan** 생성 → `#beta`·스냅샷 태그로 force-push

즉 release notes에는 staging 해시가, 실제 `#beta`/태그에는 정리 후 해시가 들어가 모든 베타에서 불일치. 실제 사례: `3.0.0-beta.b36d7b5` 재게시 시 notes `1600e8c` ≠ 게시 `9c74bb0`.

## 수정

release 생성 step(L763)은 publish step(L727) 이후이고, publish step이 실제 게시 sha를 `steps.publish.outputs.sha`(L761)로 노출한다. release body의 commit 표기를 이 값의 단축 해시로 교체:

```diff
-COMMIT_HASH="${{ steps.release-info.outputs.commit_hash }}"
+COMMIT_HASH="${{ steps.publish.outputs.sha }}"
+COMMIT_HASH="${COMMIT_HASH:0:7}"
```

release body는 commit-tree에 포함되지 않으므로(self-reference 아님) 실제 게시 커밋과 정확히 일치시킬 수 있다.

## 영향 범위

- release notes **표기 정확성만** 변경. 게시 ref(`#beta` 브랜치/스냅샷 태그)·`package.json`·런타임 동작 불변.
- `package.json.description`의 해시(L694)는 self-reference라 staging 값 유지(별도, 본 PR 범위 밖).
- 이미 게시된 `b36d7b5` Release body는 `9c74bb0`로 **수동 교정 완료**.

## 검증

다음 베타 릴리즈에서 notes `🔗 Commit` 이 `#beta` HEAD·스냅샷 태그 대상과 동일한지 확인.