### PR TITLE
기능: 스트리밍 에셋 brotli(.br) 인코딩 — 폰트 무압축+br, 텍스처 조건부 채택

### DIFF
--- a/Editor/AITBrotliCompressor.cs
+++ b/Editor/AITBrotliCompressor.cs
@@ -1,0 +1,301 @@
+// -----------------------------------------------------------------------
+// <copyright file="AITBrotliCompressor.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Streaming asset brotli compressor (build-time)
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Debug = UnityEngine.Debug;
+
+namespace AppsInToss.Editor
+{
+    /// <summary>
+    /// 스트리밍 외부화 산출물(ait-stream-*)을 SDK 내장 Node.js(zlib.brotliCompressSync)로
+    /// 일괄 brotli 압축하는 빌드타임 유틸리티.
+    ///
+    /// Editor mono BCL에는 brotli "인코더"가 없다(디코더 가용성조차 프로파일 의존 —
+    /// AITWarmManifestEmitter가 reflection으로 참조하는 이유). 인코딩은 빌드 파이프라인이
+    /// 어차피 보장하는 내장 Node(AITNodeJSDownloader)로 위임한다. Node 미가용 시 압축을
+    /// 생략하고 원본을 유지한다(기능 저하 없음 — 번들 크기만 종전과 동일).
+    /// </summary>
+    internal static class AITBrotliCompressor
+    {
+        /// <summary>brotli 품질(0~11). 빌드타임 1회 비용이므로 최고 압축률을 쓴다.</summary>
+        private const int Quality = 11;
+
+        /// <summary>node 일괄 압축 타임아웃(ms). q11로 수십 MB를 눌러도 여유 있는 값.</summary>
+        private const int TimeoutMs = 600000;
+
+        /// <summary>
+        /// 기본 채택 임계(%). br 산출물이 원본보다 이 비율 이상 작을 때만 채택한다.
+        /// 이미 엔트로피 코딩된 포맷(PNG/JPG/LZ4 번들)의 파일럿 실측 편차(0~22%)를 근거로,
+        /// 다운로드 시 브라우저의 추가 gzip/br 협상 여지와 .br 파일 관리 비용을 상쇄할 최소선.
+        /// </summary>
+        internal const int DefaultMinGainPercent = 10;
+
+        /// <summary>파일 1건의 압축 결과. error 가 비어 있으면 성공.</summary>
+        [Serializable]
+        internal class Result
+        {
+            public int idx;
+            public long raw;
+            public long br;
+            public string error;
+
+            public bool Ok => string.IsNullOrEmpty(error) && raw > 0 && br > 0;
+        }
+
+        [Serializable]
+        private class Batch
+        {
+            public Result[] results;
+        }
+
+        /// <summary>
+        /// 압축 채택 판정: br 산출물이 원본 대비 minGainPercent 이상 작아야 true.
+        /// PNG/JPG처럼 이미 엔트로피 코딩이 끝난 포맷은 이득이 파일별로 0~수%에 그치는 경우가
+        /// 많아(2026-07 파일럿 실측 0~18.5%), 미달 파일은 br을 버리고 원본을 유지한다.
+        /// </summary>
+        internal static bool ShouldKeep(long rawBytes, long brBytes, int minGainPercent)
+        {
+            if (rawBytes <= 0 || brBytes <= 0)
+            {
+                return false;
+            }
+
+            return brBytes * 100L <= rawBytes * (100L - minGainPercent);
+        }
+
+        /// <summary>내장 Node 실행 파일을 해석한다(미설치 시 on-demand 다운로드 포함). 실패 시 false.</summary>
+        internal static bool TryResolveNode(out string nodeExe)
+        {
+            nodeExe = null;
+            try
+            {
+                string npm = AITNodeJSDownloader.FindEmbeddedNpm(autoDownload: true);
+                if (string.IsNullOrEmpty(npm))
+                {
+                    return false;
+                }
+
+                string nodeBin = Path.GetDirectoryName(npm);
+                string node = Path.Combine(nodeBin, AITPlatformHelper.IsWindows ? "node.exe" : "node");
+                if (!File.Exists(node))
+                {
+                    return false;
+                }
+
+                nodeExe = node;
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-Brotli] 내장 Node 해석 예외: {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// sources 각각에 대해 "&lt;원본&gt;.br" 사본을 같은 디렉토리에 만든다(원본은 건드리지 않음 —
+        /// 채택/원본삭제 판단은 호출부 몫). 반환: 원본 절대경로 → Result. node 미가용/일괄 실행
+        /// 실패 시 빈 딕셔너리를 반환하고, 호출부는 원본 유지 경로로 진행한다.
+        /// </summary>
+        internal static Dictionary<string, Result> Compress(IReadOnlyList<string> sources)
+        {
+            var map = new Dictionary<string, Result>();
+            if (sources == null || sources.Count == 0)
+            {
+                return map;
+            }
+
+            if (!TryResolveNode(out string node))
+            {
+                Debug.LogWarning("[AIT-Brotli] 내장 Node 미가용 — 스트리밍 에셋 brotli 압축을 건너뜁니다(원본 유지).");
+                return map;
+            }
+
+            string runner = null;
+            try
+            {
+                runner = WriteRunner();
+
+                var input = new StringBuilder();
+                input.Append("{\"quality\":").Append(Quality).Append(",\"files\":[");
+                for (int i = 0; i < sources.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        input.Append(',');
+                    }
+
+                    input.Append("{\"idx\":").Append(i)
+                         .Append(",\"src\":").Append(JsonStr(sources[i]))
+                         .Append(",\"dst\":").Append(JsonStr(sources[i] + ".br")).Append('}');
+                }
+
+                input.Append("]}");
+
+                if (!RunNode(node, runner, input.ToString(), out string stdout, out string stderr))
+                {
+                    Debug.LogWarning($"[AIT-Brotli] 일괄 압축 실행 실패 — 원본 유지: {Truncate(stderr ?? stdout)}");
+                    return map;
+                }
+
+                var batch = UnityEngine.JsonUtility.FromJson<Batch>(stdout);
+                if (batch?.results == null)
+                {
+                    Debug.LogWarning("[AIT-Brotli] 압축 결과 파싱 실패 — 원본 유지.");
+                    return map;
+                }
+
+                foreach (var r in batch.results)
+                {
+                    if (r != null && r.idx >= 0 && r.idx < sources.Count)
+                    {
+                        map[sources[r.idx]] = r;
+                    }
+                }
+
+                return map;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-Brotli] 압축 예외 — 원본 유지: {e.Message}");
+                map.Clear();
+                return map;
+            }
+            finally
+            {
+                if (runner != null)
+                {
+                    try { File.Delete(runner); } catch { /* 임시 파일 정리 실패 무시 */ }
+                }
+            }
+        }
+
+        // ─────────────────────────── 내부 구현 ───────────────────────────
+
+        // stdin 으로 {quality, files:[{idx,src,dst}]} 를 받아 각 파일을 brotli 압축해 dst 에 쓰고,
+        // stdout 으로 {results:[{idx,raw,br,error?}]} 를 돌려주는 단일 파일 러너.
+        // 외부 npm 패키지 불필요(zlib 내장) — AITFontSubsetProcessor 와 달리 설치 단계가 없다.
+        private const string RunnerJs =
+            "'use strict';\n" +
+            "const zlib=require('zlib'),fs=require('fs');\n" +
+            "let raw='';\n" +
+            "process.stdin.on('data',(d)=>{raw+=d;});\n" +
+            "process.stdin.on('end',()=>{\n" +
+            "  let req;\n" +
+            "  try{req=JSON.parse(raw);}catch(e){process.stdout.write('{\"results\":[]}');process.exit(2);return;}\n" +
+            "  const q=(req.quality|0)||11;\n" +
+            "  const out=[];\n" +
+            "  for(const f of (req.files||[])){\n" +
+            "    try{\n" +
+            "      const buf=fs.readFileSync(f.src);\n" +
+            "      const br=zlib.brotliCompressSync(buf,{params:{[zlib.constants.BROTLI_PARAM_QUALITY]:q,[zlib.constants.BROTLI_PARAM_SIZE_HINT]:buf.length}});\n" +
+            "      fs.writeFileSync(f.dst,br);\n" +
+            "      out.push({idx:f.idx,raw:buf.length,br:br.length});\n" +
+            "    }catch(e){out.push({idx:f.idx,raw:0,br:0,error:String((e&&e.message)||e)});}\n" +
+            "  }\n" +
+            "  process.stdout.write(JSON.stringify({results:out}));\n" +
+            "});\n";
+
+        private static string WriteRunner()
+        {
+            // 병렬 Editor 인스턴스 간 충돌을 피하기 위해 프로세스별 고유 파일명 사용.
+            string path = Path.Combine(Path.GetTempPath(), $"ait-brotli-runner-{Process.GetCurrentProcess().Id}.js");
+            File.WriteAllText(path, RunnerJs);
+            return path;
+        }
+
+        private static bool RunNode(string node, string runner, string stdinJson, out string stdout, out string stderr)
+        {
+            stdout = null;
+            stderr = null;
+            var psi = new ProcessStartInfo
+            {
+                FileName = node,
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                WorkingDirectory = Path.GetTempPath(),
+            };
+            psi.ArgumentList.Add(runner);
+
+            using (var p = new Process { StartInfo = psi })
+            {
+                p.Start();
+
+                // stderr 는 이벤트로 비동기 수집 — stdout ReadToEnd 중 stderr 버퍼가 차서
+                // 교착하는 고전적 데드락 방지(러너는 stderr 를 거의 안 쓰지만 방어).
+                var errSb = new StringBuilder();
+                p.ErrorDataReceived += (_, ev) => { if (ev.Data != null) { errSb.AppendLine(ev.Data); } };
+                p.BeginErrorReadLine();
+
+                p.StandardInput.Write(stdinJson);
+                p.StandardInput.Close();
+
+                stdout = p.StandardOutput.ReadToEnd();
+                if (!p.WaitForExit(TimeoutMs))
+                {
+                    try { p.Kill(); } catch { /* 이미 종료됨 */ }
+                    stderr = errSb.ToString();
+                    return false;
+                }
+
+                // WaitForExit(timeout) 성공 후 인자 없는 WaitForExit 로 비동기 스트림 플러시 보장.
+                p.WaitForExit();
+                stderr = errSb.ToString();
+                return p.ExitCode == 0;
+            }
+        }
+
+        private static string JsonStr(string s)
+        {
+            var sb = new StringBuilder(s.Length + 8);
+            sb.Append('"');
+            foreach (char c in s)
+            {
+                switch (c)
+                {
+                    case '"': sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (c < 0x20)
+                        {
+                            sb.Append("\\u").Append(((int)c).ToString("x4"));
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+
+                        break;
+                }
+            }
+
+            sb.Append('"');
+            return sb.ToString();
+        }
+
+        private static string Truncate(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return "(출력 없음)";
+            }
+
+            s = s.Trim();
+            return s.Length <= 300 ? s : s.Substring(0, 300) + "…";
+        }
+    }
+}

