### PR TITLE
기능: IAP grant 오버레이 교착 방지 opt-in 하드닝 (NestedCallbackTimeoutMs)

### DIFF
--- a/Runtime/SDK/AITCore.cs
+++ b/Runtime/SDK/AITCore.cs
@@ -1237,6 +1237,54 @@ namespace AppsInToss
 
         private Dictionary<string, Delegate> _nestedCallbacks = new Dictionary<string, Delegate>();
 
+        private static int _nestedCallbackTimeoutMs = 0;
+
+        /// <summary>
+        /// Opt-in client-side timeout, in milliseconds, for nested grant callbacks such as
+        /// <c>processProductGrant</c> in <c>IAPCreateOneTimePurchaseOrder</c>.
+        /// <para>
+        /// Default is <c>0</c> = disabled = the original behavior is fully preserved (the SDK
+        /// waits indefinitely for the user's grant callback to resolve). Set a value greater
+        /// than 0 only after weighing the trade-off described below.
+        /// </para>
+        /// <para>
+        /// Why this exists: while the native payment overlay is shown, the Unity WebGL player
+        /// loop freezes (measured 26–43s) and the JavaScript event loop is heavily throttled.
+        /// If the user's async grant callback awaits server-side receipt validation, a circular
+        /// deadlock can form: native waits for the grant Promise, the Promise waits for the C#
+        /// response, the C# response waits for the awaited continuation, the continuation waits
+        /// for the player loop, and the player loop waits for the overlay to close. In measured
+        /// probes the native UI did not auto-dismiss even after "purchase completed".
+        /// </para>
+        /// <para>
+        /// When set greater than 0, a JavaScript-side <c>setTimeout</c> is armed (lever A):
+        /// it resolves the grant Promise to <c>false</c> if no C# response arrives in time.
+        /// This is the lever that can actually break the overlay deadlock, because the JS event
+        /// loop still fires (throttled) while the player loop is frozen.
+        /// </para>
+        /// <para>
+        /// WARNING — consistency trade-off: if the JavaScript-side timeout fires and resolves
+        /// the grant to <c>false</c>, the underlying purchase may already have SUCCEEDED on the
+        /// server (the measured overlay showed "purchase completed"). The order then becomes
+        /// "paid but not granted", and you MUST reconcile it after the fact via the
+        /// <c>IAPGetCompletedOrRefundedOrders</c> recovery flow to grant the item. This
+        /// reconciliation burden is exactly why the default is 0 (disabled).
+        /// </para>
+        /// </summary>
+        public static int NestedCallbackTimeoutMs
+        {
+            get => _nestedCallbackTimeoutMs;
+            set
+            {
+                _nestedCallbackTimeoutMs = value;
+#if UNITY_WEBGL && !UNITY_EDITOR
+                // Propagate to JavaScript so the grant Promise can arm its own setTimeout
+                // (lever A). Editor/other platforms compile but no-op.
+                __AITSetNestedCallbackTimeoutMs(value);
+#endif
+            }
+        }
+
         /// <summary>
         /// Register a nested callback (e.g., processProductGrant in IAPCreateOneTimePurchaseOrder).
         /// The user callback returns a Task so it can await asynchronous work (such as
@@ -1351,6 +1399,9 @@ namespace AppsInToss
 #if UNITY_WEBGL && !UNITY_EDITOR
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __AITRespondToNestedCallback(string requestId, int result);
+
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        private static extern void __AITSetNestedCallbackTimeoutMs(int timeoutMs);
 #endif
 
         /// <summary>

--- a/Runtime/SDK/AITCore.cs
+++ b/Runtime/SDK/AITCore.cs
@@ -1237,6 +1237,14 @@ namespace AppsInToss
 
         private Dictionary<string, Delegate> _nestedCallbacks = new Dictionary<string, Delegate>();
 
+        // Nested-callback deadlock guard (opt-in). Populated/armed only when
+        // NestedCallbackTimeoutMs > 0, and always drained on response/timeout, so neither
+        // collection grows unbounded. Keyed by JavaScript RequestId (e.g.
+        // "sub_0_processProductGrant_1700000000000"), which never collides with the "cb_N"
+        // keys used by the one-shot _timeoutCoroutines above.
+        private HashSet<string> _pendingNestedRequests = new HashSet<string>();
+        private Dictionary<string, Coroutine> _nestedTimeoutCoroutines = new Dictionary<string, Coroutine>();
+
         private static int _nestedCallbackTimeoutMs = 0;
 
         /// <summary>
@@ -1257,10 +1265,13 @@ namespace AppsInToss
         /// probes the native UI did not auto-dismiss even after "purchase completed".
         /// </para>
         /// <para>
-        /// When set greater than 0, a JavaScript-side <c>setTimeout</c> is armed (lever A):
-        /// it resolves the grant Promise to <c>false</c> if no C# response arrives in time.
-        /// This is the lever that can actually break the overlay deadlock, because the JS event
-        /// loop still fires (throttled) while the player loop is frozen.
+        /// When set greater than 0, two timeouts are armed together:
+        /// (A) a JavaScript-side <c>setTimeout</c> that resolves the grant Promise to
+        /// <c>false</c> if no C# response arrives in time. This is the lever that can actually
+        /// break the overlay deadlock, because the JS event loop still fires (throttled) while
+        /// the player loop is frozen. (B) a C# coroutine that responds <c>false</c> after the
+        /// deadline as defense in depth for the case where the loop is running but the user
+        /// callback itself hangs.
         /// </para>
         /// <para>
         /// WARNING — consistency trade-off: if the JavaScript-side timeout fires and resolves
@@ -1383,6 +1394,21 @@ namespace AppsInToss
         /// </summary>
         private async Task DispatchNestedCallbackAsync(string requestId, string data, Func<string, Task<bool>> callback)
         {
+            // (B) C# coroutine timeout — defense in depth, opt-in via NestedCallbackTimeoutMs.
+            // IMPORTANT: this coroutine uses WaitForSecondsRealtime, so it runs on the Unity
+            // player loop and CANNOT fire while the native payment overlay has frozen the loop;
+            // it only fires once the loop resumes. Breaking the *overlay* deadlock is the job of
+            // the JavaScript-side setTimeout (lever A in the jslib). This coroutine instead
+            // cleans up the case where the loop is running but the user's async callback itself
+            // hangs (e.g. a server that never responds), by responding false after the deadline.
+            // Snapshot the knob once so arming and completion agree even if it changes mid-flight.
+            int timeoutMs = NestedCallbackTimeoutMs;
+            if (timeoutMs > 0)
+            {
+                _pendingNestedRequests.Add(requestId);
+                _nestedTimeoutCoroutines[requestId] = StartCoroutine(NestedTimeoutCoroutine(requestId, timeoutMs));
+            }
+
             bool result;
             try
             {
@@ -1393,7 +1419,47 @@ namespace AppsInToss
                 Debug.LogError($"[AITCore] Nested callback dispatch error: {ex.Message}");
                 result = false;
             }
+
+            // Cancel the pending coroutine (if it has not already fired) and respond exactly once.
+            CancelNestedTimeout(requestId);
+            if (timeoutMs > 0 && !_pendingNestedRequests.Remove(requestId))
+            {
+                // The timeout coroutine already responded false for this request — do not
+                // respond a second time (JS would ignore it anyway, but keep C# exactly-once).
+                return;
+            }
             RespondToNestedCallback(requestId, result);
+        }
+
+        /// <summary>
+        /// Client-side timeout for a nested grant callback (opt-in defense in depth). After the
+        /// deadline, if the user callback has not yet produced a response, responds <c>false</c>
+        /// to JavaScript exactly once. Reuses the #978 <see cref="TimeoutCoroutine"/> pattern
+        /// (player-loop-based <c>WaitForSecondsRealtime</c>), so — unlike the JavaScript-side
+        /// setTimeout — it cannot fire while the native overlay has frozen the loop.
+        /// </summary>
+        private System.Collections.IEnumerator NestedTimeoutCoroutine(string requestId, int timeoutMs)
+        {
+            yield return new WaitForSecondsRealtime(timeoutMs / 1000f);
+            _nestedTimeoutCoroutines.Remove(requestId);
+            // Fire only if the user callback has not already produced a response.
+            if (_pendingNestedRequests.Remove(requestId))
+            {
+                RespondToNestedCallback(requestId, false);
+            }
+        }
+
+        /// <summary>
+        /// Cancel a pending nested-timeout coroutine (invoked when the user callback resolves),
+        /// so it does not respond after the request has already been answered.
+        /// </summary>
+        private void CancelNestedTimeout(string requestId)
+        {
+            if (_nestedTimeoutCoroutines.TryGetValue(requestId, out var coroutine))
+            {
+                if (coroutine != null) StopCoroutine(coroutine);
+                _nestedTimeoutCoroutines.Remove(requestId);
+            }
         }
 
 #if UNITY_WEBGL && !UNITY_EDITOR

