### PR TITLE
기능: AIT Configuration에 navigationBar transparentBackground/theme 옵션 추가

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -172,6 +172,27 @@ namespace AppsInToss.Editor
 
             GUILayout.Space(5);
 
+            // 네비게이션 바 설정 (game 타입에서만 적용)
+            using (new EditorGUI.DisabledScope(config.webViewType != 0))
+            {
+                config.navigationBarTransparentBackground = EditorGUILayout.Toggle(
+                    new GUIContent("Transparent Nav Bar", "상단 네비게이션 바 투명 배경 (게임 풀스크린)"),
+                    config.navigationBarTransparentBackground
+                );
+
+                string[] navBarThemeOptions = { "기본 (미지정)", "light", "dark" };
+                config.navigationBarTheme = EditorGUILayout.Popup(
+                    "Nav Bar Theme", config.navigationBarTheme, navBarThemeOptions);
+            }
+
+            EditorGUILayout.HelpBox(
+                "Navigation Bar 옵션은 'game' 타입에서만 적용됩니다.\n" +
+                "Transparent Nav Bar를 켜면 상단(노치/내비게이션) 영역까지 투명하게 풀스크린 렌더링됩니다.",
+                MessageType.Info
+            );
+
+            GUILayout.Space(5);
+
             // 미디어 재생 설정
             config.allowsInlineMediaPlayback = EditorGUILayout.Toggle(
                 new GUIContent("Inline Media Playback", "인라인 미디어 재생 허용"),

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -128,6 +128,12 @@ namespace AppsInToss
         [Tooltip("WebView 타입. 게임앱은 'game' (투명배경), 일반앱은 'partner' (흰색배경)")]
         public int webViewType = 0; // 0=game, 1=partner
 
+        [Tooltip("상단 네비게이션 바 투명 배경. game 타입에서 풀스크린(노치/상단 영역까지 그리기)에 필요")]
+        public bool navigationBarTransparentBackground = true; // 기본 ON (game 풀스크린 복구)
+
+        [Tooltip("네비게이션 바 테마. 0=기본(미지정), 1=light, 2=dark")]
+        public int navigationBarTheme = 0; // 0=기본(미지정), 1=light, 2=dark
+
         [Tooltip("인라인 미디어 재생 허용")]
         public bool allowsInlineMediaPlayback = false;
 
@@ -290,6 +296,30 @@ namespace AppsInToss
                 case 1: return "partner";
                 default: return "game";
             }
+        }
+
+        /// <summary>
+        /// navigationBar 옵션을 granite.config.ts/apps-in-toss.config.ts 형식의 TS 객체 리터럴로 반환.
+        /// webViewType=game일 때만 transparentBackground/theme를 emit하고(하위호환), partner면 빈 객체를
+        /// 반환해 기존 동작과 USER_CONFIG의 navigationBar를 보존한다.
+        /// 형식 예: { transparentBackground: true, theme: 'dark' }
+        /// </summary>
+        public string GetNavigationBarJson()
+        {
+            // partner(비게임)는 동작 불변 — 빈 객체로 emit (USER_CONFIG의 navigationBar 보존)
+            if (webViewType != 0)
+                return "{}";
+
+            var parts = new System.Collections.Generic.List<string>
+            {
+                "transparentBackground: " + navigationBarTransparentBackground.ToString().ToLower()
+            };
+            if (navigationBarTheme == 1)
+                parts.Add("theme: 'light'");
+            else if (navigationBarTheme == 2)
+                parts.Add("theme: 'dark'");
+
+            return "{ " + string.Join(", ", parts) + " }";
         }
 
         /// <summary>

--- a/Editor/Package/BuildConfigMerger.cs
+++ b/Editor/Package/BuildConfigMerger.cs
@@ -377,6 +377,7 @@ namespace AppsInToss.Editor.Package
                 .Replace("%AIT_ICON_URL%", config.iconUrl)
                 .Replace("%AIT_BRIDGE_COLOR_MODE%", config.GetBridgeColorModeString())
                 .Replace("%AIT_WEBVIEW_TYPE%", config.GetWebViewTypeString())
