### PR TITLE
보안: 내부 호스트명 유출 차단 pre-push 훅 + CI 전 브랜치 스캔

### DIFF
--- a/.githooks/patterns.local.example
+++ b/.githooks/patterns.local.example
@@ -1,0 +1,17 @@
+# .githooks/patterns.local — 로컬 전용 내부호스트 denylist 템플릿
+#
+# 이 파일을 복사해 같은 디렉토리에 patterns.local 로 저장하세요:
+#     cp .githooks/patterns.local.example .githooks/patterns.local
+#
+# patterns.local 은 .gitignore 되어 있어 저장소(public)에 커밋되지 않습니다.
+# pre-push 훅이 여기 적힌 규칙으로 push 직전 트리/변경분을 검사해 내부 호스트명 유출을 차단합니다.
+#
+# 형식: 한 줄에 하나의 확장정규식(ERE). 빈 줄과 '#' 로 시작하는 줄은 무시됩니다.
+# 값은 CI의 STRING_CHECK_PATTERN secret 과 동일한 내부 호스트 규칙으로 채우세요.
+#
+# ⚠️ 실제 내부 도메인을 이 .example 파일(=커밋 대상)에는 절대 적지 마세요.
+#    아래는 자리표시자일 뿐입니다 — patterns.local 에서 실제 값으로 교체하세요.
+#
+# 예시(자리표시자):
+# \.internal-registry\.example\.invalid
+# [a-z0-9.-]+\.corp\.example\.invalid

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,10 +16,23 @@
 #       우회 가능하다(모든 git 훅 공통). 완전(우회 불가) 차단은 서버 측 push protection 또는
 #       전 브랜치 CI 스캔이 담당한다.
 #
+# 한계(의도된 스코프):
+#   - 이 훅은 '텍스트' 설정 유출을 대상으로 한다. git이 바이너리로 분류하는 파일(NUL 바이트 포함)은
+#     -I 로 건너뛴다 — Unity 바이너리 에셋을 바이트 스캔하면 오탐이 폭증하므로 의도된 스코프다.
+#     (동일 한계가 서버 측 CI String Check에도 존재; 텍스트가 아닌 유출은 코드리뷰/정책으로 커버.)
+#   - tip 트리 스캔은 '이미 공개된' 내용까지 매치할 수 있어 '경고'만 한다. 실제 push 차단은
+#     '새로 push되는 커밋의 추가 라인' 스캔(range)만 담당한다(무관한 push 영구 차단 방지).
+#
 # 옵션:
 #   PREPUSH_STRICT=1  조직 denylist(env/patterns.local) 미설정 시 경고 대신 push 거부(fail-closed).
 
 set -u
+
+# 바이트 단위 매칭 강제: UTF-8 로케일에서는 grep/git grep 이 '유효하지 않은 UTF-8 바이트'가 든 줄을
+# 조용히 건너뛰어(매칭 실패) fail-open 될 수 있다. C 로케일에서 바이트 기준으로 검사해 이를 차단한다.
+# (한국어 메시지는 printf 가 바이트를 그대로 출력하므로 표시에 영향 없음. export 는 이 훅 프로세스에만
+#  적용되며 사용자 셸로 새지 않는다.)
+export LC_ALL=C
 
 z40="0000000000000000000000000000000000000000"
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -27,7 +40,7 @@ HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 RED='\033[0;31m'; YEL='\033[1;33m'; NC='\033[0m'
 
 # 훅 자신의 '패턴 정의' 파일은 self-match 방지를 위해 스캔에서 제외한다.
-# (그 파일들의 실제 유출은 CI String Check가 secret 패턴으로 백스톱한다.)
+# (그 파일들의 실제 유출은 CI String Check가 secret 패턴으로 백스톱한다 — CI는 제외하지 않음.)
 EXC1=':!.githooks/pre-push'
 EXC2=':!.githooks/patterns.local.example'
 
@@ -75,14 +88,26 @@ if [ "$have_org" = "0" ]; then
 fi
 
 # --- push되는 각 ref 검사 ----------------------------------------------------
