### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — cs1061-user-compile-error

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1283,6 +1283,22 @@ namespace AppsInToss.Editor.ErrorTracker
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // 사용자 코드의 멤버/확장 메서드 미정의 컴파일 에러 (CS1061) — Unity 컴파일러가 직접 출력.
+            // 예: "Assets\Scripts\AppsInToss\AppsInTossRemoteConfig.cs(21,61): error CS1061:
+            //       'GameServerConfig' does not contain a definition for 'gameSettingsId' and no
+            //       accessible extension method 'gameSettingsId' accepting a first argument of
+            //       type 'GameServerConfig' could be found ..."
+            // Sentry APPS-IN-TOSS-UNITY-SDK-13G.
+            // 'GameServerConfig'는 SDK 타입이 아닌 사용자 정의 클래스이며, 파일 경로가 사용자 폴더명
+            // "AppsInToss\AppsInTossRemoteConfig.cs"를 포함해 SDK 키워드 가드가 발동하므로 CS0117과
+            // 동일하게 가드보다 먼저 매칭한다(Assets/ 경로 + .cs(L,C) 패턴). SDK 자체 코드는 Packages/
+            // 또는 Library/PackageCache/ 경로로 출력되어 안전.
+            if (message.IndexOf("error CS1061", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
             // 사용자 코드의 async/await 미사용 경고 (CS1998) — Unity 컴파일러가 직접 출력.
             // 예: "Assets\Scripts\1. System\AppsInToss\TossManager.cs(260,43): warning CS1998:
             //       This async method lacks 'await' operators and will run synchronously. ..."

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1033,14 +1033,14 @@ public class IsKnownNonSdkMessageTests
     public void OtherCSErrorInUserAssets_ReturnsFalse()
     {
         // 가드가 등록되지 않은 다른 CS 에러 코드(예: CS0535)는 composite 가드가 매칭되지 않아 통과해야 함.
-        // 본 SDK는 CS0029/CS0103/CS0105/CS0117/CS0246/CS1503 한정으로 가드.
+        // 본 SDK는 CS0029/CS0103/CS0105/CS0117/CS0246/CS1503/CS1061 한정으로 가드.
         Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Assets/Scripts/GameLogic.cs(42,10): error CS0535: 'X' does not implement interface member 'Y'"));
     }
 
     #endregion
 
-    #region 사용자 코드 CS0103/CS0117 컴파일 에러 (SDK-CR, SDK-MN, SDK-80)
+    #region 사용자 코드 CS0103/CS0117/CS1061 컴파일 에러 (SDK-CR, SDK-MN, SDK-80, SDK-13G)
 
     [Test]
     public void UserCodeCS0103_AssetsBackslashPath_ReturnsTrue()
@@ -1064,6 +1064,40 @@ public class IsKnownNonSdkMessageTests
         // Sentry SDK-80 — 사용자 BuildTool 코드가 SDK 타입의 존재하지 않는 멤버 참조.
         Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
             "Assets\\98_Tools\\BuildTool\\Editor\\BuildToolEditorWindow.cs(484,43): error CS0117: 'AppsInTossMenu' does not contain a definition for 'Package'"));
+    }
+
+    [Test]
+    public void UserCodeCS1061_GameServerConfigMissingMember_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-13G — 사용자 정의 클래스 'GameServerConfig'(SDK 타입 아님)의
+        // 존재하지 않는 멤버/확장 메서드 참조. 파일 경로에 "AppsInToss" 폴더명이 포함돼 SDK 키워드
+        // 가드가 발동하므로 CS0117과 동일하게 가드보다 먼저 매칭되어야 한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Assets\\Scripts\\AppsInToss\\AppsInTossRemoteConfig.cs(21,61): error CS1061: 'GameServerConfig' does not contain a definition for 'gameSettingsId' and no accessible extension method 'gameSettingsId' accepting a first argument of type 'GameServerConfig' could be found"));
+    }
+
+    [Test]
+    public void UserCodeCS1061_ForwardSlashPath_ReturnsTrue()
+    {
+        // POSIX 경로 변형도 동일 composite 가드(error CS1061 + Assets/ + .cs()로 매칭됨을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/Scripts/Manager/InventoryManager.cs(58,20): error CS1061: 'ItemData' does not contain a definition for 'stackSize'"));
+    }
+
+    [Test]
+    public void Cs1061_SdkPackagePath_NotFiltered()
+    {
+        // SDK 자체 .cs의 CS1061은 Packages/com.toss.apps-in-toss 경로로 출력되어 Assets/ prefix 미포함 → 보호됨.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/com.toss.apps-in-toss/Editor/Foo.cs(10,5): error CS1061: 'Bar' does not contain a definition for 'baz'"));
+    }
+
+    [Test]
+    public void Cs1061WithoutAssetsPrefix_AitProtected_ReturnsFalse()
+    {
+        // SDK 자체 진단 라인(Assets/ 경로 미포함)은 [AIT] prefix로 보호됨.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] diag: error CS1061 reported in SDK fallback path"));
     }
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-13G

