### PR TITLE
수정: Windows dev 서버 시작 시 pnpm TTY 에러 해결 (CI=true)

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -812,6 +812,11 @@ namespace AppsInToss
                 }
             }
 
+            // pnpm이 비대화형(no TTY) 환경임을 인식하도록 CI=true 설정
+            // (없으면 node_modules purge 확인 프롬프트에서 ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY 발생)
+            // AITPlatformHelper.CreateProcessStartInfo / AITAsyncCommandRunner와 동일한 컨벤션
+            startInfo.EnvironmentVariables["CI"] = "true";
+
             // 스레드 안전한 상태 플래그 (Interlocked 사용)
             // OutputDataReceived는 ThreadPool 스레드에서 호출되므로 원자적 연산 필요
             int serverStartedFlag = 0;  // 0 = false, 1 = true


### PR DESCRIPTION
## 문제

Windows에서 AIT Dev/Preview 서버 시작 시, pnpm이 비대화형(no TTY) 환경에서 `node_modules` purge 확인을 받지 못해 다음 에러로 실패한다:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
... Exit Code: 1
```

서버 프로세스가 기동되지 못해 이후 포트 감지/폴백도 실패한다.

## 원인

dev 서버 시작 경로는 (1) 의존성 install 단계와 (2) `pnpm exec -- granite dev` 실행 단계로 나뉜다.

- install 단계(`AITNpmRunner` → `AITPlatformHelper.CreateProcessStartInfo` / `AITAsyncCommandRunner`)는 이미 `CI=true`를 설정한다.
- 그러나 dev 서버 실행 단계인 `AppsInTossMenu.StartServerProcessWithPortDetection`은 자체적으로 `ProcessStartInfo`를 구성하면서 **`CI`를 설정하지 않았다.**

`CI`가 없으면 pnpm은 비대화형 환경임을 인식하지 못하고 purge 확인 프롬프트에서 TTY가 없어 중단한다. `CI=true`는 이 pnpm 에러에 대한 공식 권장 해결책이며, 코드베이스의 다른 모든 pnpm 호출과도 일치한다.

## 변경

`StartServerProcessWithPortDetection`에서 `ProcessStartInfo` 구성 직후(Windows/Unix 공통 지점) 한 줄 추가:

```csharp
startInfo.EnvironmentVariables["CI"] = "true";
```

`UseShellExecute = false`이므로 이 환경변수는 자식 프로세스(pnpm, granite가 내부적으로 띄우는 pnpm 포함)에 그대로 상속된다.

## 영향 / 검증

- `granite.config.ts`·`vite.config.ts`는 `AIT_GRANITE_*`/`AIT_VITE_*`만 읽고 `process.env.CI`는 참조하지 않으므로, dev 서버/HMR 동작에 영향 없음.
- 서버가 정상 기동되면 기존 5초 포트 폴백이 포트를 감지하므로 별도 포트 감지 로직 수정은 불필요.
- 파일 추가/삭제 없음 → `.meta` 변경 없음.
- E2E 테스트 트리거 예정.