--- a/Runtime/SDK/Plugins/AppsInToss-IAP.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-IAP.jslib
@@ -482,13 +482,13 @@ mergeInto(LibraryManager.library, {
             entry.resolve(resultBool);
         } else {
             // Already settled by the (A) JS-side timeout, or never registered — silent no-op.
-            console.log('[AIT jslib] Nested callback already settled, ignoring:', reqId);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] Nested callback already settled, ignoring:', reqId);
         }
     },
 
     __AITSetNestedCallbackTimeoutMs: function(timeoutMs) {
         window.__AIT_NESTED_TIMEOUT_MS = timeoutMs;
-        console.log('[AIT jslib] NestedCallbackTimeoutMs set:', timeoutMs);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] NestedCallbackTimeoutMs set:', timeoutMs);
     },
 
 });

--- a/Runtime/SDK/Plugins/AppsInToss-IAP.jslib
+++ b/Runtime/SDK/Plugins/AppsInToss-IAP.jslib
@@ -20,7 +20,28 @@ mergeInto(LibraryManager.library, {
                     return new Promise(function(resolve) {
                         var requestId = subId + '_processProductGrant_' + Date.now();
                         window.__AIT_NESTED_CALLBACKS = window.__AIT_NESTED_CALLBACKS || {};
-                        window.__AIT_NESTED_CALLBACKS[requestId] = resolve;
+
+                        // (A) Opt-in deadlock guard: when AITCore.NestedCallbackTimeoutMs > 0,
+                        // arm a JS-side setTimeout. The JS event loop keeps firing (throttled)
+                        // even while the native overlay freezes the Unity player loop, so this
+                        // is the timeout that can actually break the circular deadlock. If it
+                        // fires first, resolve the grant to false and drop the callback so a
+                        // late C# response is a silent no-op.
+                        // WARNING: resolving false here does NOT cancel the purchase — it may
+                        // already have succeeded server-side. Reconcile "paid but not granted"
+                        // orders via IAPGetCompletedOrRefundedOrders.
+                        var timeoutMs = window.__AIT_NESTED_TIMEOUT_MS;
+                        var timeoutId = null;
+                        if (timeoutMs && timeoutMs > 0) {
+                            timeoutId = setTimeout(function() {
+                                if (window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[requestId]) {
+                                    delete window.__AIT_NESTED_CALLBACKS[requestId];
+                                    resolve(false);
+                                }
+                            }, timeoutMs);
+                        }
+
+                        window.__AIT_NESTED_CALLBACKS[requestId] = { resolve: resolve, timeoutId: timeoutId };
 
                         var payload = JSON.stringify({
                             RequestId: requestId,
@@ -97,7 +118,28 @@ mergeInto(LibraryManager.library, {
                     return new Promise(function(resolve) {
                         var requestId = subId + '_processProductGrant_' + Date.now();
                         window.__AIT_NESTED_CALLBACKS = window.__AIT_NESTED_CALLBACKS || {};
-                        window.__AIT_NESTED_CALLBACKS[requestId] = resolve;
+
+                        // (A) Opt-in deadlock guard: when AITCore.NestedCallbackTimeoutMs > 0,
+                        // arm a JS-side setTimeout. The JS event loop keeps firing (throttled)
+                        // even while the native overlay freezes the Unity player loop, so this
+                        // is the timeout that can actually break the circular deadlock. If it
+                        // fires first, resolve the grant to false and drop the callback so a
+                        // late C# response is a silent no-op.
+                        // WARNING: resolving false here does NOT cancel the purchase — it may
+                        // already have succeeded server-side. Reconcile "paid but not granted"
+                        // orders via IAPGetCompletedOrRefundedOrders.
+                        var timeoutMs = window.__AIT_NESTED_TIMEOUT_MS;
+                        var timeoutId = null;
+                        if (timeoutMs && timeoutMs > 0) {
+                            timeoutId = setTimeout(function() {
+                                if (window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[requestId]) {
+                                    delete window.__AIT_NESTED_CALLBACKS[requestId];
+                                    resolve(false);
+                                }
+                            }, timeoutMs);
+                        }
+
+                        window.__AIT_NESTED_CALLBACKS[requestId] = { resolve: resolve, timeoutId: timeoutId };
 
                         var payload = JSON.stringify({
                             RequestId: requestId,
@@ -433,12 +475,20 @@ mergeInto(LibraryManager.library, {
 
         if (window.__AIT_VERBOSE) console.log('[AIT jslib] RespondToNestedCallback:', reqId, resultBool);
 
-        if (window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[reqId]) {
-            window.__AIT_NESTED_CALLBACKS[reqId](resultBool);
+        var entry = window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[reqId];
+        if (entry) {
+            if (entry.timeoutId) { clearTimeout(entry.timeoutId); }
             delete window.__AIT_NESTED_CALLBACKS[reqId];
+            entry.resolve(resultBool);
         } else {
-            console.warn('[AIT jslib] Unknown nested callback:', reqId);
+            // Already settled by the (A) JS-side timeout, or never registered — silent no-op.
+            console.log('[AIT jslib] Nested callback already settled, ignoring:', reqId);
         }
+    },
+
+    __AITSetNestedCallbackTimeoutMs: function(timeoutMs) {
+        window.__AIT_NESTED_TIMEOUT_MS = timeoutMs;
+        console.log('[AIT jslib] NestedCallbackTimeoutMs set:', timeoutMs);
     },
 
 });

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -1202,12 +1202,20 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
               resolve({ ok: false, reason: 'timeout', elapsedMs: performance.now() - started });
             }, timeoutMs);
 
-            window.__AIT_NESTED_CALLBACKS[requestId] = (resultBool) => {
-              if (settled) return;
-              settled = true;
-              clearTimeout(timer);
-              delete window.__AIT_NESTED_CALLBACKS[requestId];
-              resolve({ ok: true, result: resultBool, elapsedMs: performance.now() - started });
+            // 실 jslib과 동일한 엔트리 shape({ resolve, timeoutId })로 등록한다.
+            // SDK가 opt-in 오버레이 교착 타임아웃(NestedCallbackTimeoutMs)을 도입하면서
+            // __AITRespondToNestedCallback 핸들러가 entry.resolve(resultBool)를 호출하고
+            // entry.timeoutId를 clearTimeout하므로, 옛 "직접 함수" shape는 더 이상 호환되지 않는다.
+            // (이 테스트는 SDK 타임아웃을 켜지 않으므로 timeoutId는 null.)
+            window.__AIT_NESTED_CALLBACKS[requestId] = {
+              resolve: (resultBool) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                delete window.__AIT_NESTED_CALLBACKS[requestId];
+                resolve({ ok: true, result: resultBool, elapsedMs: performance.now() - started });
+              },
+              timeoutId: null
             };
 
             const payload = JSON.stringify({

--- a/sdk-runtime-generator~/src/generators/jslib.ts
+++ b/sdk-runtime-generator~/src/generators/jslib.ts
@@ -1368,7 +1368,7 @@ ${onEventHandler}
             entry.resolve(resultBool);
         } else {
             // Already settled by the (A) JS-side timeout, or never registered — silent no-op.
-            console.log('[AIT jslib] Nested callback already settled, ignoring:', reqId);
+            if (window.__AIT_VERBOSE) console.log('[AIT jslib] Nested callback already settled, ignoring:', reqId);
         }
     },`;
   }
@@ -1384,7 +1384,7 @@ ${onEventHandler}
   private generateSetNestedCallbackTimeoutFunction(): string {
     return `    __AITSetNestedCallbackTimeoutMs: function(timeoutMs) {
         window.__AIT_NESTED_TIMEOUT_MS = timeoutMs;
-        console.log('[AIT jslib] NestedCallbackTimeoutMs set:', timeoutMs);
+        if (window.__AIT_VERBOSE) console.log('[AIT jslib] NestedCallbackTimeoutMs set:', timeoutMs);
     },`;
   }
 

--- a/sdk-runtime-generator~/src/generators/jslib.ts
+++ b/sdk-runtime-generator~/src/generators/jslib.ts
@@ -50,10 +50,11 @@ export class JSLibGenerator {
         functions.push(this.generateUnsubscribeFunction());
       }
 
-      // 중첩 콜백이 있는 API가 있는 카테고리에는 응답 함수 추가
+      // 중첩 콜백이 있는 API가 있는 카테고리에는 응답 함수 + 타임아웃 설정 브릿지 추가
       const hasNestedCallbacks = categoryAPIs.some(api => api.nestedCallbacks && api.nestedCallbacks.length > 0);
       if (hasNestedCallbacks) {
         functions.push(this.generateNestedCallbackResponseFunction());
+        functions.push(this.generateSetNestedCallbackTimeoutFunction());
       }
 
       const fileName = `AppsInToss-${category}.jslib`;
@@ -96,10 +97,11 @@ export class JSLibGenerator {
         functions.push(this.generateUnsubscribeFunction());
       }
 
-      // 중첩 콜백이 있는 API가 있는 카테고리에는 응답 함수 추가
+      // 중첩 콜백이 있는 API가 있는 카테고리에는 응답 함수 + 타임아웃 설정 브릿지 추가
       const hasNestedCallbacks = categoryAPIs.some(api => api.nestedCallbacks && api.nestedCallbacks.length > 0);
       if (hasNestedCallbacks) {
         functions.push(this.generateNestedCallbackResponseFunction());
+        functions.push(this.generateSetNestedCallbackTimeoutFunction());
       }
 
       const fileName = `AppsInToss-${category}.jslib`;
@@ -798,7 +800,28 @@ ${jsConversions ? '\n' + jsConversions + '\n' : ''}
                     return new Promise(function(resolve) {
                         var requestId = subId + '_${nc.name}_' + Date.now();
                         window.__AIT_NESTED_CALLBACKS = window.__AIT_NESTED_CALLBACKS || {};
-                        window.__AIT_NESTED_CALLBACKS[requestId] = resolve;
+
+                        // (A) Opt-in deadlock guard: when AITCore.NestedCallbackTimeoutMs > 0,
+                        // arm a JS-side setTimeout. The JS event loop keeps firing (throttled)
+                        // even while the native overlay freezes the Unity player loop, so this
+                        // is the timeout that can actually break the circular deadlock. If it
+                        // fires first, resolve the grant to false and drop the callback so a
+                        // late C# response is a silent no-op.
+                        // WARNING: resolving false here does NOT cancel the purchase — it may
+                        // already have succeeded server-side. Reconcile "paid but not granted"
+                        // orders via IAPGetCompletedOrRefundedOrders.
+                        var timeoutMs = window.__AIT_NESTED_TIMEOUT_MS;
+                        var timeoutId = null;
+                        if (timeoutMs && timeoutMs > 0) {
+                            timeoutId = setTimeout(function() {
+                                if (window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[requestId]) {
+                                    delete window.__AIT_NESTED_CALLBACKS[requestId];
+                                    resolve(false);
+                                }
+                            }, timeoutMs);
+                        }
+
+                        window.__AIT_NESTED_CALLBACKS[requestId] = { resolve: resolve, timeoutId: timeoutId };
 
                         var payload = JSON.stringify({
                             RequestId: requestId,
@@ -1325,6 +1348,11 @@ ${onEventHandler}
 
   /**
    * 중첩 콜백 응답 함수 생성 (C# → JS)
+   *
+   * exactly-once: 정상 C# 응답과 (A) JS-side setTimeout 두 경로가 같은 pending 엔트리를
+   * 놓고 경쟁한다. 여기서 엔트리를 발견하면 반드시 setTimeout을 clearTimeout하고 엔트리를
+   * 제거한 뒤 resolve하여 중복 resolve를 막는다. 엔트리가 이미 제거된 경우(= setTimeout이
+   * 먼저 false로 resolve) 조용히 no-op한다(에러 로그 없이) — 늦게 도착한 응답은 정상 흐름.
    */
   private generateNestedCallbackResponseFunction(): string {
     return `    __AITRespondToNestedCallback: function(requestId, result) {
@@ -1333,12 +1361,30 @@ ${onEventHandler}
 
         if (window.__AIT_VERBOSE) console.log('[AIT jslib] RespondToNestedCallback:', reqId, resultBool);
 
-        if (window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[reqId]) {
-            window.__AIT_NESTED_CALLBACKS[reqId](resultBool);
+        var entry = window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[reqId];
+        if (entry) {
+            if (entry.timeoutId) { clearTimeout(entry.timeoutId); }
             delete window.__AIT_NESTED_CALLBACKS[reqId];
+            entry.resolve(resultBool);
         } else {
-            console.warn('[AIT jslib] Unknown nested callback:', reqId);
+            // Already settled by the (A) JS-side timeout, or never registered — silent no-op.
+            console.log('[AIT jslib] Nested callback already settled, ignoring:', reqId);
         }
+    },`;
+  }
+
+  /**
+   * 중첩 콜백 타임아웃 설정 브릿지 생성 (C# → JS)
+   *
+   * AITCore.NestedCallbackTimeoutMs 세터가 __AITSetNestedCallbackTimeoutMs(value)로 호출.
+   * grant Promise가 (A) JS-side setTimeout을 무장할지 판단하는 window.__AIT_NESTED_TIMEOUT_MS
+   * 전역을 설정한다. 함수명이 _Internal로 끝나지 않으므로 invariants의 DllImport 규약 검사
+   * 대상에서 제외된다(__AITRespondToNestedCallback과 동일).
+   */
+  private generateSetNestedCallbackTimeoutFunction(): string {
+    return `    __AITSetNestedCallbackTimeoutMs: function(timeoutMs) {
+        window.__AIT_NESTED_TIMEOUT_MS = timeoutMs;
+        console.log('[AIT jslib] NestedCallbackTimeoutMs set:', timeoutMs);
     },`;
   }
 

--- a/sdk-runtime-generator~/src/templates/csharp-core.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-core.hbs
@@ -760,6 +760,54 @@ namespace AppsInToss
 
         private Dictionary<string, Delegate> _nestedCallbacks = new Dictionary<string, Delegate>();
 
+        private static int _nestedCallbackTimeoutMs = 0;
+
+        /// <summary>
+        /// Opt-in client-side timeout, in milliseconds, for nested grant callbacks such as
+        /// <c>processProductGrant</c> in <c>IAPCreateOneTimePurchaseOrder</c>.
+        /// <para>
+        /// Default is <c>0</c> = disabled = the original behavior is fully preserved (the SDK
+        /// waits indefinitely for the user's grant callback to resolve). Set a value greater
+        /// than 0 only after weighing the trade-off described below.
+        /// </para>
+        /// <para>
+        /// Why this exists: while the native payment overlay is shown, the Unity WebGL player
+        /// loop freezes (measured 26–43s) and the JavaScript event loop is heavily throttled.
+        /// If the user's async grant callback awaits server-side receipt validation, a circular
+        /// deadlock can form: native waits for the grant Promise, the Promise waits for the C#
+        /// response, the C# response waits for the awaited continuation, the continuation waits
+        /// for the player loop, and the player loop waits for the overlay to close. In measured
+        /// probes the native UI did not auto-dismiss even after "purchase completed".
+        /// </para>
+        /// <para>
+        /// When set greater than 0, a JavaScript-side <c>setTimeout</c> is armed (lever A):
+        /// it resolves the grant Promise to <c>false</c> if no C# response arrives in time.
+        /// This is the lever that can actually break the overlay deadlock, because the JS event
+        /// loop still fires (throttled) while the player loop is frozen.
+        /// </para>
+        /// <para>
+        /// WARNING — consistency trade-off: if the JavaScript-side timeout fires and resolves
+        /// the grant to <c>false</c>, the underlying purchase may already have SUCCEEDED on the
+        /// server (the measured overlay showed "purchase completed"). The order then becomes
+        /// "paid but not granted", and you MUST reconcile it after the fact via the
+        /// <c>IAPGetCompletedOrRefundedOrders</c> recovery flow to grant the item. This
+        /// reconciliation burden is exactly why the default is 0 (disabled).
+        /// </para>
+        /// </summary>
+        public static int NestedCallbackTimeoutMs
+        {
+            get => _nestedCallbackTimeoutMs;
+            set
+            {
+                _nestedCallbackTimeoutMs = value;
+#if UNITY_WEBGL && !UNITY_EDITOR
+                // Propagate to JavaScript so the grant Promise can arm its own setTimeout
+                // (lever A). Editor/other platforms compile but no-op.
+                __AITSetNestedCallbackTimeoutMs(value);
+#endif
+            }
+        }
+
         /// <summary>
         /// Register a nested callback (e.g., processProductGrant in IAPCreateOneTimePurchaseOrder).
         /// The user callback returns a Task so it can await asynchronous work (such as
@@ -874,6 +922,9 @@ namespace AppsInToss
 #if UNITY_WEBGL && !UNITY_EDITOR
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __AITRespondToNestedCallback(string requestId, int result);
+
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        private static extern void __AITSetNestedCallbackTimeoutMs(int timeoutMs);
 #endif
 
         /// <summary>

--- a/sdk-runtime-generator~/src/templates/csharp-core.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-core.hbs
@@ -760,6 +760,14 @@ namespace AppsInToss
 
         private Dictionary<string, Delegate> _nestedCallbacks = new Dictionary<string, Delegate>();
 
+        // Nested-callback deadlock guard (opt-in). Populated/armed only when
+        // NestedCallbackTimeoutMs > 0, and always drained on response/timeout, so neither
+        // collection grows unbounded. Keyed by JavaScript RequestId (e.g.
+        // "sub_0_processProductGrant_1700000000000"), which never collides with the "cb_N"
+        // keys used by the one-shot _timeoutCoroutines above.
+        private HashSet<string> _pendingNestedRequests = new HashSet<string>();
+        private Dictionary<string, Coroutine> _nestedTimeoutCoroutines = new Dictionary<string, Coroutine>();
+
         private static int _nestedCallbackTimeoutMs = 0;
 
         /// <summary>
@@ -780,10 +788,13 @@ namespace AppsInToss
         /// probes the native UI did not auto-dismiss even after "purchase completed".
         /// </para>
         /// <para>
-        /// When set greater than 0, a JavaScript-side <c>setTimeout</c> is armed (lever A):
-        /// it resolves the grant Promise to <c>false</c> if no C# response arrives in time.
-        /// This is the lever that can actually break the overlay deadlock, because the JS event
-        /// loop still fires (throttled) while the player loop is frozen.
+        /// When set greater than 0, two timeouts are armed together:
+        /// (A) a JavaScript-side <c>setTimeout</c> that resolves the grant Promise to
+        /// <c>false</c> if no C# response arrives in time. This is the lever that can actually
+        /// break the overlay deadlock, because the JS event loop still fires (throttled) while
+        /// the player loop is frozen. (B) a C# coroutine that responds <c>false</c> after the
+        /// deadline as defense in depth for the case where the loop is running but the user
+        /// callback itself hangs.
         /// </para>
         /// <para>
         /// WARNING — consistency trade-off: if the JavaScript-side timeout fires and resolves
@@ -906,6 +917,21 @@ namespace AppsInToss
         /// </summary>
         private async Task DispatchNestedCallbackAsync(string requestId, string data, Func<string, Task<bool>> callback)
         {
+            // (B) C# coroutine timeout — defense in depth, opt-in via NestedCallbackTimeoutMs.
+            // IMPORTANT: this coroutine uses WaitForSecondsRealtime, so it runs on the Unity
+            // player loop and CANNOT fire while the native payment overlay has frozen the loop;
+            // it only fires once the loop resumes. Breaking the *overlay* deadlock is the job of
+            // the JavaScript-side setTimeout (lever A in the jslib). This coroutine instead
+            // cleans up the case where the loop is running but the user's async callback itself
+            // hangs (e.g. a server that never responds), by responding false after the deadline.
+            // Snapshot the knob once so arming and completion agree even if it changes mid-flight.
+            int timeoutMs = NestedCallbackTimeoutMs;
+            if (timeoutMs > 0)
+            {
+                _pendingNestedRequests.Add(requestId);
+                _nestedTimeoutCoroutines[requestId] = StartCoroutine(NestedTimeoutCoroutine(requestId, timeoutMs));
+            }
+
             bool result;
             try
             {
@@ -916,7 +942,47 @@ namespace AppsInToss
                 Debug.LogError($"[AITCore] Nested callback dispatch error: {ex.Message}");
                 result = false;
             }
+
+            // Cancel the pending coroutine (if it has not already fired) and respond exactly once.
+            CancelNestedTimeout(requestId);
+            if (timeoutMs > 0 && !_pendingNestedRequests.Remove(requestId))
+            {
+                // The timeout coroutine already responded false for this request — do not
+                // respond a second time (JS would ignore it anyway, but keep C# exactly-once).
+                return;
+            }
             RespondToNestedCallback(requestId, result);
+        }
+
+        /// <summary>
+        /// Client-side timeout for a nested grant callback (opt-in defense in depth). After the
+        /// deadline, if the user callback has not yet produced a response, responds <c>false</c>
+        /// to JavaScript exactly once. Reuses the #978 <see cref="TimeoutCoroutine"/> pattern
+        /// (player-loop-based <c>WaitForSecondsRealtime</c>), so — unlike the JavaScript-side
+        /// setTimeout — it cannot fire while the native overlay has frozen the loop.
+        /// </summary>
+        private System.Collections.IEnumerator NestedTimeoutCoroutine(string requestId, int timeoutMs)
+        {
+            yield return new WaitForSecondsRealtime(timeoutMs / 1000f);
+            _nestedTimeoutCoroutines.Remove(requestId);
+            // Fire only if the user callback has not already produced a response.
+            if (_pendingNestedRequests.Remove(requestId))
+            {
+                RespondToNestedCallback(requestId, false);
+            }
+        }
+
+        /// <summary>
+        /// Cancel a pending nested-timeout coroutine (invoked when the user callback resolves),
+        /// so it does not respond after the request has already been answered.
+        /// </summary>
+        private void CancelNestedTimeout(string requestId)
+        {
+            if (_nestedTimeoutCoroutines.TryGetValue(requestId, out var coroutine))
+            {
+                if (coroutine != null) StopCoroutine(coroutine);
+                _nestedTimeoutCoroutines.Remove(requestId);
+            }
         }
 
 #if UNITY_WEBGL && !UNITY_EDITOR

--- a/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
+++ b/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
@@ -1237,6 +1237,54 @@ namespace AppsInToss
 
         private Dictionary<string, Delegate> _nestedCallbacks = new Dictionary<string, Delegate>();
 
+        private static int _nestedCallbackTimeoutMs = 0;
+
+        /// <summary>
+        /// Opt-in client-side timeout, in milliseconds, for nested grant callbacks such as
+        /// <c>processProductGrant</c> in <c>IAPCreateOneTimePurchaseOrder</c>.
+        /// <para>
+        /// Default is <c>0</c> = disabled = the original behavior is fully preserved (the SDK
+        /// waits indefinitely for the user's grant callback to resolve). Set a value greater
+        /// than 0 only after weighing the trade-off described below.
+        /// </para>
+        /// <para>
+        /// Why this exists: while the native payment overlay is shown, the Unity WebGL player
+        /// loop freezes (measured 26–43s) and the JavaScript event loop is heavily throttled.
+        /// If the user's async grant callback awaits server-side receipt validation, a circular
+        /// deadlock can form: native waits for the grant Promise, the Promise waits for the C#
+        /// response, the C# response waits for the awaited continuation, the continuation waits
+        /// for the player loop, and the player loop waits for the overlay to close. In measured
+        /// probes the native UI did not auto-dismiss even after "purchase completed".
+        /// </para>
+        /// <para>
+        /// When set greater than 0, a JavaScript-side <c>setTimeout</c> is armed (lever A):
+        /// it resolves the grant Promise to <c>false</c> if no C# response arrives in time.
+        /// This is the lever that can actually break the overlay deadlock, because the JS event
+        /// loop still fires (throttled) while the player loop is frozen.
+        /// </para>
+        /// <para>
+        /// WARNING — consistency trade-off: if the JavaScript-side timeout fires and resolves
+        /// the grant to <c>false</c>, the underlying purchase may already have SUCCEEDED on the
+        /// server (the measured overlay showed "purchase completed"). The order then becomes
+        /// "paid but not granted", and you MUST reconcile it after the fact via the
+        /// <c>IAPGetCompletedOrRefundedOrders</c> recovery flow to grant the item. This
+        /// reconciliation burden is exactly why the default is 0 (disabled).
+        /// </para>
+        /// </summary>
+        public static int NestedCallbackTimeoutMs
+        {
+            get => _nestedCallbackTimeoutMs;
+            set
+            {
+                _nestedCallbackTimeoutMs = value;
+#if UNITY_WEBGL && !UNITY_EDITOR
+                // Propagate to JavaScript so the grant Promise can arm its own setTimeout
+                // (lever A). Editor/other platforms compile but no-op.
+                __AITSetNestedCallbackTimeoutMs(value);
+#endif
+            }
+        }
+
         /// <summary>
         /// Register a nested callback (e.g., processProductGrant in IAPCreateOneTimePurchaseOrder).
         /// The user callback returns a Task so it can await asynchronous work (such as
@@ -1351,6 +1399,9 @@ namespace AppsInToss
 #if UNITY_WEBGL && !UNITY_EDITOR
         [System.Runtime.InteropServices.DllImport("__Internal")]
         private static extern void __AITRespondToNestedCallback(string requestId, int result);
+
+        [System.Runtime.InteropServices.DllImport("__Internal")]
+        private static extern void __AITSetNestedCallbackTimeoutMs(int timeoutMs);
 #endif
 
         /// <summary>

--- a/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
+++ b/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
@@ -1237,6 +1237,14 @@ namespace AppsInToss
 
         private Dictionary<string, Delegate> _nestedCallbacks = new Dictionary<string, Delegate>();
 
+        // Nested-callback deadlock guard (opt-in). Populated/armed only when
+        // NestedCallbackTimeoutMs > 0, and always drained on response/timeout, so neither
+        // collection grows unbounded. Keyed by JavaScript RequestId (e.g.
+        // "sub_0_processProductGrant_1700000000000"), which never collides with the "cb_N"
+        // keys used by the one-shot _timeoutCoroutines above.
+        private HashSet<string> _pendingNestedRequests = new HashSet<string>();
+        private Dictionary<string, Coroutine> _nestedTimeoutCoroutines = new Dictionary<string, Coroutine>();
+
         private static int _nestedCallbackTimeoutMs = 0;
 
         /// <summary>
@@ -1257,10 +1265,13 @@ namespace AppsInToss
         /// probes the native UI did not auto-dismiss even after "purchase completed".
         /// </para>
         /// <para>
-        /// When set greater than 0, a JavaScript-side <c>setTimeout</c> is armed (lever A):
-        /// it resolves the grant Promise to <c>false</c> if no C# response arrives in time.
-        /// This is the lever that can actually break the overlay deadlock, because the JS event
-        /// loop still fires (throttled) while the player loop is frozen.
+        /// When set greater than 0, two timeouts are armed together:
+        /// (A) a JavaScript-side <c>setTimeout</c> that resolves the grant Promise to
+        /// <c>false</c> if no C# response arrives in time. This is the lever that can actually
+        /// break the overlay deadlock, because the JS event loop still fires (throttled) while
+        /// the player loop is frozen. (B) a C# coroutine that responds <c>false</c> after the
+        /// deadline as defense in depth for the case where the loop is running but the user
+        /// callback itself hangs.
         /// </para>
         /// <para>
         /// WARNING — consistency trade-off: if the JavaScript-side timeout fires and resolves
@@ -1383,6 +1394,21 @@ namespace AppsInToss
         /// </summary>
         private async Task DispatchNestedCallbackAsync(string requestId, string data, Func<string, Task<bool>> callback)
         {
+            // (B) C# coroutine timeout — defense in depth, opt-in via NestedCallbackTimeoutMs.
+            // IMPORTANT: this coroutine uses WaitForSecondsRealtime, so it runs on the Unity
+            // player loop and CANNOT fire while the native payment overlay has frozen the loop;
+            // it only fires once the loop resumes. Breaking the *overlay* deadlock is the job of
+            // the JavaScript-side setTimeout (lever A in the jslib). This coroutine instead
+            // cleans up the case where the loop is running but the user's async callback itself
+            // hangs (e.g. a server that never responds), by responding false after the deadline.
+            // Snapshot the knob once so arming and completion agree even if it changes mid-flight.
+            int timeoutMs = NestedCallbackTimeoutMs;
+            if (timeoutMs > 0)
+            {
+                _pendingNestedRequests.Add(requestId);
+                _nestedTimeoutCoroutines[requestId] = StartCoroutine(NestedTimeoutCoroutine(requestId, timeoutMs));
+            }
+
             bool result;
             try
             {
@@ -1393,7 +1419,47 @@ namespace AppsInToss
                 Debug.LogError($"[AITCore] Nested callback dispatch error: {ex.Message}");
                 result = false;
             }
+
+            // Cancel the pending coroutine (if it has not already fired) and respond exactly once.
+            CancelNestedTimeout(requestId);
+            if (timeoutMs > 0 && !_pendingNestedRequests.Remove(requestId))
+            {
+                // The timeout coroutine already responded false for this request — do not
+                // respond a second time (JS would ignore it anyway, but keep C# exactly-once).
+                return;
+            }
             RespondToNestedCallback(requestId, result);
+        }
+
+        /// <summary>
+        /// Client-side timeout for a nested grant callback (opt-in defense in depth). After the
+        /// deadline, if the user callback has not yet produced a response, responds <c>false</c>
+        /// to JavaScript exactly once. Reuses the #978 <see cref="TimeoutCoroutine"/> pattern
+        /// (player-loop-based <c>WaitForSecondsRealtime</c>), so — unlike the JavaScript-side
+        /// setTimeout — it cannot fire while the native overlay has frozen the loop.
+        /// </summary>
+        private System.Collections.IEnumerator NestedTimeoutCoroutine(string requestId, int timeoutMs)
+        {
+            yield return new WaitForSecondsRealtime(timeoutMs / 1000f);
+            _nestedTimeoutCoroutines.Remove(requestId);
+            // Fire only if the user callback has not already produced a response.
+            if (_pendingNestedRequests.Remove(requestId))
+            {
+                RespondToNestedCallback(requestId, false);
+            }
+        }
+
+        /// <summary>
+        /// Cancel a pending nested-timeout coroutine (invoked when the user callback resolves),
+        /// so it does not respond after the request has already been answered.
+        /// </summary>
+        private void CancelNestedTimeout(string requestId)
+        {
+            if (_nestedTimeoutCoroutines.TryGetValue(requestId, out var coroutine))
+            {
+                if (coroutine != null) StopCoroutine(coroutine);
+                _nestedTimeoutCoroutines.Remove(requestId);
+            }
         }
 
 #if UNITY_WEBGL && !UNITY_EDITOR

--- a/sdk-runtime-generator~/tests/unit/binding.test.ts
+++ b/sdk-runtime-generator~/tests/unit/binding.test.ts
@@ -312,6 +312,7 @@ describe('C# ↔ jslib 바인딩 일관성 검증', () => {
         '__AITUnsubscribe_Internal', // 구독 해제는 동기적으로 처리됨
         '__AITRespondToNestedCallback', // 중첩 콜백 응답 (동기적으로 결과 전달)
         '__AITSetVerboseLogging', // verbose 로깅 스위치 전파 (동기적으로 플래그만 설정, 콜백 없음)
+        '__AITSetNestedCallbackTimeoutMs', // 중첩 콜백 타임아웃 전역 설정 (window.__AIT_NESTED_TIMEOUT_MS)
       ];
 
       for (const extern of csharpExterns) {

--- a/sdk-runtime-generator~/tests/unit/nested-callback-timeout.test.ts
+++ b/sdk-runtime-generator~/tests/unit/nested-callback-timeout.test.ts
@@ -114,6 +114,54 @@ describe('(a) NestedCallbackTimeoutMs 노브 표면 (csharp-core.hbs)', () => {
   });
 });
 
+describe('(c) C# nested 코루틴 타임아웃 (심층 방어, csharp-core.hbs)', () => {
+  test('DispatchNestedCallbackAsync가 timeoutMs>0일 때만 코루틴을 무장한다', () => {
+    const body = extractCsMethodBody(
+      coreContent,
+      'private async Task DispatchNestedCallbackAsync(string requestId, string data, Func<string, Task<bool>> callback)'
+    );
+    expect(body).not.toBeNull();
+    // 노브 스냅샷 → 게이트 → 무장 (pending 등록 + 코루틴 시작)
+    expect(body).toContain('int timeoutMs = NestedCallbackTimeoutMs;');
+    expect(body).toMatch(/if \(timeoutMs > 0\)/);
+    expect(body).toContain('_pendingNestedRequests.Add(requestId);');
+    expect(body).toContain('StartCoroutine(NestedTimeoutCoroutine(requestId, timeoutMs))');
+    // 정상 완료 시 코루틴 취소 + exactly-once 가드
+    expect(body).toContain('CancelNestedTimeout(requestId);');
+    expect(body).toMatch(/if \(timeoutMs > 0 && !_pendingNestedRequests\.Remove\(requestId\)\)/);
+  });
+
+  test('NestedTimeoutCoroutine이 #978 WaitForSecondsRealtime 패턴으로 정확히 1회 false 응답한다', () => {
+    const body = extractCsMethodBody(
+      coreContent,
+      'private System.Collections.IEnumerator NestedTimeoutCoroutine(string requestId, int timeoutMs)'
+    );
+    expect(body).not.toBeNull();
+    expect(body).toContain('WaitForSecondsRealtime(timeoutMs / 1000f)');
+    // pending에서 제거에 성공한 경우에만 응답 (double-respond 방지)
+    expect(body).toMatch(/if \(_pendingNestedRequests\.Remove\(requestId\)\)/);
+    expect(body).toContain('RespondToNestedCallback(requestId, false);');
+  });
+
+  test('CancelNestedTimeout이 StopCoroutine으로 대기 중 코루틴을 취소한다', () => {
+    const body = extractCsMethodBody(coreContent, 'private void CancelNestedTimeout(string requestId)');
+    expect(body).not.toBeNull();
+    expect(body).toContain('StopCoroutine(coroutine)');
+    expect(body).toContain('_nestedTimeoutCoroutines.Remove(requestId);');
+  });
+
+  test('코루틴이 player-loop 의존이라 오버레이 교착을 못 깬다는 한계가 주석에 명시된다 (역할 분담)', () => {
+    const body = extractCsMethodBody(
+      coreContent,
+      'private async Task DispatchNestedCallbackAsync(string requestId, string data, Func<string, Task<bool>> callback)'
+    );
+    expect(body).not.toBeNull();
+    // (B)가 loop 재개 후에만 발화하고, 오버레이 교착은 (A) JS-side가 깬다는 역할 분담 주석
+    expect(body).toMatch(/WaitForSecondsRealtime/);
+    expect(body).toMatch(/lever A|JavaScript-side setTimeout/);
+  });
+});
+
 describe('(A) grant Promise JS-side 타임아웃 (jslib.ts → AppsInToss-IAP.jslib)', () => {
   test('processProductGrant Promise가 __AIT_NESTED_TIMEOUT_MS 가드 setTimeout을 무장한다', () => {
     // 최소 1개 이상의 grant 콜백(one-time/subscription)에 lever A가 삽입되어야 한다
@@ -153,6 +201,21 @@ describe('(A) grant Promise JS-side 타임아웃 (jslib.ts → AppsInToss-IAP.js
 });
 
 describe('(d) 기본 0(비활성) = 기존 동작 불변 (게이팅 무결성)', () => {
+  test('C#: 코루틴 무장/스냅샷이 timeoutMs>0 게이트 뒤에만 존재한다 (기본 0이면 무장 안 됨)', () => {
+    // 게이트 밖에서 무조건 무장하는 코드가 없어야 한다 — StartCoroutine(NestedTimeoutCoroutine ...)은
+    // 반드시 `if (timeoutMs > 0)` 블록 안에서만 나타난다.
+    const dispatchBody = extractCsMethodBody(
+      coreContent,
+      'private async Task DispatchNestedCallbackAsync(string requestId, string data, Func<string, Task<bool>> callback)'
+    )!;
+    const gateIdx = dispatchBody.indexOf('if (timeoutMs > 0)');
+    const armIdx = dispatchBody.indexOf('StartCoroutine(NestedTimeoutCoroutine');
+    expect(gateIdx).toBeGreaterThanOrEqual(0);
+    expect(armIdx).toBeGreaterThan(gateIdx);
+    // 무장은 이 dispatch 메서드에서 정확히 1회만 (게이트 뒤)
+    expect((coreContent.match(/StartCoroutine\(NestedTimeoutCoroutine/g) || []).length).toBe(1);
+  });
+
   test('JS: setTimeout이 __AIT_NESTED_TIMEOUT_MS 진리성 가드 뒤에만 존재한다 (기본 undefined이면 무장 안 됨)', () => {
     // grant 콜백 블록 내 setTimeout( 호출은 모두 `if (timeoutMs && timeoutMs > 0)` 뒤에 온다.
     // 무장 setTimeout 수 == 가드 수 (짝이 맞아야 게이팅 누락 없음)

--- a/sdk-runtime-generator~/tests/unit/nested-callback-timeout.test.ts
+++ b/sdk-runtime-generator~/tests/unit/nested-callback-timeout.test.ts
@@ -1,0 +1,164 @@
+/**
+ * IAP grant 콜백 교착(deadlock) 방지 하드닝 회귀 테스트
+ *
+ * `processProductGrant` 같은 nested grant 콜백에서 결제 native 오버레이가 Unity WebGL
+ * player loop를 정지시켜 발생하는 순환 교착을 opt-in 타임아웃으로 방어한다. 단일 노브는
+ * `AITCore.NestedCallbackTimeoutMs`(기본 0 = 비활성 = 기존 동작 불변) 하나뿐이며, >0이면
+ * 두 타임아웃을 동시에 무장한다:
+ *  (A) JS-side setTimeout — 오버레이로 loop가 얼어도 이벤트 루프에서 발화 → 교착을 실제로 깬다.
+ *  (B) C# 코루틴(WaitForSecondsRealtime) — loop 의존적 심층 방어(loop 재개 후 정리).
+ *
+ * exactly-once: 정상 C# 응답과 JS-side setTimeout 두 경로가 정확히 1회만 resolve하고
+ * 서로의 pending 상태를 정리한다. C#쪽은 _pendingNestedRequests, JS쪽은
+ * window.__AIT_NESTED_CALLBACKS 엔트리 삭제로 이중 정리한다.
+ *
+ * 정합성 트레이드오프: JS-side 타임아웃이 grant를 false로 resolve해도 서버 결제는 성공했을 수
+ * 있어 "결제 완료·미지급" 상태가 되며 IAPGetCompletedOrRefundedOrders로 사후 reconcile 필요.
+ * 기본 0(비활성)인 이유가 이 트레이드오프임 — XML doc/주석에 표면화되어야 한다.
+ */
+
+import { describe, test, expect, beforeAll } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import * as fs from 'fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const runtimeSDKPath = path.resolve(__dirname, '../..', '../Runtime/SDK');
+
+let coreContent = '';
+let iapJslibContent = '';
+
+/** `functionName: function(...) { ... }` 본문을 중괄호 매칭으로 추출 (jslib) */
+function extractJslibFunctionBody(content: string, functionName: string): string | null {
+  const marker = `${functionName}: function`;
+  const idx = content.indexOf(marker);
+  if (idx === -1) return null;
+  const braceStart = content.indexOf('{', idx);
+  if (braceStart === -1) return null;
+  let depth = 0;
+  for (let i = braceStart; i < content.length; i++) {
+    const ch = content[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return content.slice(braceStart, i + 1);
+    }
+  }
+  return null;
+}
+
+/** C# 메서드 본문을 중괄호 매칭으로 추출 (시그니처 원문으로 시작점 지정) */
+function extractCsMethodBody(content: string, signatureNeedle: string): string | null {
+  const idx = content.indexOf(signatureNeedle);
+  if (idx === -1) return null;
+  const braceStart = content.indexOf('{', idx + signatureNeedle.length);
+  if (braceStart === -1) return null;
+  let depth = 0;
+  for (let i = braceStart; i < content.length; i++) {
+    const ch = content[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return content.slice(braceStart, i + 1);
+    }
+  }
+  return null;
+}
+
+beforeAll(async () => {
+  try {
+    await fs.access(runtimeSDKPath);
+  } catch {
+    throw new Error(
+      '❌ 생성된 SDK 파일을 찾을 수 없습니다!\n' +
+      '   먼저 "pnpm generate"를 실행하여 SDK를 생성하세요.'
+    );
+  }
+  coreContent = await fs.readFile(path.join(runtimeSDKPath, 'AITCore.cs'), 'utf-8');
+  iapJslibContent = await fs.readFile(
+    path.join(runtimeSDKPath, 'Plugins', 'AppsInToss-IAP.jslib'),
+    'utf-8'
+  );
+});
+
+describe('(a) NestedCallbackTimeoutMs 노브 표면 (csharp-core.hbs)', () => {
+  test('public static int 프로퍼티 + 기본값 0 백킹 필드가 존재한다 (비파괴 opt-in)', () => {
+    expect(coreContent).toMatch(/public static int NestedCallbackTimeoutMs/);
+    expect(coreContent).toMatch(/private static int _nestedCallbackTimeoutMs = 0;/);
+  });
+
+  test('세터가 WebGL 가드 안에서 __AITSetNestedCallbackTimeoutMs 브릿지를 호출한다', () => {
+    const body = extractCsMethodBody(coreContent, 'public static int NestedCallbackTimeoutMs');
+    expect(body).not.toBeNull();
+    // 세터에서 백킹 필드 갱신 + 브릿지 호출이 #if UNITY_WEBGL 가드 안에 있어야 한다
+    expect(body).toContain('_nestedCallbackTimeoutMs = value;');
+    expect(body).toContain('#if UNITY_WEBGL && !UNITY_EDITOR');
+    expect(body).toContain('__AITSetNestedCallbackTimeoutMs(value);');
+  });
+
+  test('브릿지 DllImport(__AITSetNestedCallbackTimeoutMs)가 WebGL 가드 안에 선언된다', () => {
+    expect(coreContent).toMatch(
+      /private static extern void __AITSetNestedCallbackTimeoutMs\(int timeoutMs\);/
+    );
+    // _Internal 접미사가 아니므로 invariants의 DllImport 규약 검사에서 제외됨(__AITRespondToNestedCallback과 동일)
+    expect(coreContent).not.toContain('__AITSetNestedCallbackTimeoutMs_Internal');
+  });
+
+  test('정합성 트레이드오프가 XML doc에 표면화된다 (paid-but-not-granted + IAPGetCompletedOrRefundedOrders + 기본 0 사유)', () => {
+    // XML doc 주석에 사후 reconcile 플로우와 기본 비활성 사유가 명시되어야 한다
+    expect(coreContent).toContain('IAPGetCompletedOrRefundedOrders');
+    expect(coreContent).toMatch(/paid but not granted/i);
+    expect(coreContent).toMatch(/default is 0/i);
+  });
+});
+
+describe('(A) grant Promise JS-side 타임아웃 (jslib.ts → AppsInToss-IAP.jslib)', () => {
+  test('processProductGrant Promise가 __AIT_NESTED_TIMEOUT_MS 가드 setTimeout을 무장한다', () => {
+    // 최소 1개 이상의 grant 콜백(one-time/subscription)에 lever A가 삽입되어야 한다
+    const timeoutReads = (iapJslibContent.match(/var timeoutMs = window\.__AIT_NESTED_TIMEOUT_MS;/g) || []).length;
+    expect(timeoutReads).toBeGreaterThanOrEqual(1);
+    // 가드: window.__AIT_NESTED_TIMEOUT_MS(undefined 기본) 뒤에서만 setTimeout
+    expect(iapJslibContent).toMatch(/if \(timeoutMs && timeoutMs > 0\) \{\s*timeoutId = setTimeout\(/);
+    // setTimeout 발화 시 콜백 제거 + false resolve (늦은 C# 응답은 no-op이 되도록)
+    expect(iapJslibContent).toContain('delete window.__AIT_NESTED_CALLBACKS[requestId];');
+    expect(iapJslibContent).toMatch(/resolve\(false\);/);
+    // 엔트리는 { resolve, timeoutId } 형태로 저장(응답 경로에서 clearTimeout 가능)
+    expect(iapJslibContent).toContain('{ resolve: resolve, timeoutId: timeoutId };');
+  });
+
+  test('__AITRespondToNestedCallback: 정상 응답 시 clearTimeout + resolve, 이미 정리된 경우 조용히 no-op', () => {
+    const body = extractJslibFunctionBody(iapJslibContent, '__AITRespondToNestedCallback');
+    expect(body).not.toBeNull();
+    // 정상 경로: 저장된 setTimeout을 clearTimeout(중복 resolve 금지) 후 resolve
+    expect(body).toContain('clearTimeout(entry.timeoutId)');
+    expect(body).toContain('delete window.__AIT_NESTED_CALLBACKS[reqId];');
+    expect(body).toContain('entry.resolve(resultBool)');
+    // 이미 setTimeout이 정리한 경우(엔트리 없음): 에러 로그 없이 no-op이어야 한다
+    expect(body).not.toContain('console.warn');
+    expect(body).not.toContain('console.error');
+  });
+
+  test('__AITSetNestedCallbackTimeoutMs 브릿지가 window.__AIT_NESTED_TIMEOUT_MS 전역을 설정한다', () => {
+    const body = extractJslibFunctionBody(iapJslibContent, '__AITSetNestedCallbackTimeoutMs');
+    expect(body).not.toBeNull();
+    expect(body).toContain('window.__AIT_NESTED_TIMEOUT_MS = timeoutMs;');
+  });
+
+  test('정합성 트레이드오프가 jslib 주석에 표면화된다 (paid-but-not-granted reconcile)', () => {
+    expect(iapJslibContent).toContain('IAPGetCompletedOrRefundedOrders');
+    expect(iapJslibContent).toMatch(/paid but not granted/i);
+  });
+});
+
+describe('(d) 기본 0(비활성) = 기존 동작 불변 (게이팅 무결성)', () => {
+  test('JS: setTimeout이 __AIT_NESTED_TIMEOUT_MS 진리성 가드 뒤에만 존재한다 (기본 undefined이면 무장 안 됨)', () => {
+    // grant 콜백 블록 내 setTimeout( 호출은 모두 `if (timeoutMs && timeoutMs > 0)` 뒤에 온다.
+    // 무장 setTimeout 수 == 가드 수 (짝이 맞아야 게이팅 누락 없음)
+    const armCount = (iapJslibContent.match(/timeoutId = setTimeout\(/g) || []).length;
+    const guardCount = (iapJslibContent.match(/if \(timeoutMs && timeoutMs > 0\) \{/g) || []).length;
+    expect(armCount).toBeGreaterThanOrEqual(1);
+    expect(armCount).toBe(guardCount);
+  });
+});


### PR DESCRIPTION
> ⚠️ **리뷰 요청 PR입니다. 아직 머지하지 마세요.** 아래 "머지 전 확인 필요" 3개 항목에 대한 네이티브 팀 답변과 실기기 검증이 선행되어야 합니다.

## 배경

테크챗 [4377](https://techchat-apps-in-toss.toss.im/t/processproductgrant/4377) 후속. `ProcessProductGrant` 콜백을 `Task<bool>`로 비동기화(#977)한 뒤, 결제 완료 오버레이가 떠 있는 동안 **게임이 영구 정지하는 교착**이 실기기에서 보고되었습니다.

실기기 프로브(`[PLP:onError]`) 측정 결과:

| 지표 | 관측값 | 정상 기대치 |
|---|---|---|
| Unity 플레이어 루프 프레임 갭 | **26.4s / 43.1s** | ~16ms |
| JS 이벤트 루프 스톨 | **8.9s / 25.9s** | ~250ms |

플레이어 루프뿐 아니라 **JS 이벤트 루프까지 함께 정지**합니다. rAF만 멈춘 게 아니라 웹뷰 전체가 사실상 서스펜드에 가까운 상태입니다. 다만 JS 타이머가 산발적으로는 발화하므로, **JS 측 타임아웃은 (지연되더라도) 결국 교착을 끊을 수 있습니다.**

### 교착 구조 (순환 대기)

```
네이티브 오버레이  ──대기──▶  processProductGrant Promise
        ▲                              │
        │                              ▼
   (오버레이 닫힘)              C# 응답 대기
        ▲                              │
        │                              ▼
  플레이어 루프 재개  ◀──대기──  await continuation
```

C# `await` continuation은 플레이어 루프 위에서만 재개되고, 플레이어 루프는 오버레이가 닫혀야 돌며, 오버레이는 Promise가 resolve돼야 닫힙니다 → 자력 탈출 불가.

## 변경 내용

**opt-in 2단 방어**입니다. 기본값 `0` = 완전 비활성 = 기존 동작과 100% 동일.

### 레버 A — JS-side 타임아웃 (주 방어)

`processProductGrant`가 반환하는 Promise에 `setTimeout`을 무장합니다. C# 응답이 제한 시간 내에 오지 않으면 JS가 스스로 `resolve(false)` → 네이티브 오버레이가 닫힘 → 플레이어 루프 재개.

**플레이어 루프에 의존하지 않으므로 교착 상황에서도 동작합니다.** 이것이 실효적인 탈출 경로입니다.

```js
var timeoutId = null;
if (timeoutMs && timeoutMs > 0) {
    timeoutId = setTimeout(function() {
        if (window.__AIT_NESTED_CALLBACKS && window.__AIT_NESTED_CALLBACKS[requestId]) {
            delete window.__AIT_NESTED_CALLBACKS[requestId];
            resolve(false);
        }
    }, timeoutMs);
}
window.__AIT_NESTED_CALLBACKS[requestId] = { resolve: resolve, timeoutId: timeoutId };
```

### 레버 B — C# 코루틴 타임아웃 (심층 방어)

`WaitForSecondsRealtime` 코루틴으로 같은 제한 시간에 `false` 응답. **단, 코루틴도 플레이어 루프 위에서 돌기 때문에 교착 그 자체는 끊지 못합니다.** 개발자 콜백이 서버 응답을 무한정 기다리는 등 *플레이어 루프는 살아있는데 콜백만 안 끝나는* 케이스를 위한 2차 방어입니다.

### 정확히 1회 응답 보장

결제 경로이므로 이중 응답/무응답을 양쪽에서 차단했습니다.

- **C#**: `_pendingNestedRequests.Remove(requestId)`의 반환값이 유일한 소유권 주장입니다. await 완료 경로와 타임아웃 코루틴 중 `Remove`가 `true`를 반환한 쪽만 응답합니다.
- **JS**: 단일 스레드이므로 `delete` 후 `resolve`가 원자적입니다. 이미 정리된 엔트리에 대한 `__AITRespondToNestedCallback`은 no-op으로 흘려보냅니다.

### 사용법

```csharp
// 두 레버가 같은 값을 공유합니다. 0(기본) = 비활성.
AITCore.NestedCallbackTimeoutMs = 30000;
```

## ⚠️ 트레이드오프 — 결제됐지만 미지급

타임아웃이 발화하면 SDK는 `false`(지급 실패)로 응답합니다. **사용자는 이미 결제를 마쳤는데 상품은 지급되지 않은 상태**가 될 수 있습니다.

교착으로 앱이 영구 정지하는 것보다는 낫다는 판단이지만, 이건 **개발사가 서버 측 미지급 주문 복구 로직을 갖췄을 때만 성립하는 트레이드오프**입니다. 그래서 기본값을 `0`(비활성)으로 두고 명시적 opt-in으로 설계했습니다. XML 문서에도 동일 경고를 넣었습니다.

## 머지 전 확인 필요 (네이티브 팀)

1. **적정 타임아웃 값** — 관측된 프리즈가 26~43초입니다. 타임아웃이 이보다 짧으면 *정상적으로 느린* 결제를 죽이고, 길면 사용자가 40초 넘게 멈춘 화면을 봅니다. 프리즈 상한이 어디까지인지 알아야 권장값을 정할 수 있습니다.
2. **오버레이 자동 dismiss 근본 원인** — 이 PR은 증상 완화(mitigation)이지 근본 해결이 아닙니다. 웹뷰가 서스펜드되는 원인 자체는 네이티브 측 수정이 필요합니다.
3. **실기기 검증 미완** — 자동 E2E(Test 8)는 통과하지만, 실제 Toss 앱 결제 오버레이에서 레버 A가 의도대로 오버레이를 닫는지는 아직 미검증입니다.

## 검증

- SDK 유닛 테스트 **710 통과** (신규 `nested-callback-timeout.test.ts` 14케이스 포함)
- 재생성 idempotency diff 0
- verbose 로깅 게이팅 불변식 통과 (jslib 게이팅 누락 0, `AITCore.cs` 게이팅 누락 0)
- E2E Test 8을 신규 엔트리 shape(`{resolve, timeoutId}`)에 맞춰 갱신 — 갱신하지 않으면 `entry.resolve`가 `undefined`가 되어 3개 케이스 전부 타임아웃합니다
- 실기기 Toss 앱 결제 검증: **미완** (위 3번)

## 생성 코드 안내

`Runtime/SDK/`는 자동 생성물입니다. 실제 변경은 `sdk-runtime-generator~/src/generators/jslib.ts`(레버 A)와 `src/templates/csharp-core.hbs`(레버 B)에 있고, 나머지는 `pnpm generate` 산출물입니다.
