### PR TITLE
수정: regen-lockfiles release-age 게이트를 CLI 플래그로 이전 — pnpm 11이 .npmrc를 무시

### DIFF
--- a/.github/workflows/regen-lockfiles.yml
+++ b/.github/workflows/regen-lockfiles.yml
@@ -23,6 +23,20 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
+    env:
+      # 공급망 격리(minimum-release-age): 게시 3일(4320분) 미만 버전을 해석에서 제외해,
+      # 게시 직후 삭제·오염되는 버전(2026-07 enhanced-resolve@5.24.2 등)을 lockfile에
+      # 스냅샷하는 사고 방지. 사내 통제 스코프는 당일 릴리즈(SDK 버전 동시 bump)가
+      # 정상 흐름이고, 격리되면 정확 핀 해석이 아예 실패하므로 제외.
+      # ⚠️ pnpm 11은 이 설정을 .npmrc에서 읽지 않는다(조용히 무시) — pnpm-workspace.yaml
+      #    또는 --config.* CLI 플래그만 유효하며, CLI가 workspace 값보다 우선 (11.6.0 실측).
+      # ⚠️ exclude 플래그는 2개 이상 반복될 때만 배열로 파싱된다 — 1개만 남기면 문자열로
+      #    파싱돼 통째로 무시되므로(11.6.0 실측) 항목을 1개로 줄이지 말 것.
+      MRA_FLAGS: >-
+        --config.minimum-release-age=4320
+        --config.minimum-release-age-exclude=@apps-in-toss/*
+        --config.minimum-release-age-exclude=@toss/*
+        --config.minimum-release-age-exclude=@granite-js/*
 
     steps:
       - name: Checkout Repository
@@ -38,18 +52,12 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Force public registry
-        # minimum-release-age(분): 게시 3일(4320분) 미만의 버전을 해석에서 제외.
-        # 갓 게시됐다가 npm이 악성으로 삭제하는 버전(2026-07 enhanced-resolve 5.24.2 등
-        # 4종이 하루 만에 unpublish)을 lockfile에 스냅샷하는 사고 방지.
-        # 사내 통제 스코프는 당일 릴리즈(SDK 버전 동시 bump)가 정상 흐름이라 제외.
+        # registry는 .npmrc에서 정상 인식된다. minimum-release-age 계열은 pnpm 11이
+        # .npmrc를 읽지 않으므로 여기 두면 안 되고, job env의 MRA_FLAGS(CLI)로 전달한다.
         run: |
           mkdir -p ~/.config/pnpm
           cat > ~/.npmrc <<'EOF'
           registry=https://registry.npmjs.org/
-          minimum-release-age=4320
-          minimum-release-age-exclude[]=@apps-in-toss/*
-          minimum-release-age-exclude[]=@toss/*
-          minimum-release-age-exclude[]=@granite-js/*
           EOF
           pnpm config set registry https://registry.npmjs.org/
 
@@ -57,19 +65,19 @@ jobs:
         working-directory: Tests~/E2E/tests
         run: |
           rm -f pnpm-lock.yaml
-          pnpm install --lockfile-only --registry=https://registry.npmjs.org/
+          pnpm install --lockfile-only --registry=https://registry.npmjs.org/ $MRA_FLAGS
 
       - name: Regenerate BuildConfig lockfile
         working-directory: WebGLTemplates/AITTemplate/BuildConfig~
         run: |
           rm -f pnpm-lock.yaml
-          pnpm install --lockfile-only --registry=https://registry.npmjs.org/
+          pnpm install --lockfile-only --registry=https://registry.npmjs.org/ $MRA_FLAGS
 
       - name: Regenerate SDK Generator lockfile
         working-directory: sdk-runtime-generator~
         run: |
           rm -f pnpm-lock.yaml
-          pnpm install --lockfile-only --registry=https://registry.npmjs.org/
+          pnpm install --lockfile-only --registry=https://registry.npmjs.org/ $MRA_FLAGS
 
       - name: Verify lockfiles (frozen install)
         # --lockfile-only는 메타데이터만 보고 기록하므로, 메타데이터와 실제 tarball이
@@ -83,7 +91,7 @@ jobs:
           set -euo pipefail
           for dir in "Tests~/E2E/tests" "WebGLTemplates/AITTemplate/BuildConfig~" "sdk-runtime-generator~"; do
             echo "::group::verify $dir"
-            (cd "$dir" && pnpm install --frozen-lockfile --ignore-scripts)
+            (cd "$dir" && pnpm install --frozen-lockfile --ignore-scripts $MRA_FLAGS)
             echo "::endgroup::"
           done
 


### PR DESCRIPTION
## 배경

#940에서 추가한 minimum-release-age 격리 게이트가 실제로는 **무력 상태**였다. pnpm 11.6.0은 `minimum-release-age`(및 `-exclude`)를 `~/.npmrc`에서 읽지 않는다 — `pnpm-workspace.yaml` 또는 `--config.*` CLI 플래그로만 유효하다.

실측 (typescript `*` 해석, 259200분=180일 설정):

| 설정 위치 | 해석 결과 | 판정 |
|---|---|---|
| (없음, control) | typescript 6.0.3 (최신) | — |
| `~/.npmrc` | typescript 6.0.3 (최신) | ❌ 무시됨 |
| `pnpm-workspace.yaml` | typescript 5.9.3 (강등) | ✅ 유효 |
| `--config.*` CLI 플래그 | typescript 5.9.3 (강등) | ✅ 유효 (workspace 값보다 우선) |

## 실제 영향

오늘 dispatch 복구 run(→ #947)이 격리 없이 재해석되면서 게시 직후 버전들(`brace-expansion@1.1.16`, `enhanced-resolve@5.24.2`, `browserslist@4.28.5`, `caniuse-lite@1.0.30001803`)을 다시 수록했다. 이 버전들은 현재 npm CDN 엣지 간 전파가 갈라져 있어 — **US 엣지(GitHub 러너)에서는 설치되지만 KR 엣지에서는 tarball 404** — frozen 검증(US)을 통과하고도 KR에서는 여전히 설치 불가한 lockfile이 main에 머지됐다.

격리(3일)가 작동했다면 안정 버전(enhanced-resolve 5.24.1, brace-expansion 1.1.15 등)이 잡혀 어느 엣지에서든 설치 가능했다.

## 변경 내용

- 격리 설정을 job 레벨 `env.MRA_FLAGS`(`--config.*` CLI 플래그)로 이전 — regen 3곳 + frozen verify 1곳에 일괄 적용
- `.npmrc` heredoc에는 정상 인식되는 `registry`만 유지
- 함정 2건을 주석에 명시:
  - pnpm 11은 이 설정을 `.npmrc`에서 조용히 무시 (workspace yaml / CLI만 유효, CLI 우선)
  - exclude 플래그는 **2개 이상 반복될 때만** 배열로 파싱됨 — 1개로 줄이면 문자열로 파싱돼 통째로 무시 (11.6.0 실측)

## 검증

- 로컬 pnpm 11.6.0(SDK 번들 pnpm)으로 위 표의 4개 케이스 + env 변수 확장(bash) + CLI-vs-workspace 우선순위 + exclude 단일/반복 파싱 차이 실측
- `ruby -ryaml` 워크플로우 YAML 유효성 확인

## 후속

머지 후 workflow_dispatch로 재생성을 트리거하면 3일 격리가 적용된 lockfile로 교체되어 KR 엣지 404 문제까지 해소된다 (별도 확인 후 진행).
