### PR TITLE
개선: 개발용 로깅 DX 3종 (Log 탭 복사 / SDK verbose 게이팅 / IAPv2Tester 단일화)

### DIFF
--- a/Runtime/SDK/AITCore.cs
+++ b/Runtime/SDK/AITCore.cs
@@ -241,6 +241,47 @@ namespace AppsInToss
             }
         }
 
+        // ===================================================================
+        // Verbose Logging Switch
+        // ===================================================================
+
+        private static bool _verboseLogging = false;
+
+        /// <summary>
+        /// Enables verbose SDK-internal logging (raw jslib call/event/response payloads and
+        /// AITCore callback routing/registration logs). Defaults to <c>false</c> so production
+        /// WebGL builds stay quiet — each <see cref="UnityEngine.Debug.Log"/> call carries a
+        /// non-trivial per-call cost on WebGL, and every emitted event otherwise shows up
+        /// duplicated across layers in tools like vConsole.
+        /// <para>
+        /// <see cref="UnityEngine.Debug.LogWarning"/>, <see cref="UnityEngine.Debug.LogError"/>,
+        /// and jslib's <c>console.error</c>/<c>console.warn</c> are never gated by this switch —
+        /// warnings and errors are always logged regardless of its value.
+        /// </para>
+        /// <para>
+        /// Setting this property also propagates the flag to the JavaScript bridge
+        /// (<c>window.__AIT_VERBOSE</c>) on WebGL builds, so the generated jslib's informational
+        /// <c>console.log</c> calls follow the same switch. The propagation is a no-op outside
+        /// WebGL player builds (Editor, other platforms).
+        /// </para>
+        /// </summary>
+        public static bool VerboseLogging
+        {
+            get => _verboseLogging;
+            set
+            {
+                _verboseLogging = value;
+#if UNITY_WEBGL && !UNITY_EDITOR
+                __AITSetVerboseLogging(value ? 1 : 0);
+#endif
+            }
+        }
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        private static extern void __AITSetVerboseLogging(int verbose);
+#endif
+
         // Callback storage: success callbacks and error callbacks
         private int _callbackIdCounter = 0;
         private Dictionary<string, Delegate> _callbacks = new Dictionary<string, Delegate>();
@@ -419,11 +460,11 @@ namespace AppsInToss
         /// </summary>
         public void OnAITEventCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnAITEventCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnAITEventCallback received: {jsonPayload}");
             try
             {
                 var callbackData = JsonConvert.DeserializeObject<CallbackData>(jsonPayload);
-                Debug.Log($"[AITCore] Routing event callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Routing event callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
                 RouteSubscriptionCallback(callbackData.CallbackId, callbackData.TypeName, callbackData.Result);
             }
             catch (Exception ex)
@@ -442,7 +483,7 @@ namespace AppsInToss
         [Preserve]
         public void OnVisibilityStateChanged(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnVisibilityStateChanged received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnVisibilityStateChanged received: {jsonPayload}");
             try
             {
                 var data = JsonConvert.DeserializeObject<VisibilityStateData>(jsonPayload);
@@ -555,11 +596,11 @@ namespace AppsInToss
         /// </summary>
         public void OnAITCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnAITCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnAITCallback received: {jsonPayload}");
             try
             {
                 var callbackData = JsonConvert.DeserializeObject<CallbackData>(jsonPayload);
-                Debug.Log($"[AITCore] Routing callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Routing callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
                 RouteCallback(callbackData.CallbackId, callbackData.TypeName, callbackData.Result);
             }
             catch (Exception ex)
@@ -1225,7 +1266,7 @@ namespace AppsInToss
                 }
             };
             _nestedCallbacks[key] = wrapper;
-            Debug.Log($"[AITCore] Registered nested callback: {key}");
+            if (VerboseLogging) Debug.Log($"[AITCore] Registered nested callback: {key}");
         }
 
         /// <summary>
@@ -1244,7 +1285,7 @@ namespace AppsInToss
             foreach (var key in keysToRemove)
             {
                 _nestedCallbacks.Remove(key);
-                Debug.Log($"[AITCore] Removed nested callback: {key}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Removed nested callback: {key}");
             }
         }
 
