### PR TITLE
빌드: 루트 package.json 미사용 typescript devDependency 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
     "com.unity.nuget.newtonsoft-json": "3.0.2"
   },
   "category": "Platform SDK",
-  "packageManager": "pnpm@11.6.0",
-  "devDependencies": {
-    "typescript": "^7.0.2"
-  }
+  "packageManager": "pnpm@11.6.0"
 }


### PR DESCRIPTION
## 변경 내용

루트 `package.json`(UPM 매니페스트)의 `devDependencies.typescript`(^7.0.2)를 제거합니다. 유일한 devDependency였으므로 블록 전체를 제거했습니다.

## 근거

- UPM은 `devDependencies`를 해석하지 않음 (Unity 패키지 매니페스트)
- 루트에는 lockfile / tsconfig / npm 스크립트가 없어 어떤 도구도 이 항목을 소비하지 않음
- CI 워크플로우 중 루트에서 `pnpm install`을 수행하는 곳 없음 (모두 `sdk-runtime-generator~`, `BuildConfig~`, `Tests~/E2E` 하위에서 실행)
- 실사용처는 `sdk-runtime-generator~`(typescript 7.0.2)와 `WebGLTemplates/AITTemplate/BuildConfig~`(typescript 7.0.2)에 각자 핀되어 있어 영향 없음

## 효과

- 루트 npm 생태계에 대한 dependabot 업데이트 노이즈 제거 (예: #941 같은 no-op 메이저 범프 PR)

## 검증

- `node -e "require(`./package.json`)"` JSON 파싱 정상
- 로컬 `--validate` 중 Meta GUID Hygiene 등 통과. SDK Generator Unit Tests는 본 변경과 무관한 lockfile 이슈(`@apps-in-toss/user-scripts@2.10.5` npm unpublish로 인한 404)로 로컬 실패 — 별도 lockfile 재생성으로 해결 필요