--- a/Editor/AITBrotliCompressor.cs.meta
+++ b/Editor/AITBrotliCompressor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8aa779ad594d47899007ffc3ba0f601e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/AITFontExternalizer.cs
+++ b/Editor/AITFontExternalizer.cs
@@ -366,10 +366,13 @@ namespace AppsInToss.Editor
 
                 // ── Phase B: 모든 번들을 먼저 빌드(소스가 전부 아직 원본 → 풀 폰트 캡처). ──
                 //    이렇게 해야 같은 소스를 공유하는 다중 대상에서 '이미 스텁된 소스'를 캡처하는 순서 위험이 없다.
+                // brotli 인코더(내장 Node) 가용 여부를 여기서 한 번 결정: 가용하면 무압축 번들 +
+                // Phase D-1 의 .br 인코딩, 미가용이면 종전 LZ4 경로(BuildFontBundle 주석 참조).
+                bool brotliAvailable = AITBrotliCompressor.TryResolveNode(out _);
                 var built = new List<PlanEntry>();
                 foreach (var p in plan)
                 {
-                    if (BuildFontBundle(p.TmpAssetPath, p.BundleFileName, bundleTempFull, streamRootFull))
+                    if (BuildFontBundle(p.TmpAssetPath, p.BundleFileName, bundleTempFull, streamRootFull, brotliAvailable))
                     {
                         built.Add(p);
                     }
@@ -401,26 +404,73 @@ namespace AppsInToss.Editor
                 }
 
                 // ── Phase D: 스텁 치환 성공 소스만 매니페스트에 채택, 실패 소스 엔트리는 번들 제거(다운로드 낭비 방지). ──
