### PR TITLE
기능: SDK 커밋 해시 로컬/embedded 설치 폴백 추가

### DIFF
--- a/Editor/AITSdkCommitResolver.cs
+++ b/Editor/AITSdkCommitResolver.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using AppsInToss;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 릴리즈 태그(package.json description) / UPM git.hash / packages-lock 어디에도 커밋 해시가
+    /// 없는 로컬·embedded 설치를 위한 최후 폴백. SDK 패키지 자신의 git 저장소에서 직접 조회한다.
+    ///
+    /// <para><see cref="AITConvertCore"/>의 GetGitCommitHash()와 절대 혼동하지 말 것 — 그 함수는
+    /// 명시적으로 "프로젝트(게임)" 커밋을 얻는 함수이며 이 클래스와 무관하다. 이 클래스는 SDK 패키지
+    /// 경로가 게임 프로젝트와 "별도의" git 저장소일 때만 값을 반환하고, 같은 저장소이면(즉 SDK가
+    /// 프로젝트에 파일로 커밋되어 있어 구분 불가능하면) null을 반환해 프로젝트 커밋을 SDK 커밋인 양
+    /// 넣는 실수를 방지한다.</para>
+    /// </summary>
+    internal static class AITSdkCommitResolver
+    {
+        /// <summary>
+        /// SDK 패키지 경로의 git 저장소에서 short 커밋 해시를 조회한다.
+        /// 조회 불가(비-git, git 미설치/실패, 게임 프로젝트와 동일 저장소)면 <c>null</c>.
+        /// 계약: 절대 빈 문자열을 반환하지 않는다 (null 또는 비어있지 않은 hex).
+        /// </summary>
+        internal static string TryResolveLocalGitCommitHash()
+        {
+            try
+            {
+                string sdkPath = AITPackagePathResolver.GetSDKResolvedPath();
+                if (string.IsNullOrEmpty(sdkPath) || !Directory.Exists(sdkPath))
+                    return null;
+
+                string sdkToplevel = RunGit(sdkPath, "rev-parse --show-toplevel");
+                if (string.IsNullOrEmpty(sdkToplevel))
+                    return null; // SDK 경로가 git 저장소가 아님 (tarball/registry 추출본 등)
+
+                string projectToplevel = RunGit(UnityUtil.GetProjectPath(), "rev-parse --show-toplevel");
+                if (!string.IsNullOrEmpty(projectToplevel)
+                    && string.Equals(Normalize(sdkToplevel), Normalize(projectToplevel),
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    // SDK가 게임 프로젝트와 동일 git 저장소 안에 있음 → git만으로는 SDK 고유 커밋을
+                    // 프로젝트 커밋과 구분할 수 없다. 틀린 값을 넣느니 비워 둔다.
+                    return null;
+                }
+
+                string hash = RunGit(sdkToplevel, "rev-parse --short=7 HEAD");
+                return string.IsNullOrEmpty(hash) ? null : hash;
+            }
+            catch (Exception e)
+            {
+                // 로컬/embedded 설치에서 git 부재·실패는 흔한 정상 케이스 → Sentry 노이즈 억제.
+                AITLog.Warning($"[AIT] SDK 커밋 해시 로컬 조회 실패 (무시됨): {e.Message}", sentryCapture: false);
+                return null;
+            }
+        }
+
+        private static string Normalize(string path)
+        {
+            return Path.GetFullPath(path).TrimEnd('/', '\\');
+        }
+
+        /// <summary>
+        /// 지정 디렉토리에서 git 명령을 실행하고 표준출력(trim)을 반환한다.
+        /// 5초 내 종료하지 않으면 프로세스를 종료하고 <c>null</c>. exit code가 0이 아니어도 <c>null</c>.
+        /// stderr는 리다이렉트하지 않는다(파이프 미소비로 인한 교착 방지 — <see cref="AITConvertCore"/>
+        /// 의 git 호출과 동일한 방식).
+        /// </summary>
+        private static string RunGit(string workingDirectory, string arguments)
+        {
+            using (var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = arguments,
+                    WorkingDirectory = workingDirectory,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            })
+            {
+                process.Start();
+                string output = process.StandardOutput.ReadToEnd().Trim();
+                bool exited = process.WaitForExit(5000);
+                if (!exited)
+                {
+                    try { process.Kill(); } catch { /* 이미 종료됐을 수 있음 — 무시 */ }
+                    return null;
+                }
+                return process.ExitCode == 0 && !string.IsNullOrEmpty(output) ? output : null;
+            }
+        }
+    }
+}

