### PR TITLE
수정: 릴리즈 게이트를 @apps-in-toss 핀 전체로 확장

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -576,6 +576,49 @@ jobs:
             exit 1
           fi
 
+          # web-framework 외 @apps-in-toss 핀도 함께 본다.
+          #
+          # 위 동기화 스텝은 "@apps-in-toss/<pkg>@VERSION 이 npm에 있으면 VERSION 으로 맞추고,
+          # 없으면 손대지 않는다"는 규칙으로 동작한다. 여기서도 같은 규칙의 대우를 검사한다 —
+          # 해당 버전이 npm에 존재하는데 핀이 다르면 동기화가 누락된 것이므로 막는다.
+          # (존재하지 않으면 핀이 달라도 정상이다. 구버전 백필에서 흔하다.)
+          FAILED=0
+          for PKG in web-analytics bridge-core; do
+            PIN=$(jq -r --arg k "@apps-in-toss/${PKG}" '.dependencies[$k] // "none"' "$BUILDCONFIG_PKG")
+            [ "$PIN" = "none" ] && continue
+            if npm view "@apps-in-toss/${PKG}@${VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+              if [ "$PIN" != "$VERSION" ]; then
+                echo "::error::@apps-in-toss/${PKG}@${VERSION} 이 npm에 존재하는데 BuildConfig 핀은 ${PIN} 입니다 — 동기화 누락."
+                FAILED=1
+              else
+                echo "  ${PKG}: ${PIN} (일치)"
+              fi
+            else
+              echo "  ${PKG}: ${PIN} (npm에 ${VERSION} 없음 — 검사 생략)"
+            fi
+          done
+
+          # 핀이 가리키는 버전이 실제로 설치 가능한지 확인한다.
+          #
+          # 2026-07 사례: @apps-in-toss 2.10.7 이 게시 직후 unpublish 되었는데, 그 사이에
+          # 돌던 자동화들이 해당 버전을 핀/lockfile 에 새겨 넣었다. 존재하지 않는 버전이
+          # BuildConfig 에 박히면 그 태그를 설치한 환경에서 ERR_PNPM_FETCH_404 가 난다.
+          #
+          # ⚠️ 한계: 이 조회는 러너가 붙는 CDN 엣지의 응답에 의존한다. npm 의 unpublish 퍼지는
+          #    엣지마다 비동기로 전파되므로, 아직 해당 버전을 서빙하는 엣지에서 실행되면
+          #    통과할 수 있다. 완전한 방어가 아니라 "이미 전파된 유령 버전"을 잡는 그물이다.
+          for PKG in $(jq -r '.dependencies | keys[] | select(startswith("@apps-in-toss/"))' "$BUILDCONFIG_PKG"); do
+            PIN=$(jq -r --arg k "$PKG" '.dependencies[$k]' "$BUILDCONFIG_PKG")
+            if ! npm view "${PKG}@${PIN}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+              echo "::error::${PKG}@${PIN} 을 npm에서 찾을 수 없습니다 — 존재하지 않는 버전을 핀한 채로 태그를 만들 수 없습니다."
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" -ne 0 ]; then
+            exit 1
+          fi
+
           echo "✅ 버전 정합성 검증 통과: ${VERSION}"
 
       - name: 릴리즈 태그 생성 (Orphan Commit)


### PR DESCRIPTION
## 배경

`create-release-tag` 잡의 "버전 정합성 검증 (태그 생성 전 게이트)"는 현재 **`@apps-in-toss/web-framework` 핀 하나만** 검사합니다.

```sh
if [ "$WF_PIN" != "$VERSION" ]; then   # ← 여기까지가 전부
```

그런데 `BuildConfig~/package.json`에는 `web-analytics`, `bridge-core` 핀도 함께 들어 있고, 이 둘이 어긋나거나 **존재하지 않는 버전**을 가리켜도 태그가 그대로 만들어집니다.

## 변경 내용

