### PR TITLE
수정: 동작하지 않는 enabledMcpjsonServers 설정 제거

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,5 @@
 {
   "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "playwright"
-  ],
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## 변경 내용

`.claude/settings.json`에서 동작하지 않는 `enabledMcpjsonServers: ["playwright"]` 줄을 제거합니다.

## 배경

- `enabledMcpjsonServers`는 **프로젝트 `.mcp.json` 파일에 선언된 MCP 서버** 중 활성화할 항목을 가리키는 설정입니다.
- 그러나 이 저장소에는 루트에도 `.claude/`에도 `.mcp.json` 파일이 **존재하지 않습니다.** 따라서 `"playwright"` 항목은 가리킬 대상이 없는 **no-op(유물)** 설정입니다.
- 현재 playwright MCP는 전적으로 `enabledPlugins`(플러그인 메커니즘)로 동작하며 — `claude mcp list`에서 `plugin:playwright:playwright`로 표시됨 — 이 줄과는 무관합니다.

## 영향 범위

- `enabledMcpjsonServers` 한 키(3줄)만 삭제합니다.
- playwright 동작에는 변화가 없습니다 (`enabledPlugins`가 계속 담당).
- Runtime/SDK 차단 hook, `enableAllProjectMcpServers`, `enabledPlugins` 등 나머지 설정은 그대로 유지됩니다.

## 검증

- `jq empty .claude/settings.json` → 유효한 JSON
- 삭제 후 남은 키: `enableAllProjectMcpServers`, `enabledPlugins`, `hooks`