+                var adopted = new List<PlanEntry>();
+                foreach (var p in built)
+                {
+                    if (disabledSources.Contains(p.SrcFontPath))
+                    {
+                        adopted.Add(p);
+                    }
+                    else
+                    {
+                        SafeDelete(Path.Combine(streamRootFull, p.BundleFileName));
+                    }
+                }
+
+                // ── Phase D-1: 채택 번들 brotli(.br) 인코딩(Phase B 에서 무압축으로 빌드된 전제). ──
+                // 채택 시 원본을 지우고 "<guid>.bundle.br"만 남긴다(런타임 AITStreamingCodec 이
+                // 매직 스니핑으로 서버 해제/클라이언트 해제 양쪽을 처리). 압축 실패·이득 미달 시
+                // 무압축 원본 유지 — 기능은 정상이나 크기가 LZ4 시절보다 커서 경고로 가시화.
+                var brFileNames = new Dictionary<string, string>();
+                if (brotliAvailable && adopted.Count > 0)
+                {
+                    var brSources = new List<string>();
+                    foreach (var p in adopted)
+                    {
+                        brSources.Add(Path.Combine(streamRootFull, p.BundleFileName));
+                    }
+
+                    var brResults = AITBrotliCompressor.Compress(brSources);
+                    foreach (var p in adopted)
+                    {
+                        string abs = Path.Combine(streamRootFull, p.BundleFileName);
+                        if (brResults.TryGetValue(abs, out var r) && r.Ok
+                            && AITBrotliCompressor.ShouldKeep(r.raw, r.br, AITBrotliCompressor.DefaultMinGainPercent))
+                        {
+                            SafeDelete(abs);
+                            brFileNames[p.BundleFileName] = p.BundleFileName + ".br";
+                            Debug.Log($"[AIT-StreamingFont]   brotli 채택 {p.BundleFileName}: {r.raw / 1048576f:0.00}MB → {r.br / 1048576f:0.00}MB");
+                        }
+                        else
+                        {
+                            SafeDelete(abs + ".br");
+                            Debug.LogWarning($"[AIT-StreamingFont]   brotli 미채택(실패/이득 미달) — 무압축 번들 유지: {p.BundleFileName}");
+                        }
+                    }
+                }
+
                 var entries = new List<string>();
                 int n = 0;
                 long deferredBytes = 0;
-                foreach (var p in built)
+                foreach (var p in adopted)
                 {
-                    if (!disabledSources.Contains(p.SrcFontPath))
+                    string fileName;
+                    bool isBr = brFileNames.TryGetValue(p.BundleFileName, out fileName);
+                    if (!isBr)
                     {
-                        SafeDelete(Path.Combine(streamRootFull, p.BundleFileName));
-                        continue;
+                        fileName = p.BundleFileName;
                     }
 
                     string[] fontNames = CollectFontAssetNames(p.TmpAssetPath);
-                    entries.Add("{\"guid\":\"" + p.Guid + "\",\"bundle\":" + JsonStr(p.BundleFileName)
+                    entries.Add("{\"guid\":\"" + p.Guid + "\",\"bundle\":" + JsonStr(fileName)
+                                + (isBr ? ",\"encoding\":\"br\"" : string.Empty)
                                 + ",\"fonts\":[" + string.Join(",", Array.ConvertAll(fontNames, JsonStr)) + "]}");
                     n++;
                     // Phase A 에서 스텁 치환 전 캡처한 원본 크기(p.SrcBytes)를 보고. 지금 파일을 다시
                     // 재면 이미 612B 스텁이라 0.00MB 로 잘못 나온다.
                     long srcBytes = p.SrcBytes;
                     deferredBytes += srcBytes;
-                    Debug.Log($"[AIT-StreamingFont]   외부화 {Path.GetFileName(p.TmpAssetPath)} (소스 {Path.GetFileName(p.SrcFontPath)} {srcBytes / 1048576f:0.00}MB) → {p.BundleFileName}");
+                    Debug.Log($"[AIT-StreamingFont]   외부화 {Path.GetFileName(p.TmpAssetPath)} (소스 {Path.GetFileName(p.SrcFontPath)} {srcBytes / 1048576f:0.00}MB) → {fileName}");
                 }
 
                 handle.Active = n > 0;
@@ -579,7 +629,7 @@ namespace AppsInToss.Editor
         }
 
         /// <summary>지정 TMP_FontAsset 을 단일 WebGL AssetBundle 로 빌드하여 StreamingAssets 로 복사. 성공 시 true.</summary>
-        private static bool BuildFontBundle(string tmpAssetPath, string bundleFileName, string bundleTempFull, string streamRootFull)
+        private static bool BuildFontBundle(string tmpAssetPath, string bundleFileName, string bundleTempFull, string streamRootFull, bool uncompressed)
         {
             try
             {
@@ -589,14 +639,18 @@ namespace AppsInToss.Editor
                     assetNames = new[] { tmpAssetPath },
                 };
 
-                // ChunkBasedCompression(LZ4): 런타임 LoadFromMemoryAsync 가 빠름(post-boot 배경 로드라 TTFF 무관).
+                // uncompressed=true(내장 Node 가용): 후속 brotli(.br) 인코딩 전제로 무압축 빌드 —
+                //   LZ4 위에 brotli 를 겹치면 이득이 실측 ~21%에 그치지만, 무압축 폰트 바이트는
+                //   brotli 단일 계층이 훨씬 깊게 누른다. LoadFromMemoryAsync 는 무압축이 가장 빠른 경로.
+                // uncompressed=false(Node 미가용): 종전 ChunkBasedCompression(LZ4) 유지 —
+                //   무압축 원본이 .br 없이 그대로 나가는 크기 회귀를 방지.
                 // BuildTarget.WebGL: 플레이어와 동일 타깃.
                 // (DeterministicAssetBundle은 Unity 5.0+에서 항상 적용되는 기본 동작이라 명시 불필요 —
                 //  6000.3에서 obsolete-as-error로 승격되어 빌드를 깨뜨리므로 플래그에서 제거)
                 var manifest = BuildPipeline.BuildAssetBundles(
                     bundleTempFull,
                     new[] { build },
-                    BuildAssetBundleOptions.ChunkBasedCompression,
+                    uncompressed ? BuildAssetBundleOptions.UncompressedAssetBundle : BuildAssetBundleOptions.ChunkBasedCompression,
                     BuildTarget.WebGL);
 
                 if (manifest == null)

--- a/Editor/AITLargeTextureExternalizer.cs
+++ b/Editor/AITLargeTextureExternalizer.cs
@@ -242,8 +242,9 @@ namespace AppsInToss.Editor
                     }
                 }
 