기존 web-framework 검사 뒤에 두 가지를 추가합니다.

### 1. 동기화 누락 검사 (`web-analytics`, `bridge-core`)

앞선 동기화 스텝은 "`@apps-in-toss/<pkg>@VERSION`이 npm에 있으면 `VERSION`으로 맞추고, 없으면 손대지 않는다"는 규칙으로 동작합니다. 게이트에서는 그 규칙의 **대우**를 검사합니다.

| npm에 `<pkg>@VERSION` | 핀 == VERSION | 판정 |
|---|---|---|
| 존재 | O | 통과 |
| 존재 | X | **차단** (동기화 누락) |
| 없음 | — | 검사 생략 |

"없으면 생략"이 중요합니다. 구버전 백필에서는 `bridge-core@2.4.0`처럼 해당 버전이 애초에 게시되지 않은 경우가 정상적으로 존재하기 때문입니다.

### 2. 게시 여부 실검증 (`@apps-in-toss/*` 전체)

핀이 가리키는 버전이 **실제로 설치 가능한지** `npm view`로 확인합니다.

2026-07에 `@apps-in-toss` 2.10.7이 게시 직후 unpublish 되었고, 그 사이에 돌던 자동화들(SDK Update / dependabot / regen-lockfiles)이 유령 버전을 핀과 lockfile에 새겨 넣었습니다. 존재하지 않는 버전이 `BuildConfig~`에 박히면 그 태그를 설치한 환경에서 `ERR_PNPM_FETCH_404`가 납니다.

## ⚠️ 한계 — 이 PR이 그 사건 자체를 막았을까?

**아닙니다.** 솔직하게 적어둡니다.

2번 조회는 러너가 붙는 **CDN 엣지의 응답에 의존**합니다. npm의 unpublish 퍼지는 엣지마다 비동기로 전파되므로, 아직 해당 버전을 서빙하는 엣지에서 실행되면 `npm view`가 200을 돌려주고 그대로 통과합니다. 실제로 이번 사건에서도 한국 엣지는 이미 purge됐지만 GitHub 러너 엣지는 여전히 2.10.7을 서빙하고 있었습니다.

즉 이 검사는 **완전한 방어가 아니라 "이미 전파된 유령 버전"을 잡는 그물**입니다. 같은 내용을 코드 주석에도 남겼습니다.

1번(동기화 누락)은 엣지와 무관하게 결정적으로 동작합니다.

## 왜 게이트가 동기화된 값을 보는가

`regenerate-sdk` 잡이 BuildConfig 동기화 결과를 working tree에 쓰고 → `git add -A` → orphan commit → `refs/heads/_build/release-v${VERSION}`로 push하고, `create-release-tag`가 `needs.regenerate-sdk.outputs.ref`를 체크아웃합니다. 따라서 게이트는 **동기화 이후 값**을 봅니다. 앞선 "UPM 패키지 정리" 스텝이 `.github/`·`Tests~/`·`sdk-runtime-generator~/`를 지우지만 `package.json`과 `WebGLTemplates/`는 남기므로 검사 대상 파일 2개는 그대로 있습니다.

## 검증

- `release.yml` YAML 파싱 통과
- 셸 로직을 **실제 npm 레지스트리**에 대해 3케이스로 검증
  - 전부 `2.10.6` → ✅ 통과
  - `web-analytics=2.10.7`(유령) → ❌ 두 검사 모두 차단
  - `web-analytics=2.10.5`(동기화 누락) → ❌ 1번이 차단
- **오탐 회귀 검증**: 실제 릴리즈된 태그 7종의 `BuildConfig~/package.json`을 그대로 넣어 실행 — `v2.4.0 / 2.5.0 / 2.7.0 / 2.9.0 / 2.10.0 / 2.10.4 / 2.10.6` **전부 통과**(차단 0건)

## 관련

- #985 — 태그 열거 경로 prerelease 필터
- #988 — 명시 입력 경로 prerelease 필터
