### PR TITLE
기능: 전 async API에 optional 타임아웃 파라미터(timeoutMs) 및 AITClientTimeoutException 추가

### DIFF
--- a/Runtime/SDK/AIT.Advertising.cs
+++ b/Runtime/SDK/AIT.Advertising.cs
@@ -86,17 +86,21 @@ namespace AppsInToss
         /// <summary>
         /// 이 함수는 `loadAppsInTossAdMob` 로 광고가 잘 불러와졌는지 확인해요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Advertising")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<bool> GoogleAdMobIsAppsInTossAdMobLoaded(IsAdMobLoadedOptions args_0)
+        public static async Awaitable<bool> GoogleAdMobIsAppsInTossAdMobLoaded(IsAdMobLoadedOptions args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<bool>();
             string callbackId = AITCore.Instance.RegisterCallback<bool>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GoogleAdMobIsAppsInTossAdMobLoaded"
             );
             __GoogleAdMobIsAppsInTossAdMobLoaded_Internal(AITJsonSettings.Serialize(args_0), callbackId, "bool");
             return await acs.Awaitable;
@@ -108,13 +112,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<bool> GoogleAdMobIsAppsInTossAdMobLoaded(IsAdMobLoadedOptions args_0)
+        public static async Task<bool> GoogleAdMobIsAppsInTossAdMobLoaded(IsAdMobLoadedOptions args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<bool>();
             string callbackId = AITCore.Instance.RegisterCallback<bool>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GoogleAdMobIsAppsInTossAdMobLoaded"
             );
             __GoogleAdMobIsAppsInTossAdMobLoaded_Internal(AITJsonSettings.Serialize(args_0), callbackId, "bool");
             return await tcs.Task;
