### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — package-manager-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1415,11 +1415,13 @@ namespace AppsInToss.Editor.ErrorTracker
 
             // Unity Package Manager가 사용자 환경(네트워크/Git 인증/SSL 등) 문제로 Git 패키지 추가/제거 실패 시 직접 출력.
             // 예: "[Package Manager Window] Error adding/removing packages: https://github.com/toss/apps-in-toss-unity-sdk.git #release/v2.4.3."
-            // URL에 'apps-in-toss' 토큰이 단어 경계로 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
-            // "[Package Manager Window]" + "Error adding/removing packages" 합성으로 일반 PM 메시지와 충돌 방지.
-            // Sentry APPS-IN-TOSS-UNITY-SDK-QQ, APPS-IN-TOSS-UNITY-SDK-7Y.
+            //     "[Package Manager Window] Error adding package: im.toss.apps-in-toss-unity-sdk@https://...#2.9.0"
+            // URL/패키지 ID에 'apps-in-toss' 토큰이 단어 경계로 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
+            // "[Package Manager Window]" + ("Error adding/removing packages" OR "Error adding package:") 합성으로 일반 PM 메시지와 충돌 방지.
+            // Sentry APPS-IN-TOSS-UNITY-SDK-QQ, APPS-IN-TOSS-UNITY-SDK-7Y, APPS-IN-TOSS-UNITY-SDK-12Q.
             if (message.IndexOf("[Package Manager Window]", StringComparison.Ordinal) >= 0
-                && message.IndexOf("Error adding/removing packages", StringComparison.Ordinal) >= 0)
+                && (message.IndexOf("Error adding/removing packages", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Error adding package:", StringComparison.Ordinal) >= 0))
                 return true;
 
             // Unity Package Manager가 의존성 해석 실패 시 직접 출력 — 사용자 환경 manifest.json 충돌 또는 네트워크 장애.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1685,7 +1685,7 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
-    #region 사용자 환경 / 빌드 외부 노이즈 (SDK-QQ, SDK-7Y, SDK-V1, SDK-TS, SDK-RG)
+    #region 사용자 환경 / 빌드 외부 노이즈 (SDK-QQ, SDK-7Y, SDK-V1, SDK-TS, SDK-RG, APPS-IN-TOSS-UNITY-SDK-12Q)
 
     [Test]
     public void PackageManager_ErrorAddingPackages_ReturnsTrue()
@@ -1728,6 +1728,25 @@ public class IsKnownNonSdkMessageTests
         // Sentry SDK-RG — Windows cmd 인코딩/PATH 문제.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "AIT: [stderr] '��e' is not recognized as an internal or external command,"));
+    }
+
+    [Test]
+    public void PackageManager_ErrorAddingPackageSingular_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-12Q — UPM이 단일 패키지 추가 실패 시 출력하는 단수형 변형.
+        // "Error adding/removing packages"(복수형, QQ/7Y)와 달리 "Error adding package:"(단수형 + 콜론)으로 출력됨.
+        // 패키지 ID에 'apps-in-toss' 토큰이 포함되어 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭된다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: [Package Manager Window] Error adding package: " +
+            "im.toss.apps-in-toss-unity-sdk@https://github.com/toss/apps-in-toss-unity-sdk.git#2.9.0"));
+    }
+
+    [Test]
+    public void PackageManager_ErrorAddingPackageSingular_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙으면 SDK 자체 로그로 간주되어 필터링되지 않아야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] [Package Manager Window] Error adding package: im.toss.apps-in-toss-unity-sdk@https://example.com#2.9.0"));
     }
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-12Q

## 묶음 항목

| source | id | title |
|--------|----|----|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-12Q | \"UnityError: [Package Manager Window] Error adding package: im.toss.apps-in-toss-unity-sdk@...#2.9.0\" |

## 추출 패턴 및 추가 위치

**`Editor/ErrorTracker/AITEditorErrorTracker.cs`** — `IsKnownNonSdkMessage` 내 기존 복합 조건 확장:

기존 QQ/7Y 패턴은 복수형(`\"Error adding/removing packages\"`)만 처리하고 있었으나, APPS-IN-TOSS-UNITY-SDK-12Q는 단수형(`\"Error adding package:\"`)으로 출력되어 매칭 누락. 패키지 ID에 `apps-in-toss` 토큰이 포함되어 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭되는 기존 복합 조건에 OR 분기를 추가.

**`Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`** — positive 테스트 1개 + negative(AIT prefix 보호) 테스트 1개 추가.

## --validate 결과

- E2E Test Files Validation: ✓
- Playwright Config Validation: ✓
- SDK Generator Unit Tests: ✗ (pre-existing 인프라 문제 — `shell-quote@1.9.0` stale 미러 404. main 브랜치도 동일 실패 확인)
- Meta GUID Hygiene: ✓

SDK Generator Unit Tests 실패는 이 PR 변경과 무관한 npm 미러 문제임을 main 브랜치 재현으로 확인함.

## 사람 머지 검토 필요