+# 새 브랜치 range 스캔은 '이 push의 대상 원격'을 기준으로 한정한다. bare '--not --remotes'는
+# 다른 원격(사설 미러/포크/stale ref)에 있는 커밋까지 제외해 유출을 놓칠 수 있으므로, 대상 원격이
+# 이름으로 식별되면 그 원격만 기준으로 삼는다(식별 불가한 URL push 등은 보수적으로 모든 원격 기준).
+REMOTE_NAME="${1:-}"
+if [ -n "$REMOTE_NAME" ] && git config "remote.$REMOTE_NAME.url" >/dev/null 2>&1; then
+  NOT_REMOTES="--remotes=$REMOTE_NAME"
+else
+  NOT_REMOTES="--remotes"
+fi
+
 fail=0
 while read -r localref localsha remoteref remotesha; do
   [ -z "${localsha:-}" ] && continue
   [ "$localsha" = "$z40" ] && continue   # 삭제 push: 스캔할 tip 없음
 
-  # (1) tip tree 스캔 — 항상 실행. tip에 내부호스트가 남아있으면 차단.
-  #     git grep 종료코드: 0=매치, 1=미매치, >=2=오류(예: 구버전 git의 pathspec 미지원).
-  #     오류는 조용히 통과시키지 않고 fail-closed로 차단한다.
+  # (1) tip tree 스캔 — 경고 전용. tip 트리 '전체'를 훑기 때문에 이미 공개된 내용까지 매치할 수
+  #     있어(예: 오래전 머지된 문서의 사설 IP 예시) 여기서 차단하면 무관한 push가 영구히 막힌다.
+  #     따라서 tip 매치는 '경고'만 하고, 실제 차단은 아래 (2) range 스캔이 담당한다.
+  #     (트리 전체 청결성 강제는 서버 측 CI String Check가 맡는다.)
+  #     git grep 종료코드: 0=매치, 1=미매치, >=2=오류. 오류는 스캔 불능이므로 fail-closed.
   hits="$(git grep -I -i -n -E "$PATTERNS" "$localsha" -- . "$EXC1" "$EXC2" 2>/dev/null)"
   rc=$?
   if [ "$rc" -ge 2 ]; then
@@ -90,27 +115,31 @@ while read -r localref localsha remoteref remotesha; do
     printf "  git 버전/pathspec 지원을 확인하세요(:! exclude 는 git 1.9+ 필요).\n" >&2
     fail=1
   elif [ "$rc" -eq 0 ] && [ -n "$hits" ]; then
-    printf "${RED}[pre-push] 차단: 내부 호스트/자격증명 패턴 감지 (tip %s).${NC}\n" "${localsha:0:12}" >&2
+    printf "${YEL}[pre-push] 경고: tip 트리에 내부 호스트/자격증명 패턴이 있습니다 (tip %s).${NC}\n" "${localsha:0:12}" >&2
     printf '%s\n' "$hits" | awk -F: '{print "    " $2 ":" $3 "  (redacted)"}' | sort -u >&2
-    fail=1
+    printf "  이미 공개된 내용이면 정리를 권장합니다. (이 항목만으로는 push를 막지 않습니다.)\n" >&2
   fi
 
-  # (2) push 범위 커밋별 추가 라인 스캔 — 중간 커밋에서 add된 뒤 tip에서 지워졌더라도
-  #     그 중간 커밋 객체는 push되어 공개되므로 함께 검사. origin/main 에 의존하지 않도록
-  #     '리모트에 아직 없는 커밋'을 --not --remotes 로 정의(shallow/orphan/비-main 기본브랜치 안전).
+  # (2) push 범위 커밋별 추가 라인 스캔 — 차단의 핵심. 중간 커밋에서 add된 뒤 tip에서 지워졌더라도
+  #     그 커밋 객체는 push되어 공개되므로 함께 검사. origin/main 에 의존하지 않도록 '대상 원격에
+  #     아직 없는 커밋'을 --not $NOT_REMOTES 로 정의(shallow/orphan/비-main 기본브랜치 안전).
+  #     --full-history: pathspec(-- .)로 인한 history simplification 이 --no-ff 머지에서 정리된
+  #     side-branch 유출 커밋을 walk에서 누락시키는 것을 방지.
   if [ "$remotesha" != "$z40" ]; then
-    RANGE="$remotesha..$localsha"          # 기존 브랜치 업데이트: 정확한 범위
+    RANGE="$remotesha..$localsha"                 # 기존 브랜치 업데이트: 정확한 범위
   else
-    RANGE="$localsha --not --remotes"      # 새 브랜치: 리모트에 없는 모든 커밋
+    RANGE="$localsha --not $NOT_REMOTES"          # 새 브랜치: 대상 원격에 없는 모든 커밋
   fi