+                .Replace("%AIT_NAVIGATION_BAR%", config.GetNavigationBarJson())
                 .Replace("%AIT_ALLOWS_INLINE_MEDIA_PLAYBACK%", config.allowsInlineMediaPlayback.ToString().ToLower())
                 .Replace("%AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%", config.mediaPlaybackRequiresUserAction.ToString().ToLower())
                 .Replace("%AIT_VITE_HOST%", config.viteHost)
@@ -437,6 +438,7 @@ namespace AppsInToss.Editor.Package
                 .Replace("%AIT_PRIMARY_COLOR%", config.primaryColor)
                 .Replace("%AIT_ALLOWS_INLINE_MEDIA_PLAYBACK%", config.allowsInlineMediaPlayback.ToString().ToLower())
                 .Replace("%AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%", config.mediaPlaybackRequiresUserAction.ToString().ToLower())
+                .Replace("%AIT_NAVIGATION_BAR%", config.GetNavigationBarJson())
                 .Replace("%AIT_PERMISSIONS%", config.GetPermissionsJson());
 
             // USER_CONFIG 결정:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerTemplateTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerTemplateTests.cs
@@ -130,7 +130,7 @@ namespace AppsInToss.Editor.Package.Tests
         [Test]
         public void UpdateGraniteConfig_SubstitutesAllPlaceholders_WhenAllPresent()
         {
-            // UpdateGraniteConfig가 치환하는 12개 플레이스홀더 전부 포함
+            // UpdateGraniteConfig가 치환하는 13개 플레이스홀더 전부 포함
             File.WriteAllText(Path.Combine(_sdkDir, "granite.config.ts"),
                 "export default {\n" +
                 "  name: '%AIT_APP_NAME%',\n" +
@@ -139,6 +139,7 @@ namespace AppsInToss.Editor.Package.Tests
                 "  icon: '%AIT_ICON_URL%',\n" +
                 "  bridgeColorMode: '%AIT_BRIDGE_COLOR_MODE%',\n" +
                 "  webViewType: '%AIT_WEBVIEW_TYPE%',\n" +
+                "  navigationBar: %AIT_NAVIGATION_BAR%,\n" +
                 "  allowsInlineMediaPlayback: %AIT_ALLOWS_INLINE_MEDIA_PLAYBACK%,\n" +
                 "  mediaPlaybackRequiresUserAction: %AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%,\n" +
                 "  viteHost: '%AIT_VITE_HOST%',\n" +
@@ -157,6 +158,8 @@ namespace AppsInToss.Editor.Package.Tests
             StringAssert.Contains("test.example.com", merged);
             StringAssert.Contains("4242", merged);
             StringAssert.Contains("test-dist", merged);
+            // webViewType 기본값(0=game) → navigationBar.transparentBackground emit
+            StringAssert.Contains("transparentBackground: true", merged);
             // GetBridgeColorModeString/GetWebViewTypeString/GetPermissionsJson 호출 확인 — 결과 토큰이 사라지면 됨
             Assert.IsFalse(Regex.IsMatch(merged, "%AIT_[A-Z_]+%"),
                 $"치환되지 않은 %AIT_*% 플레이스홀더가 남아있음:\n{merged}");
@@ -203,6 +206,87 @@ namespace AppsInToss.Editor.Package.Tests
             StringAssert.Contains("4242", merged);
             Assert.IsFalse(Regex.IsMatch(merged, "%AIT_[A-Z_]+%"),
                 "프로젝트 파일이 없을 때도 SDK 템플릿의 플레이스홀더는 모두 치환되어야 함");
+        }
+
+        // ----- GetNavigationBarJson -----
+
+        [Test]
+        public void GetNavigationBarJson_EmitsTransparentBackgroundTrue_WhenGameAndDefault()
+        {
+            var cfg = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+            try
+            {
+                cfg.webViewType = 0; // game
+                // navigationBarTransparentBackground 기본값 true, theme 기본값 0(미지정)
+                string json = cfg.GetNavigationBarJson();
+                StringAssert.Contains("transparentBackground: true", json);
+                Assert.IsFalse(json.Contains("theme:"), "theme 미지정일 때 theme 키가 없어야 함");
+            }
+            finally { Object.DestroyImmediate(cfg); }
+        }
+
+        [Test]
+        public void GetNavigationBarJson_EmitsTheme_WhenGameAndThemeSet()
+        {
+            var cfg = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+            try
+            {
+                cfg.webViewType = 0; // game
+                cfg.navigationBarTheme = 2; // dark
+                string json = cfg.GetNavigationBarJson();
+                StringAssert.Contains("transparentBackground: true", json);
+                StringAssert.Contains("theme: 'dark'", json);
+            }
+            finally { Object.DestroyImmediate(cfg); }
+        }
+
+        [Test]
+        public void GetNavigationBarJson_EmitsTransparentBackgroundFalse_WhenGameAndToggleOff()
+        {
+            var cfg = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+            try
+            {
+                cfg.webViewType = 0; // game
+                cfg.navigationBarTransparentBackground = false;
+                string json = cfg.GetNavigationBarJson();
+                StringAssert.Contains("transparentBackground: false", json);
+            }
+            finally { Object.DestroyImmediate(cfg); }
+        }
+
+        [Test]
+        public void GetNavigationBarJson_ReturnsEmptyObject_WhenPartner()
+        {
+            var cfg = ScriptableObject.CreateInstance<AITEditorScriptObject>();
+            try
+            {
+                cfg.webViewType = 1; // partner
+                cfg.navigationBarTransparentBackground = true;
+                cfg.navigationBarTheme = 2;
+                // 하위호환: partner는 navigationBar 필드를 emit하지 않음
+                Assert.AreEqual("{}", cfg.GetNavigationBarJson());
+            }
+            finally { Object.DestroyImmediate(cfg); }
+        }
+
+        // ----- UpdateAppsInTossConfig (3.x) -----
+
+        [Test]
+        public void UpdateAppsInTossConfig_SubstitutesNavigationBarPlaceholder_NoLeak()
+        {
+            File.WriteAllText(Path.Combine(_sdkDir, "apps-in-toss.config.ts"),
+                "export default {\n" +
+                "  name: '%AIT_APP_NAME%',\n" +
+                "  navigationBar: %AIT_NAVIGATION_BAR%,\n" +
+                "}");
+
+            BuildConfigMerger.UpdateAppsInTossConfig(_projectDir, _sdkDir, _destDir, _config);
+
+            string merged = File.ReadAllText(Path.Combine(_destDir, "apps-in-toss.config.ts"));
+            // webViewType 기본값(0=game) → transparentBackground emit
+            StringAssert.Contains("transparentBackground: true", merged);
+            Assert.IsFalse(Regex.IsMatch(merged, "%AIT_[A-Z_]+%"),
+                $"apps-in-toss.config.ts에 치환되지 않은 %AIT_*% 플레이스홀더가 남아있음:\n{merged}");
         }
     }
 }