-                // ─── 3단계: 외부화 실행 ─────────────────────────────────────────
-                var entries = new List<string>();
+                // ─── 3단계: 외부화 실행(스텁 치환 + 스트리밍 소스 복사) ──────────────
+                //    엔트리 문자열은 4단계의 brotli 채택 판정 후 확정하므로, 여기서는 레코드만 수집.
+                var records = new List<(string g, string streamFile, string texName, int w, int h, long size)>();
                 int n = 0;
                 long stubbedBytes = 0;
                 var detailLines = new List<string>();
@@ -285,6 +286,8 @@ namespace AppsInToss.Editor
                     {
                         // 스텁 생성 실패 → 이 텍스처는 백업 되돌리고 건너뜀.
                         RevertSingle(srcFull, metaFull, srcBak, metaBak, projectRoot);
+                        // 스트리밍 소스 복사본도 정리(매니페스트에 안 실릴 고아 파일 방지).
+                        SafeDelete(Path.Combine(projectRoot, StreamRootAssets, streamFile));
                         continue;
                     }
 
@@ -300,12 +303,57 @@ namespace AppsInToss.Editor
                         ti2.SaveAndReimport();
                     }
 
-                    entries.Add("{\"guid\":\"" + g + "\",\"name\":" + JsonStr(texName)
-                                + ",\"file\":" + JsonStr(streamFile)
-                                + ",\"width\":" + w + ",\"height\":" + h + "}");
+                    records.Add((g, streamFile, texName, w, h, size));
                     n++;
                     stubbedBytes += size;
                     detailLines.Add($"  {texName} ({w}x{h}, {size / 1048576f:0.00}MB) → {streamFile}");
+                }
+
+                // ─── 3-1단계: 스트리밍 소스 brotli(.br) 인코딩 ────────────────────────
+                //    <guid><ext> 는 아직 원본 바이트(스텁 치환은 프로젝트 내 소스에만 적용, 복사본은
+                //    복사 시점의 원본). PNG/JPG 는 이미 엔트로피 코딩돼 이득이 파일별 0~18.5%로 편차가
+                //    커서, ShouldKeep(≥10%) 채택 파일만 <guid><ext>.br 로 대체하고 원본은 제거한다.
+                //    런타임 AITStreamingCodec 이 encoding="br" 를 매직 스니핑으로 해제(서버 해제 포함).
+                var texBr = new Dictionary<string, string>(); // streamFile → streamFile+".br"
+                if (records.Count > 0 && AITBrotliCompressor.TryResolveNode(out _))
+                {
+                    var brSources = new List<string>();
+                    foreach (var rec in records)
+                    {
+                        brSources.Add(Path.Combine(projectRoot, StreamRootAssets, rec.streamFile));
+                    }
+
+                    var brResults = AITBrotliCompressor.Compress(brSources);
+                    foreach (var rec in records)
+                    {
+                        string abs = Path.Combine(projectRoot, StreamRootAssets, rec.streamFile);
+                        if (brResults.TryGetValue(abs, out var r) && r.Ok
+                            && AITBrotliCompressor.ShouldKeep(r.raw, r.br, AITBrotliCompressor.DefaultMinGainPercent))
+                        {
+                            SafeDelete(abs);            // 원본 제거 — .br 만 스트리밍.
+                            SafeDelete(abs + ".meta");  // Refresh 전이라 대개 없음(방어적).
+                            texBr[rec.streamFile] = rec.streamFile + ".br";
+                        }
+                        else
+                        {
+                            SafeDelete(abs + ".br");    // 이득 미달/실패 → 무압축 원본 유지.
+                        }
+                    }
+                }
+
+                var entries = new List<string>();
+                foreach (var rec in records)
+                {
+                    bool isBr = texBr.TryGetValue(rec.streamFile, out string fileName);
+                    if (!isBr)
+                    {
+                        fileName = rec.streamFile;
+                    }
+
+                    entries.Add("{\"guid\":\"" + rec.g + "\",\"name\":" + JsonStr(rec.texName)
+                                + ",\"file\":" + JsonStr(fileName)
+                                + (isBr ? ",\"encoding\":\"br\"" : string.Empty)
+                                + ",\"width\":" + rec.w + ",\"height\":" + rec.h + "}");
                 }
 
                 // ─── 4단계: 매니페스트 동봉 ─────────────────────────────────────
@@ -774,5 +822,21 @@ namespace AppsInToss.Editor
 
         private static string JsonStr(string s)
             => "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+
+        // 존재하지 않는 경로에 대해 조용히 no-op(brotli 채택/폐기 정리용).
+        private static void SafeDelete(string full)
+        {
+            try
+            {
+                if (File.Exists(full))
+                {
+                    File.Delete(full);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[AIT-StreamingTexture] 파일 삭제 실패(무시): {full} — {e.Message}");
+            }
+        }
     }
 }