-  # shellcheck disable=SC2086  # RANGE 는 의도적으로 여러 토큰으로 분리
-  plog="$(git log -p --no-color $RANGE -- . "$EXC1" "$EXC2" 2>/dev/null)"
+  # shellcheck disable=SC2086  # RANGE/NOT_REMOTES 는 의도적으로 여러 토큰으로 분리
+  plog="$(git log -p --no-color --full-history $RANGE -- . "$EXC1" "$EXC2" 2>/dev/null)"
   lrc=$?
   if [ "$lrc" -ne 0 ]; then
     printf "${RED}[pre-push] 오류: 범위 스캔 실패(git log rc=%s). 안전을 위해 push를 중단합니다.${NC}\n" "$lrc" >&2
     fail=1
   else
-    dhits="$(printf '%s\n' "$plog" | grep -E "^\+" | grep -icE "$PATTERNS")"
+    # 추가된 실제 내용 라인만 검사: '^+' 중 diff 헤더('+++ b/path')는 제외해, 파일 경로가 패턴과
+    # 겹치는 것만으로 오탐하지 않게 한다.
+    dhits="$(printf '%s\n' "$plog" | grep -E "^\+" | grep -vE "^\+\+\+ " | grep -icE "$PATTERNS")"
     if [ "${dhits:-0}" -gt 0 ] 2>/dev/null; then
       printf "${RED}[pre-push] 차단: push 범위 커밋에서 추가된 내부 호스트 패턴 %s건 감지 (tip %s).${NC}\n" "$dhits" "${localsha:0:12}" >&2
       fail=1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# 내부 호스트명 / 자격증명 URL이 공개 원격으로 push되기 전에 차단하는 훅.
