### PR TITLE
개선: Bulk Release 대상에서 npm 미존재 버전 사전 제외

### DIFF
--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -40,6 +40,7 @@ jobs:
       versions: ${{ steps.extract.outputs.versions }}
       version_count: ${{ steps.extract.outputs.count }}
       min_version: ${{ steps.extract.outputs.min_version }}
+      skipped_missing: ${{ steps.extract.outputs.skipped_missing }}
 
     steps:
       - name: Checkout
@@ -87,6 +88,29 @@ jobs:
           done
           VERSIONS=$(echo "$VERSIONS" | sed '/^$/d')
 
+          # npm 사전 존재 체크 — npm에서 제거된(unpublish) web-framework 버전은
+          # regenerate-sdk가 ERR_PNPM_NO_MATCHING_VERSION으로 반드시 실패하므로
+          # 대상에서 미리 제외한다 (주로 수명이 끝난 beta 스냅샷 태그).
+          # 패큐먼트 조회 실패 시에는 기존 동작 그대로 전체 버전을 시도한다 (fail-open).
+          SKIPPED_MISSING=""
+          NPM_VERSIONS=$(curl -fsSL --retry 3 "https://registry.npmjs.org/@apps-in-toss%2fweb-framework" | jq -r '.versions | keys[]' || echo "")
+          if [ -z "$NPM_VERSIONS" ]; then
+            echo "::warning::web-framework 패큐먼트 조회 실패 — npm 사전 존재 체크를 건너뜁니다"
+          else
+            EXISTING=""
+            for V in $VERSIONS; do
+              if echo "$NPM_VERSIONS" | grep -Fqx "$V"; then
+                EXISTING="${EXISTING}${V}"$'\n'
+              else
+                SKIPPED_MISSING="${SKIPPED_MISSING}${V}"$'\n'
+                echo "  v${V}: npm에 @apps-in-toss/web-framework@${V} 없음 → 스킵"
+              fi
+            done
+            VERSIONS=$(echo "$EXISTING" | sed '/^$/d')
+          fi
+          SKIPPED_MISSING_CSV=$(echo "$SKIPPED_MISSING" | sed '/^$/d' | paste -sd, -)
+          echo "skipped_missing=${SKIPPED_MISSING_CSV}" >> $GITHUB_OUTPUT
+
           # 버전이 없으면 에러
           if [ -z "$VERSIONS" ]; then
             echo "::error::릴리즈할 버전이 없습니다"
@@ -126,6 +150,11 @@ jobs:
 
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**총 ${{ steps.extract.outputs.count }}개 버전**" >> $GITHUB_STEP_SUMMARY
+          SKIPPED_MISSING="${{ steps.extract.outputs.skipped_missing }}"
+          if [ -n "$SKIPPED_MISSING" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**npm 미존재로 스킵**: ${SKIPPED_MISSING}" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**최소 버전**: ${{ steps.extract.outputs.min_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**동시 실행 수**: ${{ inputs.max_parallel || 2 }}" >> $GITHUB_STEP_SUMMARY
@@ -376,6 +405,12 @@ jobs:
             RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${TAG_NAME}"
             echo "- [v${VERSION}](${RELEASE_URL})" >> $GITHUB_STEP_SUMMARY
           done
+
+          SKIPPED_MISSING="${{ needs.prepare-versions.outputs.skipped_missing }}"
+          if [ -n "$SKIPPED_MISSING" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**npm 미존재로 스킵된 버전**: ${SKIPPED_MISSING}" >> $GITHUB_STEP_SUMMARY
+          fi
 
           # 배포 URL + QR 코드 테이블 추가
           if [ -d "all-deploy-results" ]; then


### PR DESCRIPTION
## 개요

Bulk Release가 npm에서 이미 제거된(unpublish) `@apps-in-toss/web-framework` 버전을 대상으로 잡으면, 해당 버전 릴리즈는 SDK 재생성 단계에서 `ERR_PNPM_NO_MATCHING_VERSION`으로 반드시 실패합니다. 2026-07-03 bulk run(28647599929)에서 수명이 끝난 beta 스냅샷 태그 2건(`v2.10.1-beta.48b3324`, `v2.10.4-beta.bc88005`)이 이 사유로 실패해 run 전체가 `failure`로 표기됐습니다.

`prepare-versions` job에 **npm 사전 존재 체크**를 추가해 이런 버전을 대상에서 미리 제외합니다.

## 변경 사항

- **사전 체크**: min_version 필터 직후, web-framework 패큐먼트를 1회 조회(`curl --retry 3` + `jq`)해 npm에 존재하지 않는 버전을 대상 목록에서 제외
- **가시성**: 스킵된 버전을 job 로그, `버전 목록 요약` step summary, 최종 `일괄 릴리즈 요약`에 모두 표기 (`skipped_missing` output 추가)
- **fail-open**: 패큐먼트 조회 실패(네트워크 등) 시 경고만 남기고 기존 동작대로 전체 버전을 시도 — 사전 체크가 새로운 단일 실패점이 되지 않도록 함
- 전부 스킵되어 대상이 비면 기존 `릴리즈할 버전이 없습니다` 에러 경로로 진입

## 검증

- YAML 구문 파싱 통과
- 필터 로직을 CI와 동일한 셸 옵션(`set -e -o pipefail`)에서 fixture로 시뮬레이션:
  - 존재 버전 유지 / 미존재 beta 2종 스킵 / CSV output 정상
  - 전부 스킵 시 빈 목록 에러 경로 진입 확인
  - curl 실패 시 fail-open 경로 생존 확인 (스텝이 죽지 않음)
