### PR TITLE
빌드: regen-lockfiles 검증 게이트 추가 — frozen 설치·release age·레지스트리 가드

### DIFF
--- a/.github/workflows/regen-lockfiles.yml
+++ b/.github/workflows/regen-lockfiles.yml
@@ -38,10 +38,18 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Force public registry
+        # minimum-release-age(분): 게시 3일(4320분) 미만의 버전을 해석에서 제외.
+        # 갓 게시됐다가 npm이 악성으로 삭제하는 버전(2026-07 enhanced-resolve 5.24.2 등
+        # 4종이 하루 만에 unpublish)을 lockfile에 스냅샷하는 사고 방지.
+        # 사내 통제 스코프는 당일 릴리즈(SDK 버전 동시 bump)가 정상 흐름이라 제외.
         run: |
           mkdir -p ~/.config/pnpm
           cat > ~/.npmrc <<'EOF'
           registry=https://registry.npmjs.org/
+          minimum-release-age=4320
+          minimum-release-age-exclude[]=@apps-in-toss/*
+          minimum-release-age-exclude[]=@toss/*
+          minimum-release-age-exclude[]=@granite-js/*
           EOF
           pnpm config set registry https://registry.npmjs.org/
 
@@ -62,6 +70,55 @@ jobs:
         run: |
           rm -f pnpm-lock.yaml
           pnpm install --lockfile-only --registry=https://registry.npmjs.org/
+
+      - name: Verify lockfiles (frozen install)
+        # --lockfile-only는 메타데이터만 보고 기록하므로, 메타데이터와 실제 tarball이
+        # 어긋난 패키지(integrity 오염·게시 직후 삭제로 404)를 그대로 스냅샷할 수 있다.
+        # 실제 frozen 설치로 존재+integrity를 검증해, 설치 불가능한 lockfile이
+        # PR·자동머지로 흘러가는 것을 차단한다 (2026-07 #939가 머지 후 수 시간 만에
+        # 404 3종으로 전 소비자 설치 불능이 된 사고의 재발 방지).
+        # --ignore-scripts: 검증 목적은 fetch+integrity뿐 — 서드파티 postinstall을
+        # 러너에서 실행하지 않는다(악성 버전 유입 시 실행 벡터 제거).
+        run: |
+          set -euo pipefail
+          for dir in "Tests~/E2E/tests" "WebGLTemplates/AITTemplate/BuildConfig~" "sdk-runtime-generator~"; do
+            echo "::group::verify $dir"
+            (cd "$dir" && pnpm install --frozen-lockfile --ignore-scripts)
+            echo "::endgroup::"
+          done
+
+      - name: Verify lockfiles (registry/string guard)
+        # 이 워크플로우의 산출 경로는 string-check.yml이 실제로 돌지 않는 사각지대다:
+        # bot PR은 IS_BOT_PR로 scan skip + 아래에서 scan=success 수동 보고,
+        # GITHUB_TOKEN push는 GitHub 정책상 push 트리거 워크플로우를 발화시키지 않음.
+        # 그래서 PR 생성 전에 동일한 조직 denylist(STRING_CHECK_PATTERN)로 직접 검사하고,
+        # 추가로 tarball URL이 public registry(npmjs)만 가리키는지 구조 검증한다.
+        env:
+          PATTERN: ${{ secrets.STRING_CHECK_PATTERN }}
+          LC_ALL: C
+        run: |
+          set -euo pipefail
+          if [ -z "$PATTERN" ]; then
+            echo "::error::STRING_CHECK_PATTERN repository secret이 설정되지 않았습니다."
+            exit 1
+          fi
+          echo "::add-mask::$PATTERN"
+          FILES="Tests~/E2E/tests/pnpm-lock.yaml WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml sdk-runtime-generator~/pnpm-lock.yaml"
+          for f in $FILES; do
+            # rc: 0=매치(차단), 1=미매치(정상), >=2=오류(fail-closed) — string-check.yml과 동일 규약
+            if grep -qiE "$PATTERN" "$f"; then
+              echo "::error file=$f::재생성된 lockfile에서 금지 패턴 감지 (redacted)"
+              exit 1
+            elif [ "$?" -ge 2 ]; then
+              echo "::error::lockfile 스캔 실패($f, grep rc>=2). 안전을 위해 실패 처리합니다."
+              exit 1
+            fi
+            if grep -PHn "tarball: (?!https://registry\.npmjs\.org/)" "$f"; then
+              echo "::error file=$f::public registry 외 tarball URL이 있습니다"
+              exit 1
+            fi
+          done
+          echo "✓ lockfile 3개 모두 public registry만 참조 (금지 패턴 없음)"
 
       - name: Open PR if changed
         env:


### PR DESCRIPTION
## 배경 (2026-07-08~09 사고)

nightly `regen-lockfiles.yml`은 `--lockfile-only`로 재생성한 lockfile을 **검증 없이 PR 생성 → 자동 squash 머지**한다. 그 결과:

- #939(7/9 03:33 KST 자동머지)가 기록한 `enhanced-resolve@5.24.2`, `browserslist@4.28.5`, `caniuse-lite@1.0.30001803`이 **수 시간 만에 npm에서 unpublish**되어, 현재 main의 BuildConfig lockfile은 tarball 404로 **모든 신규 설치(frozen 포함)가 실패**한다.
- 서로 무관한 인기 패키지들의 신규 패치 버전이 시간 단위로 생성→삭제되는 패턴은 악성 게시를 npm이 지우는 활성 공급망 사고의 시그니처로, 무검증 자동머지는 이 창에서 악성 버전을 lockfile에 고정할 수도 있다.
- 별개로 `@toss/tds-react-native@2.0.3`은 npm 메타데이터(integrity/shasum)가 실제 서빙 tarball과 불일치한 상태(콘텐츠 변조는 아님 — 바이트 동일 확인)라, 재해석 시점에 따라 설치 불가능한 integrity가 기록될 수 있다.

## 변경 사항 (regen-lockfiles.yml 3중 게이트)

1. **frozen install 검증 게이트** — 재생성 직후 3개 디렉토리에서 `pnpm install --frozen-lockfile --ignore-scripts` 실행. 메타데이터·tarball 불일치(integrity 오염, 게시 직후 삭제 404)를 **PR 생성 전에** 실패로 차단. `--ignore-scripts`로 서드파티 postinstall 실행 벡터 제거.
2. **`minimum-release-age=4320`(3일)** — 게시 3일 미만 버전을 해석에서 제외해 "갓 게시된 악성 버전" 창을 회피. 사내 통제 스코프(`@apps-in-toss/*`, `@toss/*`, `@granite-js/*`)는 당일 릴리즈가 정상 흐름이라 제외.
3. **레지스트리/문자열 가드** — 이 워크플로우의 산출 경로는 string-check.yml의 사각지대다(bot PR은 scan skip + `scan=success` 수동 보고, `GITHUB_TOKEN` push는 push 트리거를 발화시키지 않음). 동일한 `STRING_CHECK_PATTERN` denylist로 PR 생성 전 직접 검사하고, `tarball:` URL이 `registry.npmjs.org`만 가리키는지 구조 검증(내부 레지스트리 호스트의 public 노출 + 사외 파트너 설치 파손 이중 차단).

기존 상시 스캔(string-check.yml)과의 중복을 피하기 위해 lint 워크플로우에는 손대지 않았고, string-check가 실제로 돌지 않는 bot 산출 경로만 내부 게이트로 메웠다.

## 후속

- 머지 후 `workflow_dispatch`로 즉시 재생성을 실행해 망가진 main lockfile 복구 (검증 게이트가 통과하는 조합만 머지됨)
- `@toss/tds-react-native@2.0.3` 메타데이터 불일치는 소유팀에 2.0.4 클린 게시 요청 필요 (published 버전의 integrity 필드는 수정 불가)