--- a/Runtime/Helpers/AIT.StreamingCodec.cs
+++ b/Runtime/Helpers/AIT.StreamingCodec.cs
@@ -1,0 +1,150 @@
+// -----------------------------------------------------------------------
+// <copyright file="AIT.StreamingCodec.cs" company="Toss">
+//     Copyright (c) Toss. All rights reserved.
+//     Apps in Toss Unity SDK - Streaming payload codec (brotli)
+// </copyright>
+// -----------------------------------------------------------------------
+//
+// 스트리밍 에셋(ait-stream-*)의 brotli(.br) 페이로드를 런타임에서 판별/해제한다.
+//
+// 서빙 경로가 둘로 갈린다:
+//   1) 서버/CDN이 .br 파일에 Content-Encoding: br 을 붙이면 브라우저(fetch)가 투명 해제
+//      → UnityWebRequest 가 받은 바이트는 이미 원본 포맷(PNG/JPG/UnityFS). 로컬 vite
+//      dev/preview 는 unityWebContentEncodingPlugin 이 모든 *.br 에 이 헤더를 붙인다.
+//   2) 헤더가 없으면 raw brotli 바이트가 그대로 도착 → 여기서 명시적으로 해제.
+// 프로덕션 CDN이 ait-stream-* 경로의 .br 에 헤더를 줄지는 배포 인프라 의존이라 단정할 수
+// 없으므로, 매직 바이트 스니핑으로 두 경우를 판별해 필요할 때만 해제한다(brotli 는 포맷
+// 자체에 매직 바이트가 없어 "이미 기대 포맷인지"를 기준으로 역판별한다).
+//
+// BrotliStream 은 .NET Standard 2.1 프로파일에만 존재한다. .NET Framework(4.x) API 레벨
+// 프로젝트에서는 컴파일이 불가하므로 조건부 컴파일로 분리하고, 미지원 프로파일에서는 해제
+// 없이 원본을 반환한다(그 경우 서버 Content-Encoding 경로(1)가 유일한 성공 경로 — 경고로
+// 가시화). 해제는 메인 스레드에서 일어나지만 스트리밍 재수화는 첫 프레임(TTFF) 이후의
+// 배경 작업이라 부팅 임계 경로에 끼지 않는다.
+
+using System;
+using UnityEngine;
+#if NET_STANDARD_2_1 || NET_STANDARD
+using System.IO;
+using System.IO.Compression;
+#endif
+
+namespace AppsInToss
+{
+    /// <summary>
+    /// ait-stream-* 페이로드의 brotli 인코딩 판별/해제 유틸(순수 로직 — EditMode 테스트 가능).
+    /// 매니페스트 entry 의 encoding 필드("br")와 짝을 이루는 런타임 소비자.
+    /// </summary>
+    internal static class AITStreamingCodec
+    {
+        /// <summary>manifest entry.encoding 의 brotli 값(빌드타임 AITBrotliCompressor 채택 시 기록).</summary>
+        internal const string EncodingBrotli = "br";
+
+        /// <summary>
+        /// 현재 컴파일 프로파일에서 raw brotli 클라이언트 해제(BrotliStream)가 가능한지.
+        /// 이 어셈블리(런타임)가 어떤 API 레벨로 컴파일됐는지에 따라 결정된다 — Editor 테스트
+        /// 어셈블리의 자체 define(NET_4_6)과 무관하므로, 테스트는 자신의 #if 가 아니라 이 값을
+        /// 조회해 기대치를 분기해야 한다(그러지 않으면 프로파일 불일치로 오검출).
+        /// </summary>
+        internal static bool CanDecompressBrotli =>
+#if NET_STANDARD_2_1 || NET_STANDARD
+            true;
+#else
+            false;
+#endif
+
+        internal static bool LooksLikePng(byte[] d)
+        {
+            return d != null && d.Length >= 4 && d[0] == 0x89 && d[1] == 0x50 && d[2] == 0x4E && d[3] == 0x47;
+        }
+
+        internal static bool LooksLikeJpg(byte[] d)
+        {
+            return d != null && d.Length >= 3 && d[0] == 0xFF && d[1] == 0xD8 && d[2] == 0xFF;
+        }
+
+        /// <summary>Texture2D.LoadImage 가 처리 가능한 포맷(PNG/JPG)인지.</summary>
+        internal static bool LooksLikeImage(byte[] d)
+        {
+            return LooksLikePng(d) || LooksLikeJpg(d);
+        }
+
+        /// <summary>UnityFS(AssetBundle) 시그니처("UnityFS\0")인지.</summary>
+        internal static bool LooksLikeUnityFs(byte[] d)
+        {
+            return d != null && d.Length >= 8
+                && d[0] == (byte)'U' && d[1] == (byte)'n' && d[2] == (byte)'i' && d[3] == (byte)'t'
+                && d[4] == (byte)'y' && d[5] == (byte)'F' && d[6] == (byte)'S' && d[7] == 0x00;
+        }
+
+        /// <summary>
+        /// encoding=="br" 페이로드를 소비 가능한 원본 포맷으로 정규화한다.
+        /// 이미 기대 포맷이면(서버가 Content-Encoding 으로 해제) 그대로, raw brotli 면 해제해서
+        /// 반환한다. 해제 불가/실패 시 원본을 그대로 돌려주고 경고를 남긴다(호출부의 기존
+        /// 실패 처리에 자연 합류).
+        /// </summary>
+        internal static byte[] DecodePayload(string encoding, byte[] data, Func<byte[], bool> looksDecoded, string label)
+        {
+            if (data == null || encoding != EncodingBrotli)
+            {
+                return data;
+            }
+
+            if (looksDecoded != null && looksDecoded(data))
+            {
+                return data; // 경로 1: 서버가 이미 해제
+            }
+
+            if (TryBrotliDecompress(data, out byte[] decoded) && (looksDecoded == null || looksDecoded(decoded)))
+            {
+                return decoded; // 경로 2: 클라이언트 해제
+            }
+
+            Debug.LogWarning($"[AIT-Streaming] brotli 해제 실패 — 수신 바이트를 그대로 사용합니다: {label}");
+            return data;
+        }
+
+        /// <summary>
+        /// brotli 해제 시도. 미지원 프로파일(.NET Framework API 레벨)이거나 유효한 brotli
+        /// 스트림이 아니면 false.
+        /// </summary>
+        internal static bool TryBrotliDecompress(byte[] src, out byte[] result)
+        {
+            result = null;
+            if (src == null || src.Length == 0)
+            {
+                return false;
+            }
+
+#if NET_STANDARD_2_1 || NET_STANDARD
+            try
+            {
+                using (var input = new MemoryStream(src, false))
+                using (var brotli = new BrotliStream(input, CompressionMode.Decompress))
+                using (var output = new MemoryStream(src.Length * 3))
+                {
+                    brotli.CopyTo(output);
+                    if (output.Length == 0)
+                    {
+                        return false;
+                    }
+
+                    result = output.ToArray();
+                    return true;
+                }
+            }
+            catch
+            {
+                // 유효한 brotli 스트림이 아님(예: 서버가 이미 해제했지만 매직 스니핑이 못 알아본
+                // 비정형 페이로드) — 호출부가 원본으로 진행하도록 false.
+                result = null;
+                return false;
+            }
+#else
+            // .NET Framework(4.x) API 레벨: BrotliStream 부재 — 클라이언트 해제 불가.
+            // 서버 Content-Encoding 경로만 유효하며, DecodePayload 가 경고로 가시화한다.
+            return false;
+#endif
+        }
+    }
+}

