### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — gradle-build-failed

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -307,6 +307,13 @@ namespace AppsInToss.Editor.ErrorTracker
             // SDK 코드는 키스토어 경로/비밀번호를 직접 다루지 않으므로 SDK 버그 아님.
             // SDK는 이 문자열을 출력하지 않음(AitKeywords에 없음).
             "Unable to list keys in the keystore",
+
+            // Unity Editor가 Android Gradle/Java 외부 빌드 실패를 출력하는 순수 외부 노이즈.
+            // 사용자 프로젝트 Android 빌드 설정 문제(JDK/SDK 경로, Gradle 버전 호환성 등)이며
+            // SDK 코드와 무관. 과거 동일 패턴(S5)이 auto로 처리된 선례 있음.
+            // 예: "CommandInvokationFailure: Gradle build failed." (APPS-IN-TOSS-UNITY-SDK-134)
+            // SDK는 이 문자열을 출력하지 않음(AitKeywords에 없음).
+            "CommandInvokationFailure: Gradle build failed",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2475,6 +2475,36 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region Android Gradle 빌드 실패 노이즈 (APPS-IN-TOSS-UNITY-SDK-134)
+
+    [Test]
+    public void GradleBuildFailed_CommandInvokationFailure_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-134 — Unity Editor가 Android Gradle/Java 외부 빌드 실패를
+        // 출력하는 순수 외부 노이즈. 사용자 프로젝트 Android 빌드 설정 문제(JDK/SDK 경로,
+        // Gradle 버전 호환성 등)이며 SDK 코드와 무관.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "CommandInvokationFailure: Gradle build failed."));
+    }
+
+    [Test]
+    public void GradleBuildFailed_WithTrailingDetail_ReturnsTrue()
+    {
+        // 빌드 에러 상세 내용이 후행하는 변형도 부분 문자열 매칭으로 드롭됨을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "CommandInvokationFailure: Gradle build failed.\r\nstderr[\r\nFAILURE: Build failed with an exception."));
+    }
+
+    [Test]
+    public void GradleBuildFailed_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] CommandInvokationFailure: Gradle build failed."));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-134

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-134 | CommandInvokationFailure: Gradle build failed. |

## 추출 패턴

- \`NonSdkMessagePatterns\`에 추가: \`"CommandInvokationFailure: Gradle build failed"\`
- 추가 위치: \`Editor/ErrorTracker/AITEditorErrorTracker.cs\`

## 분류 근거

Unity Editor가 Android Gradle/Java 외부 빌드 실패를 출력하는 순수 외부 노이즈. 사용자 프로젝트 Android 빌드 설정 문제(JDK/SDK 경로, Gradle 버전 호환성 등)이며 SDK 코드와 무관. 과거 동일 패턴(S5)이 auto로 처리된 선례 있음. SDK는 \`CommandInvokationFailure: Gradle build failed\` 문자열을 출력하지 않음(AitKeywords에 없음).

## 추가된 테스트 (IsKnownNonSdkMessageTests.cs)

- \`GradleBuildFailed_CommandInvokationFailure_ReturnsTrue\` — 기본 메시지 positive
- \`GradleBuildFailed_WithTrailingDetail_ReturnsTrue\` — 후행 상세 내용 포함 변형 positive
- \`GradleBuildFailed_WithAitPrefix_NeverFiltered\` — AIT prefix 보호 negative

## --validate 결과

\`SDK Generator Unit Tests\` (C# ↔ jslib invariants) 단계에서 사내 nexus 미러 stale 문제로 \`ERR_PNPM_FETCH_404\` 실패 발생 (\`shell-quote@1.9.0\`, \`@apps-in-toss/bridge-core@2.9.3\` 등). 이 실패는 내 변경과 무관한 환경 문제(public npm에는 정상 배포되어 있으나 nexus 미러가 뒤처진 상태)로, 1회 retry 후에도 동일하게 실패해 런북 정책에 따라 포기함. 나머지 3개 항목(E2E 구조 검증, Playwright 설정 검증, Meta GUID 위생)은 모두 통과.

**사람 머지 검토 필요**