### PR TITLE
리팩토링: AITConvertCore에서 WebGL 빌드 실행부와 에러 카탈로그 분리

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -108,6 +108,9 @@ namespace AppsInToss
 
         #region Error Handling
 
+        // 에러 메시지 변환 구현은 AITExportErrorCatalog로 분리(#36의 AITBuildCancellation과 동일 패턴).
+        // 아래 3개 메서드는 기존 공개 API 호환을 위한 위임이며 동작은 변경되지 않는다.
+
         public enum AITExportError
         {
             SUCCEED = 0,
@@ -131,174 +134,18 @@ namespace AppsInToss
         /// <summary>
         /// 에러 코드를 사용자 친화적 메시지로 변환
         /// </summary>
-        public static string GetErrorMessage(AITExportError error)
-        {
-            switch (error)
-            {
-                case AITExportError.SUCCEED:
-                    return "성공";
-
-                case AITExportError.NODE_NOT_FOUND:
-                    return "Node.js를 찾을 수 없습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. https://nodejs.org 에서 Node.js 설치\n" +
-                           "2. Unity Editor 재시작\n" +
-                           "3. 터미널에서 'node --version' 확인";
-
-                case AITExportError.BUILD_WEBGL_FAILED:
-                    return "WebGL 빌드에 실패했습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. Unity Console 창에서 에러 메시지 확인\n" +
-                           "2. WebGL Build Support가 설치되어 있는지 확인\n" +
-                           "3. 프로젝트에 빌드 오류가 없는지 확인\n" +
-                           "4. File > Build Settings > WebGL에서 직접 빌드 시도";
-
-                case AITExportError.INVALID_APP_CONFIG:
-                    return "앱 설정이 올바르지 않습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. Apps in Toss > Build & Deploy Window 열기\n" +
-                           "2. 설정 섹션에서 아이콘 URL 입력 (필수)\n" +
-                           "3. 앱 ID, 버전 등 기본 정보 확인";
-
-                case AITExportError.NETWORK_ERROR:
-                    return "네트워크 오류가 발생했습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. 인터넷 연결 확인\n" +
-                           "2. npm 레지스트리 접속 가능 여부 확인\n" +
-                           "3. 방화벽 또는 프록시 설정 확인";
-
-                case AITExportError.CANCELLED:
-                    return "사용자에 의해 빌드가 취소되었습니다.";
-
-                case AITExportError.FAIL_NPM_BUILD:
-                    return "pnpm 빌드에 실패했습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. Unity Console 창에서 에러 메시지 확인\n" +
-                           "2. ait-build 폴더에서 직접 pnpm install 시도\n" +
-                           "3. package.json 파일이 올바른지 확인\n" +
-                           "4. ~/.ait-unity-sdk/nodejs 폴더를 삭제 후 다시 빌드 시도";
-
-                case AITExportError.BUILD_FOLDER_MISSING:
-                    return "WebGL 빌드의 Build 폴더를 찾을 수 없습니다.\n\n" +
-                           "WebGL 빌드가 실행되지 않았거나 빌드 결과물이 삭제되었습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. 'Build & Package' 메뉴로 전체 빌드를 실행하세요.\n" +
-                           "2. webgl/ 폴더가 존재하는지 확인하세요.";
-
-                case AITExportError.REQUIRED_FILE_MISSING:
-                    return "WebGL 빌드 필수 파일이 누락되었습니다.\n\n" +
-                           "loader.js, data, framework.js, wasm 파일 중 일부가 없습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n" +
-                           "2. Unity Console에서 빌드 에러를 확인하세요.";
-
-                case AITExportError.INDEX_HTML_MISSING:
-                    return "WebGL 빌드의 index.html을 찾을 수 없습니다.\n\n" +
-                           "WebGL 템플릿이 올바르게 설정되지 않았을 수 있습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. AIT > Clean 메뉴로 빌드 폴더 삭제 후 재빌드\n" +
-                           "2. 'Clean Build' 옵션 활성화 후 재빌드";
-
-                case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED:
-                    return "빌드 산출물(index.html 또는 apps-in-toss.config.ts/granite.config.ts)의 필수 플레이스홀더가 치환되지 않았습니다.\n\n" +
-                           "이 상태로 배포하면 'createUnityInstance is not defined' 에러가 발생하거나 앱 설정(bundle.json)이 깨집니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n" +
-                           "2. AIT > Clean 메뉴로 빌드 폴더 삭제 후 재빌드하세요.";
-
-                case AITExportError.DIST_FOLDER_MISSING:
-                    return "granite build가 완료되었으나 dist 폴더가 생성되지 않았습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. ait-build/ 폴더에서 수동으로 'npm run build' 실행하여 오류 확인\n" +
-                           "2. granite.config.ts의 플레이스홀더가 올바르게 치환되었는지 확인\n" +
-                           "3. AIT > Clean 메뉴 실행 후 Clean Build 재시도";
-
-                case AITExportError.AIT_FILE_MISSING:
-                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.\n\n" +
-                           "해결 방법:\n" +
-                           "1. ait-build/dist/ 폴더의 내용을 확인하세요\n" +
-                           "2. granite.config.ts 설정을 확인하세요\n" +
-                           "3. AIT > Clean 메뉴 실행 후 Clean Build 재시도";
-
-                default:
-                    return $"알 수 없는 오류가 발생했습니다. (코드: {error})";
-            }
-        }
+        public static string GetErrorMessage(AITExportError error) => Editor.AITExportErrorCatalog.GetErrorMessage(error);
 
         /// <summary>
         /// 다이얼로그 제목에 붙일 짧은 사유 라벨을 반환합니다.
         /// 예: "빌드 실패 ({shortReason})" 형태로 조합됩니다.
         /// </summary>
-        public static string GetErrorShortReason(AITExportError error)
-        {
-            switch (error)
-            {
-                case AITExportError.SUCCEED: return "성공";
-                case AITExportError.NODE_NOT_FOUND: return "Node.js 없음";
-                case AITExportError.BUILD_WEBGL_FAILED: return "WebGL 빌드 오류";
-                case AITExportError.INVALID_APP_CONFIG: return "앱 설정 오류";
-                case AITExportError.NETWORK_ERROR: return "네트워크 오류";
-                case AITExportError.CANCELLED: return "사용자 취소";
-                case AITExportError.FAIL_NPM_BUILD: return "pnpm 빌드 오류";
-                case AITExportError.BUILD_FOLDER_MISSING: return "Build 폴더 없음";
-                case AITExportError.REQUIRED_FILE_MISSING: return "필수 파일 누락";
-                case AITExportError.INDEX_HTML_MISSING: return "index.html 없음";
-                case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED: return "플레이스홀더 미치환";
-                case AITExportError.DIST_FOLDER_MISSING: return "dist 폴더 없음";
-                case AITExportError.AIT_FILE_MISSING: return ".ait 파일 없음";
-                default: return error.ToString();
-            }
-        }
+        public static string GetErrorShortReason(AITExportError error) => Editor.AITExportErrorCatalog.GetErrorShortReason(error);
 
         /// <summary>
         /// 다이얼로그 본문에 사용할 원인 한 단락을 반환합니다. 해결 방법은 포함하지 않습니다.
         /// </summary>
-        public static string GetErrorCause(AITExportError error)
-        {
-            switch (error)
-            {
-                case AITExportError.SUCCEED:
-                    return "성공";
-                case AITExportError.NODE_NOT_FOUND:
-                    return "SDK 가 사용할 Node.js 실행 파일을 찾을 수 없습니다.\n" +
-                           "내장 Node 바이너리(~/.ait-unity-sdk/nodejs) 또는 시스템 PATH에서 node를 찾지 못했습니다.";
-                case AITExportError.BUILD_WEBGL_FAILED:
-                    return "Unity WebGL 빌드 중 오류가 발생했습니다.\n" +
-                           "Console 창에서 컴파일 오류나 스택 트레이스를 확인해주세요.";
-                case AITExportError.INVALID_APP_CONFIG:
-                    return "앱 설정이 올바르지 않거나 필수 필드(App ID, 아이콘 URL 등)가 누락되었습니다.\n" +
-                           "AIT > Configuration 창에서 설정을 확인해주세요.";
-                case AITExportError.NETWORK_ERROR:
-                    return "빌드 과정에서 네트워크 요청에 실패했습니다.\n" +
-                           "인터넷 연결 또는 프록시/방화벽 설정을 확인해주세요.";
-                case AITExportError.CANCELLED:
-                    return "사용자에 의해 빌드가 취소되었습니다.";
-                case AITExportError.FAIL_NPM_BUILD:
-                    return "ait-build 디렉터리의 pnpm/granite 빌드 단계에서 오류가 발생했습니다.\n" +
-                           "Console 창에서 빌드 로그를 확인해주세요.";
-                case AITExportError.BUILD_FOLDER_MISSING:
-                    return "WebGL 빌드 결과물의 Build 폴더가 존재하지 않습니다.\n" +
-                           "WebGL 빌드가 완료되지 않았거나 결과물이 삭제되었을 수 있습니다.";
-                case AITExportError.REQUIRED_FILE_MISSING:
-                    return "WebGL 빌드 결과물(loader.js, data, framework.js, wasm) 중 일부가 누락되었습니다.\n" +
-                           "Clean Build 옵션을 켜고 다시 빌드해보세요.";
-                case AITExportError.INDEX_HTML_MISSING:
-                    return "WebGL 빌드의 index.html 이 생성되지 않았습니다.\n" +
-                           "WebGL 템플릿(AITTemplate) 설정이 올바른지 확인해주세요.";
-                case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED:
-                    return "빌드 산출물(index.html 또는 apps-in-toss.config.ts/granite.config.ts)의 필수 플레이스홀더가 치환되지 않은 채 저장되었습니다.\n" +
-                           "이 상태로 배포하면 런타임에 'createUnityInstance is not defined' 오류가 발생하거나 앱 설정(bundle.json)이 깨집니다.\n" +
-                           "Clean Build 옵션으로 재빌드해보세요.";
-                case AITExportError.DIST_FOLDER_MISSING:
-                    return "granite 빌드가 완료되었지만 dist 폴더가 생성되지 않았습니다.\n" +
-                           "granite.config.ts 의 플레이스홀더가 올바르게 치환되었는지 확인해주세요.";
-                case AITExportError.AIT_FILE_MISSING:
-                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.\n" +
-                           "granite 빌드 설정을 확인한 뒤 Clean Build 로 재시도해주세요.";
-                default:
-                    return $"알 수 없는 오류 (코드: {error}).";
-            }
-        }
+        public static string GetErrorCause(AITExportError error) => Editor.AITExportErrorCatalog.GetErrorCause(error);
 
         #endregion
 
@@ -491,7 +338,7 @@ namespace AppsInToss
                         Editor.ErrorTracker.AITEditorErrorTracker.AddBreadcrumb("build", "WebGL 빌드 시작");
                     var webglSpan = transaction?.StartSpan("webgl.build", "Unity WebGL Build");
                     AITBuildSession.SetStage(BuildStage.WebGLBuild);
-                    var webglResult = BuildWebGL(cleanBuild, profile);
+                    var webglResult = Editor.AITWebGLBuilder.BuildWebGL(cleanBuild, profile);
                     webglSpan?.Finish(webglResult == AITExportError.SUCCEED ? "ok" : "internal_error");
 
                     if (webglResult != AITExportError.SUCCEED)
@@ -649,7 +496,7 @@ namespace AppsInToss
                     onProgress?.Invoke(BuildPhase.WebGLBuild, 0.05f, "WebGL 빌드 중... (pnpm install 병렬 실행 중)");
 
                     AITBuildSession.SetStage(BuildStage.WebGLBuild);
-                    var webglResult = BuildWebGL(cleanBuild, profile);
+                    var webglResult = Editor.AITWebGLBuilder.BuildWebGL(cleanBuild, profile);
                     if (webglResult != AITExportError.SUCCEED)
                     {
                         earlyCtx.CancelAndDisposePnpm();
@@ -693,7 +540,7 @@ namespace AppsInToss
                     onProgress?.Invoke(BuildPhase.WebGLBuild, 0.05f, "WebGL 빌드 중... (Unity 제한으로 에디터가 일시 정지됩니다)");
 
                     AITBuildSession.SetStage(BuildStage.WebGLBuild);
-                    var webglResult = BuildWebGL(cleanBuild, profile);
+                    var webglResult = Editor.AITWebGLBuilder.BuildWebGL(cleanBuild, profile);
                     if (webglResult != AITExportError.SUCCEED)
                     {
                         try { snapshot.Restore(); }
@@ -797,404 +644,9 @@ namespace AppsInToss
 
         #region WebGL Build
 
-        /// <summary>
-        /// 기존 빌드 캐시가 유효한지 검증하여 clean build 필요 여부를 판단합니다.
-        /// 빌드 마커 없음, Unity 버전 불일치, 필수 파일 누락 시 true를 반환합니다.
-        /// </summary>
-        private static bool ShouldForceCleanBuild(string outputPath, bool cleanBuild)
-        {
-            if (cleanBuild) return true;
-            if (!Directory.Exists(outputPath)) return false;
-
-            var buildInfo = ReadBuildMarker(outputPath);
-            if (buildInfo == null)
-            {
-                AITLog.Warning("[AIT] 빌드 마커가 없습니다. Clean build를 수행합니다.", sentryCapture: false);
-                return true;
-            }
-            if (buildInfo.unityVersion != Application.unityVersion)
-            {
-                AITLog.Warning($"[AIT] Unity 버전 불일치: 빌드 {buildInfo.unityVersion} vs 현재 {Application.unityVersion}. Clean build를 수행합니다.", sentryCapture: false);
-                return true;
-            }
-
-            string buildDir = Path.Combine(outputPath, "Build");
-            if (!Directory.Exists(buildDir) || Directory.GetFiles(buildDir, "*.loader.js").Length == 0)
-            {
-                AITLog.Warning("[AIT] 빌드 필수 파일이 없습니다. Clean build를 수행합니다.", sentryCapture: false);
-                return true;
-            }
-
-            return false;
-        }
-
-        private static AITExportError BuildWebGL(bool cleanBuild = false, AITBuildProfile profile = null)
-        {
-            // WebGL Build Support 모듈 설치 여부 사전 체크
-            if (!BuildPipeline.IsBuildTargetSupported(BuildTargetGroup.WebGL, BuildTarget.WebGL))
-            {
-                // 사용자 환경 문제(Unity Hub에서 WebGL Build Support 미설치)이지 SDK 버그가 아니다.
-                // 메시지 첫머리의 '[AIT' 토큰이 트래커 SDK 키워드 가드를 먼저 발동시켜 NonSdkMessagePatterns를
-                // 무력화하므로, sentryCapture:false가 Sentry 차단의 유일하게 확실한 방법이다 (SDK-DB).
-                AITLog.Error(
-                    "[AIT] ✗ WebGL Build Support 모듈이 설치되지 않았습니다.\n" +
-                    "Unity Hub를 열고 현재 Unity 버전(" + Application.unityVersion + ")에 WebGL Build Support를 추가 설치하세요.\n" +
-                    "Unity Hub > Installs > Unity " + Application.unityVersion + " > Add Modules > WebGL Build Support",
-                    sentryCapture: false);
-                return AITExportError.BUILD_WEBGL_FAILED;
-            }
-
-            if (EditorUserBuildSettings.activeBuildTarget != BuildTarget.WebGL)
-            {
-                bool confirm = AITPlatformHelper.ShowConfirmDialog(
-                    "빌드 타겟 전환 필요",
-                    $"현재 빌드 타겟이 {EditorUserBuildSettings.activeBuildTarget}입니다.\n" +
-                    "WebGL 빌드를 위해 빌드 타겟을 WebGL로 전환해야 합니다.",
-                    "전환",
-                    "취소");
-
-                if (!confirm)
-                {
-                    Debug.Log("[AIT] 사용자가 빌드 타겟 전환을 취소했습니다.");
-                    return AITExportError.CANCELLED;
-                }
-
-                Debug.Log($"[AIT] 빌드 타겟을 {EditorUserBuildSettings.activeBuildTarget}에서 WebGL로 전환합니다...");
-                if (!EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WebGL, BuildTarget.WebGL))
-                {
-                    AITLog.Error("[AIT] ✗ WebGL 빌드 타겟으로 전환할 수 없습니다.", sentryCapture: false);
-                    return AITExportError.BUILD_WEBGL_FAILED;
-                }
-            }
-
-            string[] scenes = UnityUtil.GetBuildScenes();
-            string outputPath = Path.Combine(UnityUtil.GetProjectPath(), webglDir);
-
-            // 빌드 캐시 유효성 검증
-            if (ShouldForceCleanBuild(outputPath, cleanBuild))
-            {
-                if (!cleanBuild)
-                    Debug.Log("[AIT] 빌드 캐시 검증 실패. 자동으로 clean build를 수행합니다.");
-                cleanBuild = true;
-            }
-
-            Debug.Log($"[AIT] WebGL 빌드를 시작합니다... ({(cleanBuild ? "클린 빌드" : "증분 빌드")})");
-
-            // 클린 빌드 시에만 기존 빌드 폴더 삭제
-            if (cleanBuild && Directory.Exists(outputPath))
-            {
-                Debug.Log("[AIT] 클린 빌드: 기존 WebGL 빌드 폴더 삭제 중...");
-                Directory.Delete(outputPath, true);
-            }
-
-            // 프로필이 없으면 기본 프로필 사용
-            if (profile == null)
-            {
-                profile = AITBuildProfile.CreateProductionProfile();
-            }
-
-            // 빌드 옵션 설정
-            BuildOptions buildOptions = BuildOptions.None;
-
-            // Development Build 옵션 (빌드 속도 향상, 디버깅 편의)
-            if (profile.developmentBuild)
-            {
-                buildOptions |= BuildOptions.Development;
-                Debug.Log("[AIT] Development Build 활성화");
-            }
-
-            // LZ4 압축으로 빌드 속도 향상
-            if (profile.enableLZ4Compression)
-            {
-                buildOptions |= BuildOptions.CompressWithLz4;
-            }
-
-            // Unity 2021.3에서 Bee 빌드 캐시 문제로 인한 빌드 루프 방지
-            // cleanBuild 시 CleanBuildCache 옵션 추가
-            if (cleanBuild)
-            {
-                buildOptions |= BuildOptions.CleanBuildCache;
-            }
-
-            BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions
-            {
-                scenes = scenes,
-                locationPathName = outputPath,
-                target = BuildTarget.WebGL,
-                options = buildOptions,
-#if UNITY_2023_3_OR_NEWER
-                // Unity 2023.3+ (Unity 6): 최신 기능 활성화 (문서 권장)
-                extraScriptingDefines = new[]
-                {
-                    "APPSINTOS_OPTIMIZED",
-                    "WEBGL_2_0",
-                    "UNITY_6_FEATURES"
-                }
-#elif UNITY_2022_3_OR_NEWER
-                // Unity 2022.3+: WebGL 2.0 최적화 (문서 권장)
-                extraScriptingDefines = new[]
-                {
-                    "APPSINTOS_OPTIMIZED",
-                    "WEBGL_2_0"
-                }
-#endif
-            };
-
-            // 빌드 직전: Resources JSON으로 Version/CommitHash/ReleaseDateTime 기록
-            // .cs 파일 수정과 달리 .json은 스크립트 컴파일을 유발하지 않으므로 도메인 리로드 없음
-            bool versionInfoWritten = WriteVersionInfoJson(out bool createdResourcesDir);
-
-            UnityEditor.Build.Reporting.BuildReport result;
-            try
-            {
-                result = BuildPipeline.BuildPlayer(buildPlayerOptions);
-            }
-            finally
-            {
-                // 빌드 완료 후 (성공/실패 무관) 생성한 JSON 제거 — 사용자 프로젝트에 산출물 남기지 않음
-                if (versionInfoWritten)
-                {
-                    RemoveVersionInfoJson(createdResourcesDir);
-                }
-            }
-
-            // 빌드 리포트를 에러 리포터에 저장 (Issue 신고 시 사용)
-            AITErrorReporter.SetBuildReport(result);
-
-            if (result.summary.result != UnityEditor.Build.Reporting.BuildResult.Succeeded)
-            {
-                // 사용자가 빌드를 취소한 경우 — Unity가 BuildResult.Cancelled를 반환한다.
-                // 이것은 사용자 의사이므로 SDK 결함 보고 대상이 아니다.
-                if (result.summary.result == UnityEditor.Build.Reporting.BuildResult.Cancelled)
-                {
-                    AITLog.Warning("[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.", sentryCapture: false);
-                    return AITExportError.CANCELLED;
-                }
-
-                // 실패 진단 메시지를 step에서 평탄화 수집(에러/경고 캡 분리는 BuildFailureSummary가 처리).
-                var collected = new List<(LogType type, string content)>();
-                foreach (var step in result.steps)
-                {
-                    foreach (var message in step.messages)
-                    {
-                        collected.Add((message.type, message.content));
-                    }
-                }
-
-                // BuildReport.steps에 에러/경고가 전혀 없으면(Bee/IL2CPP의 .o 실패 등 무진단 실패)
-                // 에디터 로그 꼬리를 첨부해 단서를 남긴다. 그 외에는 step 메시지로 충분하다.
-                bool hasDiagnosticMessage = false;
-                foreach (var m in collected)
-                {
-                    if (m.type == LogType.Error || m.type == LogType.Exception
-                        || m.type == LogType.Assert || m.type == LogType.Warning)
-                    {
-                        hasDiagnosticMessage = true;
-                        break;
-                    }
-                }
-                string logTail = hasDiagnosticMessage ? null : AITWebGLBuildDiagnostics.ReadEditorLogTail(Application.consoleLogPath);
-
-                // BuildSummary.totalErrors/totalWarnings는 uint이므로 int 시그니처로 명시 캐스트
-                // (실패 빌드의 카운트는 항상 int 범위 — overflow 우려 없음).
-                string failureSummary = AITWebGLBuildDiagnostics.BuildFailureSummary(
-                    result.summary.result.ToString(),
-                    (int)result.summary.totalErrors,
-                    (int)result.summary.totalWarnings,
-                    collected,
-                    logTail);
-
-                // BuildPipeline.BuildPlayer 실패는 거의 항상 사용자 프로젝트(컴파일 에러,
-                // 사용자 에셋 문제, 환경 OOM 등) 또는 Unity 자체의 비정상 종료에서 비롯되며
-                // SDK 측에서 분기/수정할 수 있는 정보가 아니다. 콘솔에는 진단 메시지를 남기되
-                // Sentry로는 보내지 않아 분류 노이즈를 만들지 않는다.
-                AITLog.Error(failureSummary, sentryCapture: false);
-                return AITExportError.BUILD_WEBGL_FAILED;
-            }
-
-            Debug.Log("[AIT] WebGL 빌드가 완료되었습니다.");
-
-            // AIT 빌드 마커 파일 생성 (빌드 정보 기록용)
-            try
-            {
-                var buildInfo = new AITBuildInfo
-                {
-                    sdkVersion = AITVersion.Version,
-                    buildTime = DateTime.UtcNow.ToString("o"),
-                    compressionFormat = (int)PlayerSettings.WebGL.compressionFormat,
-                    decompressionFallback = PlayerSettings.WebGL.decompressionFallback,
-                    profileName = profile?.developmentBuild == true ? "Development" : "Production",
-                    unityVersion = Application.unityVersion
-                };
-                WriteBuildMarker(outputPath, buildInfo);
-            }
-            catch (Exception e)
-            {
-                Debug.LogWarning($"[AIT] 빌드 마커 생성 실패 (무시됨): {e}");
-            }
-
-            return AITExportError.SUCCEED;
-        }
-
-        // Unity Resources 폴더는 사용자 프로젝트 소유 — SDK 패키지(UPM Git 설치 시 immutable)가 아니라
-        // 여기에 쓰면 설치 방식에 무관하게 쓰기 가능. 플레이어 번들은 Resources/ 를 자동 포함함.
-        private const string VersionInfoAssetPath = "Assets/Resources/AITVersionInfo.json";
-
-        /// <summary>
-        /// 빌드 직전 Assets/Resources/AITVersionInfo.json 에 Version/CommitHash/ReleaseDateTime 기록.
-        /// .cs 파일 수정과 달리 .json은 스크립트 컴파일/도메인 리로드를 유발하지 않는다.
-        /// </summary>
-        /// <param name="createdResourcesDir">
-        /// 이번 호출에서 Assets/Resources/ 폴더를 새로 생성했는지. 파일 쓰기까지 성공한 경우에만
-        /// true 로 설정되어, cleanup 단계가 "우리가 만든 빈 폴더" 만 지우고 사용자의 기존
-        /// Resources/ 는 보존하도록 한다.
-        /// </param>
-        /// <returns>파일을 성공적으로 기록했으면 true (빌드 후 정리 대상)</returns>
-        private static bool WriteVersionInfoJson(out bool createdResourcesDir)
-        {
-            createdResourcesDir = false;
-            try
-            {
-                // AITVersion.Version은 EnsureLoaded 경로에 따라 "unknown"으로 초기화될 수 있어
-                // 패키지의 권위 있는 소스인 package.json 에서 직접 읽는다.
-                var payload = new AITVersion.VersionInfoPayload
-                {
-                    version = ResolveSdkVersion(),
-                    releaseDateTime = DateTime.UtcNow.ToString("yyyyMMdd_HHmm"),
-                    commitHash = GetGitCommitHash(),
-                };
-
-                // JsonUtility.ToJson 으로 직렬화 — 수동 문자열 보간의 이스케이프 누락을 방지.
-                // 필드명은 VersionInfoPayload 의 public field 이름과 런타임 read 경로가 공유.
-                string json = JsonUtility.ToJson(payload, prettyPrint: true);
-
-                string projectPath = UnityUtil.GetProjectPath();
-                string absolutePath = Path.Combine(projectPath, VersionInfoAssetPath);
-                string directory = Path.GetDirectoryName(absolutePath);
-                bool directoryCreated = false;
-                if (!Directory.Exists(directory))
-                {
-                    Directory.CreateDirectory(directory);
-                    directoryCreated = true;
-                }
-
-                File.WriteAllText(absolutePath, json);
-                // 파일 쓰기까지 성공한 후에야 "우리가 만든 폴더" 로 확정 — 쓰기 실패 시 폴더가
-                // 남더라도 caller 는 정리하지 않아 시스템이 일관된 상태를 유지.
-                createdResourcesDir = directoryCreated;
-
-                // Resources로 인식시키기 위해 임포트 (스크립트가 아니므로 도메인 리로드 없음)
-                AssetDatabase.ImportAsset(VersionInfoAssetPath, ImportAssetOptions.ForceSynchronousImport);
-                Debug.Log($"[AIT] 버전 정보 JSON 기록: Version={payload.version}, CommitHash={payload.commitHash}, ReleaseDateTime={payload.releaseDateTime}");
-                return true;
-            }
-            catch (Exception e)
-            {
-                Debug.LogWarning($"[AIT] 버전 정보 JSON 기록 실패 (무시됨): {e.Message}");
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// SDK package.json 의 version 필드를 직접 읽는다.
-        /// AITVersion.Version 은 EnsureLoaded 경로 / 설치 방식에 따라 "unknown" 일 수 있으므로
-        /// 빌드 산출물에 박는 값은 package.json 을 권위 있는 소스로 사용.
-        /// </summary>
-        private static string ResolveSdkVersion()
-        {
-            try
-            {
-                if (!AITPackagePathResolver.TryResolveFile("package.json", out string packageJsonPath))
-                {
-                    return AITVersion.Version;
-                }
-
-                string content = File.ReadAllText(packageJsonPath);
-                // "version": "x.y.z" 최소 파싱 (JSON 라이브러리 의존성 없이)
-                var match = System.Text.RegularExpressions.Regex.Match(
-                    content,
-                    "\"version\"\\s*:\\s*\"([^\"]+)\"");
-                return match.Success ? match.Groups[1].Value : AITVersion.Version;
-            }
-            catch
-            {
-                return AITVersion.Version;
-            }
-        }
-
-        /// <summary>
-        /// 빌드 후 Assets/Resources/AITVersionInfo.json 및 .meta 파일을 제거해
-        /// 사용자 프로젝트에 산출물이 남지 않도록 한다.
-        /// </summary>
-        /// <param name="createdResourcesDir">
-        /// 같은 빌드에서 WriteVersionInfoJson 이 Resources/ 폴더를 새로 생성했는지.
-        /// true 인 경우 빈 폴더도 함께 정리한다 (사용자가 원래 사용 중이던 Resources/ 는 보존).
-        /// </param>
-        private static void RemoveVersionInfoJson(bool createdResourcesDir)
-        {
-            try
-            {
-                // AssetDatabase.DeleteAsset이 파일과 .meta를 함께 삭제 (스크립트 아님 → 리로드 없음)
-                if (!AssetDatabase.DeleteAsset(VersionInfoAssetPath))
-                {
-                    return;
-                }
-
-                Debug.Log("[AIT] 버전 정보 JSON 제거 완료");
-
-                // 우리가 생성한 빈 Resources/ 폴더 정리 (Finder 등이 만든 .DS_Store 같은 hidden
-                // 파일이 있으면 Directory.GetFileSystemEntries 가 0 이 아니므로 보존되는데, 이는
-                // 안전한 방향의 기본값).
-                if (createdResourcesDir)
-                {
-                    string projectPath = UnityUtil.GetProjectPath();
-                    string resourcesAbs = Path.Combine(projectPath, "Assets/Resources");
-                    if (Directory.Exists(resourcesAbs)
-                        && Directory.GetFileSystemEntries(resourcesAbs).Length == 0)
-                    {
-                        AssetDatabase.DeleteAsset("Assets/Resources");
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Debug.LogWarning($"[AIT] 버전 정보 JSON 제거 실패 (무시됨): {e.Message}");
-            }
-        }
-
-        /// <summary>
-        /// git rev-parse --short=7 HEAD로 현재 커밋 해시를 가져옵니다.
-        /// Unity 프로젝트 루트에서 실행하여 프로젝트 커밋 해시를 반환합니다.
-        /// (SDK가 UPM git 패키지로 설치된 경우에도 프로젝트의 커밋 해시를 사용)
-        /// </summary>
-        private static string GetGitCommitHash()
-        {
-            try
-            {
-                using (var process = new System.Diagnostics.Process
-                {
-                    StartInfo = new System.Diagnostics.ProcessStartInfo
-                    {
-                        FileName = "git",
-                        Arguments = "rev-parse --short=7 HEAD",
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        CreateNoWindow = true,
-                        WorkingDirectory = UnityUtil.GetProjectPath()
-                    }
-                })
-                {
-                    process.Start();
-                    string output = process.StandardOutput.ReadToEnd().Trim();
-                    bool exited = process.WaitForExit(5000);
-                    return exited && process.ExitCode == 0 && !string.IsNullOrEmpty(output) ? output : "unknown";
-                }
-            }
-            catch
-            {
-                return "unknown";
-            }
-        }
+        // WebGL 빌드 실행부(ShouldForceCleanBuild/BuildWebGL/버전 정보 JSON 기록·정리)는
+        // AITWebGLBuilder로 분리(#36의 AITBuildCancellation과 동일 패턴).
+        // 빌드 파이프라인은 Editor.AITWebGLBuilder.BuildWebGL을 호출하며 동작은 변경되지 않는다.
 
         #endregion
 

--- a/Editor/AITErrorReporter.cs
+++ b/Editor/AITErrorReporter.cs
@@ -86,7 +86,7 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>
-        /// 빌드 리포트 저장 (AITConvertCore.BuildWebGL에서 호출)
+        /// 빌드 리포트 저장 (AITWebGLBuilder.BuildWebGL에서 호출)
         /// </summary>
         public static void SetBuildReport(BuildReport report)
         {

--- a/Editor/AITExportErrorCatalog.cs
+++ b/Editor/AITExportErrorCatalog.cs
@@ -1,0 +1,185 @@
+// 스위치 본문을 AITConvertCore에서 그대로 옮기기 위한 별칭 (AITExportError.XXX 표기 유지)
+using AITExportError = AppsInToss.AITConvertCore.AITExportError;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 에러 코드 → 사용자 메시지 카탈로그 (AITConvertCore에서 분리).
+    /// AITConvertCore의 공개 에러 메시지 API(GetErrorMessage/GetErrorShortReason/GetErrorCause)가
+    /// 이 클래스로 위임하며 동작은 기존과 동일하다.
+    /// </summary>
+    internal static class AITExportErrorCatalog
+    {
+        /// <summary>
+        /// 에러 코드를 사용자 친화적 메시지로 변환
+        /// </summary>
+        internal static string GetErrorMessage(AITConvertCore.AITExportError error)
+        {
+            switch (error)
+            {
+                case AITExportError.SUCCEED:
+                    return "성공";
+
+                case AITExportError.NODE_NOT_FOUND:
+                    return "Node.js를 찾을 수 없습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. https://nodejs.org 에서 Node.js 설치\n" +
+                           "2. Unity Editor 재시작\n" +
+                           "3. 터미널에서 'node --version' 확인";
+
+                case AITExportError.BUILD_WEBGL_FAILED:
+                    return "WebGL 빌드에 실패했습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. Unity Console 창에서 에러 메시지 확인\n" +
+                           "2. WebGL Build Support가 설치되어 있는지 확인\n" +
+                           "3. 프로젝트에 빌드 오류가 없는지 확인\n" +
+                           "4. File > Build Settings > WebGL에서 직접 빌드 시도";
+
+                case AITExportError.INVALID_APP_CONFIG:
+                    return "앱 설정이 올바르지 않습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. Apps in Toss > Build & Deploy Window 열기\n" +
+                           "2. 설정 섹션에서 아이콘 URL 입력 (필수)\n" +
+                           "3. 앱 ID, 버전 등 기본 정보 확인";
+
+                case AITExportError.NETWORK_ERROR:
+                    return "네트워크 오류가 발생했습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. 인터넷 연결 확인\n" +
+                           "2. npm 레지스트리 접속 가능 여부 확인\n" +
+                           "3. 방화벽 또는 프록시 설정 확인";
+
+                case AITExportError.CANCELLED:
+                    return "사용자에 의해 빌드가 취소되었습니다.";
+
+                case AITExportError.FAIL_NPM_BUILD:
+                    return "pnpm 빌드에 실패했습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. Unity Console 창에서 에러 메시지 확인\n" +
+                           "2. ait-build 폴더에서 직접 pnpm install 시도\n" +
+                           "3. package.json 파일이 올바른지 확인\n" +
+                           "4. ~/.ait-unity-sdk/nodejs 폴더를 삭제 후 다시 빌드 시도";
+
+                case AITExportError.BUILD_FOLDER_MISSING:
+                    return "WebGL 빌드의 Build 폴더를 찾을 수 없습니다.\n\n" +
+                           "WebGL 빌드가 실행되지 않았거나 빌드 결과물이 삭제되었습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. 'Build & Package' 메뉴로 전체 빌드를 실행하세요.\n" +
+                           "2. webgl/ 폴더가 존재하는지 확인하세요.";
+
+                case AITExportError.REQUIRED_FILE_MISSING:
+                    return "WebGL 빌드 필수 파일이 누락되었습니다.\n\n" +
+                           "loader.js, data, framework.js, wasm 파일 중 일부가 없습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n" +
+                           "2. Unity Console에서 빌드 에러를 확인하세요.";
+
+                case AITExportError.INDEX_HTML_MISSING:
+                    return "WebGL 빌드의 index.html을 찾을 수 없습니다.\n\n" +
+                           "WebGL 템플릿이 올바르게 설정되지 않았을 수 있습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. AIT > Clean 메뉴로 빌드 폴더 삭제 후 재빌드\n" +
+                           "2. 'Clean Build' 옵션 활성화 후 재빌드";
+
+                case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED:
+                    return "빌드 산출물(index.html 또는 apps-in-toss.config.ts/granite.config.ts)의 필수 플레이스홀더가 치환되지 않았습니다.\n\n" +
+                           "이 상태로 배포하면 'createUnityInstance is not defined' 에러가 발생하거나 앱 설정(bundle.json)이 깨집니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. 'Clean Build' 옵션을 활성화하고 다시 빌드하세요.\n" +
+                           "2. AIT > Clean 메뉴로 빌드 폴더 삭제 후 재빌드하세요.";
+
+                case AITExportError.DIST_FOLDER_MISSING:
+                    return "granite build가 완료되었으나 dist 폴더가 생성되지 않았습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. ait-build/ 폴더에서 수동으로 'npm run build' 실행하여 오류 확인\n" +
+                           "2. granite.config.ts의 플레이스홀더가 올바르게 치환되었는지 확인\n" +
+                           "3. AIT > Clean 메뉴 실행 후 Clean Build 재시도";
+
+                case AITExportError.AIT_FILE_MISSING:
+                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.\n\n" +
+                           "해결 방법:\n" +
+                           "1. ait-build/dist/ 폴더의 내용을 확인하세요\n" +
+                           "2. granite.config.ts 설정을 확인하세요\n" +
+                           "3. AIT > Clean 메뉴 실행 후 Clean Build 재시도";
+
+                default:
+                    return $"알 수 없는 오류가 발생했습니다. (코드: {error})";
+            }
+        }
+
+        /// <summary>
+        /// 다이얼로그 제목에 붙일 짧은 사유 라벨을 반환합니다.
+        /// 예: "빌드 실패 ({shortReason})" 형태로 조합됩니다.
+        /// </summary>
+        internal static string GetErrorShortReason(AITConvertCore.AITExportError error)
+        {
+            switch (error)
+            {
+                case AITExportError.SUCCEED: return "성공";
+                case AITExportError.NODE_NOT_FOUND: return "Node.js 없음";
+                case AITExportError.BUILD_WEBGL_FAILED: return "WebGL 빌드 오류";
+                case AITExportError.INVALID_APP_CONFIG: return "앱 설정 오류";
+                case AITExportError.NETWORK_ERROR: return "네트워크 오류";
+                case AITExportError.CANCELLED: return "사용자 취소";
+                case AITExportError.FAIL_NPM_BUILD: return "pnpm 빌드 오류";
+                case AITExportError.BUILD_FOLDER_MISSING: return "Build 폴더 없음";
+                case AITExportError.REQUIRED_FILE_MISSING: return "필수 파일 누락";
+                case AITExportError.INDEX_HTML_MISSING: return "index.html 없음";
+                case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED: return "플레이스홀더 미치환";
+                case AITExportError.DIST_FOLDER_MISSING: return "dist 폴더 없음";
+                case AITExportError.AIT_FILE_MISSING: return ".ait 파일 없음";
+                default: return error.ToString();
+            }
+        }
+
+        /// <summary>
+        /// 다이얼로그 본문에 사용할 원인 한 단락을 반환합니다. 해결 방법은 포함하지 않습니다.
+        /// </summary>
+        internal static string GetErrorCause(AITConvertCore.AITExportError error)
+        {
+            switch (error)
+            {
+                case AITExportError.SUCCEED:
+                    return "성공";
+                case AITExportError.NODE_NOT_FOUND:
+                    return "SDK 가 사용할 Node.js 실행 파일을 찾을 수 없습니다.\n" +
+                           "내장 Node 바이너리(~/.ait-unity-sdk/nodejs) 또는 시스템 PATH에서 node를 찾지 못했습니다.";
+                case AITExportError.BUILD_WEBGL_FAILED:
+                    return "Unity WebGL 빌드 중 오류가 발생했습니다.\n" +
+                           "Console 창에서 컴파일 오류나 스택 트레이스를 확인해주세요.";
+                case AITExportError.INVALID_APP_CONFIG:
+                    return "앱 설정이 올바르지 않거나 필수 필드(App ID, 아이콘 URL 등)가 누락되었습니다.\n" +
+                           "AIT > Configuration 창에서 설정을 확인해주세요.";
+                case AITExportError.NETWORK_ERROR:
+                    return "빌드 과정에서 네트워크 요청에 실패했습니다.\n" +
+                           "인터넷 연결 또는 프록시/방화벽 설정을 확인해주세요.";
+                case AITExportError.CANCELLED:
+                    return "사용자에 의해 빌드가 취소되었습니다.";
+                case AITExportError.FAIL_NPM_BUILD:
+                    return "ait-build 디렉터리의 pnpm/granite 빌드 단계에서 오류가 발생했습니다.\n" +
+                           "Console 창에서 빌드 로그를 확인해주세요.";
+                case AITExportError.BUILD_FOLDER_MISSING:
+                    return "WebGL 빌드 결과물의 Build 폴더가 존재하지 않습니다.\n" +
+                           "WebGL 빌드가 완료되지 않았거나 결과물이 삭제되었을 수 있습니다.";
+                case AITExportError.REQUIRED_FILE_MISSING:
+                    return "WebGL 빌드 결과물(loader.js, data, framework.js, wasm) 중 일부가 누락되었습니다.\n" +
+                           "Clean Build 옵션을 켜고 다시 빌드해보세요.";
+                case AITExportError.INDEX_HTML_MISSING:
+                    return "WebGL 빌드의 index.html 이 생성되지 않았습니다.\n" +
+                           "WebGL 템플릿(AITTemplate) 설정이 올바른지 확인해주세요.";
+                case AITExportError.PLACEHOLDER_SUBSTITUTION_FAILED:
+                    return "빌드 산출물(index.html 또는 apps-in-toss.config.ts/granite.config.ts)의 필수 플레이스홀더가 치환되지 않은 채 저장되었습니다.\n" +
+                           "이 상태로 배포하면 런타임에 'createUnityInstance is not defined' 오류가 발생하거나 앱 설정(bundle.json)이 깨집니다.\n" +
+                           "Clean Build 옵션으로 재빌드해보세요.";
+                case AITExportError.DIST_FOLDER_MISSING:
+                    return "granite 빌드가 완료되었지만 dist 폴더가 생성되지 않았습니다.\n" +
+                           "granite.config.ts 의 플레이스홀더가 올바르게 치환되었는지 확인해주세요.";
+                case AITExportError.AIT_FILE_MISSING:
+                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.\n" +
+                           "granite 빌드 설정을 확인한 뒤 Clean Build 로 재시도해주세요.";
+                default:
+                    return $"알 수 없는 오류 (코드: {error}).";
+            }
+        }
+    }
+}

--- a/Editor/AITExportErrorCatalog.cs.meta
+++ b/Editor/AITExportErrorCatalog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75a5de7dc96a49e08655894aa56eb251
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/AITWebGLBuilder.cs
+++ b/Editor/AITWebGLBuilder.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using AppsInToss;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// Unity WebGL 빌드 실행부 (AITConvertCore에서 분리).
+    /// 빌드 캐시 유효성 검증, BuildPipeline 실행, 빌드 마커 기록,
+    /// 버전 정보 JSON 기록/정리를 한 곳에서 관리한다.
+    /// AITConvertCore의 빌드 파이프라인(DoExport/DoExportAsync)이 이 클래스를 호출하며 동작은 기존과 동일하다.
+    /// </summary>
+    internal static class AITWebGLBuilder
+    {
+        /// <summary>
+        /// 기존 빌드 캐시가 유효한지 검증하여 clean build 필요 여부를 판단합니다.
+        /// 빌드 마커 없음, Unity 버전 불일치, 필수 파일 누락 시 true를 반환합니다.
+        /// </summary>
+        internal static bool ShouldForceCleanBuild(string outputPath, bool cleanBuild)
+        {
+            if (cleanBuild) return true;
+            if (!Directory.Exists(outputPath)) return false;
+
+            var buildInfo = AITConvertCore.ReadBuildMarker(outputPath);
+            if (buildInfo == null)
+            {
+                AITLog.Warning("[AIT] 빌드 마커가 없습니다. Clean build를 수행합니다.", sentryCapture: false);
+                return true;
+            }
+            if (buildInfo.unityVersion != Application.unityVersion)
+            {
+                AITLog.Warning($"[AIT] Unity 버전 불일치: 빌드 {buildInfo.unityVersion} vs 현재 {Application.unityVersion}. Clean build를 수행합니다.", sentryCapture: false);
+                return true;
+            }
+
+            string buildDir = Path.Combine(outputPath, "Build");
+            if (!Directory.Exists(buildDir) || Directory.GetFiles(buildDir, "*.loader.js").Length == 0)
+            {
+                AITLog.Warning("[AIT] 빌드 필수 파일이 없습니다. Clean build를 수행합니다.", sentryCapture: false);
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static AITConvertCore.AITExportError BuildWebGL(bool cleanBuild = false, AITBuildProfile profile = null)
+        {
+            // WebGL Build Support 모듈 설치 여부 사전 체크
+            if (!BuildPipeline.IsBuildTargetSupported(BuildTargetGroup.WebGL, BuildTarget.WebGL))
+            {
+                // 사용자 환경 문제(Unity Hub에서 WebGL Build Support 미설치)이지 SDK 버그가 아니다.
+                // 메시지 첫머리의 '[AIT' 토큰이 트래커 SDK 키워드 가드를 먼저 발동시켜 NonSdkMessagePatterns를
+                // 무력화하므로, sentryCapture:false가 Sentry 차단의 유일하게 확실한 방법이다 (SDK-DB).
+                AITLog.Error(
+                    "[AIT] ✗ WebGL Build Support 모듈이 설치되지 않았습니다.\n" +
+                    "Unity Hub를 열고 현재 Unity 버전(" + Application.unityVersion + ")에 WebGL Build Support를 추가 설치하세요.\n" +
+                    "Unity Hub > Installs > Unity " + Application.unityVersion + " > Add Modules > WebGL Build Support",
+                    sentryCapture: false);
+                return AITConvertCore.AITExportError.BUILD_WEBGL_FAILED;
+            }
+
+            if (EditorUserBuildSettings.activeBuildTarget != BuildTarget.WebGL)
+            {
+                bool confirm = AITPlatformHelper.ShowConfirmDialog(
+                    "빌드 타겟 전환 필요",
+                    $"현재 빌드 타겟이 {EditorUserBuildSettings.activeBuildTarget}입니다.\n" +
+                    "WebGL 빌드를 위해 빌드 타겟을 WebGL로 전환해야 합니다.",
+                    "전환",
+                    "취소");
+
+                if (!confirm)
+                {
+                    Debug.Log("[AIT] 사용자가 빌드 타겟 전환을 취소했습니다.");
+                    return AITConvertCore.AITExportError.CANCELLED;
+                }
+
+                Debug.Log($"[AIT] 빌드 타겟을 {EditorUserBuildSettings.activeBuildTarget}에서 WebGL로 전환합니다...");
+                if (!EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WebGL, BuildTarget.WebGL))
+                {
+                    AITLog.Error("[AIT] ✗ WebGL 빌드 타겟으로 전환할 수 없습니다.", sentryCapture: false);
+                    return AITConvertCore.AITExportError.BUILD_WEBGL_FAILED;
+                }
+            }
+
+            string[] scenes = UnityUtil.GetBuildScenes();
+            string outputPath = Path.Combine(UnityUtil.GetProjectPath(), AITConvertCore.webglDir);
+
+            // 빌드 캐시 유효성 검증
+            if (ShouldForceCleanBuild(outputPath, cleanBuild))
+            {
+                if (!cleanBuild)
+                    Debug.Log("[AIT] 빌드 캐시 검증 실패. 자동으로 clean build를 수행합니다.");
+                cleanBuild = true;
+            }
+
+            Debug.Log($"[AIT] WebGL 빌드를 시작합니다... ({(cleanBuild ? "클린 빌드" : "증분 빌드")})");
+
+            // 클린 빌드 시에만 기존 빌드 폴더 삭제
+            if (cleanBuild && Directory.Exists(outputPath))
+            {
+                Debug.Log("[AIT] 클린 빌드: 기존 WebGL 빌드 폴더 삭제 중...");
+                Directory.Delete(outputPath, true);
+            }
+
+            // 프로필이 없으면 기본 프로필 사용
+            if (profile == null)
+            {
+                profile = AITBuildProfile.CreateProductionProfile();
+            }
+
+            // 빌드 옵션 설정
+            BuildOptions buildOptions = BuildOptions.None;
+
+            // Development Build 옵션 (빌드 속도 향상, 디버깅 편의)
+            if (profile.developmentBuild)
+            {
+                buildOptions |= BuildOptions.Development;
+                Debug.Log("[AIT] Development Build 활성화");
+            }
+
+            // LZ4 압축으로 빌드 속도 향상
+            if (profile.enableLZ4Compression)
+            {
+                buildOptions |= BuildOptions.CompressWithLz4;
+            }
+
+            // Unity 2021.3에서 Bee 빌드 캐시 문제로 인한 빌드 루프 방지
+            // cleanBuild 시 CleanBuildCache 옵션 추가
+            if (cleanBuild)
+            {
+                buildOptions |= BuildOptions.CleanBuildCache;
+            }
+
+            BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions
+            {
+                scenes = scenes,
+                locationPathName = outputPath,
+                target = BuildTarget.WebGL,
+                options = buildOptions,
+#if UNITY_2023_3_OR_NEWER
+                // Unity 2023.3+ (Unity 6): 최신 기능 활성화 (문서 권장)
+                extraScriptingDefines = new[]
+                {
+                    "APPSINTOS_OPTIMIZED",
+                    "WEBGL_2_0",
+                    "UNITY_6_FEATURES"
+                }
+#elif UNITY_2022_3_OR_NEWER
+                // Unity 2022.3+: WebGL 2.0 최적화 (문서 권장)
+                extraScriptingDefines = new[]
+                {
+                    "APPSINTOS_OPTIMIZED",
+                    "WEBGL_2_0"
+                }
+#endif
+            };
+
+            // 빌드 직전: Resources JSON으로 Version/CommitHash/ReleaseDateTime 기록
+            // .cs 파일 수정과 달리 .json은 스크립트 컴파일을 유발하지 않으므로 도메인 리로드 없음
+            bool versionInfoWritten = WriteVersionInfoJson(out bool createdResourcesDir);
+
+            UnityEditor.Build.Reporting.BuildReport result;
+            try
+            {
+                result = BuildPipeline.BuildPlayer(buildPlayerOptions);
+            }
+            finally
+            {
+                // 빌드 완료 후 (성공/실패 무관) 생성한 JSON 제거 — 사용자 프로젝트에 산출물 남기지 않음
+                if (versionInfoWritten)
+                {
+                    RemoveVersionInfoJson(createdResourcesDir);
+                }
+            }
+
+            // 빌드 리포트를 에러 리포터에 저장 (Issue 신고 시 사용)
+            AITErrorReporter.SetBuildReport(result);
+
+            if (result.summary.result != UnityEditor.Build.Reporting.BuildResult.Succeeded)
+            {
+                // 사용자가 빌드를 취소한 경우 — Unity가 BuildResult.Cancelled를 반환한다.
+                // 이것은 사용자 의사이므로 SDK 결함 보고 대상이 아니다.
+                if (result.summary.result == UnityEditor.Build.Reporting.BuildResult.Cancelled)
+                {
+                    AITLog.Warning("[AIT] 사용자에 의해 WebGL 빌드가 취소되었습니다.", sentryCapture: false);
+                    return AITConvertCore.AITExportError.CANCELLED;
+                }
+
+                // 실패 진단 메시지를 step에서 평탄화 수집(에러/경고 캡 분리는 BuildFailureSummary가 처리).
+                var collected = new List<(LogType type, string content)>();
+                foreach (var step in result.steps)
+                {
+                    foreach (var message in step.messages)
+                    {
+                        collected.Add((message.type, message.content));
+                    }
+                }
+
+                // BuildReport.steps에 에러/경고가 전혀 없으면(Bee/IL2CPP의 .o 실패 등 무진단 실패)
+                // 에디터 로그 꼬리를 첨부해 단서를 남긴다. 그 외에는 step 메시지로 충분하다.
+                bool hasDiagnosticMessage = false;
+                foreach (var m in collected)
+                {
+                    if (m.type == LogType.Error || m.type == LogType.Exception
+                        || m.type == LogType.Assert || m.type == LogType.Warning)
+                    {
+                        hasDiagnosticMessage = true;
+                        break;
+                    }
+                }
+                string logTail = hasDiagnosticMessage ? null : AITWebGLBuildDiagnostics.ReadEditorLogTail(Application.consoleLogPath);
+
+                // BuildSummary.totalErrors/totalWarnings는 uint이므로 int 시그니처로 명시 캐스트
+                // (실패 빌드의 카운트는 항상 int 범위 — overflow 우려 없음).
+                string failureSummary = AITWebGLBuildDiagnostics.BuildFailureSummary(
+                    result.summary.result.ToString(),
+                    (int)result.summary.totalErrors,
+                    (int)result.summary.totalWarnings,
+                    collected,
+                    logTail);
+
+                // BuildPipeline.BuildPlayer 실패는 거의 항상 사용자 프로젝트(컴파일 에러,
+                // 사용자 에셋 문제, 환경 OOM 등) 또는 Unity 자체의 비정상 종료에서 비롯되며
+                // SDK 측에서 분기/수정할 수 있는 정보가 아니다. 콘솔에는 진단 메시지를 남기되
+                // Sentry로는 보내지 않아 분류 노이즈를 만들지 않는다.
+                AITLog.Error(failureSummary, sentryCapture: false);
+                return AITConvertCore.AITExportError.BUILD_WEBGL_FAILED;
+            }
+
+            Debug.Log("[AIT] WebGL 빌드가 완료되었습니다.");
+
+            // AIT 빌드 마커 파일 생성 (빌드 정보 기록용)
+            try
+            {
+                var buildInfo = new AITBuildInfo
+                {
+                    sdkVersion = AITVersion.Version,
+                    buildTime = DateTime.UtcNow.ToString("o"),
+                    compressionFormat = (int)PlayerSettings.WebGL.compressionFormat,
+                    decompressionFallback = PlayerSettings.WebGL.decompressionFallback,
+                    profileName = profile?.developmentBuild == true ? "Development" : "Production",
+                    unityVersion = Application.unityVersion
+                };
+                AITConvertCore.WriteBuildMarker(outputPath, buildInfo);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] 빌드 마커 생성 실패 (무시됨): {e}");
+            }
+
+            return AITConvertCore.AITExportError.SUCCEED;
+        }
+
+        // Unity Resources 폴더는 사용자 프로젝트 소유 — SDK 패키지(UPM Git 설치 시 immutable)가 아니라
+        // 여기에 쓰면 설치 방식에 무관하게 쓰기 가능. 플레이어 번들은 Resources/ 를 자동 포함함.
+        private const string VersionInfoAssetPath = "Assets/Resources/AITVersionInfo.json";
+
+        /// <summary>
+        /// 빌드 직전 Assets/Resources/AITVersionInfo.json 에 Version/CommitHash/ReleaseDateTime 기록.
+        /// .cs 파일 수정과 달리 .json은 스크립트 컴파일/도메인 리로드를 유발하지 않는다.
+        /// </summary>
+        /// <param name="createdResourcesDir">
+        /// 이번 호출에서 Assets/Resources/ 폴더를 새로 생성했는지. 파일 쓰기까지 성공한 경우에만
+        /// true 로 설정되어, cleanup 단계가 "우리가 만든 빈 폴더" 만 지우고 사용자의 기존
+        /// Resources/ 는 보존하도록 한다.
+        /// </param>
+        /// <returns>파일을 성공적으로 기록했으면 true (빌드 후 정리 대상)</returns>
+        private static bool WriteVersionInfoJson(out bool createdResourcesDir)
+        {
+            createdResourcesDir = false;
+            try
+            {
+                // AITVersion.Version은 EnsureLoaded 경로에 따라 "unknown"으로 초기화될 수 있어
+                // 패키지의 권위 있는 소스인 package.json 에서 직접 읽는다.
+                var payload = new AITVersion.VersionInfoPayload
+                {
+                    version = ResolveSdkVersion(),
+                    releaseDateTime = DateTime.UtcNow.ToString("yyyyMMdd_HHmm"),
+                    commitHash = GetGitCommitHash(),
+                };
+
+                // JsonUtility.ToJson 으로 직렬화 — 수동 문자열 보간의 이스케이프 누락을 방지.
+                // 필드명은 VersionInfoPayload 의 public field 이름과 런타임 read 경로가 공유.
+                string json = JsonUtility.ToJson(payload, prettyPrint: true);
+
+                string projectPath = UnityUtil.GetProjectPath();
+                string absolutePath = Path.Combine(projectPath, VersionInfoAssetPath);
+                string directory = Path.GetDirectoryName(absolutePath);
+                bool directoryCreated = false;
+                if (!Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                    directoryCreated = true;
+                }
+
+                File.WriteAllText(absolutePath, json);
+                // 파일 쓰기까지 성공한 후에야 "우리가 만든 폴더" 로 확정 — 쓰기 실패 시 폴더가
+                // 남더라도 caller 는 정리하지 않아 시스템이 일관된 상태를 유지.
+                createdResourcesDir = directoryCreated;
+
+                // Resources로 인식시키기 위해 임포트 (스크립트가 아니므로 도메인 리로드 없음)
+                AssetDatabase.ImportAsset(VersionInfoAssetPath, ImportAssetOptions.ForceSynchronousImport);
+                Debug.Log($"[AIT] 버전 정보 JSON 기록: Version={payload.version}, CommitHash={payload.commitHash}, ReleaseDateTime={payload.releaseDateTime}");
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] 버전 정보 JSON 기록 실패 (무시됨): {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// SDK package.json 의 version 필드를 직접 읽는다.
+        /// AITVersion.Version 은 EnsureLoaded 경로 / 설치 방식에 따라 "unknown" 일 수 있으므로
+        /// 빌드 산출물에 박는 값은 package.json 을 권위 있는 소스로 사용.
+        /// </summary>
+        private static string ResolveSdkVersion()
+        {
+            try
+            {
+                if (!AITPackagePathResolver.TryResolveFile("package.json", out string packageJsonPath))
+                {
+                    return AITVersion.Version;
+                }
+
+                string content = File.ReadAllText(packageJsonPath);
+                // "version": "x.y.z" 최소 파싱 (JSON 라이브러리 의존성 없이)
+                var match = System.Text.RegularExpressions.Regex.Match(
+                    content,
+                    "\"version\"\\s*:\\s*\"([^\"]+)\"");
+                return match.Success ? match.Groups[1].Value : AITVersion.Version;
+            }
+            catch
+            {
+                return AITVersion.Version;
+            }
+        }
+
+        /// <summary>
+        /// 빌드 후 Assets/Resources/AITVersionInfo.json 및 .meta 파일을 제거해
+        /// 사용자 프로젝트에 산출물이 남지 않도록 한다.
+        /// </summary>
+        /// <param name="createdResourcesDir">
+        /// 같은 빌드에서 WriteVersionInfoJson 이 Resources/ 폴더를 새로 생성했는지.
+        /// true 인 경우 빈 폴더도 함께 정리한다 (사용자가 원래 사용 중이던 Resources/ 는 보존).
+        /// </param>
+        private static void RemoveVersionInfoJson(bool createdResourcesDir)
+        {
+            try
+            {
+                // AssetDatabase.DeleteAsset이 파일과 .meta를 함께 삭제 (스크립트 아님 → 리로드 없음)
+                if (!AssetDatabase.DeleteAsset(VersionInfoAssetPath))
+                {
+                    return;
+                }
+
+                Debug.Log("[AIT] 버전 정보 JSON 제거 완료");
+
+                // 우리가 생성한 빈 Resources/ 폴더 정리 (Finder 등이 만든 .DS_Store 같은 hidden
+                // 파일이 있으면 Directory.GetFileSystemEntries 가 0 이 아니므로 보존되는데, 이는
+                // 안전한 방향의 기본값).
+                if (createdResourcesDir)
+                {
+                    string projectPath = UnityUtil.GetProjectPath();
+                    string resourcesAbs = Path.Combine(projectPath, "Assets/Resources");
+                    if (Directory.Exists(resourcesAbs)
+                        && Directory.GetFileSystemEntries(resourcesAbs).Length == 0)
+                    {
+                        AssetDatabase.DeleteAsset("Assets/Resources");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT] 버전 정보 JSON 제거 실패 (무시됨): {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// git rev-parse --short=7 HEAD로 현재 커밋 해시를 가져옵니다.
+        /// Unity 프로젝트 루트에서 실행하여 프로젝트 커밋 해시를 반환합니다.
+        /// (SDK가 UPM git 패키지로 설치된 경우에도 프로젝트의 커밋 해시를 사용)
+        /// </summary>
+        private static string GetGitCommitHash()
+        {
+            try
+            {
+                using (var process = new System.Diagnostics.Process
+                {
+                    StartInfo = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = "git",
+                        Arguments = "rev-parse --short=7 HEAD",
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        CreateNoWindow = true,
+                        WorkingDirectory = UnityUtil.GetProjectPath()
+                    }
+                })
+                {
+                    process.Start();
+                    string output = process.StandardOutput.ReadToEnd().Trim();
+                    bool exited = process.WaitForExit(5000);
+                    return exited && process.ExitCode == 0 && !string.IsNullOrEmpty(output) ? output : "unknown";
+                }
+            }
+            catch
+            {
+                return "unknown";
+            }
+        }
+    }
+}

--- a/Editor/AITWebGLBuilder.cs.meta
+++ b/Editor/AITWebGLBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88a50072e5034cc09567f72822a29a3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TODO.md
+++ b/TODO.md
@@ -2,13 +2,4 @@
 
 > 2026-04-14 전체 리뷰 기준 작성 · 2026-06-16 코드 대조로 완료 항목 정리.
 > 우선순위 P1(높음) ~ P3(낮음).
-
-## 리팩토링 (대형 파일 분리)
-
-- **P2 — `Editor/AITConvertCore.cs` (1,298행)**: 빌드 초기화·에셋 내보내기·WebGL 생성·에러 처리가 한 클래스에 집중. 단계별 Strategy/Pipeline 분리.
-
-## 비동기 / 스레드 안전성
-
-- **P2 — `Thread.Sleep` 블로킹**: 백그라운드 ThreadPool 폴링 루프 2곳을 `await Task.Delay`로 전환 — `AITAsyncCommandRunner.cs`(프로세스 종료 폴링), `Editor/Package/PnpmRunner.cs`(pnpm install 폴링). 두 루프 모두 내부에서 메인 스레드 API를 쓰지 않아 대기 중 풀 스레드 반납이 안전. 나머지는 동기 유지가 불가피(전환 시 데드락/계약 위반):
-  - 같은 루프에서 메인 스레드 진행률 UI 호출: `AITNodeJSDownloader.cs:143`, `AITNpmRunner.cs:307`, `AITPackageInitializer.cs:337` (`EditorUtility.DisplayProgressBar`).
-  - 동기 종료 계약: `AITProcessTreeManager.cs:283`(`IDisposable.Dispose`의 SIGTERM→SIGKILL 유예), `AITSentryTransport.cs:268`(`EditorApplication.quitting` 동기 핸들러의 마지막 flush).
+> 2026-07-08 P2 잔여 항목 완료로 정리.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildMarkerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildMarkerTests.cs
@@ -7,7 +7,6 @@
 using NUnit.Framework;
 using System;
 using System.IO;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.TestTools;
 using AppsInToss;
@@ -127,15 +126,6 @@ public class BuildMarkerTests
     private const string EXPECTED_MISSING_MARKER_WARNING =
         "[AIT] 빌드 마커가 없습니다. Clean build를 수행합니다.";
 
-    private static bool InvokeShouldForceCleanBuild(string outputPath, bool cleanBuild)
-    {
-        MethodInfo m = typeof(AITConvertCore).GetMethod(
-            "ShouldForceCleanBuild",
-            BindingFlags.Static | BindingFlags.NonPublic);
-        Assert.IsNotNull(m, "ShouldForceCleanBuild 메서드를 찾을 수 없습니다.");
-        return (bool)m.Invoke(null, new object[] { outputPath, cleanBuild });
-    }
-
     [Test]
     public void ShouldForceCleanBuild_ReturnsTrueAndWarns_WhenMarkerIsMissing()
     {
@@ -147,7 +137,8 @@ public class BuildMarkerTests
 
         LogAssert.Expect(LogType.Warning, EXPECTED_MISSING_MARKER_WARNING);
 
-        bool shouldClean = InvokeShouldForceCleanBuild(outputPath, false);
+        // internal 접근은 Editor/AssemblyInfo.cs의 InternalsVisibleTo("AppsInTossEditModeTests")로 허용됨
+        bool shouldClean = AppsInToss.Editor.AITWebGLBuilder.ShouldForceCleanBuild(outputPath, false);
 
         Assert.IsTrue(shouldClean,
             "마커가 없으면 ShouldForceCleanBuild는 true를 반환해야 합니다.");


### PR DESCRIPTION
## 배경

TODO.md P2 항목 정리: `Editor/AITConvertCore.cs`(1,235행)에 빌드 캐시 검증·WebGL 빌드 실행·에러 메시지 변환이 집중되어 있어, #36(AITBuildCancellation 분리)과 동일한 **파사드 위임 패턴**으로 단계별 분리한다.

## 변경 내용

### 1. `Editor/AITWebGLBuilder.cs` 신설 (417행, `internal static`)

Unity WebGL 빌드 실행부를 이동:

- `ShouldForceCleanBuild` — 빌드 마커/Unity 버전/필수 파일 기반 clean build 판정
- `BuildWebGL` — BuildPipeline 실행, 빌드 마커 기록, BuildReport 전달 (`UNITY_2022_3`/`UNITY_2023_3` 분기의 `extraScriptingDefines` 블록 포함 그대로 이동)
- `WriteVersionInfoJson` / `ResolveSdkVersion` / `RemoveVersionInfoJson` / `GetGitCommitHash` — 버전 정보 JSON 기록/정리

### 2. `Editor/AITExportErrorCatalog.cs` 신설 (185행, `internal static`)

`GetErrorMessage` / `GetErrorShortReason` / `GetErrorCause` 스위치 본문을 이동. **에러 메시지 문자열은 한 글자도 변경하지 않음** — Sentry 분류기와 테스트가 문자열에 결합되어 있음.

### 3. `Editor/AITConvertCore.cs` — 1,235행 → 687행 파사드

- 공개 API 시그니처 전부 유지 (`GetErrorMessage` 등은 한 줄 위임)
- `DoExport`/`DoExportAsync`의 `BuildWebGL` 호출 3곳을 `Editor.AITWebGLBuilder.BuildWebGL(cleanBuild, profile)`로 전환
- `AITExportError` enum, `AITBuildInfo`, 빌드 마커 IO, 취소 래퍼 등은 파사드에 유지

### 4. 테스트·주석 정합

- `BuildMarkerTests.cs`: `typeof(AITConvertCore)` private 리플렉션 호출 → `AppsInToss.Editor.AITWebGLBuilder.ShouldForceCleanBuild` 직접 호출 (기존 `InternalsVisibleTo("AppsInTossEditModeTests")` 활용, 단언·기대 경고 문자열 무변경)
- `AITErrorReporter.cs`: 이동된 호출 주체를 가리키는 주석 1줄 갱신

### 5. TODO.md P2 잔여 2건 정리

- **AITConvertCore 분리** — 본 PR로 완료
- **`Thread.Sleep` → `await Task.Delay` 전환** — 코드 대조 결과 #860에서 이미 완료된 항목(`AITAsyncCommandRunner.cs`, `PnpmRunner.cs` 모두 `await Task.Delay(...).ConfigureAwait(false)` 폴링)이라 잔재만 제거

## 동작 불변 근거

- 이동은 전부 verbatim(메서드 본문 그대로), 접근 한정자만 `private` → `internal`
- 에러 문자열·빌드 마커 포맷·로그 메시지 무변경
- 공개 API(`AITConvertCore.*`) 시그니처 무변경 — 외부 호출부 영향 없음

## 검증

- `./run-local-tests.sh --validate` — 4/4 통과 (파일 구조 + SDK 유닛 테스트 + jslib invariants + Meta GUID 위생 237개)
- EditMode 배치모드 수동 실행 — 981건 중 **967 통과 / 0 실패** / 1 inconclusive(Windows 전용 테스트, macOS 정상) / 13 skipped(의도적 Ignore), `BuildMarkerTests` 5/5 통과
- 리뷰 4개 관점(동작 보존/공개 API 호환/Unity 규약/저장소 정책) 교차 검증 — 지적 사항(주석의 InternalsVisibleTo 어셈블리명 오기 1건)은 수정 반영 완료