--- a/Runtime/Helpers/AIT.StreamingCodec.cs.meta
+++ b/Runtime/Helpers/AIT.StreamingCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c977d790fba4f0c9803659cddda3b16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Helpers/AIT.StreamingFont.cs
+++ b/Runtime/Helpers/AIT.StreamingFont.cs
@@ -63,6 +63,9 @@ namespace AppsInToss
             public string guid;
             public string bundle;
             public string[] fonts;
+
+            /// <summary>페이로드 인코딩("br" = brotli). 빈 값이면 무압축(구 매니페스트 호환).</summary>
+            public string encoding;
         }
 
         [Serializable]
@@ -217,6 +220,10 @@ namespace AppsInToss
 
                 data = req.downloadHandler.data;
             }
+
+            // .br 외부화 페이로드 정규화: 서버가 Content-Encoding 으로 이미 해제했으면 그대로,
+            // raw brotli 면 여기서 해제(UnityFS 매직으로 판별). 무압축 엔트리는 no-op.
+            data = AITStreamingCodec.DecodePayload(e.encoding, data, AITStreamingCodec.LooksLikeUnityFs, e.bundle);
 
             // stripping High 가 잘라낸 GetAssetBundle/DownloadHandlerAssetBundle 대신
             // DownloadHandlerBuffer 로 받은 바이트를 LoadFromMemoryAsync 로 적재(가상 FS 캐시 비의존).

--- a/Runtime/Helpers/AIT.StreamingTexture.cs
+++ b/Runtime/Helpers/AIT.StreamingTexture.cs
@@ -61,6 +61,9 @@ namespace AppsInToss
             public string file;
             public int width;
             public int height;
+
+            /// <summary>페이로드 인코딩("br" = brotli). 빈 값이면 무압축(구 매니페스트 호환).</summary>
+            public string encoding;
         }
 
         [System.Serializable]
