### PR TITLE
빌드: gitignore에 orphan .meta 규칙 추가 (*.tgz.meta, docs/superpowers.meta)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ yarn-error.log*
 
 # Package files
 *.tgz
+*.tgz.meta
 *.tar.gz
 
 # Runtime logs
@@ -198,3 +199,4 @@ yarn.lock.meta
 
 # Superpowers 플랜 문서 (Claude Code 작업용, 커밋 불필요)
 docs/superpowers/
+docs/superpowers.meta


### PR DESCRIPTION
## 요약
이미 gitignore된 본체의 곁다리로 남은 orphan `.meta` 파일들을 ignore에 추가하는 파일 위생 변경입니다. 추적되는 코드/동작 변화는 없습니다.

## 배경
`git status`에 아래 3개 untracked `.meta`가 떠 있었습니다 — 모두 Unity가 로컬에서 자동 생성한 import 메타인데, 짝이 되는 본체는 이미 gitignore 대상입니다:

| `.meta` (untracked) | 본체 | 본체 ignore 규칙 | 메타 ignore |
|---|---|---|---|
| `*-beta.973c8c3.tgz.meta` | `*.tgz` 로컬 베타 tarball | `*.tgz` ✅ | ❌ 누락 |
| `*-beta.b705d2b.tgz.meta` | `*.tgz` 로컬 베타 tarball | `*.tgz` ✅ | ❌ 누락 |
| `docs/superpowers.meta` | `docs/superpowers/` (로컬 작업폴더) | `docs/superpowers/` ✅ | ❌ 누락 |

본체가 추적되지 않으므로 이 메타들도 커밋되면 안 됩니다(dangling meta).

## 변경
저장소의 기존 패턴(`node_modules.meta`, `pnpm-lock.yaml.meta` 등 — ignore된 항목의 `.meta`는 개별 ignore)에 맞춰 본체 규칙 바로 뒤에 2줄 추가:
- `*.tgz.meta` (← `*.tgz` 뒤)
- `docs/superpowers.meta` (← `docs/superpowers/` 뒤)

## 검증
- `git check-ignore`로 3개 orphan 메타가 모두 ignore됨 확인.
- 변경 후 `git status`는 `.gitignore`만 남음(orphan 메타 사라짐).
- 회귀 확인: 현재 추적 중인 `*.tgz.meta` / `docs/superpowers.meta` 없음 → 새 규칙이 기존 추적 파일을 ignore로 바꾸지 않음.