@@ -131,17 +137,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __GoogleAdMobIsAppsInTossAdMobLoaded_Internal(string args_0, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Advertising")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable TossAdsInitialize(InitializeOptions options)
+        public static async Awaitable TossAdsInitialize(InitializeOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "TossAdsInitialize"
             );
             __TossAdsInitialize_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
             await acs.Awaitable;
@@ -153,13 +163,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task TossAdsInitialize(InitializeOptions options)
+        public static async Task TossAdsInitialize(InitializeOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "TossAdsInitialize"
             );
             __TossAdsInitialize_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
             await tcs.Task;
@@ -176,18 +188,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __TossAdsInitialize_Internal(string options, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Obsolete("attach는 더 이상 권장되지 않습니다. attachBanner를 사용해주세요.")]
         [Preserve]
         [APICategory("Advertising")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable TossAdsAttach(string adGroupId, string target, TossAdsAttachOptions options = null)
+        public static async Awaitable TossAdsAttach(string adGroupId, string target, TossAdsAttachOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "TossAdsAttach"
             );
             __TossAdsAttach_Internal(adGroupId, target, AITJsonSettings.Serialize(options), callbackId, "void");
             await acs.Awaitable;
@@ -199,13 +215,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task TossAdsAttach(string adGroupId, string target, TossAdsAttachOptions options = null)
+        public static async Task TossAdsAttach(string adGroupId, string target, TossAdsAttachOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "TossAdsAttach"
             );
             __TossAdsAttach_Internal(adGroupId, target, AITJsonSettings.Serialize(options), callbackId, "void");
             await tcs.Task;
@@ -222,18 +240,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __TossAdsAttach_Internal(string adGroupId, string target, string options, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Obsolete("CSS 셀렉터 기반 attachBanner는 더 이상 권장되지 않습니다. AITBannerAdView 컴포넌트 또는 AITBannerAd.Show를 사용해주세요.")]
         [Preserve]
         [APICategory("Advertising")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<AttachBannerResult> TossAdsAttachBanner(string adGroupId, string target, TossAdsAttachBannerOptions options = null)
+        public static async Awaitable<AttachBannerResult> TossAdsAttachBanner(string adGroupId, string target, TossAdsAttachBannerOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<AttachBannerResult>();
             string callbackId = AITCore.Instance.RegisterCallback<AttachBannerResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "TossAdsAttachBanner"
             );
             __TossAdsAttachBanner_Internal(adGroupId, target, AITJsonSettings.Serialize(options), callbackId, "AttachBannerResult");
             return await acs.Awaitable;
@@ -245,13 +267,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<AttachBannerResult> TossAdsAttachBanner(string adGroupId, string target, TossAdsAttachBannerOptions options = null)
+        public static async Task<AttachBannerResult> TossAdsAttachBanner(string adGroupId, string target, TossAdsAttachBannerOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<AttachBannerResult>();
             string callbackId = AITCore.Instance.RegisterCallback<AttachBannerResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "TossAdsAttachBanner"
             );
             __TossAdsAttachBanner_Internal(adGroupId, target, AITJsonSettings.Serialize(options), callbackId, "AttachBannerResult");
             return await tcs.Task;
@@ -268,17 +292,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __TossAdsAttachBanner_Internal(string adGroupId, string target, string options, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Advertising")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable TossAdsDestroy(string slotId)
+        public static async Awaitable TossAdsDestroy(string slotId, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "TossAdsDestroy"
             );
             __TossAdsDestroy_Internal(slotId, callbackId, "void");
             await acs.Awaitable;
@@ -290,13 +318,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task TossAdsDestroy(string slotId)
+        public static async Task TossAdsDestroy(string slotId, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "TossAdsDestroy"
             );
             __TossAdsDestroy_Internal(slotId, callbackId, "void");
             await tcs.Task;
@@ -313,17 +343,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __TossAdsDestroy_Internal(string slotId, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Advertising")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable TossAdsDestroyAll()
+        public static async Awaitable TossAdsDestroyAll(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "TossAdsDestroyAll"
             );
             __TossAdsDestroyAll_Internal(callbackId, "void");
             await acs.Awaitable;
@@ -335,13 +369,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task TossAdsDestroyAll()
+        public static async Task TossAdsDestroyAll(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "TossAdsDestroyAll"
             );
             __TossAdsDestroyAll_Internal(callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.Analytics.cs
+++ b/Runtime/SDK/AIT.Analytics.cs
@@ -21,17 +21,21 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Analytics")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable AnalyticsScreen(object paramsParam = null)
+        public static async Awaitable AnalyticsScreen(object paramsParam = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "AnalyticsScreen"
             );
             __AnalyticsScreen_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await acs.Awaitable;
@@ -43,13 +47,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task AnalyticsScreen(object paramsParam = null)
+        public static async Task AnalyticsScreen(object paramsParam = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "AnalyticsScreen"
             );
             __AnalyticsScreen_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await tcs.Task;
@@ -66,17 +72,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __AnalyticsScreen_Internal(string paramsParam, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Analytics")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable AnalyticsImpression(object paramsParam = null)
+        public static async Awaitable AnalyticsImpression(object paramsParam = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "AnalyticsImpression"
             );
             __AnalyticsImpression_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await acs.Awaitable;
@@ -88,13 +98,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task AnalyticsImpression(object paramsParam = null)
+        public static async Task AnalyticsImpression(object paramsParam = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "AnalyticsImpression"
             );
             __AnalyticsImpression_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await tcs.Task;
@@ -111,17 +123,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __AnalyticsImpression_Internal(string paramsParam, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Analytics")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable AnalyticsClick(object paramsParam = null)
+        public static async Awaitable AnalyticsClick(object paramsParam = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "AnalyticsClick"
             );
             __AnalyticsClick_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await acs.Awaitable;
@@ -133,13 +149,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task AnalyticsClick(object paramsParam = null)
+        public static async Task AnalyticsClick(object paramsParam = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "AnalyticsClick"
             );
             __AnalyticsClick_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.Authentication.cs
+++ b/Runtime/SDK/AIT.Authentication.cs
@@ -21,17 +21,21 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Authentication")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<AppLoginResult> AppLogin()
+        public static async Awaitable<AppLoginResult> AppLogin(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<AppLoginResult>();
             string callbackId = AITCore.Instance.RegisterCallback<AppLoginResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "AppLogin"
             );
             __appLogin_Internal(callbackId, "AppLoginResult");
             return await acs.Awaitable;
@@ -43,13 +47,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<AppLoginResult> AppLogin()
+        public static async Task<AppLoginResult> AppLogin(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<AppLoginResult>();
             string callbackId = AITCore.Instance.RegisterCallback<AppLoginResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "AppLogin"
             );
             __appLogin_Internal(callbackId, "AppLoginResult");
             return await tcs.Task;
@@ -66,18 +72,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __appLogin_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>토스 로그인이 연동된 유저인지 여부를 반환해요. true: 토스 로그인이 연동된 유저에요. false: 토스 로그인이 연동되지 않은 유저에요. undefined: 앱 버전이 최소 지원 버전보다 낮아요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Authentication")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<bool?> GetIsTossLoginIntegratedService()
+        public static async Awaitable<bool?> GetIsTossLoginIntegratedService(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<bool?>();
             string callbackId = AITCore.Instance.RegisterCallback<bool?>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetIsTossLoginIntegratedService"
             );
             __getIsTossLoginIntegratedService_Internal(callbackId, "bool?");
             return await acs.Awaitable;
@@ -89,13 +99,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<bool?> GetIsTossLoginIntegratedService()
+        public static async Task<bool?> GetIsTossLoginIntegratedService(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<bool?>();
             string callbackId = AITCore.Instance.RegisterCallback<bool?>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetIsTossLoginIntegratedService"
             );
             __getIsTossLoginIntegratedService_Internal(callbackId, "bool?");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.Certificate.cs
+++ b/Runtime/SDK/AIT.Certificate.cs
@@ -22,17 +22,21 @@ namespace AppsInToss
     public static partial class AIT
     {
         /// <param name="paramsParam">서명에 필요한 파라미터를 포함하는 객체예요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Certificate")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable AppsInTossSignTossCert(AppsInTossSignTossCertParams paramsParam)
+        public static async Awaitable AppsInTossSignTossCert(AppsInTossSignTossCertParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "AppsInTossSignTossCert"
             );
             __appsInTossSignTossCert_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await acs.Awaitable;
@@ -44,13 +48,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task AppsInTossSignTossCert(AppsInTossSignTossCertParams paramsParam)
+        public static async Task AppsInTossSignTossCert(AppsInTossSignTossCertParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "AppsInTossSignTossCert"
             );
             __appsInTossSignTossCert_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.Clipboard.cs
+++ b/Runtime/SDK/AIT.Clipboard.cs
@@ -21,17 +21,21 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Clipboard")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetClipboardText()
+        public static async Awaitable<string> GetClipboardText(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetClipboardText"
             );
             __getClipboardText_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -43,13 +47,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetClipboardText()
+        public static async Task<string> GetClipboardText(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetClipboardText"
             );
             __getClipboardText_Internal(callbackId, "string");
             return await tcs.Task;
@@ -66,17 +72,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getClipboardText_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Clipboard")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable SetClipboardText(string text)
+        public static async Awaitable SetClipboardText(string text, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SetClipboardText"
             );
             __setClipboardText_Internal(text, callbackId, "void");
             await acs.Awaitable;
@@ -88,13 +98,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task SetClipboardText(string text)
+        public static async Task SetClipboardText(string text, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SetClipboardText"
             );
             __setClipboardText_Internal(text, callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.Device.cs
+++ b/Runtime/SDK/AIT.Device.cs
@@ -21,17 +21,21 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Device")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable GenerateHapticFeedback(HapticFeedbackOptions options)
+        public static async Awaitable GenerateHapticFeedback(HapticFeedbackOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GenerateHapticFeedback"
             );
             __generateHapticFeedback_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
             await acs.Awaitable;
@@ -43,13 +47,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task GenerateHapticFeedback(HapticFeedbackOptions options)
+        public static async Task GenerateHapticFeedback(HapticFeedbackOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GenerateHapticFeedback"
             );
             __generateHapticFeedback_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
             await tcs.Task;
@@ -67,18 +73,22 @@ namespace AppsInToss
         private static extern void __generateHapticFeedback_Internal(string options, string callbackId, string typeName);
 #endif
         /// <param name="options">화면 방향 설정 값이에요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>화면 방향 설정이 완료되면 해결되는 Promise를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Device")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable SetDeviceOrientation(SetDeviceOrientationOptions options)
+        public static async Awaitable SetDeviceOrientation(SetDeviceOrientationOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SetDeviceOrientation"
             );
             __setDeviceOrientation_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
             await acs.Awaitable;
@@ -90,13 +100,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task SetDeviceOrientation(SetDeviceOrientationOptions options)
+        public static async Task SetDeviceOrientation(SetDeviceOrientationOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SetDeviceOrientation"
             );
             __setDeviceOrientation_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
             await tcs.Task;
@@ -114,17 +126,21 @@ namespace AppsInToss
         private static extern void __setDeviceOrientation_Internal(string options, string callbackId, string typeName);
 #endif
         /// <param name="options">스와이프하여 뒤로가기 기능을 활성화하거나 비활성화하는 옵션이에요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Device")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable SetIosSwipeGestureEnabled(SetIosSwipeGestureEnabledOptions options)
+        public static async Awaitable SetIosSwipeGestureEnabled(SetIosSwipeGestureEnabledOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SetIosSwipeGestureEnabled"
             );
             __setIosSwipeGestureEnabled_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
             await acs.Awaitable;
@@ -136,13 +152,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task SetIosSwipeGestureEnabled(SetIosSwipeGestureEnabledOptions options)
+        public static async Task SetIosSwipeGestureEnabled(SetIosSwipeGestureEnabledOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SetIosSwipeGestureEnabled"
             );
             __setIosSwipeGestureEnabled_Internal(AITJsonSettings.Serialize(options), callbackId, "void");
             await tcs.Task;
@@ -160,18 +178,22 @@ namespace AppsInToss
         private static extern void __setIosSwipeGestureEnabled_Internal(string options, string callbackId, string typeName);
 #endif
         /// <param name="options">화면 항상 켜짐 모드의 설정 값이에요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>현재 화면 항상 켜짐 모드의 설정 상태를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Device")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<SetScreenAwakeModeResult> SetScreenAwakeMode(SetScreenAwakeModeOptions options)
+        public static async Awaitable<SetScreenAwakeModeResult> SetScreenAwakeMode(SetScreenAwakeModeOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<SetScreenAwakeModeResult>();
             string callbackId = AITCore.Instance.RegisterCallback<SetScreenAwakeModeResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SetScreenAwakeMode"
             );
             __setScreenAwakeMode_Internal(AITJsonSettings.Serialize(options), callbackId, "SetScreenAwakeModeResult");
             return await acs.Awaitable;
@@ -183,13 +205,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<SetScreenAwakeModeResult> SetScreenAwakeMode(SetScreenAwakeModeOptions options)
+        public static async Task<SetScreenAwakeModeResult> SetScreenAwakeMode(SetScreenAwakeModeOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<SetScreenAwakeModeResult>();
             string callbackId = AITCore.Instance.RegisterCallback<SetScreenAwakeModeResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SetScreenAwakeMode"
             );
             __setScreenAwakeMode_Internal(AITJsonSettings.Serialize(options), callbackId, "SetScreenAwakeModeResult");
             return await tcs.Task;
@@ -207,18 +231,22 @@ namespace AppsInToss
         private static extern void __setScreenAwakeMode_Internal(string options, string callbackId, string typeName);
 #endif
         /// <param name="options">화면 캡쳐 설정 옵션이에요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>: boolean} 현재 설정된 캡쳐 차단 상태를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Device")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<SetSecureScreenResult> SetSecureScreen(SetSecureScreenOptions options)
+        public static async Awaitable<SetSecureScreenResult> SetSecureScreen(SetSecureScreenOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<SetSecureScreenResult>();
             string callbackId = AITCore.Instance.RegisterCallback<SetSecureScreenResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SetSecureScreen"
             );
             __setSecureScreen_Internal(AITJsonSettings.Serialize(options), callbackId, "SetSecureScreenResult");
             return await acs.Awaitable;
@@ -230,13 +258,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<SetSecureScreenResult> SetSecureScreen(SetSecureScreenOptions options)
+        public static async Task<SetSecureScreenResult> SetSecureScreen(SetSecureScreenOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<SetSecureScreenResult>();
             string callbackId = AITCore.Instance.RegisterCallback<SetSecureScreenResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SetSecureScreen"
             );
             __setSecureScreen_Internal(AITJsonSettings.Serialize(options), callbackId, "SetSecureScreenResult");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.Environment.cs
+++ b/Runtime/SDK/AIT.Environment.cs
@@ -21,17 +21,21 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Environment")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> EnvGetDeploymentId()
+        public static async Awaitable<string> EnvGetDeploymentId(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "EnvGetDeploymentId"
             );
             __envGetDeploymentId_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -43,13 +47,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> EnvGetDeploymentId()
+        public static async Task<string> EnvGetDeploymentId(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "EnvGetDeploymentId"
             );
             __envGetDeploymentId_Internal(callbackId, "string");
             return await tcs.Task;
@@ -66,17 +72,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __envGetDeploymentId_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Environment")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<AppsInTossGlobals> GetAppsInTossGlobals()
+        public static async Awaitable<AppsInTossGlobals> GetAppsInTossGlobals(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<AppsInTossGlobals>();
             string callbackId = AITCore.Instance.RegisterCallback<AppsInTossGlobals>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetAppsInTossGlobals"
             );
             __getAppsInTossGlobals_Internal(callbackId, "AppsInTossGlobals");
             return await acs.Awaitable;
@@ -88,13 +98,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<AppsInTossGlobals> GetAppsInTossGlobals()
+        public static async Task<AppsInTossGlobals> GetAppsInTossGlobals(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<AppsInTossGlobals>();
             string callbackId = AITCore.Instance.RegisterCallback<AppsInTossGlobals>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetAppsInTossGlobals"
             );
             __getAppsInTossGlobals_Internal(callbackId, "AppsInTossGlobals");
             return await tcs.Task;
@@ -112,18 +124,22 @@ namespace AppsInToss
         private static extern void __getAppsInTossGlobals_Internal(string callbackId, string typeName);
 #endif
         /// <param name="minVersions">플랫폼별 최소 버전 요구사항을 지정하는 객체예요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>현재 앱 버전이 최소 버전 이상이면 true, 그렇지 않으면 false를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Environment")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<bool> IsMinVersionSupported(IsMinVersionSupportedMinVersions minVersions)
+        public static async Awaitable<bool> IsMinVersionSupported(IsMinVersionSupportedMinVersions minVersions, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<bool>();
             string callbackId = AITCore.Instance.RegisterCallback<bool>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "IsMinVersionSupported"
             );
             __isMinVersionSupported_Internal(AITJsonSettings.Serialize(minVersions), callbackId, "bool");
             return await acs.Awaitable;
@@ -135,13 +151,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<bool> IsMinVersionSupported(IsMinVersionSupportedMinVersions minVersions)
+        public static async Task<bool> IsMinVersionSupported(IsMinVersionSupportedMinVersions minVersions, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<bool>();
             string callbackId = AITCore.Instance.RegisterCallback<bool>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "IsMinVersionSupported"
             );
             __isMinVersionSupported_Internal(AITJsonSettings.Serialize(minVersions), callbackId, "bool");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.Events.cs
+++ b/Runtime/SDK/AIT.Events.cs
@@ -22,18 +22,22 @@ namespace AppsInToss
     public static partial class AIT
     {
         /// <param name="paramsParam">로그 기록에 필요한 매개변수 객체예요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>로그 기록이 완료되면 해결되는 Promise예요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Events")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable EventLog(EventLogParams paramsParam)
+        public static async Awaitable EventLog(EventLogParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "EventLog"
             );
             __eventLog_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await acs.Awaitable;
@@ -45,13 +49,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task EventLog(EventLogParams paramsParam)
+        public static async Task EventLog(EventLogParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "EventLog"
             );
             __eventLog_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.GameCenter.cs
+++ b/Runtime/SDK/AIT.GameCenter.cs
@@ -21,18 +21,22 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>프로필 정보 또는 undefined를 반환해요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("GameCenter")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<GameCenterGameProfileResponse> GetGameCenterGameProfile()
+        public static async Awaitable<GameCenterGameProfileResponse> GetGameCenterGameProfile(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<GameCenterGameProfileResponse>();
             string callbackId = AITCore.Instance.RegisterCallback<GameCenterGameProfileResponse>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetGameCenterGameProfile"
             );
             __getGameCenterGameProfile_Internal(callbackId, "GameCenterGameProfileResponse");
             return await acs.Awaitable;
@@ -44,13 +48,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<GameCenterGameProfileResponse> GetGameCenterGameProfile()
+        public static async Task<GameCenterGameProfileResponse> GetGameCenterGameProfile(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<GameCenterGameProfileResponse>();
             string callbackId = AITCore.Instance.RegisterCallback<GameCenterGameProfileResponse>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetGameCenterGameProfile"
             );
             __getGameCenterGameProfile_Internal(callbackId, "GameCenterGameProfileResponse");
             return await tcs.Task;
@@ -67,17 +73,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getGameCenterGameProfile_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("GameCenter")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetUserKeyForGame()
+        public static async Awaitable<string> GetUserKeyForGame(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetUserKeyForGame"
             );
             __getUserKeyForGame_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -89,13 +99,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetUserKeyForGame()
+        public static async Task<string> GetUserKeyForGame(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetUserKeyForGame"
             );
             __getUserKeyForGame_Internal(callbackId, "string");
             return await tcs.Task;
@@ -113,18 +125,22 @@ namespace AppsInToss
         private static extern void __getUserKeyForGame_Internal(string callbackId, string typeName);
 #endif
         /// <param name="paramsParam">포인트를 지급하기 위해 필요한 정보예요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>포인트 지급 결과를 반환해요. { key: string }: 포인트 지급에 성공했어요. key는 리워드 키를 의미해요. { errorCode: string, message: string }: 포인트 지급에 실패했어요. 에러 코드는 다음과 같아요. "40000": 게임이 아닌 미니앱에서 호출했을 때 "4100": 프로모션 정보를 찾을 수 없을 때 "4104": 프로모션이 중지되었을 때 "4105": 프로모션이 종료되었을 때 "4108": 프로모션이 승인되지 않았을 때 "4109": 프로모션이 실행중이 아닐 때 "4110": 리워드를 지급/회수할 수 없을 때 "4112": 프로모션 머니가 부족할 때 "4113": 이미 지급/회수된 내역일 때 "4114": 프로모션에 설정된 1회 지급 금액을 초과할 때 'ERROR': 알 수 없는 오류가 발생했어요. undefined: 앱 버전이 최소 지원 버전보다 낮아요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("GameCenter")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<GrantPromotionRewardResult> GrantPromotionRewardForGame(GrantPromotionRewardForGameParams paramsParam)
+        public static async Awaitable<GrantPromotionRewardResult> GrantPromotionRewardForGame(GrantPromotionRewardForGameParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<GrantPromotionRewardResult>();
             string callbackId = AITCore.Instance.RegisterCallback<GrantPromotionRewardResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GrantPromotionRewardForGame"
             );
             __grantPromotionRewardForGame_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "GrantPromotionRewardResult");
             return await acs.Awaitable;
@@ -136,13 +152,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<GrantPromotionRewardResult> GrantPromotionRewardForGame(GrantPromotionRewardForGameParams paramsParam)
+        public static async Task<GrantPromotionRewardResult> GrantPromotionRewardForGame(GrantPromotionRewardForGameParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<GrantPromotionRewardResult>();
             string callbackId = AITCore.Instance.RegisterCallback<GrantPromotionRewardResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GrantPromotionRewardForGame"
             );
             __grantPromotionRewardForGame_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "GrantPromotionRewardResult");
             return await tcs.Task;
@@ -159,18 +177,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __grantPromotionRewardForGame_Internal(string paramsParam, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>리더보드 웹뷰를 호출해요. 앱 버전이 낮으면 아무 동작도 하지 않고 undefined를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("GameCenter")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable OpenGameCenterLeaderboard()
+        public static async Awaitable OpenGameCenterLeaderboard(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "OpenGameCenterLeaderboard"
             );
             __openGameCenterLeaderboard_Internal(callbackId, "void");
             await acs.Awaitable;
@@ -182,13 +204,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task OpenGameCenterLeaderboard()
+        public static async Task OpenGameCenterLeaderboard(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "OpenGameCenterLeaderboard"
             );
             __openGameCenterLeaderboard_Internal(callbackId, "void");
             await tcs.Task;
@@ -205,18 +229,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __openGameCenterLeaderboard_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>점수 제출 결과를 반환해요. 앱 버전이 최소 지원 버전보다 낮으면 아무 동작도 하지 않고 undefined를 반환해요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("GameCenter")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<SubmitGameCenterLeaderBoardScoreResponse> SubmitGameCenterLeaderBoardScore(SubmitGameCenterLeaderBoardScoreParams paramsParam)
+        public static async Awaitable<SubmitGameCenterLeaderBoardScoreResponse> SubmitGameCenterLeaderBoardScore(SubmitGameCenterLeaderBoardScoreParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<SubmitGameCenterLeaderBoardScoreResponse>();
             string callbackId = AITCore.Instance.RegisterCallback<SubmitGameCenterLeaderBoardScoreResponse>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SubmitGameCenterLeaderBoardScore"
             );
             __submitGameCenterLeaderBoardScore_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "SubmitGameCenterLeaderBoardScoreResponse");
             return await acs.Awaitable;
@@ -228,13 +256,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<SubmitGameCenterLeaderBoardScoreResponse> SubmitGameCenterLeaderBoardScore(SubmitGameCenterLeaderBoardScoreParams paramsParam)
+        public static async Task<SubmitGameCenterLeaderBoardScoreResponse> SubmitGameCenterLeaderBoardScore(SubmitGameCenterLeaderBoardScoreParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<SubmitGameCenterLeaderBoardScoreResponse>();
             string callbackId = AITCore.Instance.RegisterCallback<SubmitGameCenterLeaderBoardScoreResponse>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SubmitGameCenterLeaderBoardScore"
             );
             __submitGameCenterLeaderBoardScore_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "SubmitGameCenterLeaderBoardScoreResponse");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.IAP.cs
+++ b/Runtime/SDK/AIT.IAP.cs
@@ -126,17 +126,21 @@ namespace AppsInToss
         /// <summary>
         /// 인앱결제로 구매할 수 있는 상품 목록을 가져와요. 상품 목록 화면에 진입할 때 호출해요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("IAP")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<IAPGetProductItemListResult> IAPGetProductItemList()
+        public static async Awaitable<IAPGetProductItemListResult> IAPGetProductItemList(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<IAPGetProductItemListResult>();
             string callbackId = AITCore.Instance.RegisterCallback<IAPGetProductItemListResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "IAPGetProductItemList"
             );
             __IAPGetProductItemList_Internal(callbackId, "IAPGetProductItemListResult");
             return await acs.Awaitable;
@@ -148,13 +152,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<IAPGetProductItemListResult> IAPGetProductItemList()
+        public static async Task<IAPGetProductItemListResult> IAPGetProductItemList(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<IAPGetProductItemListResult>();
             string callbackId = AITCore.Instance.RegisterCallback<IAPGetProductItemListResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "IAPGetProductItemList"
             );
             __IAPGetProductItemList_Internal(callbackId, "IAPGetProductItemListResult");
             return await tcs.Task;
@@ -174,17 +180,21 @@ namespace AppsInToss
         /// <summary>
         /// 대기 중인 주문 목록을 가져와요. 이 함수를 사용하면 결제가 아직 완료되지 않은 주문 정보를 확인할 수 있어요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("IAP")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<IAPGetPendingOrdersResult> IAPGetPendingOrders()
+        public static async Awaitable<IAPGetPendingOrdersResult> IAPGetPendingOrders(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<IAPGetPendingOrdersResult>();
             string callbackId = AITCore.Instance.RegisterCallback<IAPGetPendingOrdersResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "IAPGetPendingOrders"
             );
             __IAPGetPendingOrders_Internal(callbackId, "IAPGetPendingOrdersResult");
             return await acs.Awaitable;
@@ -196,13 +206,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<IAPGetPendingOrdersResult> IAPGetPendingOrders()
+        public static async Task<IAPGetPendingOrdersResult> IAPGetPendingOrders(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<IAPGetPendingOrdersResult>();
             string callbackId = AITCore.Instance.RegisterCallback<IAPGetPendingOrdersResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "IAPGetPendingOrders"
             );
             __IAPGetPendingOrders_Internal(callbackId, "IAPGetPendingOrdersResult");
             return await tcs.Task;
@@ -222,17 +234,21 @@ namespace AppsInToss
         /// <summary>
         /// 인앱결제로 구매하거나 환불한 주문 목록을 가져와요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("IAP")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<CompletedOrRefundedOrdersResult> IAPGetCompletedOrRefundedOrders()
+        public static async Awaitable<CompletedOrRefundedOrdersResult> IAPGetCompletedOrRefundedOrders(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<CompletedOrRefundedOrdersResult>();
             string callbackId = AITCore.Instance.RegisterCallback<CompletedOrRefundedOrdersResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "IAPGetCompletedOrRefundedOrders"
             );
             __IAPGetCompletedOrRefundedOrders_Internal(callbackId, "CompletedOrRefundedOrdersResult");
             return await acs.Awaitable;
@@ -244,13 +260,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<CompletedOrRefundedOrdersResult> IAPGetCompletedOrRefundedOrders()
+        public static async Task<CompletedOrRefundedOrdersResult> IAPGetCompletedOrRefundedOrders(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<CompletedOrRefundedOrdersResult>();
             string callbackId = AITCore.Instance.RegisterCallback<CompletedOrRefundedOrdersResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "IAPGetCompletedOrRefundedOrders"
             );
             __IAPGetCompletedOrRefundedOrders_Internal(callbackId, "CompletedOrRefundedOrdersResult");
             return await tcs.Task;
@@ -270,17 +288,21 @@ namespace AppsInToss
         /// <summary>
         /// 상품 지급 처리를 완료했다는 메시지를 앱에 전달해요. 이 함수를 사용하면 결제가 완료된 주문의 상품 지급이 정상적으로 완료되었음을 알릴 수 있어요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("IAP")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<bool> IAPCompleteProductGrant(IAPCompleteProductGrantArgs_0 args_0)
+        public static async Awaitable<bool> IAPCompleteProductGrant(IAPCompleteProductGrantArgs_0 args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<bool>();
             string callbackId = AITCore.Instance.RegisterCallback<bool>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "IAPCompleteProductGrant"
             );
             __IAPCompleteProductGrant_Internal(AITJsonSettings.Serialize(args_0), callbackId, "bool");
             return await acs.Awaitable;
@@ -292,13 +314,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<bool> IAPCompleteProductGrant(IAPCompleteProductGrantArgs_0 args_0)
+        public static async Task<bool> IAPCompleteProductGrant(IAPCompleteProductGrantArgs_0 args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<bool>();
             string callbackId = AITCore.Instance.RegisterCallback<bool>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "IAPCompleteProductGrant"
             );
             __IAPCompleteProductGrant_Internal(AITJsonSettings.Serialize(args_0), callbackId, "bool");
             return await tcs.Task;
@@ -315,17 +339,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __IAPCompleteProductGrant_Internal(string args_0, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("IAP")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<IapSubscriptionInfoResponse> IAPGetSubscriptionInfo(IAPGetSubscriptionInfoArgs_0 args_0)
+        public static async Awaitable<IapSubscriptionInfoResponse> IAPGetSubscriptionInfo(IAPGetSubscriptionInfoArgs_0 args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<IapSubscriptionInfoResponse>();
             string callbackId = AITCore.Instance.RegisterCallback<IapSubscriptionInfoResponse>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "IAPGetSubscriptionInfo"
             );
             __IAPGetSubscriptionInfo_Internal(AITJsonSettings.Serialize(args_0), callbackId, "IapSubscriptionInfoResponse");
             return await acs.Awaitable;
@@ -337,13 +365,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<IapSubscriptionInfoResponse> IAPGetSubscriptionInfo(IAPGetSubscriptionInfoArgs_0 args_0)
+        public static async Task<IapSubscriptionInfoResponse> IAPGetSubscriptionInfo(IAPGetSubscriptionInfoArgs_0 args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<IapSubscriptionInfoResponse>();
             string callbackId = AITCore.Instance.RegisterCallback<IapSubscriptionInfoResponse>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "IAPGetSubscriptionInfo"
             );
             __IAPGetSubscriptionInfo_Internal(AITJsonSettings.Serialize(args_0), callbackId, "IapSubscriptionInfoResponse");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.Location.cs
+++ b/Runtime/SDK/AIT.Location.cs
@@ -21,17 +21,21 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Location")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<Location> GetCurrentLocation(GetCurrentLocationOptions options)
+        public static async Awaitable<Location> GetCurrentLocation(GetCurrentLocationOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<Location>();
             string callbackId = AITCore.Instance.RegisterCallback<Location>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetCurrentLocation"
             );
             __getCurrentLocation_Internal(AITJsonSettings.Serialize(options), callbackId, "Location");
             return await acs.Awaitable;
@@ -43,13 +47,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<Location> GetCurrentLocation(GetCurrentLocationOptions options)
+        public static async Task<Location> GetCurrentLocation(GetCurrentLocationOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<Location>();
             string callbackId = AITCore.Instance.RegisterCallback<Location>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetCurrentLocation"
             );
             __getCurrentLocation_Internal(AITJsonSettings.Serialize(options), callbackId, "Location");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.Media.cs
+++ b/Runtime/SDK/AIT.Media.cs
@@ -22,18 +22,22 @@ namespace AppsInToss
     public static partial class AIT
     {
         /// <param name="options">조회 옵션을 담은 객체예요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>선택한 미디어 목록을 반환해요. 취소 시 빈 배열을 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Media")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<AlbumItemResponse[]> FetchAlbumItems(FetchAlbumItemsOptions options = null)
+        public static async Awaitable<AlbumItemResponse[]> FetchAlbumItems(FetchAlbumItemsOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<AlbumItemResponse[]>();
             string callbackId = AITCore.Instance.RegisterCallback<AlbumItemResponse[]>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "FetchAlbumItems"
             );
             __fetchAlbumItems_Internal(AITJsonSettings.Serialize(options), callbackId, "AlbumItemResponse[]");
             return await acs.Awaitable;
@@ -45,13 +49,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<AlbumItemResponse[]> FetchAlbumItems(FetchAlbumItemsOptions options = null)
+        public static async Task<AlbumItemResponse[]> FetchAlbumItems(FetchAlbumItemsOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<AlbumItemResponse[]>();
             string callbackId = AITCore.Instance.RegisterCallback<AlbumItemResponse[]>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "FetchAlbumItems"
             );
             __fetchAlbumItems_Internal(AITJsonSettings.Serialize(options), callbackId, "AlbumItemResponse[]");
             return await tcs.Task;
@@ -68,17 +74,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __fetchAlbumItems_Internal(string options, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Media")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<ImageResponse[]> FetchAlbumPhotos(FetchAlbumPhotosOptions options = null)
+        public static async Awaitable<ImageResponse[]> FetchAlbumPhotos(FetchAlbumPhotosOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<ImageResponse[]>();
             string callbackId = AITCore.Instance.RegisterCallback<ImageResponse[]>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "FetchAlbumPhotos"
             );
             __fetchAlbumPhotos_Internal(AITJsonSettings.Serialize(options), callbackId, "ImageResponse[]");
             return await acs.Awaitable;
@@ -90,13 +100,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<ImageResponse[]> FetchAlbumPhotos(FetchAlbumPhotosOptions options = null)
+        public static async Task<ImageResponse[]> FetchAlbumPhotos(FetchAlbumPhotosOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<ImageResponse[]>();
             string callbackId = AITCore.Instance.RegisterCallback<ImageResponse[]>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "FetchAlbumPhotos"
             );
             __fetchAlbumPhotos_Internal(AITJsonSettings.Serialize(options), callbackId, "ImageResponse[]");
             return await tcs.Task;
@@ -113,17 +125,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __fetchAlbumPhotos_Internal(string options, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Media")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<ImageResponse> OpenCamera(OpenCameraOptions options = null)
+        public static async Awaitable<ImageResponse> OpenCamera(OpenCameraOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<ImageResponse>();
             string callbackId = AITCore.Instance.RegisterCallback<ImageResponse>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "OpenCamera"
             );
             __openCamera_Internal(AITJsonSettings.Serialize(options), callbackId, "ImageResponse");
             return await acs.Awaitable;
@@ -135,13 +151,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<ImageResponse> OpenCamera(OpenCameraOptions options = null)
+        public static async Task<ImageResponse> OpenCamera(OpenCameraOptions options = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<ImageResponse>();
             string callbackId = AITCore.Instance.RegisterCallback<ImageResponse>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "OpenCamera"
             );
             __openCamera_Internal(AITJsonSettings.Serialize(options), callbackId, "ImageResponse");
             return await tcs.Task;
@@ -159,17 +177,21 @@ namespace AppsInToss
         private static extern void __openCamera_Internal(string options, string callbackId, string typeName);
 #endif
         /// <param name="paramsParam">저장할 데이터와 파일 정보를 담은 객체예요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Media")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable SaveBase64Data(SaveBase64DataParams paramsParam)
+        public static async Awaitable SaveBase64Data(SaveBase64DataParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SaveBase64Data"
             );
             __saveBase64Data_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await acs.Awaitable;
@@ -181,13 +203,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task SaveBase64Data(SaveBase64DataParams paramsParam)
+        public static async Task SaveBase64Data(SaveBase64DataParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SaveBase64Data"
             );
             __saveBase64Data_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.Navigation.cs
+++ b/Runtime/SDK/AIT.Navigation.cs
@@ -21,17 +21,21 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Navigation")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable CloseView()
+        public static async Awaitable CloseView(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "CloseView"
             );
             __closeView_Internal(callbackId, "void");
             await acs.Awaitable;
@@ -43,13 +47,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task CloseView()
+        public static async Task CloseView(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "CloseView"
             );
             __closeView_Internal(callbackId, "void");
             await tcs.Task;
@@ -67,18 +73,22 @@ namespace AppsInToss
         private static extern void __closeView_Internal(string callbackId, string typeName);
 #endif
         /// <param name="url">열고자 하는 URL 주소</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>URL이 성공적으로 열렸을 때 해결되는 Promise</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Navigation")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable OpenURL(string url)
+        public static async Awaitable OpenURL(string url, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "OpenURL"
             );
             __openURL_Internal(url, callbackId, "void");
             await acs.Awaitable;
@@ -90,13 +100,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task OpenURL(string url)
+        public static async Task OpenURL(string url, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "OpenURL"
             );
             __openURL_Internal(url, callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.Other.cs
+++ b/Runtime/SDK/AIT.Other.cs
@@ -21,18 +21,22 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>사용자 키 조회 결과를 반환해요. GetAnonymousKeyResponse: 사용자 키 조회에 성공했어요. { type: 'HASH', hash: string } 형태로 반환돼요. 'ERROR': 알 수 없는 오류가 발생했어요. undefined: 앱 버전이 최소 지원 버전보다 낮아요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Other")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<GetAnonymousKeyResult> GetAnonymousKey()
+        public static async Awaitable<GetAnonymousKeyResult> GetAnonymousKey(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<GetAnonymousKeyResult>();
             string callbackId = AITCore.Instance.RegisterCallback<GetAnonymousKeyResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetAnonymousKey"
             );
             __getAnonymousKey_Internal(callbackId, "GetAnonymousKeyResult");
             return await acs.Awaitable;
@@ -44,13 +48,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<GetAnonymousKeyResult> GetAnonymousKey()
+        public static async Task<GetAnonymousKeyResult> GetAnonymousKey(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<GetAnonymousKeyResult>();
             string callbackId = AITCore.Instance.RegisterCallback<GetAnonymousKeyResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetAnonymousKey"
             );
             __getAnonymousKey_Internal(callbackId, "GetAnonymousKeyResult");
             return await tcs.Task;
@@ -68,18 +74,22 @@ namespace AppsInToss
         private static extern void __getAnonymousKey_Internal(string callbackId, string typeName);
 #endif
         /// <param name="options">동의 데이터 요청 옵션이에요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>서버에서 제공하는 사용자 데이터를 반환해요. 토스앱 버전이 5.264.0 미만이면 undefined를 반환해요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Other")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<Dictionary<ConsentedUserDataKey, string>> GetConsentedUserData(GetConsentedUserDataOptions options)
+        public static async Awaitable<Dictionary<ConsentedUserDataKey, string>> GetConsentedUserData(GetConsentedUserDataOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<Dictionary<ConsentedUserDataKey, string>>();
             string callbackId = AITCore.Instance.RegisterCallback<Dictionary<ConsentedUserDataKey, string>>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetConsentedUserData"
             );
             __getConsentedUserData_Internal(AITJsonSettings.Serialize(options), callbackId, "Dictionary<ConsentedUserDataKey, string>");
             return await acs.Awaitable;
@@ -91,13 +101,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<Dictionary<ConsentedUserDataKey, string>> GetConsentedUserData(GetConsentedUserDataOptions options)
+        public static async Task<Dictionary<ConsentedUserDataKey, string>> GetConsentedUserData(GetConsentedUserDataOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<Dictionary<ConsentedUserDataKey, string>>();
             string callbackId = AITCore.Instance.RegisterCallback<Dictionary<ConsentedUserDataKey, string>>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetConsentedUserData"
             );
             __getConsentedUserData_Internal(AITJsonSettings.Serialize(options), callbackId, "Dictionary<ConsentedUserDataKey, string>");
             return await tcs.Task;
@@ -114,17 +126,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getConsentedUserData_Internal(string options, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Other")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<DeclaredAgeRange> GetDeclaredAgeRange(GetDeclaredAgeRangeParams paramsParam)
+        public static async Awaitable<DeclaredAgeRange> GetDeclaredAgeRange(GetDeclaredAgeRangeParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<DeclaredAgeRange>();
             string callbackId = AITCore.Instance.RegisterCallback<DeclaredAgeRange>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetDeclaredAgeRange"
             );
             __getDeclaredAgeRange_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "DeclaredAgeRange");
             return await acs.Awaitable;
@@ -136,13 +152,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<DeclaredAgeRange> GetDeclaredAgeRange(GetDeclaredAgeRangeParams paramsParam)
+        public static async Task<DeclaredAgeRange> GetDeclaredAgeRange(GetDeclaredAgeRangeParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<DeclaredAgeRange>();
             string callbackId = AITCore.Instance.RegisterCallback<DeclaredAgeRange>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetDeclaredAgeRange"
             );
             __getDeclaredAgeRange_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "DeclaredAgeRange");
             return await tcs.Task;
@@ -159,18 +177,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getDeclaredAgeRange_Internal(string paramsParam, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>그룹 ID</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Other")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetGroupId()
+        public static async Awaitable<string> GetGroupId(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetGroupId"
             );
             __getGroupId_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -182,13 +204,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetGroupId()
+        public static async Task<string> GetGroupId(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetGroupId"
             );
             __getGroupId_Internal(callbackId, "string");
             return await tcs.Task;
@@ -206,18 +230,22 @@ namespace AppsInToss
         private static extern void __getGroupId_Internal(string callbackId, string typeName);
 #endif
         /// <param name="paramsParam">포인트를 지급하기 위해 필요한 정보예요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>포인트 지급 결과를 반환해요. { key: string }: 포인트 지급에 성공했어요. key는 리워드 키를 의미해요. { errorCode: string, message: string }: 포인트 지급에 실패했어요. 에러 코드는 다음과 같아요. "4100": 프로모션 정보를 찾을 수 없을 때 "4104": 프로모션이 중지되었을 때 "4105": 프로모션이 종료되었을 때 "4108": 프로모션이 승인되지 않았을 때 "4109": 프로모션이 실행중이 아닐 때 "4110": 리워드를 지급/회수할 수 없을 때 "4112": 프로모션 머니가 부족할 때 "4113": 이미 지급/회수된 내역일 때 "4114": 프로모션에 설정된 1회 지급 금액을 초과할 때 'ERROR': 알 수 없는 오류가 발생했어요. undefined: 앱 버전이 최소 지원 버전보다 낮아요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Other")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<GrantPromotionRewardResult> GrantPromotionReward(GrantPromotionRewardParams paramsParam)
+        public static async Awaitable<GrantPromotionRewardResult> GrantPromotionReward(GrantPromotionRewardParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<GrantPromotionRewardResult>();
             string callbackId = AITCore.Instance.RegisterCallback<GrantPromotionRewardResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GrantPromotionReward"
             );
             __grantPromotionReward_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "GrantPromotionRewardResult");
             return await acs.Awaitable;
@@ -229,13 +257,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<GrantPromotionRewardResult> GrantPromotionReward(GrantPromotionRewardParams paramsParam)
+        public static async Task<GrantPromotionRewardResult> GrantPromotionReward(GrantPromotionRewardParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<GrantPromotionRewardResult>();
             string callbackId = AITCore.Instance.RegisterCallback<GrantPromotionRewardResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GrantPromotionReward"
             );
             __grantPromotionReward_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "GrantPromotionRewardResult");
             return await tcs.Task;
@@ -281,18 +311,22 @@ namespace AppsInToss
         private static extern void __requestNotificationAgreement_Internal(string options, string subscriptionId, string typeName);
 #endif
         /// <param name="paramsParam">PDF 데이터와 파일 이름을 담은 객체예요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>PDF 뷰어가 닫히면 'CLOSE'를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Other")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> OpenPDFViewer(OpenPDFViewerParams paramsParam)
+        public static async Awaitable<string> OpenPDFViewer(OpenPDFViewerParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "OpenPDFViewer"
             );
             __openPDFViewer_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "string");
             return await acs.Awaitable;
@@ -304,13 +338,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> OpenPDFViewer(OpenPDFViewerParams paramsParam)
+        public static async Task<string> OpenPDFViewer(OpenPDFViewerParams paramsParam, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "OpenPDFViewer"
             );
             __openPDFViewer_Internal(AITJsonSettings.Serialize(paramsParam), callbackId, "string");
             return await tcs.Task;
@@ -327,17 +363,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __openPDFViewer_Internal(string paramsParam, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Other")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable RequestReview()
+        public static async Awaitable RequestReview(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "RequestReview"
             );
             __requestReview_Internal(callbackId, "void");
             await acs.Awaitable;
@@ -349,13 +389,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task RequestReview()
+        public static async Task RequestReview(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "RequestReview"
             );
             __requestReview_Internal(callbackId, "void");
             await tcs.Task;
@@ -373,18 +415,22 @@ namespace AppsInToss
         private static extern void __requestReview_Internal(string callbackId, string typeName);
 #endif
         /// <param name="options">정기결제창을 띄울 때 필요한 옵션이에요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>인증 성공 여부를 포함한 결과를 반환해요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Other")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<RequestTossPayPaysBillingResult> RequestTossPayPaysBilling(RequestTossPayPaysBillingOptions options)
+        public static async Awaitable<RequestTossPayPaysBillingResult> RequestTossPayPaysBilling(RequestTossPayPaysBillingOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<RequestTossPayPaysBillingResult>();
             string callbackId = AITCore.Instance.RegisterCallback<RequestTossPayPaysBillingResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "RequestTossPayPaysBilling"
             );
             __requestTossPayPaysBilling_Internal(AITJsonSettings.Serialize(options), callbackId, "RequestTossPayPaysBillingResult");
             return await acs.Awaitable;
@@ -396,13 +442,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<RequestTossPayPaysBillingResult> RequestTossPayPaysBilling(RequestTossPayPaysBillingOptions options)
+        public static async Task<RequestTossPayPaysBillingResult> RequestTossPayPaysBilling(RequestTossPayPaysBillingOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<RequestTossPayPaysBillingResult>();
             string callbackId = AITCore.Instance.RegisterCallback<RequestTossPayPaysBillingResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "RequestTossPayPaysBilling"
             );
             __requestTossPayPaysBilling_Internal(AITJsonSettings.Serialize(options), callbackId, "RequestTossPayPaysBillingResult");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.Partner.cs
+++ b/Runtime/SDK/AIT.Partner.cs
@@ -24,17 +24,21 @@ namespace AppsInToss
         /// <summary>
         /// 상단 네비게이션의 악세서리 버튼을 추가해요. callback에 대한 정의는 `tdsEvent.addEventListener("navigationAccessoryEvent", callback)`를 참고해주세요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Partner")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable PartnerAddAccessoryButton(AddAccessoryButtonOptions args_0)
+        public static async Awaitable PartnerAddAccessoryButton(AddAccessoryButtonOptions args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "PartnerAddAccessoryButton"
             );
             __partnerAddAccessoryButton_Internal(AITJsonSettings.Serialize(args_0), callbackId, "void");
             await acs.Awaitable;
@@ -46,13 +50,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task PartnerAddAccessoryButton(AddAccessoryButtonOptions args_0)
+        public static async Task PartnerAddAccessoryButton(AddAccessoryButtonOptions args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "PartnerAddAccessoryButton"
             );
             __partnerAddAccessoryButton_Internal(AITJsonSettings.Serialize(args_0), callbackId, "void");
             await tcs.Task;
@@ -72,17 +78,21 @@ namespace AppsInToss
         /// <summary>
         /// 상단 네비게이션의 악세서리 버튼을 제거해요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Partner")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable PartnerRemoveAccessoryButton()
+        public static async Awaitable PartnerRemoveAccessoryButton(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "PartnerRemoveAccessoryButton"
             );
             __partnerRemoveAccessoryButton_Internal(callbackId, "void");
             await acs.Awaitable;
@@ -94,13 +104,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task PartnerRemoveAccessoryButton()
+        public static async Task PartnerRemoveAccessoryButton(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "PartnerRemoveAccessoryButton"
             );
             __partnerRemoveAccessoryButton_Internal(callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.Payment.cs
+++ b/Runtime/SDK/AIT.Payment.cs
@@ -22,18 +22,22 @@ namespace AppsInToss
     public static partial class AIT
     {
         /// <param name="options">결제창을 띄울 때 필요한 옵션이에요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>인증 성공 여부를 포함한 결과를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Payment")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<CheckoutPaymentResult> CheckoutPayment(CheckoutPaymentOptions options)
+        public static async Awaitable<CheckoutPaymentResult> CheckoutPayment(CheckoutPaymentOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<CheckoutPaymentResult>();
             string callbackId = AITCore.Instance.RegisterCallback<CheckoutPaymentResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "CheckoutPayment"
             );
             __checkoutPayment_Internal(AITJsonSettings.Serialize(options), callbackId, "CheckoutPaymentResult");
             return await acs.Awaitable;
@@ -45,13 +49,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<CheckoutPaymentResult> CheckoutPayment(CheckoutPaymentOptions options)
+        public static async Task<CheckoutPaymentResult> CheckoutPayment(CheckoutPaymentOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<CheckoutPaymentResult>();
             string callbackId = AITCore.Instance.RegisterCallback<CheckoutPaymentResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "CheckoutPayment"
             );
             __checkoutPayment_Internal(AITJsonSettings.Serialize(options), callbackId, "CheckoutPaymentResult");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.Permission.cs
+++ b/Runtime/SDK/AIT.Permission.cs
@@ -21,18 +21,22 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>권한의 현재 상태를 반환해요. 반환값은 다음 중 하나예요: allowed: 권한이 허용된 상태예요. denied: 권한이 거부된 상태예요. notDetermined: 아직 권한 요청에 대한 결정이 이루어지지 않은 상태예요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Permission")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<PermissionStatus> GetPermission(GetPermissionPermission permission)
+        public static async Awaitable<PermissionStatus> GetPermission(GetPermissionPermission permission, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<PermissionStatus>();
             string callbackId = AITCore.Instance.RegisterCallback<PermissionStatus>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetPermission"
             );
             __getPermission_Internal(AITJsonSettings.Serialize(permission), callbackId, "PermissionStatus");
             return await acs.Awaitable;
@@ -44,13 +48,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<PermissionStatus> GetPermission(GetPermissionPermission permission)
+        public static async Task<PermissionStatus> GetPermission(GetPermissionPermission permission, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<PermissionStatus>();
             string callbackId = AITCore.Instance.RegisterCallback<PermissionStatus>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetPermission"
             );
             __getPermission_Internal(AITJsonSettings.Serialize(permission), callbackId, "PermissionStatus");
             return await tcs.Task;
@@ -67,18 +73,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getPermission_Internal(string permission, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>권한의 현재 상태를 반환해요. 반환값은 다음 중 하나예요: allowed: 권한이 허용된 상태예요. denied: 권한이 거부된 상태예요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Permission")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> OpenPermissionDialog(OpenPermissionDialogPermission permission)
+        public static async Awaitable<string> OpenPermissionDialog(OpenPermissionDialogPermission permission, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "OpenPermissionDialog"
             );
             __openPermissionDialog_Internal(AITJsonSettings.Serialize(permission), callbackId, "string");
             return await acs.Awaitable;
@@ -90,13 +100,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> OpenPermissionDialog(OpenPermissionDialogPermission permission)
+        public static async Task<string> OpenPermissionDialog(OpenPermissionDialogPermission permission, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "OpenPermissionDialog"
             );
             __openPermissionDialog_Internal(AITJsonSettings.Serialize(permission), callbackId, "string");
             return await tcs.Task;
@@ -113,18 +125,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __openPermissionDialog_Internal(string permission, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>사용자가 선택한 최종 권한 상태를 반환해요. 반환값은 다음 중 하나예요: allowed: 권한이 허용된 경우 denied: 권한이 거부된 경우</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Permission")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> RequestPermission(RequestPermissionPermission permission)
+        public static async Awaitable<string> RequestPermission(RequestPermissionPermission permission, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "RequestPermission"
             );
             __requestPermission_Internal(AITJsonSettings.Serialize(permission), callbackId, "string");
             return await acs.Awaitable;
@@ -136,13 +152,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> RequestPermission(RequestPermissionPermission permission)
+        public static async Task<string> RequestPermission(RequestPermissionPermission permission, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "RequestPermission"
             );
             __requestPermission_Internal(AITJsonSettings.Serialize(permission), callbackId, "string");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.SafeArea.cs
+++ b/Runtime/SDK/AIT.SafeArea.cs
@@ -21,17 +21,21 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SafeArea")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<SafeAreaInsets> SafeAreaInsetsGet()
+        public static async Awaitable<SafeAreaInsets> SafeAreaInsetsGet(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<SafeAreaInsets>();
             string callbackId = AITCore.Instance.RegisterCallback<SafeAreaInsets>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SafeAreaInsetsGet"
             );
             __SafeAreaInsetsGet_Internal(callbackId, "SafeAreaInsets");
             return await acs.Awaitable;
@@ -43,13 +47,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<SafeAreaInsets> SafeAreaInsetsGet()
+        public static async Task<SafeAreaInsets> SafeAreaInsetsGet(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<SafeAreaInsets>();
             string callbackId = AITCore.Instance.RegisterCallback<SafeAreaInsets>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SafeAreaInsetsGet"
             );
             __SafeAreaInsetsGet_Internal(callbackId, "SafeAreaInsets");
             return await tcs.Task;
@@ -66,17 +72,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __SafeAreaInsetsGet_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SafeArea")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<System.Action> SafeAreaInsetsSubscribe(SafeAreaInsetsSubscribe__0 __0)
+        public static async Awaitable<System.Action> SafeAreaInsetsSubscribe(SafeAreaInsetsSubscribe__0 __0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<System.Action>();
             string callbackId = AITCore.Instance.RegisterCallback<System.Action>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "SafeAreaInsetsSubscribe"
             );
             __SafeAreaInsetsSubscribe_Internal(AITJsonSettings.Serialize(__0), callbackId, "System.Action");
             return await acs.Awaitable;
@@ -88,13 +98,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<System.Action> SafeAreaInsetsSubscribe(SafeAreaInsetsSubscribe__0 __0)
+        public static async Task<System.Action> SafeAreaInsetsSubscribe(SafeAreaInsetsSubscribe__0 __0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<System.Action>();
             string callbackId = AITCore.Instance.RegisterCallback<System.Action>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "SafeAreaInsetsSubscribe"
             );
             __SafeAreaInsetsSubscribe_Internal(AITJsonSettings.Serialize(__0), callbackId, "System.Action");
             return await tcs.Task;

--- a/Runtime/SDK/AIT.Share.cs
+++ b/Runtime/SDK/AIT.Share.cs
@@ -49,17 +49,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __contactsViral_Internal(string options, string subscriptionId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Share")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<ContactResult> FetchContacts(FetchContactsOptions options)
+        public static async Awaitable<ContactResult> FetchContacts(FetchContactsOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<ContactResult>();
             string callbackId = AITCore.Instance.RegisterCallback<ContactResult>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "FetchContacts"
             );
             __fetchContacts_Internal(AITJsonSettings.Serialize(options), callbackId, "ContactResult");
             return await acs.Awaitable;
@@ -71,13 +75,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<ContactResult> FetchContacts(FetchContactsOptions options)
+        public static async Task<ContactResult> FetchContacts(FetchContactsOptions options, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<ContactResult>();
             string callbackId = AITCore.Instance.RegisterCallback<ContactResult>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "FetchContacts"
             );
             __fetchContacts_Internal(AITJsonSettings.Serialize(options), callbackId, "ContactResult");
             return await tcs.Task;
@@ -95,18 +101,22 @@ namespace AppsInToss
         private static extern void __fetchContacts_Internal(string options, string callbackId, string typeName);
 #endif
         /// <param name="path">딥링크로 열고 싶은 경로예요. intoss://로 시작하는 문자열이어야 해요.</param>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>deep_link_value가 포함된 토스 공유 링크를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Share")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetTossShareLink(string path, string ogImageUrl = null)
+        public static async Awaitable<string> GetTossShareLink(string path, string ogImageUrl = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetTossShareLink"
             );
             __getTossShareLink_Internal(path, ogImageUrl, callbackId, "string");
             return await acs.Awaitable;
@@ -118,13 +128,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetTossShareLink(string path, string ogImageUrl = null)
+        public static async Task<string> GetTossShareLink(string path, string ogImageUrl = null, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetTossShareLink"
             );
             __getTossShareLink_Internal(path, ogImageUrl, callbackId, "string");
             return await tcs.Task;
@@ -141,17 +153,21 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getTossShareLink_Internal(string path, string ogImageUrl, string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Share")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable Share(ShareMessage message)
+        public static async Awaitable Share(ShareMessage message, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "Share"
             );
             __share_Internal(AITJsonSettings.Serialize(message), callbackId, "void");
             await acs.Awaitable;
@@ -163,13 +179,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task Share(ShareMessage message)
+        public static async Task Share(ShareMessage message, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "Share"
             );
             __share_Internal(AITJsonSettings.Serialize(message), callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.Storage.cs
+++ b/Runtime/SDK/AIT.Storage.cs
@@ -24,18 +24,22 @@ namespace AppsInToss
         /// <summary>
         /// 모바일 앱의 로컬 저장소에서 문자열 데이터를 가져와요. 주로 앱이 종료되었다가 다시 시작해도 데이터가 유지되어야 하는 경우에 사용해요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>결과 값 또는 null</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Storage")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> StorageGetItem(string args_0)
+        public static async Awaitable<string> StorageGetItem(string args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "StorageGetItem"
             );
             __StorageGetItem_Internal(args_0, callbackId, "string");
             return await acs.Awaitable;
@@ -47,13 +51,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> StorageGetItem(string args_0)
+        public static async Task<string> StorageGetItem(string args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "StorageGetItem"
             );
             __StorageGetItem_Internal(args_0, callbackId, "string");
             return await tcs.Task;
@@ -73,17 +79,21 @@ namespace AppsInToss
         /// <summary>
         /// 모바일 앱의 로컬 저장소에 문자열 데이터를 저장해요. 주로 앱이 종료되었다가 다시 시작해도 데이터가 유지되어야 하는 경우에 사용해요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Storage")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable StorageSetItem(string args_0, string args_1)
+        public static async Awaitable StorageSetItem(string args_0, string args_1, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "StorageSetItem"
             );
             __StorageSetItem_Internal(args_0, args_1, callbackId, "void");
             await acs.Awaitable;
@@ -95,13 +105,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task StorageSetItem(string args_0, string args_1)
+        public static async Task StorageSetItem(string args_0, string args_1, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "StorageSetItem"
             );
             __StorageSetItem_Internal(args_0, args_1, callbackId, "void");
             await tcs.Task;
@@ -121,17 +133,21 @@ namespace AppsInToss
         /// <summary>
         /// 모바일 앱의 로컬 저장소에서 특정 키에 해당하는 아이템을 삭제해요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Storage")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable StorageRemoveItem(string args_0)
+        public static async Awaitable StorageRemoveItem(string args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "StorageRemoveItem"
             );
             __StorageRemoveItem_Internal(args_0, callbackId, "void");
             await acs.Awaitable;
@@ -143,13 +159,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task StorageRemoveItem(string args_0)
+        public static async Task StorageRemoveItem(string args_0, int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "StorageRemoveItem"
             );
             __StorageRemoveItem_Internal(args_0, callbackId, "void");
             await tcs.Task;
@@ -169,17 +187,21 @@ namespace AppsInToss
         /// <summary>
         /// 모바일 앱의 로컬 저장소의 모든 아이템을 삭제해요.
         /// </summary>
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("Storage")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable StorageClearItems()
+        public static async Awaitable StorageClearItems(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "StorageClearItems"
             );
             __StorageClearItems_Internal(callbackId, "void");
             await acs.Awaitable;
@@ -191,13 +213,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task StorageClearItems()
+        public static async Task StorageClearItems(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "StorageClearItems"
             );
             __StorageClearItems_Internal(callbackId, "void");
             await tcs.Task;

--- a/Runtime/SDK/AIT.SystemInfo.cs
+++ b/Runtime/SDK/AIT.SystemInfo.cs
@@ -21,18 +21,22 @@ namespace AppsInToss
     /// </summary>
     public static partial class AIT
     {
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>기기의 고유 식별자를 나타내는 문자열이에요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SystemInfo")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetDeviceId()
+        public static async Awaitable<string> GetDeviceId(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetDeviceId"
             );
             __getDeviceId_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -44,13 +48,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetDeviceId()
+        public static async Task<string> GetDeviceId(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetDeviceId"
             );
             __getDeviceId_Internal(callbackId, "string");
             return await tcs.Task;
@@ -67,18 +73,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getDeviceId_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>사용자의 로케일 정보를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SystemInfo")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetLocale()
+        public static async Awaitable<string> GetLocale(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetLocale"
             );
             __getLocale_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -90,13 +100,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetLocale()
+        public static async Task<string> GetLocale(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetLocale"
             );
             __getLocale_Internal(callbackId, "string");
             return await tcs.Task;
@@ -113,18 +125,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getLocale_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>네트워크 상태를 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SystemInfo")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<NetworkStatus> GetNetworkStatus()
+        public static async Awaitable<NetworkStatus> GetNetworkStatus(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<NetworkStatus>();
             string callbackId = AITCore.Instance.RegisterCallback<NetworkStatus>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetNetworkStatus"
             );
             __getNetworkStatus_Internal(callbackId, "NetworkStatus");
             return await acs.Awaitable;
@@ -136,13 +152,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<NetworkStatus> GetNetworkStatus()
+        public static async Task<NetworkStatus> GetNetworkStatus(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<NetworkStatus>();
             string callbackId = AITCore.Instance.RegisterCallback<NetworkStatus>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetNetworkStatus"
             );
             __getNetworkStatus_Internal(callbackId, "NetworkStatus");
             return await tcs.Task;
@@ -159,18 +177,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getNetworkStatus_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>현재 운영 환경을 나타내는 문자열이에요. 'toss': 토스 앱에서 실행 중이에요. 'sandbox': 샌드박스 환경에서 실행 중이에요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SystemInfo")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetOperationalEnvironment()
+        public static async Awaitable<string> GetOperationalEnvironment(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetOperationalEnvironment"
             );
             __getOperationalEnvironment_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -182,13 +204,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetOperationalEnvironment()
+        public static async Task<string> GetOperationalEnvironment(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetOperationalEnvironment"
             );
             __getOperationalEnvironment_Internal(callbackId, "string");
             return await tcs.Task;
@@ -205,18 +229,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getOperationalEnvironment_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>현재 실행 중인 플랫폼</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SystemInfo")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetPlatformOS()
+        public static async Awaitable<string> GetPlatformOS(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetPlatformOS"
             );
             __getPlatformOS_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -228,13 +256,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetPlatformOS()
+        public static async Task<string> GetPlatformOS(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetPlatformOS"
             );
             __getPlatformOS_Internal(callbackId, "string");
             return await tcs.Task;
@@ -251,18 +281,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getPlatformOS_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>처음에 화면에 진입한 스킴 값을 반환해요.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SystemInfo")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetSchemeUri()
+        public static async Awaitable<string> GetSchemeUri(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetSchemeUri"
             );
             __getSchemeUri_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -274,13 +308,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetSchemeUri()
+        public static async Task<string> GetSchemeUri(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetSchemeUri"
             );
             __getSchemeUri_Internal(callbackId, "string");
             return await tcs.Task;
@@ -297,18 +333,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getSchemeUri_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>서버 시간을 Unix timestamp 밀리초 단위로 반환해요. (예: 1705123456789) 지원하지 않는 버전에서는 undefined를 반환해요. 값이 없으면 null을 반환합니다.</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SystemInfo")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<double?> GetServerTime()
+        public static async Awaitable<double?> GetServerTime(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<double?>();
             string callbackId = AITCore.Instance.RegisterCallback<double?>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetServerTime"
             );
             __getServerTime_Internal(callbackId, "double?");
             return await acs.Awaitable;
@@ -320,13 +360,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<double?> GetServerTime()
+        public static async Task<double?> GetServerTime(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<double?>();
             string callbackId = AITCore.Instance.RegisterCallback<double?>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetServerTime"
             );
             __getServerTime_Internal(callbackId, "double?");
             return await tcs.Task;
@@ -343,18 +385,22 @@ namespace AppsInToss
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __getServerTime_Internal(string callbackId, string typeName);
 #endif
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
         /// <returns>토스 앱 버전</returns>
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
         [Preserve]
         [APICategory("SystemInfo")]
 #if UNITY_6000_0_OR_NEWER
-        public static async Awaitable<string> GetTossAppVersion()
+        public static async Awaitable<string> GetTossAppVersion(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var acs = new AwaitableCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "GetTossAppVersion"
             );
             __getTossAppVersion_Internal(callbackId, "string");
             return await acs.Awaitable;
@@ -366,13 +412,15 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async Task<string> GetTossAppVersion()
+        public static async Task<string> GetTossAppVersion(int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             var tcs = new TaskCompletionSource<string>();
             string callbackId = AITCore.Instance.RegisterCallback<string>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "GetTossAppVersion"
             );
             __getTossAppVersion_Internal(callbackId, "string");
             return await tcs.Task;

--- a/Runtime/SDK/AITCore.cs
+++ b/Runtime/SDK/AITCore.cs
@@ -181,6 +181,25 @@ namespace AppsInToss
     }
 
     /// <summary>
+    /// Exception thrown when an Apps in Toss API call exceeds its client-side timeout
+    /// (the <c>timeoutMs</c> argument). Only the C# wait is abandoned — the underlying
+    /// JavaScript/platform work may still complete, and its late result is discarded.
+    /// Inherits <see cref="AITException"/>, so existing <c>catch (AITException)</c> blocks
+    /// still handle it; catch <see cref="AITClientTimeoutException"/> to react to timeouts specifically.
+    /// </summary>
+    public partial class AITClientTimeoutException : AITException
+    {
+        /// <summary>The client-side timeout, in milliseconds, that elapsed.</summary>
+        public int TimeoutMs { get; }
+
+        public AITClientTimeoutException(string apiName, int timeoutMs)
+            : base(apiName, $"'{apiName}' timed out after {timeoutMs}ms while waiting for the Apps in Toss bridge response (client-side wait only).", "TIMEOUT")
+        {
+            TimeoutMs = timeoutMs;
+        }
+    }
+
+    /// <summary>
     /// API response from JavaScript bridge.
     /// Uses explicit success/data/error format to avoid IL2CPP stripping issues.
     /// </summary>
@@ -227,15 +246,26 @@ namespace AppsInToss
         private Dictionary<string, Delegate> _callbacks = new Dictionary<string, Delegate>();
         private Dictionary<string, Action<AITException>> _errorCallbacks = new Dictionary<string, Action<AITException>>();
 
+        // Pending client-side timeout coroutines, keyed by callback ID (armed only when timeoutMs > 0).
+        private Dictionary<string, Coroutine> _timeoutCoroutines = new Dictionary<string, Coroutine>();
+
         /// <summary>
         /// Register success and error callbacks, return the callback ID.
         /// Used by async API methods with TaskCompletionSource.
+        /// When <paramref name="timeoutMs"/> is greater than 0, a client-side timeout is armed:
+        /// if no response arrives within the deadline, the pending callback is removed and the
+        /// error callback is invoked with an <see cref="AITClientTimeoutException"/>. A value of 0
+        /// (the default) waits indefinitely, preserving the original no-timeout behavior.
         /// </summary>
-        public string RegisterCallback<T>(Action<T> onSuccess, Action<AITException> onError)
+        public string RegisterCallback<T>(Action<T> onSuccess, Action<AITException> onError, int timeoutMs = 0, string apiName = null)
         {
             string id = $"cb_{_callbackIdCounter++}";
             _callbacks[id] = onSuccess;
             _errorCallbacks[id] = onError;
+            if (timeoutMs > 0)
+            {
+                _timeoutCoroutines[id] = StartCoroutine(TimeoutCoroutine(id, timeoutMs, apiName));
+            }
             return id;
         }
 
@@ -261,6 +291,7 @@ namespace AppsInToss
                 callback = rawCallback as Action<T>;
                 _callbacks.Remove(callbackId);
                 _errorCallbacks.Remove(callbackId);
+                CancelTimeout(callbackId);
                 return callback != null;
             }
             callback = null;
@@ -276,6 +307,7 @@ namespace AppsInToss
             {
                 _callbacks.Remove(callbackId);
                 _errorCallbacks.Remove(callbackId);
+                CancelTimeout(callbackId);
                 return callback != null;
             }
             callback = null;
@@ -289,6 +321,40 @@ namespace AppsInToss
         {
             _callbacks.Remove(callbackId);
             _errorCallbacks.Remove(callbackId);
+            CancelTimeout(callbackId);
+        }
+
+        /// <summary>
+        /// Client-side timeout for a one-shot callback. After the deadline, if the callback is
+        /// still pending (no response arrived), removes it and faults the awaiter with an
+        /// <see cref="AITClientTimeoutException"/>. Runs on the Unity player loop (WebGL-safe,
+        /// single-threaded); WaitForSecondsRealtime is used so the deadline is wall-clock, not
+        /// affected by Time.timeScale.
+        /// </summary>
+        private System.Collections.IEnumerator TimeoutCoroutine(string callbackId, int timeoutMs, string apiName)
+        {
+            yield return new WaitForSecondsRealtime(timeoutMs / 1000f);
+            _timeoutCoroutines.Remove(callbackId);
+            // Fire only if the real response has not already resolved this callback.
+            if (_errorCallbacks.TryGetValue(callbackId, out var onError))
+            {
+                _callbacks.Remove(callbackId);
+                _errorCallbacks.Remove(callbackId);
+                onError?.Invoke(new AITClientTimeoutException(apiName ?? string.Empty, timeoutMs));
+            }
+        }
+
+        /// <summary>
+        /// Cancel a pending timeout coroutine (invoked when the real response arrives or the
+        /// callback is removed), so it does not fire after the callback has been resolved.
+        /// </summary>
+        private void CancelTimeout(string callbackId)
+        {
+            if (_timeoutCoroutines.TryGetValue(callbackId, out var coroutine))
+            {
+                if (coroutine != null) StopCoroutine(coroutine);
+                _timeoutCoroutines.Remove(callbackId);
+            }
         }
 
         // ===================================================================

--- a/sdk-runtime-generator~/src/templates/csharp-category-partial.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-category-partial.hbs
@@ -228,6 +228,7 @@ namespace AppsInToss
         /// <param name="{{this.paramName}}">{{xmlSafe this.description}}</param>
 {{/if}}
 {{/each}}
+        /// <param name="timeoutMs">Optional client-side timeout in milliseconds. 0 (the default) waits indefinitely; a positive value throws <see cref="AITClientTimeoutException"/> if no response arrives before the deadline. The underlying platform work is not cancelled.</param>
 {{#if this.returnDescription}}
         /// <returns>{{xmlSafe this.returnDescription}}{{#if this.isNullableReturn}} 값이 없으면 null을 반환합니다.{{/if}}</returns>
 {{else if this.isNullableReturn}}
@@ -235,20 +236,23 @@ namespace AppsInToss
 {{/if}}
 {{#if this.isAsync}}
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
 {{#if this.isDeprecated}}
         [Obsolete("{{this.deprecatedMessage}}")]
 {{/if}}
         [Preserve]
         [APICategory("{{../categoryName}}")]
 #if UNITY_6000_0_OR_NEWER
-        public static async {{#if (eq this.callbackType "void")}}Awaitable{{else}}Awaitable<{{{this.callbackType}}}>{{/if}} {{{this.pascalName}}}({{#each this.parameters}}{{{this.paramType}}} {{this.paramName}}{{#if this.optional}} = null{{/if}}{{#unless @last}}, {{/unless}}{{/each}})
+        public static async {{#if (eq this.callbackType "void")}}Awaitable{{else}}Awaitable<{{{this.callbackType}}}>{{/if}} {{{this.pascalName}}}({{#each this.parameters}}{{{this.paramType}}} {{this.paramName}}{{#if this.optional}} = null{{/if}}, {{/each}}int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
 {{#if (eq this.callbackType "void")}}
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "{{{this.pascalName}}}"
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
             await acs.Awaitable;
@@ -256,7 +260,9 @@ namespace AppsInToss
             var acs = new AwaitableCompletionSource<{{{this.callbackType}}}>();
             string callbackId = AITCore.Instance.RegisterCallback<{{{this.callbackType}}}>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "{{{this.pascalName}}}"
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
             return await acs.Awaitable;
@@ -283,14 +289,16 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async {{#if (eq this.callbackType "void")}}Task{{else}}Task<{{{this.callbackType}}}>{{/if}} {{{this.pascalName}}}({{#each this.parameters}}{{{this.paramType}}} {{this.paramName}}{{#if this.optional}} = null{{/if}}{{#unless @last}}, {{/unless}}{{/each}})
+        public static async {{#if (eq this.callbackType "void")}}Task{{else}}Task<{{{this.callbackType}}}>{{/if}} {{{this.pascalName}}}({{#each this.parameters}}{{{this.paramType}}} {{this.paramName}}{{#if this.optional}} = null{{/if}}, {{/each}}int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
 {{#if (eq this.callbackType "void")}}
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "{{{this.pascalName}}}"
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
             await tcs.Task;
@@ -298,7 +306,9 @@ namespace AppsInToss
             var tcs = new TaskCompletionSource<{{{this.callbackType}}}>();
             string callbackId = AITCore.Instance.RegisterCallback<{{{this.callbackType}}}>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "{{{this.pascalName}}}"
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
             return await tcs.Task;
@@ -332,20 +342,23 @@ namespace AppsInToss
 #endif
 {{else}}
         /// <exception cref="AITException">Thrown when the API call fails</exception>
+        /// <exception cref="AITClientTimeoutException">Thrown when the timeoutMs deadline elapses before a response arrives</exception>
 {{#if this.isDeprecated}}
         [Obsolete("{{this.deprecatedMessage}}")]
 {{/if}}
         [Preserve]
         [APICategory("{{../categoryName}}")]
 #if UNITY_6000_0_OR_NEWER
-        public static async {{#if (eq this.callbackType "void")}}Awaitable{{else}}Awaitable<{{{this.callbackType}}}>{{/if}} {{{this.pascalName}}}({{#each this.parameters}}{{{this.paramType}}} {{this.paramName}}{{#if this.optional}} = null{{/if}}{{#unless @last}}, {{/unless}}{{/each}})
+        public static async {{#if (eq this.callbackType "void")}}Awaitable{{else}}Awaitable<{{{this.callbackType}}}>{{/if}} {{{this.pascalName}}}({{#each this.parameters}}{{{this.paramType}}} {{this.paramName}}{{#if this.optional}} = null{{/if}}, {{/each}}int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
 {{#if (eq this.callbackType "void")}}
             var acs = new AwaitableCompletionSource();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => acs.SetResult(),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "{{{this.pascalName}}}"
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
             await acs.Awaitable;
@@ -353,7 +366,9 @@ namespace AppsInToss
             var acs = new AwaitableCompletionSource<{{{this.callbackType}}}>();
             string callbackId = AITCore.Instance.RegisterCallback<{{{this.callbackType}}}>(
                 result => acs.SetResult(result),
-                error => acs.SetException(error)
+                error => acs.SetException(error),
+                timeoutMs,
+                "{{{this.pascalName}}}"
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
             return await acs.Awaitable;
@@ -378,14 +393,16 @@ namespace AppsInToss
 #endif
         }
 #else
-        public static async {{#if (eq this.callbackType "void")}}Task{{else}}Task<{{{this.callbackType}}}>{{/if}} {{{this.pascalName}}}({{#each this.parameters}}{{{this.paramType}}} {{this.paramName}}{{#if this.optional}} = null{{/if}}{{#unless @last}}, {{/unless}}{{/each}})
+        public static async {{#if (eq this.callbackType "void")}}Task{{else}}Task<{{{this.callbackType}}}>{{/if}} {{{this.pascalName}}}({{#each this.parameters}}{{{this.paramType}}} {{this.paramName}}{{#if this.optional}} = null{{/if}}, {{/each}}int timeoutMs = 0)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
 {{#if (eq this.callbackType "void")}}
             var tcs = new TaskCompletionSource<object>();
             string callbackId = AITCore.Instance.RegisterCallback<object>(
                 result => tcs.TrySetResult(null),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "{{{this.pascalName}}}"
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
             await tcs.Task;
@@ -393,7 +410,9 @@ namespace AppsInToss
             var tcs = new TaskCompletionSource<{{{this.callbackType}}}>();
             string callbackId = AITCore.Instance.RegisterCallback<{{{this.callbackType}}}>(
                 result => tcs.TrySetResult(result),
-                error => tcs.TrySetException(error)
+                error => tcs.TrySetException(error),
+                timeoutMs,
+                "{{{this.pascalName}}}"
             );
             __{{{this.name}}}_Internal({{#each this.parameters}}{{#if this.isPrimitive}}{{this.paramName}}{{else}}AITJsonSettings.Serialize({{this.paramName}}){{/if}}, {{/each}}callbackId, "{{{this.callbackType}}}");
             return await tcs.Task;

--- a/sdk-runtime-generator~/src/templates/csharp-core.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-core.hbs
@@ -181,6 +181,25 @@ namespace AppsInToss
     }
 
     /// <summary>
+    /// Exception thrown when an Apps in Toss API call exceeds its client-side timeout
+    /// (the <c>timeoutMs</c> argument). Only the C# wait is abandoned — the underlying
+    /// JavaScript/platform work may still complete, and its late result is discarded.
+    /// Inherits <see cref="AITException"/>, so existing <c>catch (AITException)</c> blocks
+    /// still handle it; catch <see cref="AITClientTimeoutException"/> to react to timeouts specifically.
+    /// </summary>
+    public partial class AITClientTimeoutException : AITException
+    {
+        /// <summary>The client-side timeout, in milliseconds, that elapsed.</summary>
+        public int TimeoutMs { get; }
+
+        public AITClientTimeoutException(string apiName, int timeoutMs)
+            : base(apiName, $"'{apiName}' timed out after {timeoutMs}ms while waiting for the Apps in Toss bridge response (client-side wait only).", "TIMEOUT")
+        {
+            TimeoutMs = timeoutMs;
+        }
+    }
+
+    /// <summary>
     /// API response from JavaScript bridge.
     /// Uses explicit success/data/error format to avoid IL2CPP stripping issues.
     /// </summary>
@@ -227,15 +246,26 @@ namespace AppsInToss
         private Dictionary<string, Delegate> _callbacks = new Dictionary<string, Delegate>();
         private Dictionary<string, Action<AITException>> _errorCallbacks = new Dictionary<string, Action<AITException>>();
 
+        // Pending client-side timeout coroutines, keyed by callback ID (armed only when timeoutMs > 0).
+        private Dictionary<string, Coroutine> _timeoutCoroutines = new Dictionary<string, Coroutine>();
+
         /// <summary>
         /// Register success and error callbacks, return the callback ID.
         /// Used by async API methods with TaskCompletionSource.
+        /// When <paramref name="timeoutMs"/> is greater than 0, a client-side timeout is armed:
+        /// if no response arrives within the deadline, the pending callback is removed and the
+        /// error callback is invoked with an <see cref="AITClientTimeoutException"/>. A value of 0
+        /// (the default) waits indefinitely, preserving the original no-timeout behavior.
         /// </summary>
-        public string RegisterCallback<T>(Action<T> onSuccess, Action<AITException> onError)
+        public string RegisterCallback<T>(Action<T> onSuccess, Action<AITException> onError, int timeoutMs = 0, string apiName = null)
         {
             string id = $"cb_{_callbackIdCounter++}";
             _callbacks[id] = onSuccess;
             _errorCallbacks[id] = onError;
+            if (timeoutMs > 0)
+            {
+                _timeoutCoroutines[id] = StartCoroutine(TimeoutCoroutine(id, timeoutMs, apiName));
+            }
             return id;
         }
 
@@ -261,6 +291,7 @@ namespace AppsInToss
                 callback = rawCallback as Action<T>;
                 _callbacks.Remove(callbackId);
                 _errorCallbacks.Remove(callbackId);
+                CancelTimeout(callbackId);
                 return callback != null;
             }
             callback = null;
@@ -276,6 +307,7 @@ namespace AppsInToss
             {
                 _callbacks.Remove(callbackId);
                 _errorCallbacks.Remove(callbackId);
+                CancelTimeout(callbackId);
                 return callback != null;
             }
             callback = null;
@@ -289,6 +321,40 @@ namespace AppsInToss
         {
             _callbacks.Remove(callbackId);
             _errorCallbacks.Remove(callbackId);
+            CancelTimeout(callbackId);
+        }
+
+        /// <summary>
+        /// Client-side timeout for a one-shot callback. After the deadline, if the callback is
+        /// still pending (no response arrived), removes it and faults the awaiter with an
+        /// <see cref="AITClientTimeoutException"/>. Runs on the Unity player loop (WebGL-safe,
+        /// single-threaded); WaitForSecondsRealtime is used so the deadline is wall-clock, not
+        /// affected by Time.timeScale.
+        /// </summary>
+        private System.Collections.IEnumerator TimeoutCoroutine(string callbackId, int timeoutMs, string apiName)
+        {
+            yield return new WaitForSecondsRealtime(timeoutMs / 1000f);
+            _timeoutCoroutines.Remove(callbackId);
+            // Fire only if the real response has not already resolved this callback.
+            if (_errorCallbacks.TryGetValue(callbackId, out var onError))
+            {
+                _callbacks.Remove(callbackId);
+                _errorCallbacks.Remove(callbackId);
+                onError?.Invoke(new AITClientTimeoutException(apiName ?? string.Empty, timeoutMs));
+            }
+        }
+
+        /// <summary>
+        /// Cancel a pending timeout coroutine (invoked when the real response arrives or the
+        /// callback is removed), so it does not fire after the callback has been resolved.
+        /// </summary>
+        private void CancelTimeout(string callbackId)
+        {
+            if (_timeoutCoroutines.TryGetValue(callbackId, out var coroutine))
+            {
+                if (coroutine != null) StopCoroutine(coroutine);
+                _timeoutCoroutines.Remove(callbackId);
+            }
         }
 
         // ===================================================================

--- a/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
+++ b/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
@@ -181,6 +181,25 @@ namespace AppsInToss
     }
 
     /// <summary>
+    /// Exception thrown when an Apps in Toss API call exceeds its client-side timeout
+    /// (the <c>timeoutMs</c> argument). Only the C# wait is abandoned — the underlying
+    /// JavaScript/platform work may still complete, and its late result is discarded.
+    /// Inherits <see cref="AITException"/>, so existing <c>catch (AITException)</c> blocks
+    /// still handle it; catch <see cref="AITClientTimeoutException"/> to react to timeouts specifically.
+    /// </summary>
+    public partial class AITClientTimeoutException : AITException
+    {
+        /// <summary>The client-side timeout, in milliseconds, that elapsed.</summary>
+        public int TimeoutMs { get; }
+
+        public AITClientTimeoutException(string apiName, int timeoutMs)
+            : base(apiName, $"'{apiName}' timed out after {timeoutMs}ms while waiting for the Apps in Toss bridge response (client-side wait only).", "TIMEOUT")
+        {
+            TimeoutMs = timeoutMs;
+        }
+    }
+
+    /// <summary>
     /// API response from JavaScript bridge.
     /// Uses explicit success/data/error format to avoid IL2CPP stripping issues.
     /// </summary>
@@ -227,15 +246,26 @@ namespace AppsInToss
         private Dictionary<string, Delegate> _callbacks = new Dictionary<string, Delegate>();
         private Dictionary<string, Action<AITException>> _errorCallbacks = new Dictionary<string, Action<AITException>>();
 
+        // Pending client-side timeout coroutines, keyed by callback ID (armed only when timeoutMs > 0).
+        private Dictionary<string, Coroutine> _timeoutCoroutines = new Dictionary<string, Coroutine>();
+
         /// <summary>
         /// Register success and error callbacks, return the callback ID.
         /// Used by async API methods with TaskCompletionSource.
+        /// When <paramref name="timeoutMs"/> is greater than 0, a client-side timeout is armed:
+        /// if no response arrives within the deadline, the pending callback is removed and the
+        /// error callback is invoked with an <see cref="AITClientTimeoutException"/>. A value of 0
+        /// (the default) waits indefinitely, preserving the original no-timeout behavior.
         /// </summary>
-        public string RegisterCallback<T>(Action<T> onSuccess, Action<AITException> onError)
+        public string RegisterCallback<T>(Action<T> onSuccess, Action<AITException> onError, int timeoutMs = 0, string apiName = null)
         {
             string id = $"cb_{_callbackIdCounter++}";
             _callbacks[id] = onSuccess;
             _errorCallbacks[id] = onError;
+            if (timeoutMs > 0)
+            {
+                _timeoutCoroutines[id] = StartCoroutine(TimeoutCoroutine(id, timeoutMs, apiName));
+            }
             return id;
         }
 
@@ -261,6 +291,7 @@ namespace AppsInToss
                 callback = rawCallback as Action<T>;
                 _callbacks.Remove(callbackId);
                 _errorCallbacks.Remove(callbackId);
+                CancelTimeout(callbackId);
                 return callback != null;
             }
             callback = null;
@@ -276,6 +307,7 @@ namespace AppsInToss
             {
                 _callbacks.Remove(callbackId);
                 _errorCallbacks.Remove(callbackId);
+                CancelTimeout(callbackId);
                 return callback != null;
             }
             callback = null;
@@ -289,6 +321,40 @@ namespace AppsInToss
         {
             _callbacks.Remove(callbackId);
             _errorCallbacks.Remove(callbackId);
+            CancelTimeout(callbackId);
+        }
+
+        /// <summary>
+        /// Client-side timeout for a one-shot callback. After the deadline, if the callback is
+        /// still pending (no response arrived), removes it and faults the awaiter with an
+        /// <see cref="AITClientTimeoutException"/>. Runs on the Unity player loop (WebGL-safe,
+        /// single-threaded); WaitForSecondsRealtime is used so the deadline is wall-clock, not
+        /// affected by Time.timeScale.
+        /// </summary>
+        private System.Collections.IEnumerator TimeoutCoroutine(string callbackId, int timeoutMs, string apiName)
+        {
+            yield return new WaitForSecondsRealtime(timeoutMs / 1000f);
+            _timeoutCoroutines.Remove(callbackId);
+            // Fire only if the real response has not already resolved this callback.
+            if (_errorCallbacks.TryGetValue(callbackId, out var onError))
+            {
+                _callbacks.Remove(callbackId);
+                _errorCallbacks.Remove(callbackId);
+                onError?.Invoke(new AITClientTimeoutException(apiName ?? string.Empty, timeoutMs));
+            }
+        }
+
+        /// <summary>
+        /// Cancel a pending timeout coroutine (invoked when the real response arrives or the
+        /// callback is removed), so it does not fire after the callback has been resolved.
+        /// </summary>
+        private void CancelTimeout(string callbackId)
+        {
+            if (_timeoutCoroutines.TryGetValue(callbackId, out var coroutine))
+            {
+                if (coroutine != null) StopCoroutine(coroutine);
+                _timeoutCoroutines.Remove(callbackId);
+            }
         }
 
         // ===================================================================

--- a/sdk-runtime-generator~/tests/unit/timeout-param.test.ts
+++ b/sdk-runtime-generator~/tests/unit/timeout-param.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Optional 타임아웃 파라미터(timeoutMs) 회귀 테스트
+ *
+ * 모든 cs-waits-js 비동기 API(C#이 JS 브릿지 응답을 기다리는 `public static async`
+ * 메서드)에 opt-in 클라이언트 타임아웃 파라미터 `int timeoutMs = 0`이 일관되게
+ * 부여되는지, 그리고 그 값이 AITCore.RegisterCallback으로 정확히 전달되는지 검증한다.
+ *
+ * 설계 계약 (비파괴적 opt-in):
+ *  - `timeoutMs = 0`(기본값) → 무한 대기 = 기존 동작 그대로 (기존 사용자 코드 컴파일/동작 불변)
+ *  - `timeoutMs > 0` → 마감 초과 시 AITClientTimeoutException으로 awaiter를 fault
+ *  - 타임아웃은 C# 측 대기만 포기 — JS/플랫폼 작업은 계속되며 늦은 결과는 폐기
+ *
+ * 대상은 정확히 cs-waits-js 71개 API(× Awaitable/Task 두 브랜치 = 142). Action을
+ * 반환하는 nested-callback(RegisterNestedCallback) / event-subscription API는
+ * await하지 않으므로 타임아웃 대상이 아니며 timeoutMs가 새어들면 안 된다.
+ */
+
+import { describe, test, expect, beforeAll } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as fs from 'fs/promises';
+import { glob } from 'glob';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const runtimeSDKPath = path.resolve(__dirname, '../..', '../Runtime/SDK');
+
+interface AsyncMethod {
+  /** 메서드명 (= PascalName, apiName 문자열과 일치해야 함) */
+  name: string;
+  /** 시그니처의 파라미터 목록 원문 */
+  params: string;
+  /** 여는 중괄호부터 매칭되는 닫는 중괄호까지의 본문 */
+  body: string;
+  file: string;
+}
+
+/**
+ * `public static async <ret> <Name>(<params>) { ... }` 메서드를 중괄호 매칭으로 추출.
+ * 반환 타입에 중첩 제네릭(Awaitable<List<X>>)이 있어도 파라미터 목록의 첫 '('까지만
+ * 소비하도록 non-greedy로 매칭한다. Action 반환(비-async) 메서드는 매칭되지 않는다.
+ */
+function extractAsyncMethods(content: string, file: string): AsyncMethod[] {
+  const methods: AsyncMethod[] = [];
+  const sigRe = /public static async [^\n(]+?\s+(\w+)\s*\(([^)]*)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = sigRe.exec(content)) !== null) {
+    const name = m[1];
+    const params = m[2];
+    const braceStart = content.indexOf('{', sigRe.lastIndex);
+    if (braceStart === -1) continue;
+    let depth = 0;
+    let end = braceStart;
+    for (let i = braceStart; i < content.length; i++) {
+      const ch = content[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    methods.push({ name, params, body: content.slice(braceStart, end + 1), file });
+  }
+  return methods;
+}
+
+/** RegisterCallback<...>( ... ) 호출의 인자 목록 원문을 추출 (본문 내 첫 호출) */
+function extractRegisterCallbackArgs(body: string): string | null {
+  const idx = body.indexOf('RegisterCallback<');
+  if (idx === -1) return null;
+  const open = body.indexOf('(', idx);
+  if (open === -1) return null;
+  let depth = 0;
+  for (let i = open; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return body.slice(open + 1, i);
+    }
+  }
+  return null;
+}
+
+let coreContent = '';
+let apiFiles: { name: string; content: string }[] = [];
+let asyncMethods: AsyncMethod[] = [];
+
+beforeAll(async () => {
+  try {
+    await fs.access(runtimeSDKPath);
+  } catch {
+    throw new Error(
+      '❌ 생성된 SDK 파일을 찾을 수 없습니다!\n' +
+      '   먼저 "pnpm generate"를 실행하여 SDK를 생성하세요.'
+    );
+  }
+
+  coreContent = await fs.readFile(path.join(runtimeSDKPath, 'AITCore.cs'), 'utf-8');
+
+  const csFiles = await glob('AIT.*.cs', { cwd: runtimeSDKPath });
+  for (const fileName of csFiles) {
+    if (fileName.startsWith('AIT.Types') || fileName === 'AIT.cs') continue;
+    const content = await fs.readFile(path.join(runtimeSDKPath, fileName), 'utf-8');
+    apiFiles.push({ name: fileName, content });
+    asyncMethods.push(...extractAsyncMethods(content, fileName));
+  }
+});
+
+describe('AITCore 타임아웃 인프라 (csharp-core.hbs)', () => {
+  test('AITClientTimeoutException이 AITException을 상속하고 TimeoutMs를 노출한다', () => {
+    expect(coreContent).toMatch(/public partial class AITClientTimeoutException\s*:\s*AITException/);
+    expect(coreContent).toContain('public int TimeoutMs { get; }');
+    // catch (AITException) 하위호환: 생성자가 base(...)로 위임
+    expect(coreContent).toMatch(/public AITClientTimeoutException\(string apiName, int timeoutMs\)/);
+  });
+
+  test('RegisterCallback가 opt-in timeoutMs/apiName 파라미터를 받는다 (기본값 0 = 무한 대기)', () => {
+    expect(coreContent).toMatch(
+      /public string RegisterCallback<T>\([^)]*int timeoutMs = 0, string apiName = null\)/
+    );
+    // timeoutMs > 0 일 때만 코루틴 무장
+    expect(coreContent).toMatch(/if \(timeoutMs > 0\)/);
+    expect(coreContent).toMatch(/StartCoroutine\(TimeoutCoroutine\(id, timeoutMs, apiName\)\)/);
+  });
+
+  test('TimeoutCoroutine / CancelTimeout 메서드가 존재한다', () => {
+    expect(coreContent).toMatch(
+      /private System\.Collections\.IEnumerator TimeoutCoroutine\(string callbackId, int timeoutMs, string apiName\)/
+    );
+    expect(coreContent).toContain('WaitForSecondsRealtime(timeoutMs / 1000f)');
+    // 마감 초과 시 AITClientTimeoutException으로 에러 콜백 호출
+    expect(coreContent).toMatch(/new AITClientTimeoutException\(apiName \?\? string\.Empty, timeoutMs\)/);
+    expect(coreContent).toMatch(/private void CancelTimeout\(string callbackId\)/);
+  });
+
+  test('실제 응답 도착/콜백 제거 경로에서 CancelTimeout으로 코루틴을 취소한다 (double-complete 방지)', () => {
+    // TryGetCallback / TryGetErrorCallback / RemoveCallback 3곳에서 취소
+    const cancelCalls = (coreContent.match(/CancelTimeout\(callbackId\);/g) || []).length;
+    expect(cancelCalls).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('cs-waits-js async API의 timeoutMs 파라미터 (csharp-category-partial.hbs)', () => {
+  test('추출된 async 메서드가 존재하고 Awaitable/Task 두 브랜치로 짝수 개다', () => {
+    expect(asyncMethods.length).toBeGreaterThan(0);
+    expect(asyncMethods.length % 2).toBe(0);
+  });
+
+  test('모든 async 메서드의 마지막 파라미터가 int timeoutMs = 0 이다 (비파괴적 기본값)', () => {
+    const missing = asyncMethods.filter(
+      (mth) => !/(?:^|,\s*)int timeoutMs = 0\s*$/.test(mth.params.trim())
+    );
+    expect(
+      missing.map((x) => `${x.file}:${x.name}(${x.params})`)
+    ).toEqual([]);
+  });
+
+  test('모든 async 메서드가 timeoutMs와 자신의 이름을 RegisterCallback으로 전달한다', () => {
+    const violations: string[] = [];
+    for (const mth of asyncMethods) {
+      const args = extractRegisterCallbackArgs(mth.body);
+      if (args === null) {
+        violations.push(`${mth.file}:${mth.name} — RegisterCallback 호출 없음`);
+        continue;
+      }
+      if (!/\btimeoutMs\b/.test(args)) {
+        violations.push(`${mth.file}:${mth.name} — timeoutMs 미전달`);
+      }
+      // apiName 문자열이 메서드명과 정확히 일치
+      if (!args.includes(`"${mth.name}"`)) {
+        violations.push(`${mth.file}:${mth.name} — apiName "${mth.name}" 미전달`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test('async 메서드 수 == int timeoutMs = 0 시그니처 수 == RegisterCallback 호출 수 (1:1:1)', () => {
+    let sigCount = 0;
+    let regCount = 0;
+    for (const { content } of apiFiles) {
+      sigCount += (content.match(/int timeoutMs = 0\)/g) || []).length;
+      regCount += (content.match(/RegisterCallback</g) || []).length;
+    }
+    expect(sigCount).toBe(asyncMethods.length);
+    expect(regCount).toBe(asyncMethods.length);
+  });
+});
+
+describe('비대상 API 격리 (nested-callback / event-subscription)', () => {
+  test('RegisterNestedCallback 호출은 timeoutMs를 전달하지 않는다', () => {
+    for (const { name, content } of apiFiles) {
+      for (const m of content.matchAll(/RegisterNestedCallback\(([\s\S]*?)\);/g)) {
+        expect(
+          m[1].includes('timeoutMs'),
+          `${name}: RegisterNestedCallback가 timeoutMs를 전달함`
+        ).toBe(false);
+      }
+    }
+  });
+
+  test('Action 반환(비-async) 시그니처에 timeoutMs가 새어들지 않는다', () => {
+    const leaks: string[] = [];
+    for (const { name, content } of apiFiles) {
+      for (const m of content.matchAll(/public static (?:System\.)?Action[^\n]*/g)) {
+        if (m[0].includes('timeoutMs')) leaks.push(`${name}: ${m[0].trim()}`);
+      }
+    }
+    expect(leaks).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 개요

C#이 Apps in Toss JS 브릿지 응답을 기다리는 **cs-waits-js 비동기 API 71개**
(`Awaitable`/`Task` 두 브랜치 = 142) 전부에 **opt-in 클라이언트 타임아웃 파라미터**
`int timeoutMs = 0`을 일관되게 제공합니다.

기존 SDK 사용자에게 방해가 없도록 **비파괴적**으로 설계했습니다.

## 설계

- **비파괴적 기본값**: `timeoutMs = 0`(기본) → 무한 대기 = 기존 동작 그대로.
  기존 호출부(`await AIT.IAPGetProductItemList()` 등)와 람다는 시그니처·동작 모두
  불변이라 **컴파일이 깨지지 않습니다**. 필요할 때만 `timeoutMs: N`으로 opt-in.
- **타임아웃 발생**: `timeoutMs > 0`일 때 마감 초과 시
  `AITClientTimeoutException`(`: AITException`)으로 awaiter를 fault. 기존
  `catch (AITException)`이 그대로 처리하며, 타임아웃만 구분하려면
  `AITClientTimeoutException`을 catch.
- **registry-side 구현**: `AITCore.RegisterCallback`이 `timeoutMs > 0`일 때만
  `WaitForSecondsRealtime` 코루틴을 무장하고, 실제 응답 도착/콜백 제거 시
  `CancelTimeout`으로 취소(double-complete 방지). `await` 사이트는 불변이라
  `Awaitable`/`Task` 두 경로가 동일하게 동작합니다.
- **C# 측 대기만 포기**: web-bridge에 취소(AbortSignal)가 없어 JS/플랫폼 작업은
  계속되며 늦은 결과는 폐기됩니다. **jslib(JS 브릿지) 무변경**.
- **비대상 격리**: `Action`을 반환하는 nested-callback(`RegisterNestedCallback`)
  및 event-subscription API는 `await`하지 않으므로 `timeoutMs` 미부여.

## 사용 예

```csharp
// 기존 코드 — 변경 불필요, 무한 대기 그대로 컴파일/동작
var items = await AIT.IAPGetProductItemList();

// 타임아웃 opt-in — 5초 내 응답 없으면 AITClientTimeoutException
try
{
    var items = await AIT.IAPGetProductItemList(timeoutMs: 5000);
}
catch (AITClientTimeoutException ex)
{
    Debug.LogWarning($"{ex.ApiName} timed out after {ex.TimeoutMs}ms");
}
```

## 변경 범위

| 구분 | 파일 |
|---|---|
| 생성기 템플릿 | `csharp-core.hbs`, `csharp-category-partial.hbs` |
| 생성물 | `AITCore.cs` + API 파셜 21개 (`Runtime/SDK/AIT.*.cs`) |
| 골든 | `AITCore.cs.golden` |
| 신규 테스트 | `tests/unit/timeout-param.test.ts` |

> `Runtime/SDK/`는 자동 생성물입니다. 실제 변경은 `sdk-runtime-generator~/`의
> 템플릿 2개이며, 나머지는 `pnpm generate` 재생성 산출물입니다.

## 검증

- ✅ 재생성 멱등성 (diff 해시 동일, 반복 재생성해도 불변)
- ✅ 유닛 테스트 **673/673** 통과 (differential 골든 갱신 + 신규 `timeout-param` 10 케이스)
- ✅ 1:1:1 불변식 — async 142 = `int timeoutMs = 0` 시그니처 142 = `RegisterCallback` 142
- ✅ XML 문서 — 71 `<param>` + 71 `<exception>` 주석
- ✅ Meta GUID 위생 통과
- ✅ 정적 컴파일 검토 — `base` 3-인자 생성자·`using`·`MonoBehaviour` 코루틴 API 일치

> 로컬에 Unity가 없어 실제 컴파일은 **CI Unity 빌드**에서 최종 확인됩니다.
