### PR TITLE
수정: Bulk Release 버전 순회에서 prerelease 스냅샷 태그 제외

### DIFF
--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -76,9 +76,17 @@ jobs:
             ALL_INPUT=$(git tag -l 'release/v*' | sed 's/release\/v//' | sort -V)
           fi
 
-          # min_version 이상만 필터링
+          # prerelease 스냅샷(예: 2.10.1-beta.48b3324) 제외 + min_version 이상만 필터링
+          # release.yml은 version을 publish된 web-framework npm 버전으로 검증하므로
+          # SDK 스냅샷 버전 문자열인 prerelease 태그는 항상 실패한다 (beta-release.yml 전용 경로)
           VERSIONS=""
           for V in $ALL_INPUT; do
+            case "$V" in
+              *-*)
+                echo "  v${V}: prerelease 스냅샷은 일괄 릴리즈 대상이 아니므로 스킵"
+                continue
+                ;;
+            esac
             if [ "$(printf '%s\n' "$MIN_VERSION" "$V" | sort -V | head -n1)" = "$MIN_VERSION" ] || [ "$V" = "$MIN_VERSION" ]; then
               VERSIONS="${VERSIONS}${V}"$'\n'
             else


### PR DESCRIPTION
## 배경

07-03 Bulk Release [run 28647599929](https://github.com/toss/apps-in-toss-unity-sdk/actions/runs/28647599929)에서 **prerelease 스냅샷 태그 2건만 failure**가 났습니다 (`v2.10.1-beta.48b3324`, `v2.10.4-beta.bc88005` — 나머지 stable 버전은 전부 success).

원인: `prepare-versions`가 `git tag -l 'release/v*'` 전체를 순회하는데, release.yml은 `version` 입력을 **publish된 web-framework npm 버전**으로 검증합니다. prerelease 태그의 버전 문자열은 SDK 스냅샷 버전(web-framework에 존재하지 않음)이므로 항상 다음으로 실패합니다:

```
[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for @apps-in-toss/web-framework@2.10.1-beta.48b3324
```

## 변경

- 버전 순회 필터에 prerelease 스킵 추가 (`case "$V" in *-*)` — semver prerelease는 하이픈 포함). 명시 입력(`versions`)에 포함된 경우에도 동일하게 스킵해 조기 실패를 예방합니다.
- prerelease 스냅샷의 릴리즈 경로는 기존대로 `beta-release.yml` 전용입니다.

## 검증

- 실패 run의 두 대상이 필터에 걸리는 것을 로컬 셸로 확인 (`2.10.1-beta.48b3324` → 스킵, `2.10.1` → 통과).
- 워크플로 YAML 변경만 있으므로 다음 Bulk Release dispatch에서 최종 확인 가능.