### PR TITLE
수정: pnpm 쿨다운 예외에 @toss/*·@granite-js/* 추가 (regen과 정합화)

### DIFF
--- a/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
@@ -1,14 +1,18 @@
-# 공급망 보호(minimumReleaseAge)에서 @apps-in-toss/* 패키지를 예외 처리한다.
+# 공급망 보호(minimumReleaseAge)에서 자사 1st-party 스코프를 예외 처리한다.
 #
 # pnpm은 갓 publish된 버전을 일정 시간(minimumReleaseAge)만큼 격리해 공급망 공격을 완화한다.
-# pnpm v11부터 이 값의 기본이 1440분(1일)이라, SDK가 막 배포한 @apps-in-toss/* 패키지가
-# quarantine에 걸려 미니앱 빌드가 지연될 수 있다. 우리 패키지는 신뢰 대상이므로 예외 처리해
-# 유저(게임 개발자)가 불편을 겪지 않게 한다.
+# pnpm v11부터 이 값의 기본이 1440분(1일)이라, 토스 조직이 막 배포한 패키지가 quarantine에 걸려
+# 미니앱 빌드가 지연될 수 있다. 아래 세 스코프는 모두 동일 토스 조직이 퍼블리시하는 신뢰 대상이므로
+# 예외 처리해 유저(게임 개발자)가 불편을 겪지 않게 한다. 쿨다운은 하이재킹된 '서드파티' 패키지를
+# 격리하려는 장치라 1st-party 스코프 제외는 보안 이득이 미미하고 릴리스마다 빌드만 깨진다.
+# (granite/framework 빌드 툴체인은 @granite-js/*·@toss/* 전이 의존을 대거 끌어온다.)
 #
 # 주의: pnpm은 이 설정을 pnpm-workspace.yaml에서만 읽는다 (.npmrc / package.json#pnpm 불가).
 # 이 파일은 미니앱 빌드 디렉토리로 복사되며, 사용자 프로젝트에 동명 파일이 있으면 그쪽이 우선한다.
 minimumReleaseAgeExclude:
   - '@apps-in-toss/*'
+  - '@toss/*'
+  - '@granite-js/*'
 
 # transitive 의존성 보안/호환 고정.
 # pnpm v11부터 package.json의 "pnpm" 필드(overrides 등)를 더 이상 읽지 않으므로

--- a/sdk-runtime-generator~/pnpm-workspace.yaml
+++ b/sdk-runtime-generator~/pnpm-workspace.yaml
@@ -3,12 +3,19 @@
 # 읽으므로, 기존 package.json#pnpm.overrides를 이곳으로 이전했다.
 # (pnpm은 minimumReleaseAge*/overrides 설정을 pnpm-workspace.yaml에서만 읽는다.)
 
-# 공급망 보호(minimumReleaseAge)에서 @apps-in-toss/* 패키지를 예외 처리한다.
-# pnpm v11부터 minimumReleaseAge 기본이 1440분(1일)이라, SDK가 막 배포한 @apps-in-toss/*
-# 패키지가 quarantine에 걸려 SDK 재생성/빌드가 지연될 수 있다. 자사 패키지는 신뢰 대상이므로
-# 예외 처리해 유저(게임 개발자)가 불편을 겪지 않게 한다.
+# 공급망 보호(minimumReleaseAge)에서 자사 1st-party 스코프를 예외 처리한다.
+# pnpm v11부터 minimumReleaseAge 기본이 1440분(1일)이라, 토스 조직이 막 배포한 패키지가
+# quarantine에 걸려 SDK 재생성/빌드가 지연될 수 있다. 아래 세 스코프는 모두 동일 토스 조직이
+# 퍼블리시하는 신뢰 대상이므로 예외 처리해 유저(게임 개발자)가 불편을 겪지 않게 한다.
+# 쿨다운은 하이재킹된 '서드파티' 패키지를 격리 기간 동안 걸러내려는 장치라, 1st-party 스코프는
+# 제외해도 보안 이득이 미미하고 프레임워크 릴리스마다 CI만 깨진다.
+# 주의: regen-lockfiles.yml은 CLI 플래그로 이미 세 스코프를 제외한다. 이 파일도 동일하게 맞춰
+#       validate/changelog 잡의 install(이 workspace를 읽음)과 lockfile 재생성 정책을 정합화한다.
+#       (예: @toss/tds-react-native 가 granite/framework 전이 의존으로 딸려오므로 @toss/* 필요.)
 minimumReleaseAgeExclude:
   - '@apps-in-toss/*'
