### PR TITLE
수정: 릴리즈 태그의 BuildConfig 의존성 핀 동기화 누락 해결

### DIFF
--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -74,7 +74,10 @@ jobs:
             ALL_INPUT=$(echo "$INPUT_VERSIONS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sort -V)
           else
             echo "=== Git 태그에서 버전 추출 ==="
-            ALL_INPUT=$(git tag -l 'release/v*' | sed 's/release\/v//' | sort -V)
+            # stable(X.Y.Z)만 대상으로 삼는다. prerelease 스냅샷(3.0.0-beta.<sha> 등)이 섞이면
+            # 안정 릴리즈 경로(release.yml)로 흘러가 beta 태그를 stable 템플릿으로 덮어쓴다.
+            # release.yml의 버전 검증 정규식은 prerelease를 허용하므로 여기서 걸러야 한다.
+            ALL_INPUT=$(git tag -l 'release/v*' | sed 's/release\/v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
           fi
 
           # min_version 이상만 필터링

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,54 @@ jobs:
           mv tmp.json package.json
           echo "package.json 버전: ${VERSION}"
 
+      - name: BuildConfig package.json 버전 동기화
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          BUILDCONFIG_PKG="WebGLTemplates/AITTemplate/BuildConfig~/package.json"
+
+          # 이 잡은 `ref: main`을 체크아웃하므로 BuildConfig의 @apps-in-toss 핀은 "릴리즈 대상 버전"이
+          # 아니라 "실행 시점 main의 버전"이다. 정상 릴리즈에서는 update.yml이 직전에 main을
+          # 동기화해 두어 우연히 일치하지만, bulk-release로 과거 버전을 백필하면 루트 version만
+          # 과거로 돌아가고 이 핀은 main 값에 머물러 태그가 오염된다.
+          # BuildConfig~는 빌드 시 ait-build/로 복사되어 실제 번들되는 웹 런타임을 결정하므로
+          # 여기서 반드시 대상 버전으로 함께 롤백해야 한다.
+          # (참조 구현: update.yml "BuildConfig package.json 버전 동기화")
+          #
+          # web-analytics/bridge-core는 web-framework와 lockstep으로 publish되지만, 구버전 백필 시
+          # 동일 버전이 npm에 없을 수 있으므로 존재할 때만 맞춘다 (beta-release.yml의 npm view 가드).
+          if npm view "@apps-in-toss/web-analytics@${VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            jq --arg v "$VERSION" '
+              .dependencies["@apps-in-toss/web-framework"] = $v |
+              .dependencies["@apps-in-toss/web-analytics"] = $v
+            ' "$BUILDCONFIG_PKG" > tmp.json
+          else
+            echo "::warning::@apps-in-toss/web-analytics@${VERSION} 미존재 — web-framework만 동기화"
+            jq --arg v "$VERSION" '
+              .dependencies["@apps-in-toss/web-framework"] = $v
+            ' "$BUILDCONFIG_PKG" > tmp.json
+          fi
+          mv tmp.json "$BUILDCONFIG_PKG"
+
+          # bridge-core는 직접 의존성으로 존재할 때만 갱신 — 직접 핀이 제거되어도 phantom 키를
+          # 다시 만들지 않도록 조건부 처리 (update.yml과 동일 정책).
+          if npm view "@apps-in-toss/bridge-core@${VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            jq --arg v "$VERSION" '
+              (if .dependencies["@apps-in-toss/bridge-core"]
+               then .dependencies["@apps-in-toss/bridge-core"] = $v
+               else . end)
+            ' "$BUILDCONFIG_PKG" > tmp.json
+            mv tmp.json "$BUILDCONFIG_PKG"
+          fi
+
+          echo "BuildConfig dependencies:"
+          jq '.dependencies' "$BUILDCONFIG_PKG"
+
+      - name: BuildConfig pnpm-lock.yaml 업데이트
+        run: |
+          cd WebGLTemplates/AITTemplate/BuildConfig~
+          pnpm install --no-frozen-lockfile
+          echo "BuildConfig pnpm-lock.yaml 업데이트 완료"
+
       - name: Git 설정
         run: |
           git config user.name "github-actions[bot]"
@@ -501,6 +549,35 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: 버전 정합성 검증 (태그 생성 전 게이트)
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          BUILDCONFIG_PKG="WebGLTemplates/AITTemplate/BuildConfig~/package.json"
+
+          # 릴리즈 태그의 불변식: 루트 package.json의 version 과
+          # BuildConfig~ 의 @apps-in-toss/web-framework 핀이 반드시 같아야 한다.
+          # BuildConfig~ 는 빌드 시 ait-build/ 로 복사되어 실제 번들되는 웹 런타임을 결정하므로,
+          # 이 둘이 갈리면 "vX.Y.Z 태그인데 다른 버전의 웹 런타임이 설치되는" 태그가 출하된다.
+          # 이 검증이 없어 과거 백필 실행들이 태그를 오염시켰다 — 태그를 만들기 전에 여기서 막는다.
+          PKG_VERSION=$(jq -r '.version' package.json)
+          WF_PIN=$(jq -r '.dependencies["@apps-in-toss/web-framework"]' "$BUILDCONFIG_PKG")
+
+          echo "루트 package.json version : ${PKG_VERSION}"
+          echo "BuildConfig web-framework : ${WF_PIN}"
+          echo "릴리즈 대상 버전          : ${VERSION}"
+
+          if [ "$PKG_VERSION" != "$VERSION" ]; then
+            echo "::error::루트 package.json version(${PKG_VERSION})이 릴리즈 대상 버전(${VERSION})과 다릅니다."
+            exit 1
+          fi
+
+          if [ "$WF_PIN" != "$VERSION" ]; then
+            echo "::error::BuildConfig~ 의 @apps-in-toss/web-framework 핀(${WF_PIN})이 릴리즈 대상 버전(${VERSION})과 다릅니다. 이 상태로 태그를 만들면 잘못된 웹 런타임이 번들됩니다."
+            exit 1
+          fi
+
+          echo "✅ 버전 정합성 검증 통과: ${VERSION}"
+
       - name: 릴리즈 태그 생성 (Orphan Commit)
         run: |
           VERSION="${{ needs.release.outputs.version }}"
@@ -523,8 +600,9 @@ jobs:
 
           echo "릴리즈 commit SHA: ${RELEASE_COMMIT}"
 
-          # 기존 태그가 있으면 삭제 (upsert)
-          git push origin --delete "${TAG_NAME}" 2>/dev/null || true
+          # 주의: 여기서 `git push origin --delete "${TAG_NAME}"` 로 선삭제하지 않는다.
+          # 아래 `git push -f` 만으로 upsert가 성립하며, 선삭제는 태그가 잠시 사라지는 창을 만들어
+          # 해당 태그를 참조하던 GitHub Release가 untagged draft로 강등된다 (release/v2.4.3 실측).
 
           # 태그 생성 및 푸시
           git tag -f "${TAG_NAME}" "${RELEASE_COMMIT}" -m "릴리즈: v${VERSION}
@@ -707,7 +785,18 @@ jobs:
 
       - name: Install AIT CLI
         run: |
-          WF_VERSION=$(node -p "require('./WebGLTemplates/AITTemplate/BuildConfig~/package.json').dependencies['@apps-in-toss/web-framework']")
+          # 설치 버전은 "릴리즈 대상 버전"을 기준으로 삼는다.
+          # 과거에는 태그에 실린 BuildConfig~ 핀을 그대로 읽었는데, 그 핀 자체가 오염 대상이라
+          # 배포 검증이 오염된 값을 검증하는 자기참조 루프가 되어 결함을 영원히 통과시켰다.
+          WF_VERSION="${{ needs.create-release-tag.outputs.version }}"
+
+          # 태그에 실린 핀이 대상 버전과 일치하는지 교차 확인 (create-release-tag 게이트의 이중 안전망)
+          TAG_PIN=$(node -p "require('./WebGLTemplates/AITTemplate/BuildConfig~/package.json').dependencies['@apps-in-toss/web-framework']")
+          if [ "$TAG_PIN" != "$WF_VERSION" ]; then
+            echo "::error::태그의 web-framework 핀(${TAG_PIN})이 릴리즈 대상 버전(${WF_VERSION})과 다릅니다."
+            exit 1
+          fi
+
           echo "Installing @apps-in-toss/web-framework@${WF_VERSION}"
           pnpm install -g "@apps-in-toss/web-framework@${WF_VERSION}"
           ait --version || echo "AIT CLI installed"

--- a/.github/workflows/sdk-update-rebase.yml
+++ b/.github/workflows/sdk-update-rebase.yml
@@ -262,13 +262,20 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           BUILDCONFIG_PKG="WebGLTemplates/AITTemplate/BuildConfig~/package.json"
 
-          # BuildConfig의 web-framework 버전도 동기화
+          # BuildConfig의 @apps-in-toss 패밀리 버전 동기화
+          # bridge-core는 직접 의존성으로 존재할 때만 갱신 — 향후 직접 핀이 제거되어도 phantom 키를
+          # 다시 만들지 않도록 조건부 처리 (update.yml:309-315와 동일 정책).
+          # 이 절이 없어 리베이스된 PR은 web-framework/web-analytics만 올라가고 bridge-core가
+          # 옛 버전에 남아, 머지 시 main이 패밀리 split 상태가 됐다.
           jq --arg v "$VERSION" '
             .dependencies["@apps-in-toss/web-framework"] = $v |
-            .dependencies["@apps-in-toss/web-analytics"] = $v
+            .dependencies["@apps-in-toss/web-analytics"] = $v |
+            (if .dependencies["@apps-in-toss/bridge-core"]
+             then .dependencies["@apps-in-toss/bridge-core"] = $v
+             else . end)
           ' "$BUILDCONFIG_PKG" > tmp.json
           mv tmp.json "$BUILDCONFIG_PKG"
-          echo "BuildConfig web-framework/web-analytics 버전: ${VERSION}"
+          echo "BuildConfig web-framework/web-analytics/bridge-core 버전: ${VERSION}"
 
           # 확인
           cat "$BUILDCONFIG_PKG" | jq '.dependencies'


### PR DESCRIPTION
## 배경

UPM git URL로 특정 릴리즈 태그를 핀해서 설치했는데, 빌드 산출물 `ait-build/package.json`의 `@apps-in-toss/web-framework`가 핀한 버전이 아니라 더 높은 버전으로 나온다는 제보가 있었습니다. 확인 결과 릴리즈 자동화의 구조적 결함이었습니다.

## 원인

`release.yml`의 `regenerate-sdk` 잡은 `ref: main`을 체크아웃한 뒤

- 루트 `package.json`의 `version` 필드 → 대상 버전으로 치환 ✅
- `sdk-runtime-generator~`에서 `pnpm update @apps-in-toss/web-framework@${VERSION}` → C# 브릿지는 정확히 롤백 ✅
- `WebGLTemplates/AITTemplate/BuildConfig~/package.json`의 `@apps-in-toss` 핀 → **손대지 않음** ❌

`BuildConfig~`는 빌드 시 `ait-build/`로 복사되어 **실제 번들되는 웹 런타임을 결정**합니다. 따라서 대상 버전과 실행 시점 main의 버전이 다른 모든 호출(bulk-release 백필, 구버전 수동 dispatch)이 "vX.Y.Z 태그인데 다른 버전의 웹 런타임이 설치되는" 태그를 만들어 왔습니다.

정상 릴리즈 경로가 무사했던 건 `update.yml`이 직전에 main의 루트 version과 BuildConfig 핀을 **함께** 동기화해 두어 우연히 일치했기 때문입니다. 즉 불변식이 `release.yml` **바깥에서만** 유지되고 있었습니다.

의도된 동작이 아니라는 근거:

- 형제 워크플로 `update.yml`과 `beta-release.yml`에는 **동일 이름의 "BuildConfig package.json 버전 동기화" 스텝이 이미 존재**합니다. `release.yml`에만 이식이 빠졌습니다.
- 태그 주석은 "`@apps-in-toss/web-framework` v{VERSION} 기반"이라고 적으면서 트리는 다른 버전을 핀하는 자기모순 상태였습니다.
- `release.yml`은 생성기 설치 버전이 대상과 다르면 `exit 1`로 죽습니다 — 파이프라인 스스로 버전 동일성을 계약으로 삼으면서 BuildConfig에만 전파를 빠뜨렸습니다.

### 왜 CI가 못 잡았나

- `unity-build.yml`이 빌드 워크스페이스에서 BuildConfig 핀을 대상 버전으로 패치하지만, 이 패치는 **러너 임시 디렉토리에만** 존재하고 태그 커밋에 반영되지 않습니다.
- `deploy-ait`가 AIT CLI 설치 버전을 **"태그의 (이미 오염된) 핀"에서 읽어**, 배포 검증이 오염된 값 자체를 검증하고 항상 통과했습니다.

즉 **커밋되는 트리와 검증되는 트리가 갈라져 있었습니다.**

## 변경 내용

### `release.yml`

1. **BuildConfig 핀 동기화 + lockfile 재생성** — 루트 version 치환 직후에 추가. `update.yml` / `beta-release.yml`의 기존 구현을 이식했습니다. `web-analytics` / `bridge-core`는 구버전 백필 시 동일 버전이 npm에 없을 수 있어 **존재할 때만** 맞춥니다(`npm view` 가드).
2. **태그 생성 직전 정합성 게이트** — 루트 `package.json.version` == `BuildConfig~`의 `@apps-in-toss/web-framework` 핀이 아니면 태그를 만들지 않고 실패시킵니다. 이 3줄만 있었어도 과거 백필 사고가 전부 첫 잡에서 멈췄습니다.
3. **태그 선삭제 제거** — `git push origin --delete "${TAG_NAME}"`를 없앴습니다. 뒤따르는 `git push -f`만으로 upsert가 성립하며, 선삭제는 태그가 잠시 사라지는 창을 만들어 **해당 태그를 참조하던 GitHub Release를 untagged draft로 강등**시킵니다(실측 사례 있음).
4. **자기참조 루프 차단** — `deploy-ait`의 AIT CLI 설치 버전을 태그의 BuildConfig 핀이 아니라 **릴리즈 대상 버전**에서 읽고, 태그의 핀과 교차 검증합니다.

### `bulk-release.yml`

5. **stable(X.Y.Z) 필터** — 태그 열거에서 prerelease 스냅샷을 제외합니다. `release.yml`의 버전 검증 정규식이 prerelease를 허용해, 지금은 beta 스냅샷 태그가 안정 릴리즈 경로로 흘러들어 **stable 템플릿으로 덮어써집니다**(prerelease 경고가 사라지고 릴리즈 노트가 오기됨).

### `sdk-update-rebase.yml`

6. **`bridge-core` 조건부 편입** — BuildConfig 동기화에서 `bridge-core`만 빠져 있었습니다(`update.yml`에는 있음). 리베이스된 SDK 업데이트 PR이 머지되면 main이 **`bridge-core`만 옛 버전에 남는 패밀리 split** 상태가 됩니다.

## 범위 밖 (후속)

- **기존 태그 정정은 이 PR에 포함하지 않았습니다.** 재발행은 force tag push라 이미 설치한 소비자의 고정 SHA를 무효화하므로 별도 판단이 필요합니다. 다만 **이 PR이 먼저 머지되어야** 재발행 결과가 다음 백필 실행에서 다시 오염되지 않습니다.
- 태그 push 이벤트 기반 정합성 검증 워크플로(`on: push: tags`) + 주기적 전 태그 감사는 후속 PR로 분리했습니다.
- `release.yml`이 `ref: main`을 체크아웃하는 설계 자체(태그가 "해당 버전의 Runtime/SDK + main HEAD의 Editor"라는 키메라가 되는 문제)는 이 PR의 범위를 넘습니다. 이 PR은 **핀 일치**를 보장할 뿐 **버전 스냅샷 재현성**을 주지는 않습니다.

## 검증

- 세 워크플로 YAML 파싱 통과.
- `create-release-tag`의 `outputs.version`은 잡 말미에 선언되어 있으며, `deploy-ait`의 기존 참조들과 동일한 패턴을 사용했습니다.
- `./run-local-tests.sh --validate`: 로컬에서는 `SDK Generator Unit Tests`가 `pnpm install`의 `@apps-in-toss/user-scripts@2.10.7` 404(`No authorization header was set`)로 실패했으나, **CI에서는 동일 잡이 통과**했습니다. 사내 레지스트리 인증이 없는 로컬 환경 이슈이며 이 PR과 무관합니다.
