### PR TITLE
수정: PM 노이즈 가드가 [AIT] 접두사 SDK 로그를 삼키던 회귀 해소 (E2E EditMode RED 복구)

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1426,7 +1426,12 @@ namespace AppsInToss.Editor.ErrorTracker
             // URL/패키지 ID에 'apps-in-toss' 토큰이 단어 경계로 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
             // "[Package Manager Window]" + ("Error adding/removing packages" OR "Error adding package:") 합성으로 일반 PM 메시지와 충돌 방지.
             // Sentry APPS-IN-TOSS-UNITY-SDK-QQ, APPS-IN-TOSS-UNITY-SDK-7Y, APPS-IN-TOSS-UNITY-SDK-12Q.
-            if (message.IndexOf("[Package Manager Window]", StringComparison.Ordinal) >= 0
+            // SDK 자체 로그("[AIT" prefix)는 보호한다 — SDK는 Unity PM 창 출력을 "[AIT]"로 감싸지 않으므로
+            // "[AIT" 로 시작하는 메시지는 이 외부 노이즈 패턴의 대상이 아니다. 이 선행 가드가 없으면
+            // "[AIT] [Package Manager Window] Error adding package: ..." 같은 SDK 로그가 AitKeywords 가드보다
+            // 먼저 드롭된다(#886 package-manager-noise 회귀). 회귀 테스트: ..._WithAitPrefix_NeverFiltered.
+            if (!message.StartsWith("[AIT", StringComparison.Ordinal)
+                && message.IndexOf("[Package Manager Window]", StringComparison.Ordinal) >= 0
                 && (message.IndexOf("Error adding/removing packages", StringComparison.Ordinal) >= 0
                     || message.IndexOf("Error adding package:", StringComparison.Ordinal) >= 0))
                 return true;


### PR DESCRIPTION
## 문제

main HEAD의 E2E EditMode가 전 config(5 Unity × 2 OS)에서 RED — `IsKnownNonSdkMessageTests.PackageManager_ErrorAddingPackageSingular_WithAitPrefix_NeverFiltered` 1개 테스트가 deterministic 실패(flaky/라이선스 인프라 아님).

## 원인

`#886 [auto-resolve] package-manager-noise`가 확장한 **가드-이전(pre-guard) 패턴**이 `[Package Manager Window]` + `Error adding package:`만으로 매칭되어 `IsKnownNonSdkMessage`의 AitKeywords 가드보다 **먼저** 실행됨 → `[AIT]` 접두사가 붙은 **SDK 자체 로그까지 노이즈로 드롭**.

`#887`이 이를 막는 회귀 가드 테스트(`...WithAitPrefix_NeverFiltered`, `Assert.IsFalse`)를 추가했지만 패턴 수정이 누락된 채 머지됨. E2E는 `workflow_dispatch` 전용이라 push CI(Validate/Lint)에서는 green으로 보여 가려졌음.

## 수정

PM pre-guard 패턴에 `!message.StartsWith("[AIT", StringComparison.Ordinal)` 선행 조건 추가:

- `[AIT]` 접두사 메시지 → 이 패턴을 건너뛰고 AitKeywords 가드가 `false` 반환(필터 안 함) ✓
- Unity가 직접 출력하는 `[AIT]` 없는 PM 노이즈(SDK-QQ/7Y/12Q) → 기존대로 `true`(드롭) ✓

## 검증

3-렌즈 적대적 검증(회귀 스윕 / 형제버그 / 정합)으로 `IsKnownNonSdkMessageTests` 전체 계약 위반 없음 확인:

- 실패 테스트 해소 ✓ · 회귀로 깨지는 테스트 **0건**
- PM 관련 5개 테스트 모두 유지(`ErrorAddingPackages`/`ErrorRemovingPackages_AltVersion`/`ErrorAddingPackageSingular`/`...WithAitPrefix_NeverFiltered`/`GenericPmMessage_NotFiltered`)

머지 후 E2E를 dispatch해 main green 복구를 확인하면 됨(E2E는 push 트리거가 아니므로 PR 자동 체크에는 EditMode가 포함되지 않음).

## 후속 고려 (이 PR 범위 밖 · 현재 발현·테스트 없음)

검증 중 구조적으로 유사하나 테스트로 입증된 회귀가 아닌 잠재 항목 2건이 확인됨:

1. `An error occurred while resolving packages` + `Project has invalid dependencies` 패턴(동일 파일)도 같은 `[AIT]` 선행 가드가 없음. 다만 SDK가 Unity PM 출력을 `[AIT]`로 감싸지 않아 실제 발현은 안 됨.
2. ANSI `AIT: [std` 패턴은 `[AIT]`가 아닌 `AIT:`로 시작하므로 이 수정과 무관.

미검증 동작 변경을 피하기 위해 두 항목은 이 PR에 포함하지 않음 — 필요 시 회귀 테스트와 함께 별도 PR로 정리 가능.