--- a/Editor/AITSdkCommitResolver.cs.meta
+++ b/Editor/AITSdkCommitResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7bdb8962125b4bb1b2f6c994b90e6556
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/AITUnityMetadata.cs
+++ b/Editor/AITUnityMetadata.cs
@@ -23,12 +23,26 @@ namespace AppsInToss.Editor
                 $"\"unityVersion\":{JsonEscape(Application.unityVersion)}",
                 $"\"bundleVersion\":{JsonEscape(PlayerSettings.bundleVersion)}",
                 $"\"sdkVersion\":{JsonEscape(AITVersion.Version)}",
-                $"\"sdkCommitHash\":{JsonEscape(AITVersion.CommitHash ?? "")}",
+                $"\"sdkCommitHash\":{JsonEscape(ResolveSdkCommitHash())}",
                 $"\"productName\":{JsonEscape(PlayerSettings.productName)}",
                 $"\"companyName\":{JsonEscape(PlayerSettings.companyName)}",
+                // 빌드(패키징) 시각 — .ait 생성 시점. 콘솔 배포(deploy) 시각과는 다르다.
                 $"\"buildTimestamp\":{JsonEscape(DateTime.UtcNow.ToString("o"))}",
             };
             return "{" + string.Join(",", pairs) + "}";
+        }
+
+        /// <summary>
+        /// SDK 커밋 해시를 결정합니다. 릴리즈 태그/UPM git.hash/packages-lock 경로(<see cref="AITVersion.CommitHash"/>)를
+        /// 우선하고, 그 어디에도 값이 없는 로컬·embedded 설치에서는 SDK 패키지의 git 저장소를 직접 조회하는
+        /// <see cref="AITSdkCommitResolver"/> 폴백을 사용합니다. 둘 다 실패하면 빈 문자열.
+        /// </summary>
+        private static string ResolveSdkCommitHash()
+        {
+            string hash = AITVersion.CommitHash;
+            if (!string.IsNullOrEmpty(hash))
+                return hash;
+            return AITSdkCommitResolver.TryResolveLocalGitCommitHash() ?? "";
         }
 
         private static string JsonEscape(string value)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITSdkCommitHashTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITSdkCommitHashTests.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// AITSdkCommitHashTests.cs - .ait 메타데이터 sdkCommitHash 회귀 가드