@@ -1257,7 +1298,7 @@ namespace AppsInToss
         /// </summary>
         public void OnNestedCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnNestedCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnNestedCallback received: {jsonPayload}");
             NestedCallbackRequest request;
             try
             {
@@ -1317,7 +1358,7 @@ namespace AppsInToss
         /// </summary>
         private void RespondToNestedCallback(string requestId, bool result)
         {
-            Debug.Log($"[AITCore] RespondToNestedCallback: {requestId} = {result}");
+            if (VerboseLogging) Debug.Log($"[AITCore] RespondToNestedCallback: {requestId} = {result}");
 #if UNITY_WEBGL && !UNITY_EDITOR
             __AITRespondToNestedCallback(requestId, result ? 1 : 0);
 #endif

--- a/Runtime/SDK/Plugins/AppsInToss-Advertising.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-Advertising.jslib
@@ -11,13 +11,13 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
         var optionsObj = options ? JSON.parse(UTF8ToString(options)) : {};
 
-        console.log('[AIT jslib] GoogleAdMobLoadAppsInTossAdMob called, id:', subId, 'options:', optionsObj);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] GoogleAdMobLoadAppsInTossAdMob called, id:', subId, 'options:', optionsObj);
 
         try {
             var unsubscribe = window.AppsInToss.GoogleAdMob.loadAppsInTossAdMob({
                 options: optionsObj,
                 onEvent: function(data) {
-                    console.log('[AIT jslib] GoogleAdMobLoadAppsInTossAdMob event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] GoogleAdMobLoadAppsInTossAdMob event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -30,7 +30,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] GoogleAdMobLoadAppsInTossAdMob error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] GoogleAdMobLoadAppsInTossAdMob error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
@@ -71,13 +71,13 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
         var optionsObj = options ? JSON.parse(UTF8ToString(options)) : {};
 
-        console.log('[AIT jslib] GoogleAdMobShowAppsInTossAdMob called, id:', subId, 'options:', optionsObj);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] GoogleAdMobShowAppsInTossAdMob called, id:', subId, 'options:', optionsObj);
 
         try {
             var unsubscribe = window.AppsInToss.GoogleAdMob.showAppsInTossAdMob({
                 options: optionsObj,
                 onEvent: function(data) {
-                    console.log('[AIT jslib] GoogleAdMobShowAppsInTossAdMob event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] GoogleAdMobShowAppsInTossAdMob event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -90,7 +90,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] GoogleAdMobShowAppsInTossAdMob error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] GoogleAdMobShowAppsInTossAdMob error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
@@ -131,16 +131,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] GoogleAdMobIsAppsInTossAdMobLoaded called, callbackId:', callback);
-        console.log('[AIT jslib] GoogleAdMobIsAppsInTossAdMobLoaded raw param args_0:', UTF8ToString(args_0));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] GoogleAdMobIsAppsInTossAdMobLoaded called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] GoogleAdMobIsAppsInTossAdMobLoaded raw param args_0:', UTF8ToString(args_0));
 
         try {
             var promiseResult = window.AppsInToss.GoogleAdMob.isAppsInTossAdMobLoaded(JSON.parse(UTF8ToString(args_0)));
-            console.log('[AIT jslib] isAppsInTossAdMobLoaded returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] isAppsInTossAdMobLoaded returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] isAppsInTossAdMobLoaded did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] isAppsInTossAdMobLoaded did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -152,7 +152,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] isAppsInTossAdMobLoaded resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] isAppsInTossAdMobLoaded resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -161,7 +161,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] isAppsInTossAdMobLoaded rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] isAppsInTossAdMobLoaded rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -170,7 +170,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] isAppsInTossAdMobLoaded sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] isAppsInTossAdMobLoaded sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -186,13 +186,13 @@ mergeInto(LibraryManager.library, {
 
         var adGroupIdVal = UTF8ToString(adGroupId);
 
-        console.log('[AIT jslib] loadFullScreenAd called, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] loadFullScreenAd called, id:', subId);
 
         try {
             var unsubscribe = window.AppsInToss.loadFullScreenAd({
                 options: { adGroupId: adGroupIdVal },
                 onEvent: function(data) {
-                    console.log('[AIT jslib] loadFullScreenAd event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] loadFullScreenAd event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -205,7 +205,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] loadFullScreenAd error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] loadFullScreenAd error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
@@ -247,13 +247,13 @@ mergeInto(LibraryManager.library, {
 
         var adGroupIdVal = UTF8ToString(adGroupId);
 
-        console.log('[AIT jslib] showFullScreenAd called, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] showFullScreenAd called, id:', subId);
 
         try {
             var unsubscribe = window.AppsInToss.showFullScreenAd({
                 options: { adGroupId: adGroupIdVal },
                 onEvent: function(data) {
-                    console.log('[AIT jslib] showFullScreenAd event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] showFullScreenAd event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -266,7 +266,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] showFullScreenAd error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] showFullScreenAd error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,

--- a/Runtime/SDK/Plugins/AppsInToss-Analytics.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-Analytics.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] AnalyticsScreen called, callbackId:', callback);
-        console.log('[AIT jslib] AnalyticsScreen raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] AnalyticsScreen called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] AnalyticsScreen raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.Analytics.screen(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] screen returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] screen returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] screen did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] screen did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] screen resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] screen resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] screen rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] screen rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] screen sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] screen sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -65,16 +65,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] AnalyticsImpression called, callbackId:', callback);
-        console.log('[AIT jslib] AnalyticsImpression raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] AnalyticsImpression called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] AnalyticsImpression raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.Analytics.impression(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] impression returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] impression returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] impression did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] impression did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -86,7 +86,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] impression resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] impression resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -95,7 +95,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] impression rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] impression rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -104,7 +104,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] impression sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] impression sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -119,16 +119,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] AnalyticsClick called, callbackId:', callback);
-        console.log('[AIT jslib] AnalyticsClick raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] AnalyticsClick called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] AnalyticsClick raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.Analytics.click(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] click returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] click returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] click did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] click did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -140,7 +140,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] click resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] click resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -149,7 +149,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] click rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] click rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -158,7 +158,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] click sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] click sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-AppEvents.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-AppEvents.jslib
@@ -10,13 +10,13 @@ mergeInto(LibraryManager.library, {
         var subId = UTF8ToString(subscriptionId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] GraniteEventSubscribeBackEvent subscribing, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] GraniteEventSubscribeBackEvent subscribing, id:', subId);
 
         try {
             // Subscribe to event
             var unsubscribe = window.AppsInToss.graniteEvent.addEventListener('backEvent', {
                 onEvent: function() {
-                    console.log('[AIT jslib] backEvent fired (void)');
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] backEvent fired (void)');
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -30,7 +30,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] backEvent error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] backEvent error:', error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -69,13 +69,13 @@ mergeInto(LibraryManager.library, {
         var subId = UTF8ToString(subscriptionId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] GraniteEventSubscribeHomeEvent subscribing, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] GraniteEventSubscribeHomeEvent subscribing, id:', subId);
 
         try {
             // Subscribe to event
             var unsubscribe = window.AppsInToss.graniteEvent.addEventListener('homeEvent', {
                 onEvent: function() {
-                    console.log('[AIT jslib] homeEvent fired (void)');
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] homeEvent fired (void)');
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -89,7 +89,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] homeEvent error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] homeEvent error:', error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -128,13 +128,13 @@ mergeInto(LibraryManager.library, {
         var subId = UTF8ToString(subscriptionId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] TdsEventSubscribeNavigationAccessoryEvent subscribing, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] TdsEventSubscribeNavigationAccessoryEvent subscribing, id:', subId);
 
         try {
             // Subscribe to event
             var unsubscribe = window.AppsInToss.tdsEvent.addEventListener('navigationAccessoryEvent', {
                 onEvent: function(data) {
-                    console.log('[AIT jslib] navigationAccessoryEvent fired:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] navigationAccessoryEvent fired:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -148,7 +148,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] navigationAccessoryEvent error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] navigationAccessoryEvent error:', error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -187,7 +187,7 @@ mergeInto(LibraryManager.library, {
         var subId = UTF8ToString(subscriptionId);
 
         if (window.__AIT_SUBSCRIPTIONS && window.__AIT_SUBSCRIPTIONS[subId]) {
-            console.log('[AIT jslib] Unsubscribing:', subId);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] Unsubscribing:', subId);
             var unsubscribe = window.__AIT_SUBSCRIPTIONS[subId];
             if (typeof unsubscribe === 'function') {
                 unsubscribe();

--- a/Runtime/SDK/Plugins/AppsInToss-AppLogin.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-AppLogin.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] appLogin called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] appLogin called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.appLogin();
-            console.log('[AIT jslib] appLogin returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] appLogin returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] appLogin did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] appLogin did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] appLogin resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] appLogin resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] appLogin rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] appLogin rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] appLogin sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] appLogin sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-AppsInTossSignTossCert.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-AppsInTossSignTossCert.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] appsInTossSignTossCert called, callbackId:', callback);
-        console.log('[AIT jslib] appsInTossSignTossCert raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] appsInTossSignTossCert called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] appsInTossSignTossCert raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.appsInTossSignTossCert(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] appsInTossSignTossCert returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] appsInTossSignTossCert returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] appsInTossSignTossCert did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] appsInTossSignTossCert did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] appsInTossSignTossCert resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] appsInTossSignTossCert resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] appsInTossSignTossCert rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] appsInTossSignTossCert rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] appsInTossSignTossCert sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] appsInTossSignTossCert sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-CheckoutPayment.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-CheckoutPayment.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] checkoutPayment called, callbackId:', callback);
-        console.log('[AIT jslib] checkoutPayment raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] checkoutPayment called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] checkoutPayment raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.checkoutPayment(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] checkoutPayment returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] checkoutPayment returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] checkoutPayment did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] checkoutPayment did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] checkoutPayment resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] checkoutPayment resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] checkoutPayment rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] checkoutPayment rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] checkoutPayment sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] checkoutPayment sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-CloseView.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-CloseView.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] closeView called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] closeView called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.closeView();
-            console.log('[AIT jslib] closeView returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] closeView returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] closeView did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] closeView did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] closeView resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] closeView resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] closeView rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] closeView rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] closeView sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] closeView sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-ContactsViral.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-ContactsViral.jslib
@@ -11,13 +11,13 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
         var optionsObj = options ? JSON.parse(UTF8ToString(options)) : {};
 
-        console.log('[AIT jslib] contactsViral called, id:', subId, 'options:', optionsObj);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] contactsViral called, id:', subId, 'options:', optionsObj);
 
         try {
             var unsubscribe = window.AppsInToss.contactsViral({
                 options: optionsObj,
                 onEvent: function(data) {
-                    console.log('[AIT jslib] contactsViral event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] contactsViral event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -30,7 +30,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] contactsViral error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] contactsViral error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,

--- a/Runtime/SDK/Plugins/AppsInToss-Core.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-Core.jslib
@@ -1,0 +1,16 @@
+/**
+ * AppsInToss-Core.jslib
+ *
+ * AITCore 인프라 수동 API (verbose 로깅 스위치 등 - web-framework 외부)
+ * This file is auto-generated. Do not modify directly.
+ * 이 파일은 자동 생성되었습니다. 직접 수정하지 마세요.
+ */
+
+mergeInto(LibraryManager.library, {
+    // AITCore.VerboseLogging 프로퍼티 setter에서 호출되어, C# 스위치를 JS 브릿지에 전파합니다.
+    // 생성된 jslib의 정보성 console.log는 모두 window.__AIT_VERBOSE를 따릅니다
+    // (console.error/console.warn 등 경고·에러 로그는 이 스위치와 무관하게 항상 출력됩니다).
+    __AITSetVerboseLogging: function(verbose) {
+        window.__AIT_VERBOSE = verbose !== 0;
+    },
+});

--- a/Runtime/SDK/Plugins/AppsInToss-Core.jslib.meta
+++ b/Runtime/SDK/Plugins/AppsInToss-Core.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: f373bbafdd6e30f90be2e2b15104e6c3
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/SDK/Plugins/AppsInToss-Environment.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-Environment.jslib
@@ -80,13 +80,13 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
         var optionsObj = options ? JSON.parse(UTF8ToString(options)) : {};
 
-        console.log('[AIT jslib] requestNotificationAgreement called, id:', subId, 'options:', optionsObj);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestNotificationAgreement called, id:', subId, 'options:', optionsObj);
 
         try {
             var unsubscribe = window.AppsInToss.requestNotificationAgreement({
                 options: optionsObj,
                 onEvent: function(data) {
-                    console.log('[AIT jslib] requestNotificationAgreement event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestNotificationAgreement event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -99,7 +99,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] requestNotificationAgreement error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestNotificationAgreement error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,

--- a/Runtime/SDK/Plugins/AppsInToss-EventLog.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-EventLog.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] eventLog called, callbackId:', callback);
-        console.log('[AIT jslib] eventLog raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] eventLog called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] eventLog raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.eventLog(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] eventLog returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] eventLog returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] eventLog did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] eventLog did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] eventLog resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] eventLog resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] eventLog rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] eventLog rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] eventLog sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] eventLog sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-FetchAlbumItems.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-FetchAlbumItems.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] fetchAlbumItems called, callbackId:', callback);
-        console.log('[AIT jslib] fetchAlbumItems raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumItems called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumItems raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.fetchAlbumItems(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] fetchAlbumItems returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumItems returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] fetchAlbumItems did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumItems did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] fetchAlbumItems resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumItems resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] fetchAlbumItems rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumItems rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] fetchAlbumItems sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumItems sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-FetchAlbumPhotos.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-FetchAlbumPhotos.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] fetchAlbumPhotos called, callbackId:', callback);
-        console.log('[AIT jslib] fetchAlbumPhotos raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumPhotos called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumPhotos raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.fetchAlbumPhotos(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] fetchAlbumPhotos returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumPhotos returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] fetchAlbumPhotos did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumPhotos did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] fetchAlbumPhotos resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumPhotos resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] fetchAlbumPhotos rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumPhotos rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] fetchAlbumPhotos sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchAlbumPhotos sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-FetchContacts.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-FetchContacts.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] fetchContacts called, callbackId:', callback);
-        console.log('[AIT jslib] fetchContacts raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchContacts called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchContacts raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.fetchContacts(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] fetchContacts returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchContacts returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] fetchContacts did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchContacts did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] fetchContacts resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchContacts resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] fetchContacts rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchContacts rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] fetchContacts sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] fetchContacts sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GenerateHapticFeedback.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GenerateHapticFeedback.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] generateHapticFeedback called, callbackId:', callback);
-        console.log('[AIT jslib] generateHapticFeedback raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] generateHapticFeedback called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] generateHapticFeedback raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.generateHapticFeedback(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] generateHapticFeedback returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] generateHapticFeedback returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] generateHapticFeedback did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] generateHapticFeedback did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] generateHapticFeedback resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] generateHapticFeedback resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] generateHapticFeedback rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] generateHapticFeedback rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] generateHapticFeedback sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] generateHapticFeedback sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetAnonymousKey.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetAnonymousKey.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getAnonymousKey called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getAnonymousKey called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.getAnonymousKey();
-            console.log('[AIT jslib] getAnonymousKey returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getAnonymousKey returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getAnonymousKey did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getAnonymousKey did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getAnonymousKey resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getAnonymousKey resolved:', result);
                     var resultPayload;
                     if (typeof result === 'string') {
                         resultPayload = { _type: "error", _errorCode: result, _successJson: null };
@@ -46,7 +46,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getAnonymousKey rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getAnonymousKey rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -55,7 +55,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getAnonymousKey sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getAnonymousKey sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetClipboardText.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetClipboardText.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getClipboardText called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getClipboardText called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.getClipboardText();
-            console.log('[AIT jslib] getClipboardText returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getClipboardText returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getClipboardText did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getClipboardText did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getClipboardText resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getClipboardText resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getClipboardText rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getClipboardText rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getClipboardText sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getClipboardText sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetConsentedUserData.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetConsentedUserData.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getConsentedUserData called, callbackId:', callback);
-        console.log('[AIT jslib] getConsentedUserData raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getConsentedUserData called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getConsentedUserData raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.getConsentedUserData(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] getConsentedUserData returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getConsentedUserData returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getConsentedUserData did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getConsentedUserData did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getConsentedUserData resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getConsentedUserData resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getConsentedUserData rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getConsentedUserData rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getConsentedUserData sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getConsentedUserData sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetCurrentLocation.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetCurrentLocation.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getCurrentLocation called, callbackId:', callback);
-        console.log('[AIT jslib] getCurrentLocation raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCurrentLocation called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCurrentLocation raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.getCurrentLocation(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] getCurrentLocation returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCurrentLocation returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getCurrentLocation did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCurrentLocation did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getCurrentLocation resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCurrentLocation resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getCurrentLocation rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCurrentLocation rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getCurrentLocation sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCurrentLocation sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetDeclaredAgeRange.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetDeclaredAgeRange.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getDeclaredAgeRange called, callbackId:', callback);
-        console.log('[AIT jslib] getDeclaredAgeRange raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getDeclaredAgeRange called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getDeclaredAgeRange raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.getDeclaredAgeRange(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] getDeclaredAgeRange returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getDeclaredAgeRange returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getDeclaredAgeRange did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getDeclaredAgeRange did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getDeclaredAgeRange resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getDeclaredAgeRange resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getDeclaredAgeRange rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getDeclaredAgeRange rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getDeclaredAgeRange sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getDeclaredAgeRange sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetGameCenterGameProfile.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetGameCenterGameProfile.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getGameCenterGameProfile called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getGameCenterGameProfile called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.getGameCenterGameProfile();
-            console.log('[AIT jslib] getGameCenterGameProfile returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getGameCenterGameProfile returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getGameCenterGameProfile did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getGameCenterGameProfile did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getGameCenterGameProfile resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getGameCenterGameProfile resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getGameCenterGameProfile rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getGameCenterGameProfile rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getGameCenterGameProfile sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getGameCenterGameProfile sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetIsTossLoginIntegratedService.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetIsTossLoginIntegratedService.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getIsTossLoginIntegratedService called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getIsTossLoginIntegratedService called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.getIsTossLoginIntegratedService();
-            console.log('[AIT jslib] getIsTossLoginIntegratedService returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getIsTossLoginIntegratedService returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getIsTossLoginIntegratedService did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getIsTossLoginIntegratedService did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getIsTossLoginIntegratedService resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getIsTossLoginIntegratedService resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getIsTossLoginIntegratedService rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getIsTossLoginIntegratedService rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getIsTossLoginIntegratedService sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getIsTossLoginIntegratedService sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetNetworkStatus.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetNetworkStatus.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getNetworkStatus called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getNetworkStatus called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.getNetworkStatus();
-            console.log('[AIT jslib] getNetworkStatus returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getNetworkStatus returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getNetworkStatus did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getNetworkStatus did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getNetworkStatus resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getNetworkStatus resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getNetworkStatus rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getNetworkStatus rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getNetworkStatus sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getNetworkStatus sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetPermission.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetPermission.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getPermission called, callbackId:', callback);
-        console.log('[AIT jslib] getPermission raw param permission:', UTF8ToString(permission));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPermission called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPermission raw param permission:', UTF8ToString(permission));
 
         try {
             var promiseResult = window.AppsInToss.getPermission(JSON.parse(UTF8ToString(permission)));
-            console.log('[AIT jslib] getPermission returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPermission returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getPermission did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPermission did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getPermission resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPermission resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getPermission rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPermission rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getPermission sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPermission sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetServerTime.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetServerTime.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getServerTime called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getServerTime called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.getServerTime();
-            console.log('[AIT jslib] getServerTime returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getServerTime returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getServerTime did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getServerTime did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getServerTime resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getServerTime resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getServerTime rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getServerTime rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getServerTime sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getServerTime sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetTossShareLink.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetTossShareLink.jslib
@@ -11,17 +11,17 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getTossShareLink called, callbackId:', callback);
-        console.log('[AIT jslib] getTossShareLink raw param path:', UTF8ToString(path));
-        console.log('[AIT jslib] getTossShareLink raw param ogImageUrl:', UTF8ToString(ogImageUrl));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getTossShareLink called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getTossShareLink raw param path:', UTF8ToString(path));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getTossShareLink raw param ogImageUrl:', UTF8ToString(ogImageUrl));
 
         try {
             var promiseResult = window.AppsInToss.getTossShareLink(UTF8ToString(path), UTF8ToString(ogImageUrl));
-            console.log('[AIT jslib] getTossShareLink returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getTossShareLink returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getTossShareLink did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getTossShareLink did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -33,7 +33,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getTossShareLink resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getTossShareLink resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -42,7 +42,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getTossShareLink rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getTossShareLink rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -51,7 +51,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getTossShareLink sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getTossShareLink sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GetUserKeyForGame.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GetUserKeyForGame.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] getUserKeyForGame called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] getUserKeyForGame called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.getUserKeyForGame();
-            console.log('[AIT jslib] getUserKeyForGame returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getUserKeyForGame returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getUserKeyForGame did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getUserKeyForGame did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getUserKeyForGame resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getUserKeyForGame resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getUserKeyForGame rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getUserKeyForGame rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getUserKeyForGame sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getUserKeyForGame sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GrantPromotionReward.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GrantPromotionReward.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] grantPromotionReward called, callbackId:', callback);
-        console.log('[AIT jslib] grantPromotionReward raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionReward called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionReward raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.grantPromotionReward(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] grantPromotionReward returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionReward returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] grantPromotionReward did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionReward did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] grantPromotionReward resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionReward resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] grantPromotionReward rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionReward rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] grantPromotionReward sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionReward sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-GrantPromotionRewardForGame.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-GrantPromotionRewardForGame.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] grantPromotionRewardForGame called, callbackId:', callback);
-        console.log('[AIT jslib] grantPromotionRewardForGame raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionRewardForGame called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionRewardForGame raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.grantPromotionRewardForGame(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] grantPromotionRewardForGame returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionRewardForGame returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] grantPromotionRewardForGame did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionRewardForGame did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] grantPromotionRewardForGame resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionRewardForGame resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] grantPromotionRewardForGame rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionRewardForGame rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] grantPromotionRewardForGame sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] grantPromotionRewardForGame sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-IAP.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-IAP.jslib
@@ -11,7 +11,7 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
         var parsedParams = JSON.parse(UTF8ToString(params));
 
-        console.log('[AIT jslib] IAPCreateOneTimePurchaseOrder called, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPCreateOneTimePurchaseOrder called, id:', subId);
 
         try {
             var result = window.AppsInToss.IAP.createOneTimePurchaseOrder({
@@ -33,7 +33,7 @@ mergeInto(LibraryManager.library, {
                 }
                 }),
                 onEvent: function(event) {
-                    console.log('[AIT jslib] IAPCreateOneTimePurchaseOrder event:', event);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPCreateOneTimePurchaseOrder event:', event);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -46,7 +46,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] IAPCreateOneTimePurchaseOrder error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPCreateOneTimePurchaseOrder error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
@@ -88,7 +88,7 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
         var parsedParams = JSON.parse(UTF8ToString(params));
 
-        console.log('[AIT jslib] IAPCreateSubscriptionPurchaseOrder called, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPCreateSubscriptionPurchaseOrder called, id:', subId);
 
         try {
             var result = window.AppsInToss.IAP.createSubscriptionPurchaseOrder({
@@ -110,7 +110,7 @@ mergeInto(LibraryManager.library, {
                 }
                 }),
                 onEvent: function(event) {
-                    console.log('[AIT jslib] IAPCreateSubscriptionPurchaseOrder event:', event);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPCreateSubscriptionPurchaseOrder event:', event);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -123,7 +123,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] IAPCreateSubscriptionPurchaseOrder error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPCreateSubscriptionPurchaseOrder error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
@@ -165,15 +165,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] IAPGetProductItemList called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPGetProductItemList called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.IAP.getProductItemList();
-            console.log('[AIT jslib] getProductItemList returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getProductItemList returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getProductItemList did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getProductItemList did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -185,7 +185,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getProductItemList resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getProductItemList resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -194,7 +194,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getProductItemList rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getProductItemList rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -203,7 +203,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getProductItemList sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getProductItemList sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -218,15 +218,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] IAPGetPendingOrders called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPGetPendingOrders called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.IAP.getPendingOrders();
-            console.log('[AIT jslib] getPendingOrders returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPendingOrders returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getPendingOrders did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPendingOrders did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -238,7 +238,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getPendingOrders resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPendingOrders resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -247,7 +247,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getPendingOrders rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPendingOrders rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -256,7 +256,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getPendingOrders sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getPendingOrders sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -271,15 +271,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] IAPGetCompletedOrRefundedOrders called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPGetCompletedOrRefundedOrders called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.IAP.getCompletedOrRefundedOrders();
-            console.log('[AIT jslib] getCompletedOrRefundedOrders returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCompletedOrRefundedOrders returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getCompletedOrRefundedOrders did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCompletedOrRefundedOrders did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -291,7 +291,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getCompletedOrRefundedOrders resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCompletedOrRefundedOrders resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -300,7 +300,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getCompletedOrRefundedOrders rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCompletedOrRefundedOrders rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -309,7 +309,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getCompletedOrRefundedOrders sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getCompletedOrRefundedOrders sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -324,16 +324,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] IAPCompleteProductGrant called, callbackId:', callback);
-        console.log('[AIT jslib] IAPCompleteProductGrant raw param args_0:', UTF8ToString(args_0));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPCompleteProductGrant called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPCompleteProductGrant raw param args_0:', UTF8ToString(args_0));
 
         try {
             var promiseResult = window.AppsInToss.IAP.completeProductGrant(JSON.parse(UTF8ToString(args_0)));
-            console.log('[AIT jslib] completeProductGrant returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] completeProductGrant returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] completeProductGrant did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] completeProductGrant did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -345,7 +345,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] completeProductGrant resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] completeProductGrant resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -354,7 +354,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] completeProductGrant rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] completeProductGrant rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -363,7 +363,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] completeProductGrant sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] completeProductGrant sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -378,16 +378,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] IAPGetSubscriptionInfo called, callbackId:', callback);
-        console.log('[AIT jslib] IAPGetSubscriptionInfo raw param args_0:', UTF8ToString(args_0));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPGetSubscriptionInfo called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] IAPGetSubscriptionInfo raw param args_0:', UTF8ToString(args_0));
 
         try {
             var promiseResult = window.AppsInToss.IAP.getSubscriptionInfo(JSON.parse(UTF8ToString(args_0)));
-            console.log('[AIT jslib] getSubscriptionInfo returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getSubscriptionInfo returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getSubscriptionInfo did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getSubscriptionInfo did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -399,7 +399,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getSubscriptionInfo resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getSubscriptionInfo resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -408,7 +408,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getSubscriptionInfo rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getSubscriptionInfo rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -417,7 +417,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getSubscriptionInfo sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getSubscriptionInfo sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -431,7 +431,7 @@ mergeInto(LibraryManager.library, {
         var reqId = UTF8ToString(requestId);
         var resultBool = result !== 0;
 
-        console.log('[AIT jslib] RespondToNestedCallback:', reqId, resultBool);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] RespondToNestedCallback:', reqId, resultBool);
 
         if (window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[reqId]) {
             window.__AIT_NESTED_CALLBACKS[reqId](resultBool);

--- a/Runtime/SDK/Plugins/AppsInToss-OnVisibilityChangedByTransparentServiceWeb.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-OnVisibilityChangedByTransparentServiceWeb.jslib
@@ -11,13 +11,13 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
         var optionsObj = options ? JSON.parse(UTF8ToString(options)) : {};
 
-        console.log('[AIT jslib] onVisibilityChangedByTransparentServiceWeb called, id:', subId, 'options:', optionsObj);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] onVisibilityChangedByTransparentServiceWeb called, id:', subId, 'options:', optionsObj);
 
         try {
             var unsubscribe = window.AppsInToss.onVisibilityChangedByTransparentServiceWeb({
                 options: optionsObj,
                 onEvent: function(data) {
-                    console.log('[AIT jslib] onVisibilityChangedByTransparentServiceWeb event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] onVisibilityChangedByTransparentServiceWeb event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -30,7 +30,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] onVisibilityChangedByTransparentServiceWeb error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] onVisibilityChangedByTransparentServiceWeb error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,

--- a/Runtime/SDK/Plugins/AppsInToss-OpenCamera.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-OpenCamera.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] openCamera called, callbackId:', callback);
-        console.log('[AIT jslib] openCamera raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openCamera called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openCamera raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.openCamera(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] openCamera returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openCamera returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] openCamera did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] openCamera did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] openCamera resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openCamera resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] openCamera rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openCamera rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] openCamera sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openCamera sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-OpenGameCenterLeaderboard.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-OpenGameCenterLeaderboard.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] openGameCenterLeaderboard called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openGameCenterLeaderboard called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.openGameCenterLeaderboard();
-            console.log('[AIT jslib] openGameCenterLeaderboard returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openGameCenterLeaderboard returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] openGameCenterLeaderboard did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] openGameCenterLeaderboard did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] openGameCenterLeaderboard resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openGameCenterLeaderboard resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] openGameCenterLeaderboard rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openGameCenterLeaderboard rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] openGameCenterLeaderboard sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openGameCenterLeaderboard sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-OpenPDFViewer.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-OpenPDFViewer.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] openPDFViewer called, callbackId:', callback);
-        console.log('[AIT jslib] openPDFViewer raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPDFViewer called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPDFViewer raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.openPDFViewer(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] openPDFViewer returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPDFViewer returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] openPDFViewer did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPDFViewer did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] openPDFViewer resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPDFViewer resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] openPDFViewer rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPDFViewer rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] openPDFViewer sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPDFViewer sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-OpenPermissionDialog.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-OpenPermissionDialog.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] openPermissionDialog called, callbackId:', callback);
-        console.log('[AIT jslib] openPermissionDialog raw param permission:', UTF8ToString(permission));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPermissionDialog called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPermissionDialog raw param permission:', UTF8ToString(permission));
 
         try {
             var promiseResult = window.AppsInToss.openPermissionDialog(JSON.parse(UTF8ToString(permission)));
-            console.log('[AIT jslib] openPermissionDialog returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPermissionDialog returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] openPermissionDialog did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPermissionDialog did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] openPermissionDialog resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPermissionDialog resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] openPermissionDialog rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPermissionDialog rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] openPermissionDialog sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openPermissionDialog sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-OpenURL.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-OpenURL.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] openURL called, callbackId:', callback);
-        console.log('[AIT jslib] openURL raw param url:', UTF8ToString(url));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openURL called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] openURL raw param url:', UTF8ToString(url));
 
         try {
             var promiseResult = window.AppsInToss.openURL(UTF8ToString(url));
-            console.log('[AIT jslib] openURL returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openURL returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] openURL did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] openURL did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] openURL resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openURL resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] openURL rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] openURL rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] openURL sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] openURL sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-Partner.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-Partner.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] partnerAddAccessoryButton called, callbackId:', callback);
-        console.log('[AIT jslib] partnerAddAccessoryButton raw param args_0:', UTF8ToString(args_0));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] partnerAddAccessoryButton called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] partnerAddAccessoryButton raw param args_0:', UTF8ToString(args_0));
 
         try {
             var promiseResult = window.AppsInToss.partner.addAccessoryButton(JSON.parse(UTF8ToString(args_0)));
-            console.log('[AIT jslib] addAccessoryButton returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] addAccessoryButton returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] addAccessoryButton did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] addAccessoryButton did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] addAccessoryButton resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] addAccessoryButton resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] addAccessoryButton rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] addAccessoryButton rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] addAccessoryButton sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] addAccessoryButton sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -65,15 +65,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] partnerRemoveAccessoryButton called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] partnerRemoveAccessoryButton called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.partner.removeAccessoryButton();
-            console.log('[AIT jslib] removeAccessoryButton returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeAccessoryButton returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] removeAccessoryButton did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeAccessoryButton did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -85,7 +85,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] removeAccessoryButton resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeAccessoryButton resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -94,7 +94,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] removeAccessoryButton rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeAccessoryButton rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -103,7 +103,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] removeAccessoryButton sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeAccessoryButton sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-RequestPermission.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-RequestPermission.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] requestPermission called, callbackId:', callback);
-        console.log('[AIT jslib] requestPermission raw param permission:', UTF8ToString(permission));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestPermission called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestPermission raw param permission:', UTF8ToString(permission));
 
         try {
             var promiseResult = window.AppsInToss.requestPermission(JSON.parse(UTF8ToString(permission)));
-            console.log('[AIT jslib] requestPermission returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestPermission returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] requestPermission did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestPermission did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] requestPermission resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestPermission resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] requestPermission rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestPermission rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] requestPermission sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestPermission sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-RequestReview.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-RequestReview.jslib
@@ -11,15 +11,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] requestReview called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestReview called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.requestReview();
-            console.log('[AIT jslib] requestReview returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestReview returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] requestReview did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestReview did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -31,7 +31,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] requestReview resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestReview resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -40,7 +40,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] requestReview rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestReview rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -49,7 +49,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] requestReview sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestReview sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-RequestTossPayPaysBilling.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-RequestTossPayPaysBilling.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] requestTossPayPaysBilling called, callbackId:', callback);
-        console.log('[AIT jslib] requestTossPayPaysBilling raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestTossPayPaysBilling called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestTossPayPaysBilling raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.requestTossPayPaysBilling(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] requestTossPayPaysBilling returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestTossPayPaysBilling returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] requestTossPayPaysBilling did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestTossPayPaysBilling did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] requestTossPayPaysBilling resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestTossPayPaysBilling resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] requestTossPayPaysBilling rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestTossPayPaysBilling rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] requestTossPayPaysBilling sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] requestTossPayPaysBilling sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-SaveBase64Data.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-SaveBase64Data.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] saveBase64Data called, callbackId:', callback);
-        console.log('[AIT jslib] saveBase64Data raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] saveBase64Data called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] saveBase64Data raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.saveBase64Data(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] saveBase64Data returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] saveBase64Data returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] saveBase64Data did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] saveBase64Data did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] saveBase64Data resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] saveBase64Data resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] saveBase64Data rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] saveBase64Data rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] saveBase64Data sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] saveBase64Data sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-Screen.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-Screen.jslib
@@ -28,7 +28,7 @@ mergeInto(LibraryManager.library, {
 
         // dpr이 변경되었을 때만 로깅 (window 객체에 캐시)
         if (window.__ait_last_dpr !== dpr) {
-            console.log('[AIT jslib] GetDevicePixelRatio changed:', window.__ait_last_dpr, '->', dpr);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] GetDevicePixelRatio changed:', window.__ait_last_dpr, '->', dpr);
             window.__ait_last_dpr = dpr;
         }
 

--- a/Runtime/SDK/Plugins/AppsInToss-SetClipboardText.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-SetClipboardText.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] setClipboardText called, callbackId:', callback);
-        console.log('[AIT jslib] setClipboardText raw param text:', UTF8ToString(text));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setClipboardText called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setClipboardText raw param text:', UTF8ToString(text));
 
         try {
             var promiseResult = window.AppsInToss.setClipboardText(UTF8ToString(text));
-            console.log('[AIT jslib] setClipboardText returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setClipboardText returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] setClipboardText did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] setClipboardText did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] setClipboardText resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setClipboardText resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] setClipboardText rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setClipboardText rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] setClipboardText sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setClipboardText sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-SetDeviceOrientation.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-SetDeviceOrientation.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] setDeviceOrientation called, callbackId:', callback);
-        console.log('[AIT jslib] setDeviceOrientation raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setDeviceOrientation called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setDeviceOrientation raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.setDeviceOrientation(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] setDeviceOrientation returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setDeviceOrientation returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] setDeviceOrientation did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] setDeviceOrientation did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] setDeviceOrientation resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setDeviceOrientation resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] setDeviceOrientation rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setDeviceOrientation rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] setDeviceOrientation sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setDeviceOrientation sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-SetIosSwipeGestureEnabled.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-SetIosSwipeGestureEnabled.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] setIosSwipeGestureEnabled called, callbackId:', callback);
-        console.log('[AIT jslib] setIosSwipeGestureEnabled raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setIosSwipeGestureEnabled called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setIosSwipeGestureEnabled raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.setIosSwipeGestureEnabled(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] setIosSwipeGestureEnabled returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setIosSwipeGestureEnabled returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] setIosSwipeGestureEnabled did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] setIosSwipeGestureEnabled did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] setIosSwipeGestureEnabled resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setIosSwipeGestureEnabled resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] setIosSwipeGestureEnabled rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setIosSwipeGestureEnabled rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] setIosSwipeGestureEnabled sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setIosSwipeGestureEnabled sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-SetScreenAwakeMode.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-SetScreenAwakeMode.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] setScreenAwakeMode called, callbackId:', callback);
-        console.log('[AIT jslib] setScreenAwakeMode raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setScreenAwakeMode called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setScreenAwakeMode raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.setScreenAwakeMode(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] setScreenAwakeMode returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setScreenAwakeMode returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] setScreenAwakeMode did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] setScreenAwakeMode did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] setScreenAwakeMode resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setScreenAwakeMode resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] setScreenAwakeMode rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setScreenAwakeMode rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] setScreenAwakeMode sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setScreenAwakeMode sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-SetSecureScreen.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-SetSecureScreen.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] setSecureScreen called, callbackId:', callback);
-        console.log('[AIT jslib] setSecureScreen raw param options:', UTF8ToString(options));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setSecureScreen called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] setSecureScreen raw param options:', UTF8ToString(options));
 
         try {
             var promiseResult = window.AppsInToss.setSecureScreen(JSON.parse(UTF8ToString(options)));
-            console.log('[AIT jslib] setSecureScreen returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setSecureScreen returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] setSecureScreen did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] setSecureScreen did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] setSecureScreen resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setSecureScreen resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] setSecureScreen rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setSecureScreen rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] setSecureScreen sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setSecureScreen sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-Share.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-Share.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] share called, callbackId:', callback);
-        console.log('[AIT jslib] share raw param message:', UTF8ToString(message));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] share called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] share raw param message:', UTF8ToString(message));
 
         try {
             var promiseResult = window.AppsInToss.share(JSON.parse(UTF8ToString(message)));
-            console.log('[AIT jslib] share returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] share returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] share did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] share did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] share resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] share resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] share rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] share rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] share sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] share sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-StartUpdateLocation.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-StartUpdateLocation.jslib
@@ -11,13 +11,13 @@ mergeInto(LibraryManager.library, {
         var typeNameStr = UTF8ToString(typeName);
         var optionsObj = options ? JSON.parse(UTF8ToString(options)) : {};
 
-        console.log('[AIT jslib] startUpdateLocation called, id:', subId, 'options:', optionsObj);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] startUpdateLocation called, id:', subId, 'options:', optionsObj);
 
         try {
             var unsubscribe = window.AppsInToss.startUpdateLocation({
                 options: optionsObj,
                 onEvent: function(data) {
-                    console.log('[AIT jslib] startUpdateLocation event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] startUpdateLocation event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -30,7 +30,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] startUpdateLocation error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] startUpdateLocation error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,

--- a/Runtime/SDK/Plugins/AppsInToss-Storage.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-Storage.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] StorageGetItem called, callbackId:', callback);
-        console.log('[AIT jslib] StorageGetItem raw param args_0:', UTF8ToString(args_0));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] StorageGetItem called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] StorageGetItem raw param args_0:', UTF8ToString(args_0));
 
         try {
             var promiseResult = window.AppsInToss.Storage.getItem(UTF8ToString(args_0));
-            console.log('[AIT jslib] getItem returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getItem returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] getItem did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] getItem did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] getItem resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getItem resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] getItem rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] getItem rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] getItem sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] getItem sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -65,17 +65,17 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] StorageSetItem called, callbackId:', callback);
-        console.log('[AIT jslib] StorageSetItem raw param args_0:', UTF8ToString(args_0));
-        console.log('[AIT jslib] StorageSetItem raw param args_1:', UTF8ToString(args_1));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] StorageSetItem called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] StorageSetItem raw param args_0:', UTF8ToString(args_0));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] StorageSetItem raw param args_1:', UTF8ToString(args_1));
 
         try {
             var promiseResult = window.AppsInToss.Storage.setItem(UTF8ToString(args_0), UTF8ToString(args_1));
-            console.log('[AIT jslib] setItem returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setItem returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] setItem did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] setItem did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -87,7 +87,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] setItem resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setItem resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -96,7 +96,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] setItem rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] setItem rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -105,7 +105,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] setItem sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] setItem sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -120,16 +120,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] StorageRemoveItem called, callbackId:', callback);
-        console.log('[AIT jslib] StorageRemoveItem raw param args_0:', UTF8ToString(args_0));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] StorageRemoveItem called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] StorageRemoveItem raw param args_0:', UTF8ToString(args_0));
 
         try {
             var promiseResult = window.AppsInToss.Storage.removeItem(UTF8ToString(args_0));
-            console.log('[AIT jslib] removeItem returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeItem returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] removeItem did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeItem did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -141,7 +141,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] removeItem resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeItem resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -150,7 +150,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] removeItem rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeItem rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -159,7 +159,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] removeItem sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] removeItem sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -174,15 +174,15 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] StorageClearItems called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] StorageClearItems called, callbackId:', callback);
 
         try {
             var promiseResult = window.AppsInToss.Storage.clearItems();
-            console.log('[AIT jslib] clearItems returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] clearItems returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] clearItems did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] clearItems did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -194,7 +194,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] clearItems resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] clearItems resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -203,7 +203,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] clearItems rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] clearItems rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -212,7 +212,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] clearItems sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] clearItems sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Runtime/SDK/Plugins/AppsInToss-SubmitGameCenterLeaderBoardScore.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-SubmitGameCenterLeaderBoardScore.jslib
@@ -11,16 +11,16 @@ mergeInto(LibraryManager.library, {
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] submitGameCenterLeaderBoardScore called, callbackId:', callback);
-        console.log('[AIT jslib] submitGameCenterLeaderBoardScore raw param params:', UTF8ToString(params));
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] submitGameCenterLeaderBoardScore called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] submitGameCenterLeaderBoardScore raw param params:', UTF8ToString(params));
 
         try {
             var promiseResult = window.AppsInToss.submitGameCenterLeaderBoardScore(JSON.parse(UTF8ToString(params)));
-            console.log('[AIT jslib] submitGameCenterLeaderBoardScore returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] submitGameCenterLeaderBoardScore returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] submitGameCenterLeaderBoardScore did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] submitGameCenterLeaderBoardScore did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -32,7 +32,7 @@ mergeInto(LibraryManager.library, {
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] submitGameCenterLeaderBoardScore resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] submitGameCenterLeaderBoardScore resolved:', result);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] submitGameCenterLeaderBoardScore rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] submitGameCenterLeaderBoardScore rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -50,7 +50,7 @@ mergeInto(LibraryManager.library, {
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] submitGameCenterLeaderBoardScore sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] submitGameCenterLeaderBoardScore sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,

--- a/Tests~/E2E/SharedScripts/Runtime/IAPv2Tester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/IAPv2Tester.cs
@@ -36,6 +36,9 @@ public class IAPv2Tester : MonoBehaviour
     private List<string> iapEventLog = new List<string>();
     private int _lastRenderedLogCount = 0;
 
+    /// <summary>화면 이벤트 로그(iapEventLog) 상한. 초과 시 오래된 항목을 트리밍한다.</summary>
+    private const int MaxIapEventLogCount = 300;
+
     // 구독 해제 액션
     private Action _purchaseDisposer;
 
@@ -53,6 +56,15 @@ public class IAPv2Tester : MonoBehaviour
     /// 마지막 작업 상태 메시지
     /// </summary>
     public string Status => iapStatus;
+
+    private void Awake()
+    {
+        // WebGL 빌드에서는 Debug.Log/Warning 한 줄마다 스택트레이스가 함께 캡처되어
+        // vConsole 노이즈가 커지고, 문자열 생성 비용 때문에 프레임 성능도 저하된다.
+        // 진단 가치가 큰 Error/Exception은 스택트레이스를 그대로 유지한다.
+        Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
+        Application.SetStackTraceLogType(LogType.Warning, StackTraceLogType.None);
+    }
 
     /// <summary>
     /// uGUI 기반 UI를 생성합니다.
@@ -173,6 +185,32 @@ public class IAPv2Tester : MonoBehaviour
         {
             _statusText.text = $"Status: {iapStatus}";
             _statusText.gameObject.SetActive(!string.IsNullOrEmpty(iapStatus));
+        }
+    }
+
+    /// <summary>
+    /// IAP 이벤트를 화면 로그(iapEventLog)와 콘솔(Debug.Log)에 동일한 타임스탬프로 1회씩 기록한다.
+    /// 실기기 콘솔 로그에도 발생 시각을 남기기 위해 "HH:mm:ss.fff" 타임스탬프를 공유한다.
+    /// </summary>
+    /// <param name="msg">기록할 메시지 (타임스탬프/프리픽스 제외한 본문)</param>
+    /// <param name="toConsole">false면 화면(iapEventLog)에만 남기고 콘솔에는 기록하지 않는다</param>
+    private void LogIap(string msg, bool toConsole = true)
+    {
+        string timestamp = DateTime.Now.ToString("HH:mm:ss.fff");
+        iapEventLog.Add($"[{timestamp}] {msg}");
+
+        if (iapEventLog.Count > MaxIapEventLogCount)
+        {
+            // _lastRenderedLogCount 기반 증분 렌더링은 트리밍하면 인덱스가 어긋난다.
+            // 렌더 카운트를 리셋해 다음 UpdateEventLog() 호출이 전체 재구축(단순·정확한 경로)을
+            // 타도록 강제하는 방식으로 정합을 보장한다.
+            iapEventLog.RemoveRange(0, iapEventLog.Count - MaxIapEventLogCount);
+            _lastRenderedLogCount = 0;
+        }
+
+        if (toConsole)
+        {
+            Debug.Log($"[IAPv2Tester] [{timestamp}] {msg}");
         }
     }
 
@@ -364,7 +402,7 @@ public class IAPv2Tester : MonoBehaviour
     private async void ExecuteIAPGetProductList()
     {
         iapStatus = "Loading products...";
-        iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] IAPGetProductItemList()");
+        LogIap("IAPGetProductItemList()");
         UpdateStatus();
         UpdateEventLog();
 
@@ -373,17 +411,17 @@ public class IAPv2Tester : MonoBehaviour
             iapProducts = await AIT.IAPGetProductItemList();
             int count = iapProducts?.Products?.Length ?? 0;
             iapStatus = $"Found {count} products";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Success: {count} products");
+            LogIap($"Success: {count} products");
         }
         catch (AITException ex)
         {
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Error: {ex.ErrorCode} - {ex.Message}");
+            LogIap($"Error: {ex.ErrorCode} - {ex.Message}");
         }
         catch (Exception ex)
         {
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Exception: {ex.Message}");
+            LogIap($"Exception: {ex.Message}");
         }
 
         UpdateStatus();
@@ -401,7 +439,7 @@ public class IAPv2Tester : MonoBehaviour
         }
 
         iapStatus = "Creating purchase order...";
-        iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] IAPCreateOneTimePurchaseOrder(sku: {iapSku})");
+        LogIap($"IAPCreateOneTimePurchaseOrder(sku: {iapSku})");
         UpdateStatus();
         UpdateEventLog();
 
@@ -415,10 +453,9 @@ public class IAPv2Tester : MonoBehaviour
                 // SDK는 이 Task<bool>이 완료될 때까지 주문 완료 처리를 보류한다 (true → 자동 지급 완료).
                 ProcessProductGrant = async (data) =>
                 {
-                    iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] ProcessProductGrant called: {data}");
-                    Debug.Log($"[IAPv2Tester] ProcessProductGrant called with data: {data}");
+                    LogIap($"ProcessProductGrant called: {data}");
                     bool grantSuccess = await GrantGameProduct(data);
-                    iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] ProcessProductGrant result: {grantSuccess}");
+                    LogIap($"ProcessProductGrant result: {grantSuccess}");
                     UpdateEventLog();
                     return grantSuccess;
                 }
@@ -431,7 +468,7 @@ public class IAPv2Tester : MonoBehaviour
                     iapStatus = "Purchase completed";
                     iapOrderId = successEvent.Data?.OrderId ?? "";
                     if (_orderIdInput != null) _orderIdInput.text = iapOrderId;
-                    iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] OnEvent: orderId={successEvent.Data?.OrderId}, amount={successEvent.Data?.DisplayAmount}");
+                    LogIap($"OnEvent: orderId={successEvent.Data?.OrderId}, amount={successEvent.Data?.DisplayAmount}");
                     UpdateStatus();
                     UpdateEventLog();
                 },
@@ -439,7 +476,7 @@ public class IAPv2Tester : MonoBehaviour
                 onError: (error) =>
                 {
                     iapStatus = "Purchase failed";
-                    iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] OnError: {error.ErrorCode} - {error.Message}");
+                    LogIap($"OnError: {error.ErrorCode} - {error.Message}");
                     UpdateStatus();
                     UpdateEventLog();
                 }
@@ -448,17 +485,17 @@ public class IAPv2Tester : MonoBehaviour
             ExecuteIAPCreateOrderLegacy();
 #endif
             iapStatus = "Purchase order created";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Order created successfully");
+            LogIap("Order created successfully");
         }
         catch (AITException ex)
         {
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Error: {ex.ErrorCode} - {ex.Message}");
+            LogIap($"Error: {ex.ErrorCode} - {ex.Message}");
         }
         catch (Exception ex)
         {
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Exception: {ex.Message}");
+            LogIap($"Exception: {ex.Message}");
         }
 
         UpdateStatus();
@@ -480,7 +517,7 @@ public class IAPv2Tester : MonoBehaviour
                 onEvent: (successEvent) =>
                 {
                     iapStatus = "Purchase completed (legacy)";
-                    iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] OnEvent (legacy): success");
+                    LogIap("OnEvent (legacy): success");
                     UpdateStatus();
                     UpdateEventLog();
                 },
@@ -488,7 +525,7 @@ public class IAPv2Tester : MonoBehaviour
                 onError: (error) =>
                 {
                     iapStatus = "Purchase failed (legacy)";
-                    iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] OnError (legacy): {error?.Message}");
+                    LogIap($"OnError (legacy): {error?.Message}");
                     UpdateStatus();
                     UpdateEventLog();
                 }
@@ -497,7 +534,7 @@ public class IAPv2Tester : MonoBehaviour
         catch (Exception ex)
         {
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Exception (legacy): {ex.Message}");
+            LogIap($"Exception (legacy): {ex.Message}");
         }
     }
 #endif
@@ -505,7 +542,7 @@ public class IAPv2Tester : MonoBehaviour
     private async void ExecuteIAPGetPendingOrders()
     {
         iapStatus = "Loading pending orders...";
-        iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] IAPGetPendingOrders()");
+        LogIap("IAPGetPendingOrders()");
         UpdateStatus();
         UpdateEventLog();
 
@@ -514,19 +551,19 @@ public class IAPv2Tester : MonoBehaviour
             iapPendingOrders = await AIT.IAPGetPendingOrders();
             int count = iapPendingOrders?.Orders?.Length ?? 0;
             iapStatus = $"Found {count} pending orders";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Success: {count} orders");
+            LogIap($"Success: {count} orders");
         }
         catch (AITException ex)
         {
             iapPendingOrders = null;
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Error: {ex.ErrorCode} - {ex.Message}");
+            LogIap($"Error: {ex.ErrorCode} - {ex.Message}");
         }
         catch (Exception ex)
         {
             iapPendingOrders = null;
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Exception: {ex.Message}");
+            LogIap($"Exception: {ex.Message}");
         }
 
         UpdateStatus();
@@ -537,7 +574,7 @@ public class IAPv2Tester : MonoBehaviour
     private async void ExecuteIAPGetCompletedOrRefundedOrders()
     {
         iapStatus = "Loading completed/refunded orders...";
-        iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] IAPGetCompletedOrRefundedOrders()");
+        LogIap("IAPGetCompletedOrRefundedOrders()");
         UpdateStatus();
         UpdateEventLog();
 
@@ -546,19 +583,19 @@ public class IAPv2Tester : MonoBehaviour
             iapCompletedOrders = await AIT.IAPGetCompletedOrRefundedOrders();
             int count = iapCompletedOrders?.Orders?.Length ?? 0;
             iapStatus = $"Found {count} completed/refunded orders";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Success: {count} orders, HasNext={iapCompletedOrders?.HasNext}");
+            LogIap($"Success: {count} orders, HasNext={iapCompletedOrders?.HasNext}");
         }
         catch (AITException ex)
         {
             iapCompletedOrders = null;
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Error: {ex.ErrorCode} - {ex.Message}");
+            LogIap($"Error: {ex.ErrorCode} - {ex.Message}");
         }
         catch (Exception ex)
         {
             iapCompletedOrders = null;
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Exception: {ex.Message}");
+            LogIap($"Exception: {ex.Message}");
         }
 
         UpdateStatus();
@@ -576,7 +613,7 @@ public class IAPv2Tester : MonoBehaviour
         }
 
         iapStatus = "Processing product grant...";
-        iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] IAPCompleteProductGrant(orderId: {iapOrderId})");
+        LogIap($"IAPCompleteProductGrant(orderId: {iapOrderId})");
         UpdateStatus();
         UpdateEventLog();
 
@@ -592,17 +629,17 @@ public class IAPv2Tester : MonoBehaviour
 
             bool success = await AIT.IAPCompleteProductGrant(args);
             iapStatus = success ? "Product grant completed" : "Product grant failed";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Result: {success}");
+            LogIap($"Result: {success}");
         }
         catch (AITException ex)
         {
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Error: {ex.ErrorCode} - {ex.Message}");
+            LogIap($"Error: {ex.ErrorCode} - {ex.Message}");
         }
         catch (Exception ex)
         {
             iapStatus = $"Error: {ex.Message}";
-            iapEventLog.Add($"[{DateTime.Now:HH:mm:ss}] Exception: {ex.Message}");
+            LogIap($"Exception: {ex.Message}");
         }
 
         UpdateStatus();
@@ -632,10 +669,10 @@ public class IAPv2Tester : MonoBehaviour
     /// </summary>
     private System.Collections.IEnumerator ValidateReceiptOnServer(object data, TaskCompletionSource<bool> tcs)
     {
-        Debug.Log($"[IAPv2Tester] Validating receipt on server: {data}");
+        LogIap($"Validating receipt on server: {data}");
         // 동기 스텁으로는 표현 불가했던 비동기 서버 왕복 경로
         yield return new WaitForSecondsRealtime(0.2f);
-        Debug.Log($"[IAPv2Tester] Receipt validated, granting product: {data}");
+        LogIap($"Receipt validated, granting product: {data}");
         tcs.SetResult(true);
     }
 }

--- a/WebGLTemplates/AITTemplate/Runtime/devconsole/ait-dev-console.js
+++ b/WebGLTemplates/AITTemplate/Runtime/devconsole/ait-dev-console.js
@@ -30,7 +30,19 @@
   //  vConsole 생성보다 먼저 설치해 초기(replayEarlyLogs 포함) 로그도 담는다.
   // =========================================================================
   var logMirror = [];
-  var LOG_MIRROR_MAX = 500;
+  // 500 → 2000 상향 근거: 실기기 결제 진단처럼 "수 분간 초당 수 건" 로깅되는 세션에서
+  // 500개는 5분이면 이미 몇 바퀴 밀려나가 세션 초반 로그가 유실된다(예: 5건/s × 5분 = 1500건).
+  // 2000개면 동일 조건에서 ~6~7분까지 온전히 보존.
+  // 메모리 상한: 엔트리당 텍스트는 LOG_ENTRY_MAX_CHARS(2000자) 하드 캡 + 소량 오버헤드이므로
+  // 최악의 경우(모든 엔트리가 최대 길이) 2000개 × 약 4KB(UTF-16 2byte/자 기준) ≈ 8MB — dev 빌드
+  // 전용 디버그 콘솔이 감당 가능한 수준. 실제로는 대부분의 로그가 훨씬 짧아 체감 사용량은 이보다
+  // 한참 작다(평균 100~150자/건 가정 시 총 ~0.5MB 안팎).
+  // LOG_COPY_MAX_CHARS(300000)와의 관계: 기존 500개 캡은 일반적인 로그 길이(줄당 ~140자 안팎)
+  // 기준 500×140≈70,000자로 복사 상한(300,000자)의 1/4도 못 채운 채 링버퍼가 먼저 비워졌다.
+  // 2000개로 올리면 2000×140≈280,000자로 복사 상한에 거의 맞춰져, 이미 설정된 복사 예산을
+  // 낭비하지 않고 실제로 활용하게 된다(반대로 장문 로그가 많은 세션은 여전히 복사 시점에
+  // LOG_COPY_MAX_CHARS 로 안전하게 잘린다).
+  var LOG_MIRROR_MAX = 2000;
   var LOG_ENTRY_MAX_CHARS = 2000;
 
   // JSON.stringify 는 자르기 전에 입력 전체를 직렬화하므로 대형 객체(typed array 등)에서
@@ -783,6 +795,70 @@
   }
 
   // =========================================================================
+  // vConsole 기본 "Log" 탭에도 로그 복사 버튼 노출 (발견성 개선)
+  //  Metrics 탭의 "🪵 Logs" 버튼(#metric-copy-logs-btn)은 이미 있지만, 개발자가 실제로
+  //  주로 보는 기본 Log 탭에서는 접근할 방법이 없어 발견성이 0이었다. 실기기(Toss 웹뷰)에서
+  //  로그를 수동 전사해야 했던 문제를 이 버튼으로 해소한다. buildLogsCopyText/handleCopy를
+  //  그대로 재사용해 복사 텍스트 포맷·폴백 체인·버튼 피드백을 Metrics 탭과 동일하게 맞춘다.
+  //
+  //  구현 방식(vconsole.min.js 3.15.1 기준, 코드 정독 후 선택):
+  //  vConsole 플러그인 공식 API인 VConsolePlugin#onAddTool(addTool 콜백)은 플러그인이
+  //  _initPlugin() 될 때 딱 한 번만 트리거된다. 기본 "Log" 플러그인(id: "default")은
+  //  VConsole 생성자 내부(_addBuiltInPlugins → 이후 _autoRun 시점)에서 우리가 개입하기 전에
+  //  이미 초기화가 끝나버려, 생성 후 시점에는 그 플러그인 인스턴스에 onAddTool 을 새로
+  //  등록/후킹해도 다시 트리거되지 않는다(트리거는 초기화 1회성).
+  //  대신 vConsole 자신이 addTool 결과를 반영할 때 쓰는 것과 완전히 동일한 경로 —
+  //  compInstance.pluginList["default"].toolbarList 배열에 새 항목을 push 하고
+  //  compInstance.pluginList = compInstance.pluginList 로 재대입해 (Svelte) 반응성 갱신을
+  //  유도 — 를 그대로 재사용한다. 이 재대입 트릭은 vConsole 소스의 _initPlugin() 이
+  //  addTopBar/addTool 결과를 반영할 때 쓰는 것과 동일한 코드 경로이므로, DOM을 직접
+  //  스크래핑/주입하는 방식보다 vConsole 자체 렌더링 사이클과 충돌할 위험이 낮다.
+  //  이렇게 추가한 항목은 vConsole 툴바 CSS(.vc-tool)를 그대로 상속하므로 Clear/Top/Bottom과
+  //  동일한 크기의 터치 타깃을 갖고, global:false 라 Log 탭이 활성일 때만 노출되어
+  //  vConsole 자체 버튼과 자리를 다투거나 겹치지 않는다.
+  //
+  //  타이밍: compInstance/toolbarList 준비 여부는 스크립트 로드 시점의 document.readyState
+  //  에 따라 달라질 수 있어(로딩 중이면 VConsole 이 DOMContentLoaded 까지 초기화를 미룸),
+  //  생성자 직후가 아니라 공식 옵션인 onReady 콜백(= vConsole 초기화 완전 종료 시점, 이
+  //  플러그인의 addTool 트리거 포함)에서 호출한다.
+  // =========================================================================
+  function installLogTabCopyButton(vc) {
+    try {
+      if (!vc || !vc.compInstance || !vc.compInstance.pluginList) return;
+      var pluginList = vc.compInstance.pluginList;
+      var logEntry = pluginList['default'];
+      if (!logEntry || !Array.isArray(logEntry.toolbarList)) return;
+
+      // 중복 방지(예: 향후 재초기화 경로가 생기더라도 두 번 추가되지 않도록).
+      var i;
+      for (i = 0; i < logEntry.toolbarList.length; i++) {
+        if (logEntry.toolbarList[i] && logEntry.toolbarList[i].__aitLogCopy) return;
+      }
+
+      logEntry.toolbarList.push({
+        name: '🪵 Logs',
+        global: false, // Clear/Top/Bottom과 동일하게 Log 탭이 열려 있을 때만 노출.
+        data: null,
+        __aitLogCopy: true,
+        // vConsole 은 툴 클릭 시 onClick.call(clickedDomElement, event, data) 형태로 호출한다
+        // (this = 클릭된 <i class="vc-tool"> 엘리먼트) — handleCopy(btn, text, count) 가
+        // 기대하는 버튼 참조와 정확히 호환된다.
+        onClick: function () {
+          handleCopy(this, buildLogsCopyText(), logMirror.length);
+        }
+      });
+
+      // vConsole _initPlugin() 내부와 동일한 재대입 트릭으로 반응성 갱신을 트리거해
+      // 이미 마운트된 툴바에 새 버튼이 실제로 렌더링되도록 한다.
+      vc.compInstance.pluginList = vc.compInstance.pluginList;
+    } catch (e) {
+      // 내부 구조가 다른(vConsole 버전 차이 등) 경우에도 콘솔 전체가 죽지 않도록 격리.
+      // Metrics 탭의 기존 복사 버튼은 이 실패와 무관하게 정상 동작한다.
+      console.error('[AIT] Log 탭 복사 버튼 주입 실패(무시하고 계속):', e);
+    }
+  }
+
+  // =========================================================================
   // Metrics 전용 CSS (vConsole .vc-* 와 충돌 방지 위해 #ait-metrics-root 스코프)
   // =========================================================================
   function injectMetricsCss() {
@@ -908,7 +984,13 @@
     defaultPlugins: ['system', 'network', 'storage'],
     // 최상위 maxLogNumber 는 deprecated — 경고 console.debug 가 우리 로그 미러에까지
     // 섞여 들어가므로 v3 정식 shape(log.maxLogNumber)로 전달한다.
-    log: { maxLogNumber: 1000 }
+    log: { maxLogNumber: 1000 },
+    // onReady 는 compInstance 생성 + 모든 기본 플러그인의 _initPlugin(addTool 트리거 포함)이
+    // 끝난 뒤 호출되도록 vConsole 이 보장하는 공식 훅이다(내부적으로 setTimeout(0)으로 실행되므로
+    // 이 시점엔 아래 `var vConsole = ...` 대입도 이미 끝나 있어 클로저 참조가 안전하다).
+    // document.readyState 가 "loading"이라 초기화가 DOMContentLoaded 까지 미뤄지는 경우에도
+    // 생성자 직후 호출보다 이 방식이 안전하다.
+    onReady: function () { installLogTabCopyButton(vConsole); }
   });
   window._aitVConsole = vConsole;
 

--- a/sdk-runtime-generator~/src/generators/jslib.ts
+++ b/sdk-runtime-generator~/src/generators/jslib.ts
@@ -816,7 +816,7 @@ ${jsConversions ? '\n' + jsConversions + '\n' : ''}
         var typeNameStr = UTF8ToString(typeName);
         var parsedParams = JSON.parse(UTF8ToString(params));
 
-        console.log('[AIT jslib] ${api.name} called, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} called, id:', subId);
 
         try {
             var result = ${apiCallExpr}({
@@ -824,7 +824,7 @@ ${jsConversions ? '\n' + jsConversions + '\n' : ''}
 ${nestedCallbacksCode}
                 }),
                 onEvent: function(event) {
-                    console.log('[AIT jslib] ${api.name} event:', event);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} event:', event);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -837,7 +837,7 @@ ${nestedCallbacksCode}
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] ${api.name} error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
@@ -924,13 +924,13 @@ ${nestedCallbacksCode}
         var subId = UTF8ToString(subscriptionId);
         var typeNameStr = UTF8ToString(typeName);
 ${paramConversions ? '\n' + paramConversions + '\n' : ''}
-        console.log('[AIT jslib] ${api.name} called, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} called, id:', subId);
 
         try {
             var unsubscribe = ${apiCallExpr}({
                 options: ${optionsObj},
                 onEvent: function(data) {
-                    console.log('[AIT jslib] ${api.name} event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -943,7 +943,7 @@ ${paramConversions ? '\n' + paramConversions + '\n' : ''}
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] ${api.name} error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
@@ -998,13 +998,13 @@ ${paramConversions ? '\n' + paramConversions + '\n' : ''}
         var typeNameStr = UTF8ToString(typeName);
         var optionsObj = options ? JSON.parse(UTF8ToString(options)) : {};
 
-        console.log('[AIT jslib] ${api.name} called, id:', subId, 'options:', optionsObj);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} called, id:', subId, 'options:', optionsObj);
 
         try {
             var unsubscribe = ${apiCallExpr}({
                 options: optionsObj,
                 onEvent: function(data) {
-                    console.log('[AIT jslib] ${api.name} event:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} event:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -1017,7 +1017,7 @@ ${paramConversions ? '\n' + paramConversions + '\n' : ''}
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },
                 onError: function(error) {
-                    console.log('[AIT jslib] ${api.name} error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} error:', error);
                     var errorMessage = error instanceof Error ? error.message : String(error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
@@ -1068,7 +1068,7 @@ ${paramConversions ? '\n' + paramConversions + '\n' : ''}
 
     // 파라미터 로깅
     const paramLogs = effectiveParams.map(p =>
-      `        console.log('[AIT jslib] ${api.name} raw param ${p.name}:', UTF8ToString(${p.name}));`
+      `        if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} raw param ${p.name}:', UTF8ToString(${p.name}));`
     ).join('\n');
 
     // 파라미터 변환을 인라인으로 처리 (중간 변수 없이)
@@ -1119,15 +1119,15 @@ ${paramConversions ? '\n' + paramConversions + '\n' : ''}
         var callback = UTF8ToString(callbackId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] ${api.name} called, callbackId:', callback);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} called, callbackId:', callback);
 ${paramLogs ? paramLogs + '\n' : ''}
         try {
             var promiseResult = ${apiCall};
-            console.log('[AIT jslib] ${api.originalName} returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.originalName} returned:', promiseResult, 'isPromise:', promiseResult && typeof promiseResult.then === 'function');
 
             if (!promiseResult || typeof promiseResult.then !== 'function') {
                 // Promise가 아닌 경우 (undefined, null 등) - 즉시 응답
-                console.log('[AIT jslib] ${api.originalName} did not return a Promise, sending immediate response');
+                if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.originalName} did not return a Promise, sending immediate response');
                 var payload = JSON.stringify({
                     CallbackId: callback,
                     TypeName: typeNameStr,
@@ -1139,12 +1139,12 @@ ${paramLogs ? paramLogs + '\n' : ''}
 
             promiseResult
                 .then(function(result) {
-                    console.log('[AIT jslib] ${api.originalName} resolved:', result);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.originalName} resolved:', result);
 ${resultHandling}
                     SendMessage('AITCore', 'OnAITCallback', payload);
                 })
                 .catch(function(error) {
-                    console.log('[AIT jslib] ${api.originalName} rejected:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.originalName} rejected:', error);
                     var payload = JSON.stringify({
                         CallbackId: callback,
                         TypeName: typeNameStr,
@@ -1153,7 +1153,7 @@ ${resultHandling}
                     setTimeout(function() { SendMessage('AITCore', 'OnAITCallback', payload); }, 0);
                 });
         } catch (error) {
-            console.log('[AIT jslib] ${api.originalName} sync error:', error);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.originalName} sync error:', error);
             var payload = JSON.stringify({
                 CallbackId: callback,
                 TypeName: typeNameStr,
@@ -1206,7 +1206,7 @@ ${resultHandling}
 
     const onEventHandler = hasEventData
       ? `                onEvent: function(data) {
-                    console.log('[AIT jslib] ${api.eventName} fired:', data);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.eventName} fired:', data);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -1220,7 +1220,7 @@ ${resultHandling}
                     SendMessage('AITCore', 'OnAITEventCallback', payload);
                 },`
       : `                onEvent: function() {
-                    console.log('[AIT jslib] ${api.eventName} fired (void)');
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.eventName} fired (void)');
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -1238,14 +1238,14 @@ ${resultHandling}
         var subId = UTF8ToString(subscriptionId);
         var typeNameStr = UTF8ToString(typeName);
 
-        console.log('[AIT jslib] ${api.name} subscribing, id:', subId);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.name} subscribing, id:', subId);
 
         try {
             // Subscribe to event
             var unsubscribe = window.AppsInToss.${api.namespace}.addEventListener('${api.eventName}', {
 ${onEventHandler}
                 onError: function(error) {
-                    console.log('[AIT jslib] ${api.eventName} error:', error);
+                    if (window.__AIT_VERBOSE) console.log('[AIT jslib] ${api.eventName} error:', error);
                     var payload = JSON.stringify({
                         CallbackId: subId,
                         TypeName: typeNameStr,
@@ -1311,7 +1311,7 @@ ${onEventHandler}
         var subId = UTF8ToString(subscriptionId);
 
         if (window.__AIT_SUBSCRIPTIONS && window.__AIT_SUBSCRIPTIONS[subId]) {
-            console.log('[AIT jslib] Unsubscribing:', subId);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] Unsubscribing:', subId);
             var unsubscribe = window.__AIT_SUBSCRIPTIONS[subId];
             if (typeof unsubscribe === 'function') {
                 unsubscribe();
@@ -1331,7 +1331,7 @@ ${onEventHandler}
         var reqId = UTF8ToString(requestId);
         var resultBool = result !== 0;
 
-        console.log('[AIT jslib] RespondToNestedCallback:', reqId, resultBool);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] RespondToNestedCallback:', reqId, resultBool);
 
         if (window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[reqId]) {
             window.__AIT_NESTED_CALLBACKS[reqId](resultBool);

--- a/sdk-runtime-generator~/src/generators/webgl-manual.ts
+++ b/sdk-runtime-generator~/src/generators/webgl-manual.ts
@@ -102,11 +102,37 @@ mergeInto(LibraryManager.library, {
 
         // dpr이 변경되었을 때만 로깅 (window 객체에 캐시)
         if (window.__ait_last_dpr !== dpr) {
-            console.log('[AIT jslib] GetDevicePixelRatio changed:', window.__ait_last_dpr, '->', dpr);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] GetDevicePixelRatio changed:', window.__ait_last_dpr, '->', dpr);
             window.__ait_last_dpr = dpr;
         }
 
         return dpr;
+    },
+});
+`;
+}
+
+/**
+ * AppsInToss-Core.jslib 파일 내용 생성
+ *
+ * AITCore 인프라 브릿지 (web-framework API에 속하지 않는 SDK 내부 스위치 등)를 제공합니다.
+ * 현재는 verbose 로깅 스위치(AITCore.VerboseLogging → window.__AIT_VERBOSE) 전파만 담당합니다.
+ */
+export function generateCoreManualJslib(): string {
+  return `/**
+ * AppsInToss-Core.jslib
+ *
+ * AITCore 인프라 수동 API (verbose 로깅 스위치 등 - web-framework 외부)
+ * This file is auto-generated. Do not modify directly.
+ * 이 파일은 자동 생성되었습니다. 직접 수정하지 마세요.
+ */
+
+mergeInto(LibraryManager.library, {
+    // AITCore.VerboseLogging 프로퍼티 setter에서 호출되어, C# 스위치를 JS 브릿지에 전파합니다.
+    // 생성된 jslib의 정보성 console.log는 모두 window.__AIT_VERBOSE를 따릅니다
+    // (console.error/console.warn 등 경고·에러 로그는 이 스위치와 무관하게 항상 출력됩니다).
+    __AITSetVerboseLogging: function(verbose) {
+        window.__AIT_VERBOSE = verbose !== 0;
     },
 });
 `;

--- a/sdk-runtime-generator~/src/index.ts
+++ b/sdk-runtime-generator~/src/index.ts
@@ -12,7 +12,7 @@ import { CSharpGenerator, CSharpTypeGenerator } from './generators/csharp/index.
 import { JSLibGenerator } from './generators/jslib.js';
 import { typeCheckBridgeCode, printTypeCheckResult, cleanupCache } from './generators/jslib-compiler.js';
 import { generateUnityBridge } from './generators/unity-bridge.js';
-import { generateScreenManualCs, generateScreenManualJslib } from './generators/webgl-manual.js';
+import { generateScreenManualCs, generateScreenManualJslib, generateCoreManualJslib } from './generators/webgl-manual.js';
 import { formatCommand } from './commands/format.js';
 import { FRAMEWORK_APIS, EXCLUDED_APIS, DEPRECATED_API_OVERRIDES, CATEGORY_ORDER, DEFAULT_CATEGORY, resolveApiCategory } from './categories.js';
 import { getApiImportSource, type ParsedAPI, type GeneratedTypeUnit } from './types.js';
@@ -794,6 +794,7 @@ namespace AppsInToss
     const newJslibFiles = new Set<string>([
       ...Array.from(jslibFiles.keys()).map(f => path.join(pluginsDir, f)),
       path.join(pluginsDir, 'AppsInToss-Screen.jslib'), // Screen 수동 API
+      path.join(pluginsDir, 'AppsInToss-Core.jslib'), // Core 수동 API (verbose 로깅 스위치)
     ]);
 
     // 1. 기존 .meta 파일 수집 (삭제 전에)
@@ -888,6 +889,12 @@ namespace AppsInToss
     await fs.writeFile(screenJslibPath, generateScreenManualJslib());
     await ensureMetaFile(screenJslibPath, existingMetas, 'jslib');
     console.log(picocolors.green(`  ✓ Plugins/AppsInToss-Screen.jslib`));
+
+    // Core 수동 API 파일 쓰기 (verbose 로깅 스위치 브릿지 - web-framework 외부)
+    const coreJslibPath = path.join(pluginsDir, 'AppsInToss-Core.jslib');
+    await fs.writeFile(coreJslibPath, generateCoreManualJslib());
+    await ensureMetaFile(coreJslibPath, existingMetas, 'jslib');
+    console.log(picocolors.green(`  ✓ Plugins/AppsInToss-Core.jslib`));
 
     // 9. unity-bridge.ts 생성 (WebGLTemplates/AITTemplate/BuildConfig~/)
     console.log(picocolors.cyan('\n🌉 Unity Bridge 생성 중...'));

--- a/sdk-runtime-generator~/src/templates/csharp-core.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-core.hbs
@@ -241,6 +241,47 @@ namespace AppsInToss
             }
         }
 
+        // ===================================================================
+        // Verbose Logging Switch
+        // ===================================================================
+
+        private static bool _verboseLogging = false;
+
+        /// <summary>
+        /// Enables verbose SDK-internal logging (raw jslib call/event/response payloads and
+        /// AITCore callback routing/registration logs). Defaults to <c>false</c> so production
+        /// WebGL builds stay quiet — each <see cref="UnityEngine.Debug.Log"/> call carries a
+        /// non-trivial per-call cost on WebGL, and every emitted event otherwise shows up
+        /// duplicated across layers in tools like vConsole.
+        /// <para>
+        /// <see cref="UnityEngine.Debug.LogWarning"/>, <see cref="UnityEngine.Debug.LogError"/>,
+        /// and jslib's <c>console.error</c>/<c>console.warn</c> are never gated by this switch —
+        /// warnings and errors are always logged regardless of its value.
+        /// </para>
+        /// <para>
+        /// Setting this property also propagates the flag to the JavaScript bridge
+        /// (<c>window.__AIT_VERBOSE</c>) on WebGL builds, so the generated jslib's informational
+        /// <c>console.log</c> calls follow the same switch. The propagation is a no-op outside
+        /// WebGL player builds (Editor, other platforms).
+        /// </para>
+        /// </summary>
+        public static bool VerboseLogging
+        {
+            get => _verboseLogging;
+            set
+            {
+                _verboseLogging = value;
+#if UNITY_WEBGL && !UNITY_EDITOR
+                __AITSetVerboseLogging(value ? 1 : 0);
+#endif
+            }
+        }
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        private static extern void __AITSetVerboseLogging(int verbose);
+#endif
+
         // Callback storage: success callbacks and error callbacks
         private int _callbackIdCounter = 0;
         private Dictionary<string, Delegate> _callbacks = new Dictionary<string, Delegate>();
@@ -419,11 +460,11 @@ namespace AppsInToss
         /// </summary>
         public void OnAITEventCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnAITEventCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnAITEventCallback received: {jsonPayload}");
             try
             {
                 var callbackData = JsonConvert.DeserializeObject<CallbackData>(jsonPayload);
-                Debug.Log($"[AITCore] Routing event callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Routing event callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
                 RouteSubscriptionCallback(callbackData.CallbackId, callbackData.TypeName, callbackData.Result);
             }
             catch (Exception ex)
@@ -442,7 +483,7 @@ namespace AppsInToss
         [Preserve]
         public void OnVisibilityStateChanged(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnVisibilityStateChanged received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnVisibilityStateChanged received: {jsonPayload}");
             try
             {
                 var data = JsonConvert.DeserializeObject<VisibilityStateData>(jsonPayload);
@@ -517,11 +558,11 @@ namespace AppsInToss
         /// </summary>
         public void OnAITCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnAITCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnAITCallback received: {jsonPayload}");
             try
             {
                 var callbackData = JsonConvert.DeserializeObject<CallbackData>(jsonPayload);
-                Debug.Log($"[AITCore] Routing callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Routing callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
                 RouteCallback(callbackData.CallbackId, callbackData.TypeName, callbackData.Result);
             }
             catch (Exception ex)
@@ -748,7 +789,7 @@ namespace AppsInToss
                 }
             };
             _nestedCallbacks[key] = wrapper;
-            Debug.Log($"[AITCore] Registered nested callback: {key}");
+            if (VerboseLogging) Debug.Log($"[AITCore] Registered nested callback: {key}");
         }
 
         /// <summary>
@@ -767,7 +808,7 @@ namespace AppsInToss
             foreach (var key in keysToRemove)
             {
                 _nestedCallbacks.Remove(key);
-                Debug.Log($"[AITCore] Removed nested callback: {key}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Removed nested callback: {key}");
             }
         }
 
@@ -780,7 +821,7 @@ namespace AppsInToss
         /// </summary>
         public void OnNestedCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnNestedCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnNestedCallback received: {jsonPayload}");
             NestedCallbackRequest request;
             try
             {
@@ -840,7 +881,7 @@ namespace AppsInToss
         /// </summary>
         private void RespondToNestedCallback(string requestId, bool result)
         {
-            Debug.Log($"[AITCore] RespondToNestedCallback: {requestId} = {result}");
+            if (VerboseLogging) Debug.Log($"[AITCore] RespondToNestedCallback: {requestId} = {result}");
 #if UNITY_WEBGL && !UNITY_EDITOR
             __AITRespondToNestedCallback(requestId, result ? 1 : 0);
 #endif

--- a/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
+++ b/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
@@ -241,6 +241,47 @@ namespace AppsInToss
             }
         }
 
+        // ===================================================================
+        // Verbose Logging Switch
+        // ===================================================================
+
+        private static bool _verboseLogging = false;
+
+        /// <summary>
+        /// Enables verbose SDK-internal logging (raw jslib call/event/response payloads and
+        /// AITCore callback routing/registration logs). Defaults to <c>false</c> so production
+        /// WebGL builds stay quiet — each <see cref="UnityEngine.Debug.Log"/> call carries a
+        /// non-trivial per-call cost on WebGL, and every emitted event otherwise shows up
+        /// duplicated across layers in tools like vConsole.
+        /// <para>
+        /// <see cref="UnityEngine.Debug.LogWarning"/>, <see cref="UnityEngine.Debug.LogError"/>,
+        /// and jslib's <c>console.error</c>/<c>console.warn</c> are never gated by this switch —
+        /// warnings and errors are always logged regardless of its value.
+        /// </para>
+        /// <para>
+        /// Setting this property also propagates the flag to the JavaScript bridge
+        /// (<c>window.__AIT_VERBOSE</c>) on WebGL builds, so the generated jslib's informational
+        /// <c>console.log</c> calls follow the same switch. The propagation is a no-op outside
+        /// WebGL player builds (Editor, other platforms).
+        /// </para>
+        /// </summary>
+        public static bool VerboseLogging
+        {
+            get => _verboseLogging;
+            set
+            {
+                _verboseLogging = value;
+#if UNITY_WEBGL && !UNITY_EDITOR
+                __AITSetVerboseLogging(value ? 1 : 0);
+#endif
+            }
+        }
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        private static extern void __AITSetVerboseLogging(int verbose);
+#endif
+
         // Callback storage: success callbacks and error callbacks
         private int _callbackIdCounter = 0;
         private Dictionary<string, Delegate> _callbacks = new Dictionary<string, Delegate>();
@@ -419,11 +460,11 @@ namespace AppsInToss
         /// </summary>
         public void OnAITEventCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnAITEventCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnAITEventCallback received: {jsonPayload}");
             try
             {
                 var callbackData = JsonConvert.DeserializeObject<CallbackData>(jsonPayload);
-                Debug.Log($"[AITCore] Routing event callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Routing event callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
                 RouteSubscriptionCallback(callbackData.CallbackId, callbackData.TypeName, callbackData.Result);
             }
             catch (Exception ex)
@@ -442,7 +483,7 @@ namespace AppsInToss
         [Preserve]
         public void OnVisibilityStateChanged(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnVisibilityStateChanged received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnVisibilityStateChanged received: {jsonPayload}");
             try
             {
                 var data = JsonConvert.DeserializeObject<VisibilityStateData>(jsonPayload);
@@ -555,11 +596,11 @@ namespace AppsInToss
         /// </summary>
         public void OnAITCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnAITCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnAITCallback received: {jsonPayload}");
             try
             {
                 var callbackData = JsonConvert.DeserializeObject<CallbackData>(jsonPayload);
-                Debug.Log($"[AITCore] Routing callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Routing callback: id={callbackData.CallbackId}, type={callbackData.TypeName}");
                 RouteCallback(callbackData.CallbackId, callbackData.TypeName, callbackData.Result);
             }
             catch (Exception ex)
@@ -1225,7 +1266,7 @@ namespace AppsInToss
                 }
             };
             _nestedCallbacks[key] = wrapper;
-            Debug.Log($"[AITCore] Registered nested callback: {key}");
+            if (VerboseLogging) Debug.Log($"[AITCore] Registered nested callback: {key}");
         }
 
         /// <summary>
@@ -1244,7 +1285,7 @@ namespace AppsInToss
             foreach (var key in keysToRemove)
             {
                 _nestedCallbacks.Remove(key);
-                Debug.Log($"[AITCore] Removed nested callback: {key}");
+                if (VerboseLogging) Debug.Log($"[AITCore] Removed nested callback: {key}");
             }
         }
 
@@ -1257,7 +1298,7 @@ namespace AppsInToss
         /// </summary>
         public void OnNestedCallback(string jsonPayload)
         {
-            Debug.Log($"[AITCore] OnNestedCallback received: {jsonPayload}");
+            if (VerboseLogging) Debug.Log($"[AITCore] OnNestedCallback received: {jsonPayload}");
             NestedCallbackRequest request;
             try
             {
@@ -1317,7 +1358,7 @@ namespace AppsInToss
         /// </summary>
         private void RespondToNestedCallback(string requestId, bool result)
         {
-            Debug.Log($"[AITCore] RespondToNestedCallback: {requestId} = {result}");
+            if (VerboseLogging) Debug.Log($"[AITCore] RespondToNestedCallback: {requestId} = {result}");
 #if UNITY_WEBGL && !UNITY_EDITOR
             __AITRespondToNestedCallback(requestId, result ? 1 : 0);
 #endif

--- a/sdk-runtime-generator~/tests/unit/binding.test.ts
+++ b/sdk-runtime-generator~/tests/unit/binding.test.ts
@@ -311,6 +311,7 @@ describe('C# ↔ jslib 바인딩 일관성 검증', () => {
       const syncFunctions = [
         '__AITUnsubscribe_Internal', // 구독 해제는 동기적으로 처리됨
         '__AITRespondToNestedCallback', // 중첩 콜백 응답 (동기적으로 결과 전달)
+        '__AITSetVerboseLogging', // verbose 로깅 스위치 전파 (동기적으로 플래그만 설정, 콜백 없음)
       ];
 
       for (const extern of csharpExterns) {

--- a/sdk-runtime-generator~/tests/unit/verbose-logging.test.ts
+++ b/sdk-runtime-generator~/tests/unit/verbose-logging.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Verbose Logging 스위치 게이팅 검증
+ *
+ * 생성된 SDK의 정보성 로그(jslib console.log, AITCore Debug.Log)가
+ * AITCore.VerboseLogging / window.__AIT_VERBOSE 스위치 뒤에 게이팅되어
+ * 기본값 OFF(조용)로 동작하는지 검증합니다.
+ *
+ * - console.error / console.warn, Debug.LogWarning / Debug.LogError는
+ *   경고·에러 로그이므로 게이팅되지 않고 항상 출력되어야 합니다.
+ * - AITCore.VerboseLogging 프로퍼티가 WebGL 빌드에서 jslib 브릿지
+ *   (window.__AIT_VERBOSE)로 전파되는지도 함께 검증합니다.
+ */
+
+import { describe, test, expect, beforeAll } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as fs from 'fs/promises';
+import { glob } from 'glob';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Verbose Logging 게이팅 검증', () => {
+  let coreCsContent: string;
+  let jslibFiles: Map<string, string>;
+
+  beforeAll(async () => {
+    const sdkGeneratorRoot = path.resolve(__dirname, '../..');
+    const runtimeSDKPath = path.resolve(sdkGeneratorRoot, '../Runtime/SDK');
+    const pluginsPath = path.join(runtimeSDKPath, 'Plugins');
+
+    try {
+      await fs.access(runtimeSDKPath);
+    } catch {
+      throw new Error(
+        '❌ 생성된 SDK 파일을 찾을 수 없습니다!\n' +
+          '   먼저 "pnpm generate"를 실행하여 SDK를 생성하세요.\n' +
+          `   Expected path: ${runtimeSDKPath}`
+      );
+    }
+
+    coreCsContent = await fs.readFile(path.join(runtimeSDKPath, 'AITCore.cs'), 'utf-8');
+
+    jslibFiles = new Map();
+    const jslibFileNames = await glob('*.jslib', { cwd: pluginsPath, absolute: false });
+    for (const fileName of jslibFileNames) {
+      const content = await fs.readFile(path.join(pluginsPath, fileName), 'utf-8');
+      jslibFiles.set(fileName, content);
+    }
+  });
+
+  describe('AITCore.VerboseLogging 스위치', () => {
+    test('public static bool VerboseLogging 프로퍼티가 존재해야 함', () => {
+      expect(coreCsContent).toMatch(/public\s+static\s+bool\s+VerboseLogging/);
+    });
+
+    test('VerboseLogging 프로퍼티에 XML doc 주석이 있어야 함', () => {
+      const propIndex = coreCsContent.indexOf('public static bool VerboseLogging');
+      expect(propIndex).toBeGreaterThan(-1);
+
+      // 프로퍼티 선언 직전 최대 40줄 이내에 /// <summary> 주석이 있어야 함
+      const before = coreCsContent.slice(0, propIndex);
+      const precedingLines = before.split('\n').slice(-40).join('\n');
+      expect(precedingLines).toMatch(/\/\/\/\s*<summary>/);
+    });
+
+    test('기본값은 false (조용) 이어야 함', () => {
+      expect(coreCsContent).toMatch(/_verboseLogging\s*=\s*false/);
+    });
+
+    test('setter가 WebGL 빌드에서 JS 브릿지로 전파해야 하며 다른 플랫폼/에디터에서는 컴파일만 되어야 함', () => {
+      const propIndex = coreCsContent.indexOf('public static bool VerboseLogging');
+      expect(propIndex).toBeGreaterThan(-1);
+
+      // 프로퍼티 블록만 추출 (다음 200자 내에서 balanced하게 대략 추출)
+      const propBlock = coreCsContent.slice(propIndex, propIndex + 600);
+
+      // setter 내부에서 #if UNITY_WEBGL && !UNITY_EDITOR 가드 뒤에서만 JS 브릿지 호출
+      expect(propBlock).toMatch(/#if UNITY_WEBGL && !UNITY_EDITOR[\s\S]*?__AITSetVerboseLogging\([\s\S]*?\)[\s\S]*?#endif/);
+    });
+
+    test('__AITSetVerboseLogging DllImport extern 선언이 #if UNITY_WEBGL && !UNITY_EDITOR 가드 안에 있어야 함', () => {
+      const externIndex = coreCsContent.indexOf('private static extern void __AITSetVerboseLogging');
+      expect(externIndex).toBeGreaterThan(-1);
+
+      const before = coreCsContent.slice(0, externIndex);
+      const lastIfIndex = before.lastIndexOf('#if UNITY_WEBGL && !UNITY_EDITOR');
+      const lastEndifBeforeExtern = before.lastIndexOf('#endif');
+
+      // 가장 최근의 #if가 가장 최근의 #endif보다 뒤에 있어야 (아직 닫히지 않은 가드 안에 있어야) 함
+      expect(lastIfIndex).toBeGreaterThan(-1);
+      expect(lastIfIndex).toBeGreaterThan(lastEndifBeforeExtern);
+    });
+  });
+
+  describe('AITCore.cs 정보성 Debug.Log 게이팅', () => {
+    // 게이팅되어야 하는 정보성 로그 (수신 payload / 라우팅 / 등록 / 응답)
+    const INFO_LOG_MESSAGES = [
+      'OnAITEventCallback received:',
+      'Routing event callback:',
+      'OnVisibilityStateChanged received:',
+      'OnAITCallback received:',
+      'Routing callback:',
+      'Registered nested callback:',
+      'Removed nested callback:',
+      'OnNestedCallback received:',
+      'RespondToNestedCallback:',
+    ];
+
+    test.each(INFO_LOG_MESSAGES)('"%s" Debug.Log는 VerboseLogging으로 게이팅되어야 함', (message) => {
+      // 해당 메시지를 포함하는 라인을 찾아 if (VerboseLogging) 가드가 있는지 확인
+      const lines = coreCsContent.split('\n');
+      const matchingLines = lines.filter(l => l.includes('Debug.Log(') && l.includes(message));
+
+      expect(matchingLines.length).toBeGreaterThan(0);
+      for (const line of matchingLines) {
+        expect(line).toMatch(/if\s*\(VerboseLogging\)\s*Debug\.Log\(/);
+      }
+    });
+
+    test('Debug.LogWarning / Debug.LogError는 게이팅되지 않고 항상 출력되어야 함', () => {
+      const lines = coreCsContent.split('\n');
+      const warnOrErrorLines = lines.filter(
+        l => l.includes('Debug.LogWarning(') || l.includes('Debug.LogError(')
+      );
+
+      expect(warnOrErrorLines.length).toBeGreaterThan(0);
+      for (const line of warnOrErrorLines) {
+        expect(line).not.toMatch(/if\s*\(VerboseLogging\)/);
+      }
+    });
+
+    test('AITCore.cs에 게이팅되지 않은 정보성 Debug.Log가 남아있지 않아야 함', () => {
+      const lines = coreCsContent.split('\n');
+      const violations: string[] = [];
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('Debug.Log(')) continue; // Debug.LogWarning/LogError는 다른 접두사이므로 자연히 제외
+        violations.push(trimmed);
+      }
+
+      if (violations.length > 0) {
+        console.error('❌ 게이팅되지 않은 Debug.Log:');
+        violations.forEach(v => console.error(`   - ${v}`));
+      }
+
+      expect(violations).toHaveLength(0);
+    });
+  });
+
+  describe('jslib 정보성 console.log 게이팅', () => {
+    test('모든 jslib 파일이 로딩되어야 함', () => {
+      expect(jslibFiles.size).toBeGreaterThan(0);
+    });
+
+    test('AppsInToss-IAP.jslib에 정보성 console.log가 다수 존재해야 함 (회귀 감지용)', () => {
+      const content = jslibFiles.get('AppsInToss-IAP.jslib');
+      expect(content).toBeDefined();
+      const count = (content!.match(/console\.log\(/g) || []).length;
+      expect(count).toBeGreaterThan(0);
+    });
+
+    test('모든 jslib 파일의 console.log 호출은 window.__AIT_VERBOSE 가드 뒤에 있어야 함', () => {
+      const violations: string[] = [];
+
+      for (const [fileName, content] of jslibFiles) {
+        const lines = content.split('\n');
+        for (const line of lines) {
+          if (!line.includes('console.log(')) continue;
+          if (!line.includes('if (window.__AIT_VERBOSE)')) {
+            violations.push(`${fileName}: ${line.trim()}`);
+          }
+        }
+      }
+
+      if (violations.length > 0) {
+        console.error('❌ 게이팅되지 않은 console.log:');
+        violations.forEach(v => console.error(`   - ${v}`));
+      }
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('console.error / console.warn 호출은 게이팅되지 않고 항상 출력되어야 함', () => {
+      const violations: string[] = [];
+
+      for (const [fileName, content] of jslibFiles) {
+        const lines = content.split('\n');
+        for (const line of lines) {
+          if (!line.includes('console.error(') && !line.includes('console.warn(')) continue;
+          if (line.includes('if (window.__AIT_VERBOSE)')) {
+            violations.push(`${fileName}: ${line.trim()}`);
+          }
+        }
+      }
+
+      if (violations.length > 0) {
+        console.error('❌ 잘못 게이팅된 console.error/warn:');
+        violations.forEach(v => console.error(`   - ${v}`));
+      }
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('console.error / console.warn 호출이 최소 1개 이상 존재해야 함 (에러 로그 보존 회귀 감지용)', () => {
+      let total = 0;
+      for (const content of jslibFiles.values()) {
+        total += (content.match(/console\.(error|warn)\(/g) || []).length;
+      }
+      expect(total).toBeGreaterThan(0);
+    });
+  });
+
+  describe('AppsInToss-Core.jslib (verbose 스위치 브릿지)', () => {
+    test('AppsInToss-Core.jslib 파일이 생성되어야 함', () => {
+      expect(jslibFiles.has('AppsInToss-Core.jslib')).toBe(true);
+    });
+
+    test('__AITSetVerboseLogging 함수가 window.__AIT_VERBOSE를 설정해야 함', () => {
+      const content = jslibFiles.get('AppsInToss-Core.jslib');
+      expect(content).toBeDefined();
+      expect(content).toMatch(/__AITSetVerboseLogging\s*:\s*function\s*\(verbose\)\s*\{/);
+      expect(content).toMatch(/window\.__AIT_VERBOSE\s*=\s*verbose\s*!==\s*0/);
+    });
+  });
+});


### PR DESCRIPTION
## 개요

실기기(Toss 앱 웹뷰) IAP 진단 테스트 중 드러난 **개발용 로깅 DX 3종**을 개선합니다.

1. **로그 전체 복사 발견성** — 기존 "전체 복사"는 Metrics 탭에만 있어 사용자가 주로 보는 Log 탭에서 접근 불가였음
2. **과도한 verbose 로깅** — 콜백/이벤트 1건이 jslib·C# 여러 레이어에서 무조건 정보성 로그를 남겨 노이즈 + WebGL `Debug.Log` 호출당 비용으로 성능 부담
3. **테스터 로깅 중복/비일관** — 같은 메시지를 화면·콘솔에 서로 다른 포맷으로 이중 기록, 콘솔 로그엔 타임스탬프 없음

## 변경 내용

### 1. vConsole 기본 Log 탭에 로그 복사 버튼 추가
- `WebGLTemplates/AITTemplate/Runtime/devconsole/ait-dev-console.js`
- vConsole 기본 Log 플러그인 툴바에 복사 버튼을 vConsole 자체 반응성 경로(`pluginList[id].toolbarList` 갱신)로 주입 — DOM 스크래핑 대신 내부 계약 재사용. `global:false`라 Log 탭 활성 시에만 노출
- 기존 `buildLogsCopyText`/`handleCopy`(3티어 클립보드 폴백: `setClipboardText`→`navigator.clipboard`→`execCommand`) 그대로 재사용, Metrics 탭 기존 버튼 2개 불변
- 로그 링버퍼 `LOG_MIRROR_MAX` 500→2000(장시간 세션 보존, 메모리 상한 근거 주석 명시). 모든 신규 로직 `try/catch` 방어

### 2. SDK 정보성 로그를 opt-in verbose 스위치로 게이팅
- 생성기(`sdk-runtime-generator~/`) 수정 → `Runtime/SDK/` 재생성
- `AITCore.VerboseLogging`(public static bool, **기본 false**) 단일 스위치 도입 + XML doc
- 게이팅 대상: 생성 jslib의 정보성 `console.log` 전량(406개) + `AITCore`의 수신 payload/라우팅/등록/응답 `Debug.Log` 9곳
- **경고·에러(`console.error`/`Debug.LogWarning`/`Debug.LogError`)는 무조건 유지** — 게이팅 안 함
- C#→JS 전파: `AITCore.VerboseLogging` 세터가 `#if UNITY_WEBGL && !UNITY_EDITOR` 가드 안에서 신규 브릿지 `__AITSetVerboseLogging` 호출 → `window.__AIT_VERBOSE` 설정. 에디터/타 플랫폼은 컴파일만 되고 no-op
- 신규 유닛 테스트 `verbose-logging.test.ts`(23케이스) — 게이팅 적용/에러 비게이팅/스위치 존재 검증

### 3. IAPv2Tester 로깅 단일화 (E2E 샘플/테스터)
- `Tests~/E2E/SharedScripts/Runtime/IAPv2Tester.cs`
- 단일 헬퍼 `LogIap(msg)`로 화면(`iapEventLog`)·콘솔(`Debug.Log`, `[IAPv2Tester]` 프리픽스)에 **동일 `[HH:mm:ss.fff]` 타임스탬프로 1회씩** 기록. 30개 콜사이트 통일, 완전 중복쌍 제거
- `Application.SetStackTraceLogType(Log/Warning, None)`으로 스택트레이스 억제(vConsole 노이즈 + WebGL 성능; Error/Exception은 유지)
- `iapEventLog` 상한 300 도입(증분 렌더링 인덱스 정합 유지)

## 설계 원칙
- **비파괴**: 신규 표면은 `AITCore.VerboseLogging` 하나뿐. 기존 public API 시그니처 불변
- **기본 조용**: 프로덕션 빌드는 verbose OFF가 기본 → 정보성 로그 미출력, 경고/에러만
- **생성물 규율**: `Runtime/SDK/`는 직접 수정 아님. 생성기 수정 후 `generate` 재생성 산출물

## 검증
- ✅ 재생성 멱등성 — `generate` 후 `git status` diff 0
- ✅ 유닛 테스트 **696 passed** (기존 673 + 신규 23)
- ✅ `node --check` — `ait-dev-console.js` 문법 통과
- ✅ 게이팅 누락 `console.log` **0** / E2E의 게이팅 대상 로그문자열 의존 **0**
- ✅ 세 변경 파일 집합 완전 분리(devconsole JS / 생성기+Runtime·SDK / IAPv2Tester.cs)
- ✅ 각 커밋 worktree 격리 구현 후 독립 적대적 리뷰 통과

> Unity C# 실제 컴파일은 CI Unity 빌드에서 최종 확인됩니다(로컬 Unity 부재).
