### PR TITLE
수정: Bulk Release 명시 입력 경로의 prerelease 스냅샷 누락 차단

### DIFF
--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -80,9 +80,25 @@ jobs:
             ALL_INPUT=$(git tag -l 'release/v*' | sed 's/release\/v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
           fi
 
-          # min_version 이상만 필터링
+          # prerelease 스냅샷 제외 + min_version 이상만 필터링
+          #
+          # 위의 태그 열거 경로는 grep으로 이미 stable 형태만 남기지만, 명시 입력
+          # (versions) 경로는 그 grep을 타지 않는다. 아래 npm 사전 존재 체크도
+          # 방어가 되지 않는데, prerelease 중에는 npm에 실제로 게시된 것이 있어
+          # (예: 3.0.0-beta.<sha>) 존재 체크를 통과해 버리기 때문이다. 게다가 그
+          # 체크는 패큐먼트 조회 실패 시 fail-open이라 아예 건너뛴다.
+          #
+          # prerelease가 stable 경로(release.yml)로 흘러가면 beta 태그가 stable
+          # 템플릿으로 덮어써진다(prerelease 표시가 사라지고 릴리즈 노트가 오기됨).
+          # beta 스냅샷은 beta-release.yml 전용 경로이므로 여기서 걸러낸다.
           VERSIONS=""
           for V in $ALL_INPUT; do
+            case "$V" in
+              *-*)
+                echo "  v${V}: prerelease 스냅샷은 일괄 릴리즈 대상이 아니므로 스킵"
+                continue
+                ;;
+            esac
             if [ "$(printf '%s\n' "$MIN_VERSION" "$V" | sort -V | head -n1)" = "$MIN_VERSION" ] || [ "$V" = "$MIN_VERSION" ]; then
               VERSIONS="${VERSIONS}${V}"$'\n'
             else


### PR DESCRIPTION
## 배경

#985에서 태그 열거 경로에 stable(`X.Y.Z`) grep 필터를 넣어 prerelease 스냅샷이 안정 릴리즈 경로로 흘러가는 걸 막았습니다. 그런데 **명시 입력(`versions`) 경로는 그 grep을 타지 않습니다.**

```yaml
if [ -n "$INPUT_VERSIONS" ]; then
  ALL_INPUT=$(echo "$INPUT_VERSIONS" | tr ',' '\n' | ... | sort -V)   # ← 필터 없음
else
  ALL_INPUT=$(git tag -l 'release/v*' | ... | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | ...)
fi
```

## 왜 기존 npm 존재 체크로는 부족한가

뒤따르는 "npm 사전 존재 체크"가 방어해 줄 것 같지만 두 가지 이유로 뚫립니다.

1. **게시된 prerelease가 존재한다.** `@apps-in-toss/web-framework`에는 `3.0.0-beta.<sha>` 계열이 실제로 npm에 게시되어 있어 존재 체크를 정상 통과합니다. 체크가 걸러내는 건 "npm에 없는 버전"이지 "prerelease"가 아닙니다.
2. **fail-open이다.** 패큐먼트 조회가 실패하면 (`curl -fsSL` 실패) 체크 자체를 건너뛰고 전체 버전을 그대로 시도합니다.

## 실제 영향

prerelease가 `release.yml`로 흘러가면 beta 태그가 stable 릴리즈 템플릿으로 덮어써집니다 — prerelease 표시가 사라지고 릴리즈 노트가 오기됩니다.

실측으로 `release/v3.0.0-beta.*` 태그 7개가 전부 이 경로로 오염되어 있었습니다. 각 태그의 `BuildConfig~` web-framework 핀이 자기 버전이 아니라 당시 main의 stable 버전(`2.10.5`)으로 바뀌어 있었고, 덮어쓰기 이전 원본 태그 객체를 복구해 되돌렸습니다.

## 변경 내용

`min_version` 필터 루프 안에서 prerelease를 걸러 **두 경로를 모두 커버**합니다.

```sh
for V in $ALL_INPUT; do
  case "$V" in
    *-*)
      echo "  v${V}: prerelease 스냅샷은 일괄 릴리즈 대상이 아니므로 스킵"
      continue
      ;;
  esac
  ...
```

태그 열거 쪽 grep은 **그대로 둡니다** — 자동 발견되는 태그에 대해서는 더 엄격한 형태 검사(`X.Y.Z` 정확 일치)로 동작하므로, 하이픈만 보는 이 필터와 역할이 다릅니다.

beta 스냅샷의 릴리즈 경로는 `beta-release.yml`이며 이 PR은 그 경로를 건드리지 않습니다.

## 검증

- `bulk-release.yml` YAML 파싱 통과
- 필터 로직 셸 재현: `2.4.0 / 2.10.1-beta.48b3324 / 3.0.0-beta.b36d7b5 / 2.10.4 / 2.10.6` 입력 → beta 2건만 스킵, stable 3건 통과 확인

## 참고

이 변경은 원래 `fix/bulk-release-skip-prerelease` 브랜치(`922327c4`, 2026-07-04)에 있던 것입니다. 당시엔 머지되지 않았고, #985가 열거 경로만 막으면서 나머지 절반이 비어 있는 상태였습니다.