+// Level 0: 필드 존재 + 로컬 폴백 계약(throw 금지, 빈 문자열 금지, hex 형식)
+//          검증 (빌드/파일시스템 비의존, git 프로세스 호출은 환경 의존이므로 계약만 확인)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using System.Text.RegularExpressions;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITSdkCommitHashTests
+{
+    // 필드 존재 회귀 가드: 값과 무관하게 sdkCommitHash 키는 항상 나온다.
+    [Test]
+    public void UnityMetadataJson_ContainsSdkCommitHashKey()
+    {
+        string json = AITUnityMetadata.BuildMetadataJson();
+        StringAssert.Contains("\"sdkCommitHash\":", json);
+    }
+
+    // granite로 전달되는 환경변수 딕셔너리에도 동일하게 실린다.
+    [Test]
+    public void UnityMetadataEnv_CarriesSdkCommitHashKey()
+    {
+        var env = AITUnityMetadata.BuildEnvironmentVariables();
+        Assert.IsTrue(env.ContainsKey("UNITY_METADATA"));
+        StringAssert.Contains("\"sdkCommitHash\":", env["UNITY_METADATA"]);
+    }
+
+    // 로컬 폴백 계약: 예외를 던지지 않는다(git 부재/실패해도 안전).
+    [Test]
+    public void LocalResolver_NeverThrows()
+    {
+        Assert.DoesNotThrow(() => AITSdkCommitResolver.TryResolveLocalGitCommitHash());
+    }
+
+    // 로컬 폴백 계약: null 또는 hex 문자열. 빈 문자열("")은 절대 반환하지 않는다.
+    // (호출부 ResolveSdkCommitHash의 "?? \"\"" 이중 폴백이 정상 동작하려면 이 계약이 필요)
+    [Test]
+    public void LocalResolver_ReturnsNullOrHexNeverEmpty()
+    {
+        string hash = AITSdkCommitResolver.TryResolveLocalGitCommitHash();
+        if (hash != null)
+        {
+            Assert.IsNotEmpty(hash);
+            Assert.IsTrue(Regex.IsMatch(hash, "^[0-9a-f]{7,40}$"),
+                $"기대: 7~40자리 hex, 실제: '{hash}'");
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITSdkCommitHashTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITSdkCommitHashTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 478a832c38de4e29a0fc790375e7afff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경

`.ait` 번들 메타데이터의 `sdkCommitHash` 필드는 SDK 커밋을 식별하기 위한 값이지만,
릴리즈 태그(`package.json` description) / UPM `git.hash` / `packages-lock` 어디에도
커밋 정보가 없는 **로컬·embedded 설치**에서는 항상 빈 문자열(`""`)로 남았다.
(perf 베타 채널처럼 git URL로 소비하는 개발/파일럿 설치가 대표적)

## 변경 사항

- **`Editor/AITSdkCommitResolver.cs` (신규)**: `AITVersion.CommitHash`가 비어 있을 때
  SDK 패키지 자신의 git 저장소를 직접 조회하는 최후 폴백.
  - SDK 경로가 게임 프로젝트와 **동일 git 저장소**이면 프로젝트 커밋을 SDK 커밋으로
    오인하지 않도록 `null` 반환 (same-repo guard).
  - 5초 타임아웃 + 미종료 시 프로세스 Kill, git 부재·실패는 정상 케이스로 간주해
    Sentry 노이즈 억제(`sentryCapture: false`), stderr 미리다이렉트로 파이프 교착 방지.
  - 계약: 절대 빈 문자열을 반환하지 않는다(`null` 또는 비어있지 않은 hex).
- **`Editor/AITUnityMetadata.cs`**: `sdkCommitHash`를 `ResolveSdkCommitHash()`로 연결해
  기존 경로 우선 → 로컬 폴백 순으로 결정. 겸사겸사 `buildTimestamp`가 콘솔 **배포(deploy)
  시각이 아니라 빌드(패키징) 시각**임을 주석으로 명시.
- **EditMode 회귀 테스트 추가**: 필드 존재 가드 + 폴백 계약(throw 금지 / 빈 문자열 금지 / hex 형식).

## 검증

- `./run-local-tests.sh --validate` 통과 (E2E 파일 구조 / Playwright / SDK 유닛 18개 / Meta GUID 위생).
- C# 심볼·시그니처(네임스페이스, `InternalsVisibleTo`, `AITLog.Warning(sentryCapture:)`,
  `GetSDKResolvedPath`, `UnityUtil.GetProjectPath`)는 수동 확인. EditMode 컴파일은 CI가 커버.

## 참고

- 기존에 이미 존재하던 `buildTimestamp`(배포 아님, 패키징 시각) 필드로 "배포 일시"에 준하는
  정보는 이미 커버되며, 이 PR은 그 의미를 주석으로 분명히 한다.
- perf 베타 여부는 `buildVariant="perf"` 마킹으로 표시되며, 이는 perf 채널 브랜치에만 존재한다
  (별도 PR로 동일 폴백을 perf 채널에도 반영 예정).