+  - '@toss/*'
+  - '@granite-js/*'
 
 # transitive 의존성 보안/호환 고정 (구 package.json#pnpm.overrides에서 이전).
 overrides:


### PR DESCRIPTION
## 요약

두 `pnpm-workspace.yaml`의 공급망 쿨다운 예외 목록(`minimumReleaseAgeExclude`)을 `regen-lockfiles.yml`과 정합화한다. `@apps-in-toss/*`만 있던 예외에 **`@toss/*`, `@granite-js/*`** 를 추가한다.

## 배경 — 왜 CI가 깨졌나

`main`(커밋 `a139cde`) 이후 `SDK Generator Unit Tests`·`Update API Changelog Report` 잡이 install 단계에서 실패했다:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
@toss/tds-react-native@2.0.4 was published at 2026-07-09T12:25:08.986Z,
within the minimumReleaseAge cutoff
```

원인은 **설정 불일치**였다:

| 위치 | 예외 스코프 |
|---|---|
| `regen-lockfiles.yml` (CLI flag) | `@apps-in-toss/*` · **`@toss/*`** · **`@granite-js/*`** |
| `sdk-runtime-generator~/pnpm-workspace.yaml` | `@apps-in-toss/*` 만 |
| `WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml` | `@apps-in-toss/*` 만 |

`validate.yml`·changelog 잡은 `sdk-runtime-generator~`에서 `pnpm install --no-frozen-lockfile`을 돌리며 **workspace 파일**을 읽는다. `@toss/*`가 예외에 없어, 토스 조직이 방금 배포한 `@toss/tds-react-native@2.0.4`가 쿨다운(기본 1440분)에 걸려 거부됐다. 반면 regen은 CLI로 이미 세 스코프를 신뢰하므로 lockfile 자체는 정상 생성 → **workspace 파일만 갱신이 누락된 정책 drift**(#950 도입 시 반영 누락).

## `@toss/tds-react-native`는 왜 트리에 있나 (제거 불가)

직접 의존이 아니라 **깊은 전이/peer 의존**이다:

```
@apps-in-toss/unity-sdk-generator (로컬 생성기)
  └─ @apps-in-toss/web-framework   ← 직접 핀 (+ changelog용 1.5.0~2.10.4 별칭 64종)
        └─ @granite-js/react-native
              └─ @toss/tds-react-native@2.0.4  ← peer로 딸려옴
```

토스 미니앱 프레임워크(granite)가 본질적으로 React Native 기반이라 RN 그래프 전체(`react-native`, `@granite-js/react-native`, `lottie-react-native`, `@toss/tds-react-native` …)가 프레임워크의 자체 런타임으로 딸려온다. 우리는 RN 패키지를 **하나도 직접 선언하지 않는다.** 상위가 요구하는 hard 전이 의존이라 pnpm으로 임의 제거하면 lockfile 검증이 깨지므로, "RN 의존성 배제"는 프레임워크(=SDK 생성 소스)를 버리지 않는 한 불가능하다.

## 이 변경이 옳은 이유

- 쿨다운(`minimumReleaseAge`)은 **하이재킹된 서드파티** 패키지를 격리 기간 동안 걸러내려는 장치다. `@toss` / `@apps-in-toss` / `@granite-js`는 전부 **동일 토스 조직**이 퍼블리시하는 1st-party 스코프 — 쿨다운의 보안 이득이 미미하고 프레임워크 릴리스마다 CI만 깨진다.
- `regen-lockfiles.yml`이 이미 세 스코프를 신뢰하므로, 두 workspace 파일을 동일하게 맞추는 것은 정책 정합화일 뿐이다.
- 서드파티 `react-native-*`(예: 외부 커뮤니티 패키지)는 여전히 쿨다운 적용 → **보안 후퇴 아님.**

## 검증

- **MRA 정책 통과 확인**: 수정 후 `sdk-runtime-generator~`에서 `pnpm install --no-frozen-lockfile` → `✓ Lockfile passes supply-chain policies` (이전엔 여기서 `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`).
- **lockfile 드리프트 없음**: 이 옵션은 install 시점 검증에만 영향, lockfile 내용 무변경(변경 파일은 workspace yaml 2개뿐).
- **invariants 18/18 통과** (`vitest run tests/unit/invariants.test.ts`).

## 영향 범위

- 변경 파일 2개 (workspace yaml). `Runtime/SDK/` 무수정, lockfile 무변경, `.md` 무변경, license 필드 없음.
- BuildConfig~ 파일은 미니앱 빌드 디렉토리로 복사되므로, 이후 유저 빌드에서도 자사 스코프 쿨다운 지연이 사라진다.