### PR TITLE
빌드: Sentry action-release@v3 deprecated version 입력을 release로 마이그레이션

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -893,7 +893,8 @@ jobs:
           SENTRY_ORG: toss
           SENTRY_PROJECT: apps-in-toss-unity-sdk
         with:
-          version: apps-in-toss.unity@${{ needs.beta-prepare.outputs.pkg_version }}
+          # action-release@v3에서 `version`은 deprecated이고 `release`로 대체됨(동작 동일).
+          release: apps-in-toss.unity@${{ needs.beta-prepare.outputs.pkg_version }}
           # set_commits 기본값은 "auto"(commit range 연동)이므로 반드시 "skip"으로 명시.
           # 미머지 orphan 커밋의 Fixes trailer가 stable 이슈를 조기 auto-resolve하는 것 차단(INV5).
           set_commits: skip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -668,7 +668,8 @@ jobs:
           SENTRY_ORG: toss
           SENTRY_PROJECT: apps-in-toss-unity-sdk
         with:
-          version: apps-in-toss.unity@${{ needs.create-release-tag.outputs.version }}
+          # action-release@v3에서 `version`은 deprecated이고 `release`로 대체됨(동작 동일).
+          release: apps-in-toss.unity@${{ needs.create-release-tag.outputs.version }}
           set_commits: auto
           finalize: true
 


### PR DESCRIPTION
## 요약
`getsentry/action-release@v3`에서 deprecated 처리된 `version:` 입력을 `release:`로 마이그레이션합니다. (동작 동일, 경고만 제거)

action-release@v3 실행 로그에 다음 경고가 출력되고 있었습니다:
```
##[warning]Input 'version' has been deprecated with message: Deprecated: Use "release" instead.
```

## 변경
action-release를 사용하는 두 `sentry-release` job의 입력 키를 `version` → `release`로 변경:

| 파일 | job | set_commits |
|------|-----|-------------|
| `.github/workflows/beta-release.yml` (L896) | Sentry 베타 릴리즈 등록 | `skip` (베타 격리, INV5) |
| `.github/workflows/release.yml` (L671) | Sentry 릴리즈 등록 | `auto` |

- 입력 **값/동작은 변화 없음** (`apps-in-toss.unity@<ver>` 그대로). `release:`는 `version:`의 단순 신규 별칭.
- 향후 메이저에서 `version` 입력이 제거될 때 깨지는 것을 사전 방지.

## 검증
- 두 워크플로우 YAML 파싱 성공 확인.
- action-release `with:` 블록에 `version:` 잔존 없음(`release:`만 존재) 확인.
- 직전 b36d7b5 베타 릴리즈에서 `apps-in-toss.unity@3.0.0-beta.b36d7b5`가 Sentry에 정상 생성·finalize됨을 교차검증했고, 이번 변경은 그 동작을 유지한 채 deprecation 경고만 제거합니다.