@@ -246,9 +249,14 @@ namespace AppsInToss
                 bool applied = false;
                 try
                 {
+                    // .br 외부화 페이로드 정규화: 서버가 Content-Encoding 으로 이미 해제했으면
+                    // 그대로, raw brotli 면 여기서 해제(PNG/JPG 매직으로 판별). 무압축 엔트리는 no-op.
+                    byte[] payload = AITStreamingCodec.DecodePayload(
+                        e.encoding, req.downloadHandler.data, AITStreamingCodec.LooksLikeImage, e.name);
+
                     // 동일 차원 스텁(readable+uncompressed)에 실 픽셀을 in-place 업로드.
                     // LoadImage 는 PNG/JPG 디코드 후 GPU 업로드까지 수행 → 참조하는 Sprite/Material 자동 갱신.
-                    applied = tex.LoadImage(req.downloadHandler.data, false);
+                    applied = tex.LoadImage(payload, false);
                     if (applied && (tex.width != e.width || tex.height != e.height))
                     {
                         // 스텁 차원과 원본 차원 불일치(예: crunch maxTextureSize 캡 + D1 동시 사용).

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITStreamingCodecTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITStreamingCodecTests.cs
@@ -1,0 +1,196 @@
+// -----------------------------------------------------------------------
+// AITStreamingCodecTests.cs - 스트리밍 페이로드 brotli 코덱(AITStreamingCodec) 순수 로직 검증
+// Level 0: ait-stream-* 의 .br 페이로드를 런타임에서 판별/해제하는 결정 로직 회귀 테스트.
+//   - LooksLikePng/Jpg/Image/UnityFs : 매직 바이트 스니퍼(서버 해제 여부 역판별의 근거 — 오판 시
+//                                       raw brotli 를 원본으로 오인해 디코드 파손)
+//   - TryBrotliDecompress            : raw brotli 해제(프로파일 분기 — NET_STANDARD 만 가능)
+//   - DecodePayload                  : 라우팅(비br passthrough / 서버-해제 passthrough / 클라 해제 / 실패 폴백)
+//   - AITBrotliCompressor.ShouldKeep : 빌드타임 채택 임계(%) 판정
+// 실제 네트워크 GET 은 브라우저(WebGL) 경로라 EditMode 로는 검증 불가 — E2E 가 부팅/스트리밍 재수화를
+// 커버하고, 본 테스트는 그 외 순수 결정 로직을 결정론적으로 고정한다.
+//
+// 픽스처(payloadB64/brB64)는 node zlib.brotliCompressSync(q11) 로 생성했고, br 은 payload 로
+// 정확히 라운드트립함을 사전 검증했다(브라우저/BCL BrotliStream 모두 동일 스트림 포맷).
+// -----------------------------------------------------------------------
+
+using System;
+using NUnit.Framework;
+using AppsInToss;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class AITStreamingCodecTests
+{
+    // "AIT streaming codec brotli fixture payload 0123456789 0123456789 0123456789" (75B)
+    private const string PayloadB64 =
+        "QUlUIHN0cmVhbWluZyBjb2RlYyBicm90bGkgZml4dHVyZSBwYXlsb2FkIDAxMjM0NTY3ODkgMDEyMzQ1Njc4OSAwMTIzNDU2Nzg5";
+
+    // 위 payload 를 brotli(q11) 압축한 바이트(64B).
+    private const string BrB64 =
+        "G0oA+I3UWi04bTK3UaoXos8bTfFBYSAoY4JWElULUopEROkARuBmKBbxZWDqaLxlESY9uTxw6g8ZKG2s8yGmDA==";
+
+    private static byte[] Payload => Convert.FromBase64String(PayloadB64);
+
+    private static byte[] Br => Convert.FromBase64String(BrB64);
+
+    // =====================================================
+    // 매직 스니퍼 — 서버가 이미 해제했는지 역판별하는 기준
+    // =====================================================
+
+    [Test]
+    public void LooksLikePng_TrueOnlyForPngSignature()
+    {
+        Assert.IsTrue(AITStreamingCodec.LooksLikePng(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A }));
+        Assert.IsFalse(AITStreamingCodec.LooksLikePng(new byte[] { 0xFF, 0xD8, 0xFF }));       // JPG
+        Assert.IsFalse(AITStreamingCodec.LooksLikePng(new byte[] { 0x89, 0x50 }));             // 너무 짧음
+        Assert.IsFalse(AITStreamingCodec.LooksLikePng(null));
+    }
+
+    [Test]
+    public void LooksLikeJpg_TrueOnlyForJpgSignature()
+    {
+        Assert.IsTrue(AITStreamingCodec.LooksLikeJpg(new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }));
+        Assert.IsFalse(AITStreamingCodec.LooksLikeJpg(new byte[] { 0x89, 0x50, 0x4E, 0x47 })); // PNG
+        Assert.IsFalse(AITStreamingCodec.LooksLikeJpg(new byte[] { 0xFF, 0xD8 }));             // 너무 짧음
+        Assert.IsFalse(AITStreamingCodec.LooksLikeJpg(null));
+    }
+
+    [Test]
+    public void LooksLikeImage_TruePngOrJpg_FalseOtherwise()
+    {
+        Assert.IsTrue(AITStreamingCodec.LooksLikeImage(new byte[] { 0x89, 0x50, 0x4E, 0x47 }));
+        Assert.IsTrue(AITStreamingCodec.LooksLikeImage(new byte[] { 0xFF, 0xD8, 0xFF }));
+        Assert.IsFalse(AITStreamingCodec.LooksLikeImage(Br));      // raw brotli(0x1B 0x4A…)
+        Assert.IsFalse(AITStreamingCodec.LooksLikeImage(Payload)); // 텍스트("AIT…")
+    }
+
+    [Test]
+    public void LooksLikeUnityFs_TrueOnlyForUnityFsSignature()
+    {
+        byte[] unityFs = { (byte)'U', (byte)'n', (byte)'i', (byte)'t', (byte)'y', (byte)'F', (byte)'S', 0x00 };
+        Assert.IsTrue(AITStreamingCodec.LooksLikeUnityFs(unityFs));
+
+        byte[] noNul = { (byte)'U', (byte)'n', (byte)'i', (byte)'t', (byte)'y', (byte)'F', (byte)'S', 0x01 };
+        Assert.IsFalse(AITStreamingCodec.LooksLikeUnityFs(noNul)); // 종결 NUL 아님
+        Assert.IsFalse(AITStreamingCodec.LooksLikeUnityFs(Br));
+        Assert.IsFalse(AITStreamingCodec.LooksLikeUnityFs(null));
+    }
+
+    // =====================================================
+    // TryBrotliDecompress — raw brotli 해제(프로파일 분기)
+    //   Editor 테스트 어셈블리는 NET_4_6 로 컴파일되지만, 호출 대상 AITStreamingCodec 은
+    //   런타임(Helpers) 어셈블리라 별도 프로파일(NET_STANDARD)로 컴파일된다. 따라서 기대치는
+    //   테스트의 #if 가 아니라 런타임의 CanDecompressBrotli 로 분기해야 한다.
+    // =====================================================
+
+    [Test]
+    public void TryBrotliDecompress_NullOrEmpty_ReturnsFalse()
+    {
+        // #if 이전의 이른 반환이라 프로파일 무관하게 항상 false.
+        Assert.IsFalse(AITStreamingCodec.TryBrotliDecompress(null, out _));
+        Assert.IsFalse(AITStreamingCodec.TryBrotliDecompress(Array.Empty<byte>(), out _));
+    }
+
+    [Test]
+    public void TryBrotliDecompress_ValidStream_MatchesProfileCapability()
+    {
+        bool ok = AITStreamingCodec.TryBrotliDecompress(Br, out byte[] decoded);
+        if (AITStreamingCodec.CanDecompressBrotli)
+        {
+            Assert.IsTrue(ok, "해제 가능 프로파일은 유효 brotli 를 true 로 해제해야 한다");
+            Assert.AreEqual(Payload, decoded, "해제 결과가 원본 payload 와 바이트 단위로 일치해야 한다");
+        }
+        else
+        {
+            // BrotliStream 부재 프로파일: 항상 false(서버 Content-Encoding 경로만 유효).
+            Assert.IsFalse(ok, "해제 불가 프로파일은 false 여야 한다");
+        }
+    }
+
+    // =====================================================
+    // DecodePayload — 라우팅 4분기
+    // =====================================================
+
+    [Test]
+    public void DecodePayload_NonBrEncoding_ReturnsInputUnchanged()
+    {
+        byte[] data = Payload;
+        // 무압축 엔트리(encoding=="" 또는 null)는 어떤 경우에도 원본 그대로.
+        Assert.AreSame(data, AITStreamingCodec.DecodePayload("", data, AITStreamingCodec.LooksLikeImage, "t"));
+        Assert.AreSame(data, AITStreamingCodec.DecodePayload(null, data, AITStreamingCodec.LooksLikeImage, "t"));
+    }
+
+    [Test]
+    public void DecodePayload_NullData_ReturnsNull()
+    {
+        Assert.IsNull(AITStreamingCodec.DecodePayload("br", null, AITStreamingCodec.LooksLikeImage, "t"));
+    }
+
+    [Test]
+    public void DecodePayload_ServerAlreadyDecoded_ReturnsInputUnchanged()
+    {
+        // 경로 1: 서버가 Content-Encoding: br 로 이미 해제 → 수신 바이트가 이미 기대 포맷(PNG).
+        // 매직이 통과하므로 brotli 해제를 시도하지 않고 그대로 반환.
+        byte[] png = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        Assert.AreSame(png, AITStreamingCodec.DecodePayload("br", png, AITStreamingCodec.LooksLikeImage, "t"));
+    }
+
+    [Test]
+    public void DecodePayload_RawBrotli_MatchesProfileCapability()
+    {
+        // 경로 2: 서버 헤더 없이 raw brotli 도착. looksDecoded==null 로 포맷 검증을 생략하고 해제만 검증.
+        byte[] input = Br;
+        byte[] result = AITStreamingCodec.DecodePayload("br", input, null, "t");
+        if (AITStreamingCodec.CanDecompressBrotli)
+        {
+            Assert.AreEqual(Payload, result, "raw brotli 는 해제되어 원본 payload 를 반환해야 한다");
+        }
+        else
+        {
+            // 해제 불가 프로파일: 원본(br) 그대로 반환(경고는 warning 이라 테스트를 실패시키지 않음).
+            Assert.AreSame(input, result, "해제 불가 프로파일은 수신 br 바이트를 그대로 반환해야 한다");
+        }
+    }
+
+    [Test]
+    public void DecodePayload_DecodedButUnrecognized_FallsBackToOriginal()
+    {
+        // 안전망: 해제가 성공하더라도 결과가 기대 포맷(매직)을 만족하지 못하면 원본으로 폴백.
+        // looksDecoded 를 항상 false 로 주어, 해제 성공/실패와 무관하게 폴백 계약을 결정론적으로 고정.
+        byte[] input = Br;
+        byte[] result = AITStreamingCodec.DecodePayload("br", input, _ => false, "t");
+        Assert.AreSame(input, result, "해제 결과가 기대 포맷을 만족하지 못하면 원본 바이트로 폴백해야 한다");
+    }
+
+    // =====================================================
+    // AITBrotliCompressor.ShouldKeep — 빌드타임 채택 임계(%)
+    // =====================================================
+
+    [Test]
+    public void ShouldKeep_TrueOnlyWhenGainMeetsThreshold()
+    {
+        // 정확히 10% 이득(100→90): 임계 이상 → 채택.
+        Assert.IsTrue(AITBrotliCompressor.ShouldKeep(100, 90, 10));
+        // 10% 초과(100→80): 채택.
+        Assert.IsTrue(AITBrotliCompressor.ShouldKeep(100, 80, 10));
+        // 10% 미만(100→91): 미달 → 폐기.
+        Assert.IsFalse(AITBrotliCompressor.ShouldKeep(100, 91, 10));
+        // 오히려 커짐(100→105): 폐기.
+        Assert.IsFalse(AITBrotliCompressor.ShouldKeep(100, 105, 10));
+    }
+
+    [Test]
+    public void ShouldKeep_NonPositiveInputs_ReturnFalse()
+    {
+        Assert.IsFalse(AITBrotliCompressor.ShouldKeep(0, 0, 10));
+        Assert.IsFalse(AITBrotliCompressor.ShouldKeep(100, 0, 10));
+        Assert.IsFalse(AITBrotliCompressor.ShouldKeep(0, 50, 10));
+        Assert.IsFalse(AITBrotliCompressor.ShouldKeep(-1, 50, 10));
+    }
+
+    [Test]
+    public void DefaultMinGainPercent_IsTenPercent()
+    {
+        Assert.AreEqual(10, AITBrotliCompressor.DefaultMinGainPercent);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITStreamingCodecTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITStreamingCodecTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b050d2d329c24c8eb5e48bf3aa496918
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경

perf 채널 빌드에서 번들 크기가 크게 증가하는 문제가 관찰됐다. 원인은 스트리밍 외부화 에셋(`ait-stream-{texture,audio,font}`)이 Unity `Build/*.data`의 brotli 압축 경로를 우회하고, 각자 비대한 wire 포맷(텍스처 PNG, 폰트 LZ4 AssetBundle 등)으로 재물질화되면서 `.ait` ZIP 컨테이너의 압축률(2~9%)로는 상쇄되지 않기 때문이다.

이 PR은 그중 **스트리밍 에셋 brotli(.br) 인코딩**을 도입해 폰트/텍스처 스트림의 전송 크기를 줄인다.

## 설계

**빌드타임** (`Editor/AITBrotliCompressor`)
- SDK 내장 Node(`AITNodeJSDownloader`)의 `zlib.brotliCompressSync`(q11)로 외부화 산출물을 일괄 압축한다. Editor mono BCL에는 brotli **인코더**가 없어 빌드 파이프라인이 이미 보장하는 내장 Node로 위임한다.
- `ShouldKeep(raw, br, minGain)`: br 산출물이 원본 대비 기본 10% 이상 작을 때만 채택. PNG/JPG처럼 이미 엔트로피 코딩된 포맷은 이득 편차가 커서, 미달 파일은 `.br`을 버리고 원본을 유지한다.
- **Node 미가용 시** 압축을 건너뛰고 원본을 유지한다(기능 저하 없음 — 종전 크기).

**런타임** (`Runtime/Helpers/AIT.StreamingCodec`)
- 매니페스트 `entry.encoding == "br"`을 소비. 서빙 경로가 둘로 갈린다:
  1. 서버/CDN이 `.br`에 `Content-Encoding: br`을 붙이면 브라우저가 투명 해제 → 수신 바이트가 이미 원본 포맷.
  2. 헤더가 없으면 raw brotli가 그대로 도착 → `BrotliStream`으로 명시적 해제.
- brotli는 매직 바이트가 없으므로, **기대 포맷(PNG/JPG/UnityFS) 매직 스니핑으로 두 경우를 역판별**해 필요할 때만 해제한다. 프로덕션 CDN의 `.br` 헤더 처리 여부와 무관하게 동작한다.
- `BrotliStream`은 .NET Standard 2.1 프로파일 전용이라 조건부 컴파일로 분리. 미지원 프로파일에서는 해제 없이 원본 반환(서버 헤더 경로만 유효, 경고로 가시화).

**포맷별 적용**
- **폰트**: 무압축 AssetBundle로 빌드 후 br(LZ4 위에 br을 겹치는 것보다 무압축 바이트를 단일 계층 br로 더 깊게 누른다). `LoadFromMemoryAsync`도 무압축이 가장 빠른 경로.
- **텍스처**: 스트림 소스(PNG)를 br 압축해 이득 ≥10%인 파일만 `.br`로 대체, 미달 시 원본 유지.

## 테스트

- **EditMode 14건 추가** (`AITStreamingCodecTests`): 매직 스니퍼, `TryBrotliDecompress`(프로파일 능력 분기), `DecodePayload` 라우팅 4분기(비br passthrough / 서버-해제 passthrough / 클라 해제 / 미인식 폴백), `ShouldKeep` 채택 임계. 픽스처는 node q11로 생성 후 라운드트립 사전 검증.
- 로컬 Unity 2022.3 EditMode 전체 **1152 passed / 0 failed** (기존 Windows 전용 1건 inconclusive는 macOS 무관).
- `./run-local-tests.sh --validate` 통과(파일 구조·SDK 유닛 18/18·Meta GUID 위생).

> 테스트 어셈블리는 Editor 프로파일(`NET_4_6`)로, 런타임 Helpers는 `NET_STANDARD_2_1`로 컴파일되므로, 테스트는 자체 `#if`가 아니라 런타임의 `CanDecompressBrotli`를 조회해 기대치를 분기한다(프로파일 불일치 오검출 방지).

## 무회귀 보장

Node 미가용, brotli 이득 미달, 미지원 .NET 프로파일 — 어느 경우든 원본 유지 또는 서버 헤더 경로로 폴백해 기능은 정상 동작하며, 크기만 종전과 같아진다.
