### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — mcp-build-linker-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -314,6 +314,15 @@ namespace AppsInToss.Editor.ErrorTracker
             // 예: "CommandInvokationFailure: Gradle build failed." (APPS-IN-TOSS-UNITY-SDK-134)
             // SDK는 이 문자열을 출력하지 않음(AitKeywords에 없음).
             "CommandInvokationFailure: Gradle build failed",
+
+            // 서드파티 Unity MCP 빌드 도구가 stdout/stderr에 남기는 로그 prefix. SDK 코드베이스
+            // 어디에도 "[MCP Build]" 문자열이 없으며(grep 확인), 본문은 개인/사용자 프로젝트의
+            // IL2CPP UnityLinker(ManagedStripped) 등 Unity 자체 툴체인 빌드 실패를 그대로 전달한 것.
+            // "[Dev Server]"/"[Production Server]"(ServerLogPrefixes)와 동일한 선례 패턴이며,
+            // AIT 식별자가 섞이지 않는 한 AitKeywords 보호 가드와 충돌하지 않는다.
+            // 예: "UnityError: [MCP Build] ✗ Build failed: WebGL — Building Library/Bee/artifacts/WebGL/ManagedStripped failed with output:"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-13E.
+            "[MCP Build]",
         };
 
         // DetermineErrorSource에서 메시지를 SDK로 분류하는 추가 패턴.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2524,6 +2524,45 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 서드파티 Unity MCP 빌드 도구 노이즈 (APPS-IN-TOSS-UNITY-SDK-13E)
+
+    [Test]
+    public void McpBuildPrefix_WebGLManagedStrippedFailure_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-13E — 서드파티 Unity MCP 빌드 도구가 stdout/stderr에
+        // 남기는 로그 prefix. 본문은 개인/사용자 프로젝트의 IL2CPP UnityLinker(ManagedStripped)
+        // 빌드 실패이며, SDK 코드베이스 어디에도 "[MCP Build]" 문자열이 없음(grep 확인).
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: [MCP Build] ✗ Build failed: WebGL — Building Library/Bee/artifacts/WebGL/ManagedStripped failed with output:"));
+    }
+
+    [Test]
+    public void McpBuildPrefix_BareVariant_ReturnsTrue()
+    {
+        // prefix만 있고 후행 문구가 다른 변형도 부분 문자열 매칭으로 동일하게 드롭됨을 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[MCP Build] Build failed: iOS — xcodebuild exited with code 65"));
+    }
+
+    [Test]
+    public void McpBuildPrefix_WithAitPrefix_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: [AIT] prefix가 붙은 동일 메시지는 SDK 자체 로그로 간주되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] [MCP Build] Build failed: WebGL"));
+    }
+
+    [Test]
+    public void McpBuildPrefix_WithAppsInTossKeyword_NeverFiltered()
+    {
+        // AitKeywords 가드 회귀 방지: 메시지 본문에 AppsInToss 식별자가 섞이면
+        // MessageContainsSdkKeyword 가드가 먼저 매칭되어 "[MCP Build]" 패턴보다 우선해 보호되어야 함.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[MCP Build] Build failed while referencing AppsInToss.dll during IL2CPP link step"));
+    }
+
+    #endregion
+
     #region SDK 관련 메시지는 통과 (negative cases)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-13E

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-13E | `UnityError: [MCP Build] ✗ Build failed: WebGL — Building Library/Bee/artifacts/WebGL/ManagedStripped failed with output:` |

## 원인

`[MCP Build]`는 SDK 코드베이스 어디에도 존재하지 않는(grep 확인) 서드파티 Unity MCP 빌드 도구의 로그 prefix이고, 본문은 개인/사용자 프로젝트의 IL2CPP UnityLinker(ManagedStripped) 빌드 실패 — Unity 자체 툴체인 출력입니다. AIT SDK 관련 식별자(`[AIT`, `AppsInToss`, `ait-build` 등)가 전혀 없어 `AitKeywords` 보호 가드에도 걸리지 않으며, `UnityError` exceptionType으로 보아 SDK의 전역 Console 로그 캡처가 외부 도구의 리다이렉트 로그를 그대로 주운 케이스입니다. `[Dev Server]`/`[Production Server]` (`ServerLogPrefixes`)와 동일한 선례 패턴이라 `NonSdkMessagePatterns` 추가로 닫을 수 있습니다.

## 추출 패턴

- `NonSdkMessagePatterns`에 `"[MCP Build]"` 추가

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs` — `NonSdkMessagePatterns` 배열
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs` — positive 2건(전체 evidence 메시지 + bare 변형) + AIT 키워드 혼입 negative 2건(`[AIT]` prefix, 본문 내 `AppsInToss` 식별자)

## 검증

⚠️ **동시 빌드 회피로 검증 skip — 사람 확인 필요**: PR 작성 시점에 동일 SDK repo의 다른 worktree에서 `run-local-tests.sh --validate`를 실행 중인 워커가 2개 있어(30초 간격으로 2회 확인, 둘 다 충돌), 런북의 동시 빌드 회피 정책에 따라 `--validate` 실행을 skip하고 PR을 생성했습니다. 머지 전 사람이 `./run-local-tests.sh --validate`로 직접 검증해주세요.

변경 범위는 `AITEditorErrorTracker.cs`와 `IsKnownNonSdkMessageTests.cs` 두 파일로 한정했습니다.

---
사람 머지 검토 필요합니다.