--- a/WebGLTemplates/AITTemplate/BuildConfig~/apps-in-toss.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/apps-in-toss.config.ts
@@ -15,6 +15,7 @@ const sdkConfig = {
     allowsInlineMediaPlayback: %AIT_ALLOWS_INLINE_MEDIA_PLAYBACK%,
     mediaPlaybackRequiresUserAction: %AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%,
   },
+  navigationBar: %AIT_NAVIGATION_BAR%,
   webBundleDir: 'dist/web',
 };
 //// SDK_GENERATED_END ////
@@ -36,4 +37,5 @@ export default defineConfig({
   ..._userConfig,
   ...sdkConfig,
   webView: { ..._userConfig.webView, ...sdkConfig.webView },
+  navigationBar: { ..._userConfig.navigationBar, ...sdkConfig.navigationBar },
 });

--- a/WebGLTemplates/AITTemplate/BuildConfig~/granite.config.ts
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/granite.config.ts
@@ -14,6 +14,7 @@ const sdkConfig = {
     allowsInlineMediaPlayback: %AIT_ALLOWS_INLINE_MEDIA_PLAYBACK%,
     mediaPlaybackRequiresUserAction: %AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%,
   },
+  navigationBar: %AIT_NAVIGATION_BAR%,
   web: {
     host: process.env.AIT_VITE_HOST || '%AIT_VITE_HOST%',
     port: parseInt(process.env.AIT_VITE_PORT || '%AIT_VITE_PORT%', 10),
@@ -45,4 +46,5 @@ export default defineConfig({
   ..._userConfig,
   ...sdkConfig,
   webViewProps: { ..._userConfig.webViewProps, ...sdkConfig.webViewProps },
+  navigationBar: { ..._userConfig.navigationBar, ...sdkConfig.navigationBar },
 });


### PR DESCRIPTION
## 배경

웹 SDK(`@apps-in-toss/web-framework`)는 **2.8.0**부터 `navigationBar`에 `transparentBackground`/`theme` 옵션을 추가했습니다. 이 옵션이 도입되면서 `transparentBackground: true`를 명시하지 않으면 상단 네비게이션 바·노치 영역이 불투명(회색/흰색)으로 고정되어, `webViewProps.type: 'game'`만으로는 더 이상 풀스크린 렌더링이 되지 않습니다.

그런데 Unity SDK의 **AIT Configuration**은 `navigationBar`를 어디에도 노출하지 않아, Unity로 빌드한 게임 미니앱이 상단 영역을 그릴 수 없는 상태였습니다. 지금까지는 개발자가 프로젝트의 `granite.config.ts` `userConfig`를 직접 TS로 편집해야만 우회할 수 있었습니다.

이 저장소는 이미 `@apps-in-toss/web-framework@2.10.1`을 핀하고 있어 navigationBar 옵션을 전부 지원합니다. **버전 bump 없이** Editor 설정 UI → config 치환 경로에 옵션을 배선만 하면 됩니다.

## 변경 사항

- **`AITEditorScriptObject`**: `navigationBarTransparentBackground`(기본 ON)·`navigationBarTheme` 필드와 `GetNavigationBarJson()` 빌더 추가
- **`AITConfigurationWindow`**: `Transparent Nav Bar` 토글 + `Nav Bar Theme` 팝업 노출 — `game` 타입에서만 활성화(`EditorGUI.DisabledScope`)하고 HelpBox로 게이팅을 안내
- **템플릿**: `granite.config.ts`(2.x) / `apps-in-toss.config.ts`(3.x) 양쪽에 `navigationBar` 플레이스홀더 + 딥머지 라인 추가 (`{ ..._userConfig.navigationBar, ...sdkConfig.navigationBar }` — SDK 값 우선, 사용자 추가 키 보존)
- **`BuildConfigMerger`**: `UpdateGraniteConfig`/`UpdateAppsInTossConfig` 두 치환 경로 모두에 `%AIT_NAVIGATION_BAR%` 치환 배선 (한쪽 누락 시 플레이스홀더 leak)

## 하위호환

- `webViewType=game`일 때만 navigationBar 필드를 emit하고, **partner는 빈 객체(`{}`)** 를 emit해 기존 동작과 USER_CONFIG의 navigationBar를 보존합니다.
- 구버전 `AITConfig.asset`은 신규 bool/int 필드가 Unity 역직렬화 시 C# 기본값(`transparentBackground=true`, `theme=0`)으로 채워져 마이그레이션 코드가 불필요합니다. game 프로젝트는 다음 빌드에서 자동으로 풀스크린이 복구되고, partner는 게이팅으로 동작이 불변합니다.
- web-framework 버전은 SDK가 `MergePackageJson`에서 핀(SDK 값 우선)하므로 빌드 시점 프레임워크는 항상 옵션을 지원합니다. navigationBar 필드는 optional·additive이라 spread 병합에서 안전합니다.

## 테스트

`BuildConfigMergerTemplateTests`(EditMode, Level 0)에 케이스 추가:

- `GetNavigationBarJson` 단위 4종 — game+기본 → `transparentBackground: true` & theme 키 없음 / game+theme=dark → `theme: 'dark'` / game+토글 off → `transparentBackground: false` / partner → `{}`
- `UpdateAppsInTossConfig_SubstitutesNavigationBarPlaceholder_NoLeak` — 3.x 경로 치환 + `%AIT_*%` leak 없음 검증
- `UpdateGraniteConfig_SubstitutesAllPlaceholders` 전체 치환 픽스처에 `navigationBar` 추가 (leak 정규식 유지)