+#
+# 배경: CI의 String Check(scan) 워크플로는 사후(push 이후) 탐지 계층이라, feature 브랜치를
+#       public 원격에 push하는 "노출 순간" 자체는 막지 못한다. 이 훅은 push 경계(노출 직전)에서
+#       검사해 그 갭을 예방한다. (권위 있는 백스톱은 여전히 CI String Check다.)
+#
+# 민감성 원칙: 실제 내부 도메인은 이 저장소(public)에 절대 넣지 않는다. 조직별 denylist는
+#       아래 두 소스에서만 읽는다 —
+#         1) 환경변수 STRING_CHECK_PATTERN (CI의 secret과 동일 값)
+#         2) 로컬 .githooks/patterns.local (gitignore됨; 1줄 = 1 ERE, '#' 주석 허용)
+#       저장소에는 오탐 위험이 낮은 '일반' 패턴(자격증명 URL / 사설 IP / 일반 내부 TLD)만 내장한다.
+#
+# 강제성: git 훅은 client-side라 setup.sh(core.hooksPath) 실행이 있어야 동작하고 --no-verify로
+#       우회 가능하다(모든 git 훅 공통). 완전(우회 불가) 차단은 서버 측 push protection 또는
+#       전 브랜치 CI 스캔이 담당한다.
+#
+# 옵션:
+#   PREPUSH_STRICT=1  조직 denylist(env/patterns.local) 미설정 시 경고 대신 push 거부(fail-closed).
+
+set -u
+
+z40="0000000000000000000000000000000000000000"
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+RED='\033[0;31m'; YEL='\033[1;33m'; NC='\033[0m'
+
+# 훅 자신의 '패턴 정의' 파일은 self-match 방지를 위해 스캔에서 제외한다.
+# (그 파일들의 실제 유출은 CI String Check가 secret 패턴으로 백스톱한다.)
+EXC1=':!.githooks/pre-push'
+EXC2=':!.githooks/patterns.local.example'
+
+# --- 패턴 조립 ---------------------------------------------------------------
+# 내장 일반 패턴(비민감, 저오탐). 호스트명은 대소문자 무의미하므로 스캔은 -i로 수행한다.
+#   - URL에 박힌 자격증명(user:pass@host)
+#   - http(s) URL의 사설 IP 호스트(10./192.168./172.16-31.)
+#   - 일반 내부 TLD(호스트 위치 한정): internal / intranet / corp
+BUILTIN='(://[^/@[:space:]]+:[^/@[:space:]]+@)|(https?://(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.))|(\.(internal|intranet|corp)(:[0-9]|/|["'"'"'[:space:]]|$))'
+
+PATTERNS="$BUILTIN"
+have_org=0
+
+if [ -n "${STRING_CHECK_PATTERN:-}" ]; then
+  PATTERNS="$PATTERNS|($STRING_CHECK_PATTERN)"
+  have_org=1
+fi
+
+LOCAL_FILE="$HOOK_DIR/patterns.local"
+if [ -f "$LOCAL_FILE" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|\#*) continue ;; esac
+    PATTERNS="$PATTERNS|($line)"
+    have_org=1
+  done < "$LOCAL_FILE"
+fi
+
+# 조립된 정규식이 유효한지 사전 검증(잘못된 patterns.local/env가 스캔을 조용히 무력화하는 것 방지).
+# grep 종료코드: 0=매치, 1=미매치(정상), >=2=정규식 오류.
+printf '' | grep -E "$PATTERNS" >/dev/null 2>&1
+if [ "$?" -ge 2 ]; then
+  printf "${RED}[pre-push] 오류: denylist 정규식이 유효하지 않습니다.${NC} patterns.local / STRING_CHECK_PATTERN 를 확인하세요.\n" >&2
+  exit 1   # fail-closed
+fi
+
+if [ "$have_org" = "0" ]; then
+  if [ "${PREPUSH_STRICT:-0}" = "1" ]; then
+    printf "${RED}[pre-push] STRICT: 조직 내부호스트 denylist가 설정되지 않아 push를 거부합니다.${NC}\n" >&2
+    printf "  .githooks/patterns.local 을 만들거나 STRING_CHECK_PATTERN 을 지정하세요 (템플릿: patterns.local.example).\n" >&2
+    exit 1
+  fi
+  printf "${YEL}[pre-push] 경고: 조직별 내부호스트 denylist가 설정되지 않았습니다.${NC}\n" >&2
+  printf "  일반 패턴만으로 검사합니다. 완전한 보호를 위해 .githooks/patterns.local 을 설정하거나\n" >&2
+  printf "  STRING_CHECK_PATTERN 환경변수를 지정하세요 (템플릿: .githooks/patterns.local.example).\n" >&2
+fi
+
+# --- push되는 각 ref 검사 ----------------------------------------------------
+fail=0
+while read -r localref localsha remoteref remotesha; do
+  [ -z "${localsha:-}" ] && continue
+  [ "$localsha" = "$z40" ] && continue   # 삭제 push: 스캔할 tip 없음
+
+  # (1) tip tree 스캔 — 항상 실행. tip에 내부호스트가 남아있으면 차단.
+  #     git grep 종료코드: 0=매치, 1=미매치, >=2=오류(예: 구버전 git의 pathspec 미지원).
+  #     오류는 조용히 통과시키지 않고 fail-closed로 차단한다.
+  hits="$(git grep -I -i -n -E "$PATTERNS" "$localsha" -- . "$EXC1" "$EXC2" 2>/dev/null)"
+  rc=$?
+  if [ "$rc" -ge 2 ]; then
+    printf "${RED}[pre-push] 오류: tip 스캔 실패(git grep rc=%s). 안전을 위해 push를 중단합니다.${NC}\n" "$rc" >&2
+    printf "  git 버전/pathspec 지원을 확인하세요(:! exclude 는 git 1.9+ 필요).\n" >&2
+    fail=1
+  elif [ "$rc" -eq 0 ] && [ -n "$hits" ]; then
+    printf "${RED}[pre-push] 차단: 내부 호스트/자격증명 패턴 감지 (tip %s).${NC}\n" "${localsha:0:12}" >&2
+    printf '%s\n' "$hits" | awk -F: '{print "    " $2 ":" $3 "  (redacted)"}' | sort -u >&2
+    fail=1
+  fi
+
+  # (2) push 범위 커밋별 추가 라인 스캔 — 중간 커밋에서 add된 뒤 tip에서 지워졌더라도
+  #     그 중간 커밋 객체는 push되어 공개되므로 함께 검사. origin/main 에 의존하지 않도록
+  #     '리모트에 아직 없는 커밋'을 --not --remotes 로 정의(shallow/orphan/비-main 기본브랜치 안전).
+  if [ "$remotesha" != "$z40" ]; then
+    RANGE="$remotesha..$localsha"          # 기존 브랜치 업데이트: 정확한 범위
+  else
+    RANGE="$localsha --not --remotes"      # 새 브랜치: 리모트에 없는 모든 커밋
+  fi
+  # shellcheck disable=SC2086  # RANGE 는 의도적으로 여러 토큰으로 분리
+  plog="$(git log -p --no-color $RANGE -- . "$EXC1" "$EXC2" 2>/dev/null)"
+  lrc=$?
+  if [ "$lrc" -ne 0 ]; then
+    printf "${RED}[pre-push] 오류: 범위 스캔 실패(git log rc=%s). 안전을 위해 push를 중단합니다.${NC}\n" "$lrc" >&2
+    fail=1
+  else
+    dhits="$(printf '%s\n' "$plog" | grep -E "^\+" | grep -icE "$PATTERNS")"
+    if [ "${dhits:-0}" -gt 0 ] 2>/dev/null; then
+      printf "${RED}[pre-push] 차단: push 범위 커밋에서 추가된 내부 호스트 패턴 %s건 감지 (tip %s).${NC}\n" "$dhits" "${localsha:0:12}" >&2
+      fail=1
+    fi
+  fi
+done
+
+if [ "$fail" != "0" ]; then
+  printf "${RED}[pre-push] push를 중단했습니다.${NC} 위 파일에서 내부 호스트명을 제거한 뒤 다시 시도하세요.\n" >&2
+  printf "  이 차단은 public 저장소로의 내부 인프라 정보 유출을 막기 위한 것입니다. --no-verify 우회 금지.\n" >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/setup.sh
+++ b/.githooks/setup.sh
@@ -12,4 +12,15 @@ git -C "$REPO_ROOT" config core.hooksPath .githooks
 echo "✓ Git hooks가 .githooks 디렉토리로 설정되었습니다."
 echo ""
 echo "활성화된 hooks:"
-ls -la "$SCRIPT_DIR"/*.* 2>/dev/null | grep -v setup.sh || echo "  (없음)"
+ls -1 "$SCRIPT_DIR" 2>/dev/null | grep -vE '^(setup\.sh|patterns\.local.*)$' | sed 's/^/  - /' || echo "  (없음)"
+
+# pre-push 훅(내부 호스트명 유출 차단)용 로컬 denylist 안내
+echo ""
+if [ -f "$SCRIPT_DIR/patterns.local" ]; then
+  echo "✓ pre-push denylist: .githooks/patterns.local 감지됨 (내부 호스트 검사 활성)."
+else
+  echo "ℹ pre-push 훅은 내부 호스트명 유출을 차단합니다. 완전한 보호를 위해 로컬 denylist를 만드세요:"
+  echo "    cp .githooks/patterns.local.example .githooks/patterns.local"
+  echo "  그런 다음 patterns.local 에 조직 내부 호스트 규칙(CI STRING_CHECK_PATTERN과 동일)을 채우세요."
+  echo "  (patterns.local 은 .gitignore되어 커밋되지 않습니다.)"
+fi

--- a/.github/workflows/string-check.yml
+++ b/.github/workflows/string-check.yml
@@ -1,9 +1,12 @@
 name: String Check
 
 on:
+  # 전 브랜치 push에서 스캔 — feature 브랜치를 public 원격에 push하는 "노출 순간"을
+  # 서버 측에서 탐지하기 위함(로컬 pre-push 훅은 --no-verify로 우회 가능하므로 백스톱 필요).
+  # push 이벤트는 fork PR과 달리 repository secret 접근이 가능해 STRING_CHECK_PATTERN을 쓸 수 있다.
   push:
     branches:
-      - main
+      - '**'
   pull_request:
     branches: [main]
 

--- a/.github/workflows/string-check.yml
+++ b/.github/workflows/string-check.yml
@@ -4,8 +4,13 @@ on:
   # 전 브랜치 push에서 스캔 — feature 브랜치를 public 원격에 push하는 "노출 순간"을
   # 서버 측에서 탐지하기 위함(로컬 pre-push 훅은 --no-verify로 우회 가능하므로 백스톱 필요).
   # push 이벤트는 fork PR과 달리 repository secret 접근이 가능해 STRING_CHECK_PATTERN을 쓸 수 있다.
+  # dependabot 브랜치는 secret 미접근이라 Guard가 매번 실패하므로 push 트리거에서 제외한다
+  # (dependabot PR은 pull_request 경로의 IS_BOT_PR skip이 처리). 태그 push도 노출 순간이므로 포함.
   push:
     branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
       - '**'
   pull_request:
     branches: [main]
@@ -39,12 +44,24 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$PATTERN"
+          # 정규식 유효성 사전 검증: 잘못된 ERE가 스캔을 조용히 무력화(grep rc>=2를 미매치로 취급)하는
+          # fail-open 을 방지. 빈 입력 grep 은 유효한 정규식이면 rc=1(미매치)이라, GHA 기본 셸
+          # (bash -eo pipefail)에서 set -e 로 중단되지 않도록 if/elif 조건 컨텍스트에 둔다.
+          # grep 종료코드: 0/1=정규식 유효(매치/미매치), >=2=정규식 오류.
+          if printf '' | LC_ALL=C grep -E "$PATTERN" >/dev/null 2>&1; then
+            :
+          elif [ "$?" -ge 2 ]; then
+            echo "::error::STRING_CHECK_PATTERN 이 유효한 ERE가 아닙니다(정규식 오류)."
+            exit 1
+          fi
 
       - name: Scan tree
         if: env.IS_BOT_PR != 'true'
+        env:
+          LC_ALL: C   # 바이트 단위 매칭(로케일 의존 UTF-8 스킵으로 인한 fail-open 방지)
         run: |
           set +e
-          FOUND=$(grep -rIn \
+          FOUND=$(grep -rIni \
             --exclude-dir=".git" \
             --exclude-dir="node_modules" \
             --exclude-dir="Library" \
@@ -52,6 +69,11 @@ jobs:
             -E "$PATTERN" . 2>/dev/null)
           RC=$?
           set -e
+          # grep rc: 0=매치, 1=미매치, >=2=오류. 오류를 미매치로 취급(fail-open)하지 않고 실패 처리.
+          if [ "$RC" -ge 2 ]; then
+            echo "::error::tree 스캔 실패(grep rc=$RC). 안전을 위해 실패 처리합니다."
+            exit 1
+          fi
           if [ "$RC" = "0" ] && [ -n "$FOUND" ]; then
             echo "::error::금지된 패턴이 감지되었습니다."
             echo "$FOUND" | awk -F: '{print "::error file=" $1 ",line=" $2 "::redacted"}'
@@ -61,6 +83,8 @@ jobs:
 
       - name: Scan lockfiles
         if: env.IS_BOT_PR != 'true'
+        env:
+          LC_ALL: C   # 바이트 단위 매칭(로케일 의존 UTF-8 스킵으로 인한 fail-open 방지)
         run: |
           set -e
           BAD=0
@@ -70,9 +94,14 @@ jobs:
             "sdk-runtime-generator~/pnpm-lock.yaml"
           do
             [ -f "$f" ] || continue
-            if grep -qE "$PATTERN" "$f"; then
+            # grep 을 if/elif 조건 컨텍스트에 두어 rc=1(미매치)이 set -e 로 스크립트를 중단시키지 않게 함.
+            # rc: 0=매치(차단), 1=미매치(정상), >=2=오류(fail-closed).
+            if grep -qiE "$PATTERN" "$f"; then
               echo "::error file=$f::redacted"
               BAD=1
+            elif [ "$?" -ge 2 ]; then
+              echo "::error::lockfile 스캔 실패($f, grep rc>=2). 안전을 위해 실패 처리합니다."
+              exit 1
             fi
           done
           [ "$BAD" = "0" ] || exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,6 @@ yarn.lock.meta
 # Superpowers 플랜 문서 (Claude Code 작업용, 커밋 불필요)
 docs/superpowers/
 docs/superpowers.meta
+
+# 로컬 전용 내부호스트 denylist (pre-push 훅용) — 커밋 금지. 템플릿: patterns.local.example
+.githooks/patterns.local


### PR DESCRIPTION
## 배경

CI의 **String Check(`scan`)** 워크플로는 지금까지 `main` push / PR 시점에만 도는 **사후 머지 게이트**였다. 즉 내부 호스트명이 들어간 커밋이 만들어져도, feature 브랜치를 public 원격으로 **push하는 순간의 노출 자체**는 막지 못했다(브랜치·커밋 페이지가 즉시 공개되고 GH Archive 등에 수집됨). 노출을 되돌리려면 브랜치 삭제·PR close로는 부족하고 GitHub Support 퍼지가 필요하다.

이 PR은 그 갭을 두 계층으로 메운다:
1. **push 경계(노출 직전)** 를 검사하는 로컬 `pre-push` 훅 (조기 예방)
2. **전 브랜치 push** 를 스캔하도록 확장한 CI String Check (서버 측 백스톱, `--no-verify` 우회 불가)

## 1) 로컬 pre-push 훅

push되는 각 ref에 대해:
1. **tip 트리 스캔**(`git grep -I -i`) — CI의 tree scan과 동형. tip에 내부 호스트/자격증명 패턴이 남아 있으면 차단.
2. **push 범위 커밋별 추가 라인 스캔**(`git log -p`) — 중간 커밋에서 add된 뒤 tip에서 지워졌더라도 그 커밋 객체는 push되어 공개되므로 함께 검사. 범위는 `origin/main`에 의존하지 않고 `--not --remotes`로 "리모트에 아직 없는 커밋"을 정의 → shallow/orphan/비-main 기본브랜치 clone에서도 안전.

매치 시 **파일:라인만** 노출하고 매치 내용은 redact, 비영(非0) 종료로 push를 중단한다.

**Fail-closed 설계** (조용한 무력화 방지):
- 조립된 denylist 정규식을 push 전 사전 검증 — 잘못된 `patterns.local`/env면 push 거부.
- `git grep`/`git log` 종료코드를 구분 — 스캔 자체가 실패하면(예: 구버전 git의 `:!` pathspec 미지원) 통과가 아니라 **차단**.
- 호스트명은 대소문자 무의미하므로 `-i`로 스캔(`.CORP`, `.Internal` 등 대문자 우회 차단).

**옵션**: `PREPUSH_STRICT=1` — 조직 denylist(env/`patterns.local`) 미설정 시 경고 대신 push를 거부(fail-closed).

## 민감성 원칙 (이 저장소는 public)

- **실제 내부 도메인 문자열은 저장소에 커밋하지 않는다.** 조직별 denylist는 두 소스에서만 읽는다:
  - env `STRING_CHECK_PATTERN` (CI secret과 동일 값), 또는
  - **gitignore된** `.githooks/patterns.local` (1줄 = 1 ERE, `#` 주석 허용)
- 저장소에는 **오탐 낮은 일반 패턴만 내장**한다: URL 내장 자격증명(`user:pass@`), 사설 IP(`10./192.168./172.16-31.`), 일반 내부 TLD(`internal/intranet/corp`).
- 패턴 **정의 파일**(`pre-push`, `patterns.local.example`)은 self-match 방지를 위해 스캔에서 제외한다(그 파일들의 실제 유출은 CI String Check의 secret 패턴이 백스톱).

## 2) CI String Check 전 브랜치 확장

- `push` 트리거를 `branches: [main]` → `branches: ['**']` 로 확장.
- push 이벤트는 fork PR과 달리 repository secret 접근이 가능해 `STRING_CHECK_PATTERN`을 그대로 사용.
- 로컬 훅이 미설정이거나 `--no-verify`로 우회되어도, 원격에 도달한 커밋은 서버 측에서 스캔된다.

## 변경

- `.githooks/pre-push` 추가 (실행권한)
- `.githooks/patterns.local.example` 추가 — 자리표시자 템플릿(실제 내부 도메인 없음)
- `.githooks/setup.sh` — pre-push denylist 설정 안내 추가
- `.gitignore` — `.githooks/patterns.local` 무시
- `.github/workflows/string-check.yml` — push 트리거 전 브랜치로 확장

## 한계 (정직한 범위)

- 로컬 훅은 `./.githooks/setup.sh`(core.hooksPath) 실행 + `patterns.local` 설정이 되어야 **조직 도메인**을 잡는다. 미설정 dev는 일반 패턴만 적용(경고 출력, `PREPUSH_STRICT=1`로 강제 가능). — 조직 도메인을 public repo에 하드코딩할 수 없으니 불가피.
- `--no-verify`로 훅 우회 가능(모든 git 훅 공통) → 그래서 CI 전 브랜치 스캔을 백스톱으로 둔다.
- **push 전(노출 이전) 완전 차단**은 서버 측 GitHub push protection 커스텀 패턴이 필요하나, 현재 org/repo 모두 `secret-scanning/custom-patterns` 엔드포인트가 404(기능 비활성/권한 없음)라 이 PR 범위 밖 → **org admin 후속**으로 남긴다. (CI 전 브랜치 스캔은 노출 "직후" 탐지이지 노출 "예방"은 아니다.)
- **바이너리 파일은 스코프 밖**(의도) — 훅·CI 모두 git이 바이너리로 분류하는 파일(`-I`)은 스캔하지 않는다. Unity 바이너리 에셋을 바이트 스캔하면 오탐이 폭증해 `--no-verify` 습관을 부추기므로, '텍스트 설정 유출'만 대상으로 한다. 바이너리 유출은 코드리뷰/정책으로 커버.
- **fork PR은 조직 패턴 미적용** — GitHub 정책상 fork PR은 repository secret에 접근 불가라 `STRING_CHECK_PATTERN`이 빈 값 → 내장 일반 패턴만 적용된다. 비-fork push 이벤트는 secret 접근이 가능하므로, 조직 도메인 탐지는 브랜치 push(전 브랜치 스캔) 경로가 담당한다.

## 적대적 감사 후 보강 (2차 커밋)

머지 전 훅/CI를 다중 에이전트로 적대적 감사해 확인된 결함을 보강했다. 차단의 권위는 서버 측 CI가 유지하고, 이 보강은 push 경계 예방 계층의 **놓침(fail-open)·오탐** 정확도를 끌어올린다.

**pre-push 훅**
- **로케일 fail-open 봉쇄** — `export LC_ALL=C`. UTF-8 로케일에서 grep/`git grep`이 '유효하지 않은 UTF-8 바이트'가 든 줄을 조용히 건너뛰어 유출을 놓치던 경로를 바이트 단위 매칭으로 차단.
- **머지 prune 놓침 봉쇄** — 범위 스캔에 `--full-history`. pathspec(`-- .`) history simplification이 `--no-ff` 머지에서 tip으로부터 정리된 side-branch 유출 커밋을 walk에서 누락시키던 것을 방지.
- **tip 스캔 → '경고' 강등** — tip 트리 전체 스캔은 이미 공개된 내용(오래전 머지된 문서의 사설 IP 예시 등)까지 매치해 무관한 push를 영구 차단할 수 있어 경고만 한다. 실제 차단은 '새로 push되는 커밋의 추가 라인' 범위 스캔이 담당(트리 전체 청결성은 서버 측 CI가 강제).
- **diff 헤더 오탐 제거** — 범위 스캔에서 `^+` 중 `+++ b/path` 헤더를 제외해 파일 '경로'가 패턴과 겹치는 것만으로 차단하던 오탐 제거(내용만 검사).
- **대상 원격 한정** — 새 브랜치 범위를 bare `--not --remotes` 대신 push 대상 원격(`--remotes=<name>`)으로 한정. 사설 미러/포크의 커밋까지 제외해 유출을 놓치던 것을 방지(원격 식별 불가 시 보수적으로 모든 원격).

**CI String Check**
- tree/lockfile 스캔에 `LC_ALL=C`(훅과 동일한 로케일 fail-open 봉쇄).
- tree 스캔에 `-i` 추가(`.CORP` 등 대문자 우회 차단).
- **fail-closed** — grep 종료코드 구분(0=매치, 1=미매치, ≥2=오류). 오류를 미매치로 취급하지 않고 실패 처리. GHA 기본 셸(`bash -eo pipefail`)의 set -e에 중단되지 않도록 grep을 if/elif 조건 컨텍스트에 배치.
- push 트리거에서 `dependabot/**` 제외(secret 미접근이라 Guard가 매번 실패 → PR 경로 `IS_BOT_PR` skip이 처리) + `tags:['**']` 추가(태그 push도 노출 순간).
- Guard 정규식 사전 검증을 if/elif로 배치(유효 정규식의 rc=1이 set -e로 Guard를 중단시키지 않게).

## 검증

- 로컬 plumbing 테스트 **9/9** 통과: 내부호스트 tip 차단 / 중간커밋 add→tip제거 범위 차단 / URL 자격증명 차단 / 사설 IP 차단 / 대문자 내부 TLD 차단 / 잘못된 정규식 fail-closed 차단 / 공개도메인(`toss.im`)·사설IP아님(`172.99`) 통과 / no-op 통과 / `origin/main` 트리 오탐 0건.
- 격리 저장소 end-to-end **3/3** 통과: 리모트 부재 환경의 중간커밋 유출 차단(`--not --remotes` 회귀) / `PREPUSH_STRICT` 미설정 denylist 차단 / 비-STRICT 클린 tip 통과(경고만).
- 감사-보강 회귀 **4/4** 통과: 머지에서 정리된 side유출 차단(`--full-history`) / 경로만 `.corp`·내용 클린 통과(diff헤더 오탐 제거) / tip 유출 경고-only·범위 클린 통과 / invalid-UTF8 바이트 라인 유출 차단(`LC_ALL=C`).
