### PR TITLE
수정: [AIT] prefix SDK 로그가 PM 노이즈 패턴에 잘못 필터되는 회귀 해결

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1425,10 +1425,12 @@ namespace AppsInToss.Editor.ErrorTracker
             //     "[Package Manager Window] Error adding package: im.toss.apps-in-toss-unity-sdk@https://...#2.9.0"
             // URL/패키지 ID에 'apps-in-toss' 토큰이 단어 경계로 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.
             // "[Package Manager Window]" + ("Error adding/removing packages" OR "Error adding package:") 합성으로 일반 PM 메시지와 충돌 방지.
+            // 단, "[AIT" prefix로 시작하는 SDK 자체 로그는 절대 필터링하지 않으므로 별도 가드(GUID/meta 패턴과 동일 컨벤션).
             // Sentry APPS-IN-TOSS-UNITY-SDK-QQ, APPS-IN-TOSS-UNITY-SDK-7Y, APPS-IN-TOSS-UNITY-SDK-12Q.
             if (message.IndexOf("[Package Manager Window]", StringComparison.Ordinal) >= 0
                 && (message.IndexOf("Error adding/removing packages", StringComparison.Ordinal) >= 0
-                    || message.IndexOf("Error adding package:", StringComparison.Ordinal) >= 0))
+                    || message.IndexOf("Error adding package:", StringComparison.Ordinal) >= 0)
+                && !message.StartsWith("[AIT", StringComparison.Ordinal))
                 return true;
 
             // Unity Package Manager가 의존성 해석 실패 시 직접 출력 — 사용자 환경 manifest.json 충돌 또는 네트워크 장애.


### PR DESCRIPTION
## 문제

EditMode 테스트 `IsKnownNonSdkMessageTests.PackageManager_ErrorAddingPackageSingular_WithAitPrefix_NeverFiltered` 가 실패한다:

```
Expected: False
But was:  True
  at ...IsKnownNonSdkMessageTests.cs:1748
```

EditMode 테스트는 모든 E2E Build 잡의 **첫 게이트**라, 이 실패로 인해 **2026-06-29부터 main을 타겟하는 모든 PR의 E2E가 빨간불**이었다 (마지막 성공 06-26).

## 원인

PR #886 (`[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — package-manager-noise`, c7aa951)이 단수형 노이즈 패턴

```
"[Package Manager Window]" + "Error adding package:"
```

과 그 회귀방지 테스트(`...WithAitPrefix_NeverFiltered`)를 **함께** 추가했지만, 패턴 조건에 `[AIT]` prefix 가드를 빠뜨렸다.

이 패턴은 `AITEditorErrorTracker.IsKnownNonSdkMessage`에서 SDK 키워드 가드(`MessageContainsSdkKeyword`)보다 **먼저** `return true` 하므로, `[AIT]` prefix가 붙은 **SDK 자체 로그**까지 노이즈로 필터링해 버린다. 테스트는 "`[AIT]` prefix가 붙으면 절대 필터링되면 안 됨(`Expected: False`)"을 단언하므로 실패한다.

> Validate 워크플로는 EditMode 테스트를 실행하지 않고 E2E는 수동 트리거라, #886 머지 시점에는 이 실패가 드러나지 않았다.

## 변경

같은 블록의 GUID(`AITEditorErrorTracker.cs:1240`)·meta(`:1504`) 패턴과 **동일한 컨벤션**으로, Package Manager 노이즈 조건에 `[AIT]` prefix 가드 한 줄 추가:

```csharp
if (message.IndexOf("[Package Manager Window]", StringComparison.Ordinal) >= 0
    && (message.IndexOf("Error adding/removing packages", StringComparison.Ordinal) >= 0
        || message.IndexOf("Error adding package:", StringComparison.Ordinal) >= 0)
    && !message.StartsWith("[AIT", StringComparison.Ordinal))   // ← 추가
    return true;
```

`"[AIT"`는 `AitKeywords[0]`(SDK 자체 로그 prefix)와 정확히 일치하는 토큰이다.

## 영향 / 검증

- ✅ `...WithAitPrefix_NeverFiltered`(`[AIT]` prefix) → 가드 발동 → 필터링 안 됨 (`Expected: False`)
- ✅ `...Singular_ReturnsTrue`(`UnityError:` prefix) → prefix 미일치 → 정상 드롭 (`Expected: True`)
- ✅ `...ErrorAddingPackages_ReturnsTrue` / `...ErrorRemovingPackages_AltVersion_ReturnsTrue`(복수형, prefix 없음) → 영향 없음, 정상 드롭
- prefix 없는 실제 Unity Package Manager 노이즈(SDK-QQ/7Y/12Q)는 그대로 드롭됨
- 파일 추가/삭제 없음 → `.meta` 변경 없음

E2E 트리거하여 EditMode 게이트 통과를 확인한다.