## 묶음 항목

| source | id | title |
| --- | --- | --- |
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-13G | `UnityError: Assets\Scripts\AppsInToss\AppsInTossRemoteConfig.cs(21,61): error CS1061: 'GameServerConfig' does not contain a definition for 'gameSettingsId' and no accessible extension method 'gameSettingsId' accepting a first argument of type 'GameServerConfig' cou...` |

## 판단 근거

`Assets\Scripts\AppsInToss\AppsInTossRemoteConfig.cs(21,61)`에서 발생한 `error CS1061`은 Unity C# 컴파일러가 직접 출력하는 사용자 코드 컴파일 에러입니다. `GameServerConfig`는 SDK 타입이 아닌 사용자 정의 클래스이며, 이 메시지는 사용자 프로젝트 코드 문제이지 SDK 버그가 아닙니다.

`AITEditorErrorTracker.cs`에는 이미 CS0103/CS0117/CS0029/CS1503/CS0246/CS1998/CS0618 등 거의 동일한 "`Assets/` 경로 + `.cs(` + `error/warning CS####`" composite 패턴이 다수 선례로 존재합니다(특히 CS0117 사례는 동일하게 "does not contain a definition for" 메시지). 메시지 내 `AppsInToss`는 사용자 폴더/클래스명(`AppsInToss\AppsInTossRemoteConfig.cs`)일 뿐 SDK 자체 로그 prefix(`[AIT]` 등)가 아니므로, 별도 처리하지 않으면 `AitKeywords` 보호 가드에 걸려 SDK 자체 에러로 오분류되어 계속 Sentry에 노이즈로 쌓입니다.

## 추출 패턴

`IsKnownNonSdkMessage` 내 CS0117 블록 바로 뒤에 CS1061 전용 composite AND 패턴을 추가했습니다(기존 CS0117 처리와 동일 구조):

```csharp
if (message.IndexOf("error CS1061", StringComparison.Ordinal) >= 0
    && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
        || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
    && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
    return true;
```

- SDK 자체 코드는 `Packages/com.toss.apps-in-toss/...` 또는 `Library/PackageCache/...` 경로로 컴파일 에러를 출력하므로 `Assets/` 가드에 걸리지 않아 안전하게 보호됩니다.
- `[AIT]` prefix가 붙은 SDK 자체 진단 메시지도 `Assets/` 경로 미포함으로 동일하게 보호됩니다.

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs`: `IsKnownNonSdkMessage`에 CS1061 composite 패턴 추가 (CS0117 블록 직후)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`:
  - positive: Windows 경로(`Assets\...`, 실제 Sentry 메시지 기반) / POSIX 경로(`Assets/...`) 변형 2건
  - negative: SDK 패키지 경로(`Packages/com.toss.apps-in-toss/...`) 및 `Assets/` 경로 없는 `[AIT]` 진단 메시지 보호 2건
  - 기존 "가드 대상 CS 코드 목록" 주석에 CS1061 추가 반영

## 검증

- `./run-local-tests.sh --validate`: **동시 빌드 회피로 검증 skip — 사람 확인 필요**
  - 실행 전 `pgrep -f run-local-tests` 확인 결과 다른 worker(`aitresolve-auto-android-adb-reverse-noise`)가 이미 `run-local-tests.sh --validate`를 실행 중이었습니다.
  - 30초 대기 후 재확인해도 여전히 실행 중이어서(2회 연속 충돌) 런북 정책에 따라 로컬 검증을 생략했습니다.
  - 변경은 기존 CS0117 composite 패턴과 완전히 동일한 구조를 재사용한 것으로 diff 자체는 최소화되어 있습니다(중괄호 균형/코드 스타일 수동 확인 완료). 머지 전 CI 및 사람 리뷰에서 `--validate`/EditMode 테스트 통과 여부를 반드시 재확인해 주세요.

## 변경 범위

- `Editor/ErrorTracker/AITEditorErrorTracker.cs`
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`

**사람 머지 검토 필요** — squash merge만 허용, 커밋 서명 필수.
