### PR TITLE
수정: WebGL 설정 드롭다운 저장값과 Unity enum 매핑 오류 수정

### DIFF
--- a/Editor/AITBuildInitializer.cs
+++ b/Editor/AITBuildInitializer.cs
@@ -105,9 +105,7 @@ namespace AppsInToss.Editor
             // ===== 예외 처리 (사용자 지정 또는 자동) =====
             // 출처: UnityVersion.md:393, 431
             // 실제 적용은 아래 ApplySentryFriendlyWebGLSettings에서 수행 (stack trace와 함께 관리)
-            WebGLExceptionSupport exceptionSupport = editorConfig.exceptionSupport >= 0
-                ? (WebGLExceptionSupport)editorConfig.exceptionSupport
-                : AITDefaultSettings.GetDefaultExceptionSupport();
+            WebGLExceptionSupport exceptionSupport = ConvertToExceptionSupport(editorConfig.exceptionSupport);
 
             // ===== 파일 해싱 =====
             // Unity 2021.3에서 nameFilesAsHashes = true 시 Bee 빌드 루프 버그 발생
@@ -139,8 +137,8 @@ namespace AppsInToss.Editor
             PlayerSettings.stripEngineCode = editorConfig.stripEngineCode;
 
             // ===== Managed Stripping Level (프로필 → 자동) =====
-            ManagedStrippingLevel strippingLevel = profile?.managedStrippingLevel >= 0
-                ? (ManagedStrippingLevel)profile.managedStrippingLevel
+            ManagedStrippingLevel strippingLevel = profile != null
+                ? ConvertToManagedStrippingLevel(profile.managedStrippingLevel)
                 : AITDefaultSettings.GetDefaultManagedStrippingLevel();
 #if UNITY_6000_0_OR_NEWER
             PlayerSettings.SetManagedStrippingLevel(NamedBuildTarget.WebGL, strippingLevel);
@@ -177,9 +175,7 @@ namespace AppsInToss.Editor
             // ===== Unity 6 (2023.3+) 전용 설정 =====
 #if UNITY_2023_3_OR_NEWER
             // 출처: UnityVersion.md:394-402
-            WebGLPowerPreference powerPreference = editorConfig.powerPreference >= 0
-                ? (WebGLPowerPreference)editorConfig.powerPreference
-                : AITDefaultSettings.GetDefaultPowerPreference();
+            WebGLPowerPreference powerPreference = ConvertToPowerPreference(editorConfig.powerPreference);
             PlayerSettings.WebGL.powerPreference = powerPreference;
 
             // wasmStreaming은 Unity 6000에서 deprecated됨 (decompressionFallback에 의해 자동 결정)
@@ -306,7 +302,7 @@ namespace AppsInToss.Editor
         /// 저장값: -1=자동, 0=Disabled, 1=Gzip, 2=Brotli
         /// enum값: 0=Brotli, 1=Gzip, 2=Disabled
         /// </summary>
-        private static WebGLCompressionFormat ConvertToCompressionFormat(int storedValue)
+        internal static WebGLCompressionFormat ConvertToCompressionFormat(int storedValue)
         {
             return storedValue switch
             {
@@ -316,6 +312,60 @@ namespace AppsInToss.Editor
                 _ => AITDefaultSettings.GetDefaultCompressionFormat()
             };
         }
+
+        /// <summary>
+        /// 프로필 저장값을 ManagedStrippingLevel enum으로 변환
+        /// 저장값(UI 순서): -1=자동, 0=Disabled(레거시), 1=Minimal, 2=Low, 3=Medium, 4=High
+        /// enum값: Disabled=0, Low=1, Medium=2, High=3, Minimal=4 — Minimal이 나중에 추가되어 순서가 달라 직접 캐스팅 금지
+        /// WebGL(IL2CPP)은 Disabled를 지원하지 않으므로 레거시 저장값 0은 Minimal로 폴백
+        /// </summary>
+        internal static ManagedStrippingLevel ConvertToManagedStrippingLevel(int storedValue)
+        {
+            return storedValue switch
+            {
+                0 => ManagedStrippingLevel.Minimal,
+                1 => ManagedStrippingLevel.Minimal,
+                2 => ManagedStrippingLevel.Low,
+                3 => ManagedStrippingLevel.Medium,
+                4 => ManagedStrippingLevel.High,
+                _ => AITDefaultSettings.GetDefaultManagedStrippingLevel()
+            };
+        }
+
+        /// <summary>
+        /// 설정 저장값을 WebGLExceptionSupport enum으로 변환
+        /// 저장값(UI 순서): -1=자동, 0=None, 1=ExplicitlyThrownOnly, 2=FullWithStacktrace, 3=FullWithoutStacktrace
+        /// enum값: None=0, ExplicitlyThrownExceptionsOnly=1, FullWithoutStacktrace=2, FullWithStacktrace=3 — 2·3 순서가 반대라 직접 캐스팅 금지
+        /// </summary>
+        internal static WebGLExceptionSupport ConvertToExceptionSupport(int storedValue)
+        {
+            return storedValue switch
+            {
+                0 => WebGLExceptionSupport.None,
+                1 => WebGLExceptionSupport.ExplicitlyThrownExceptionsOnly,
+                2 => WebGLExceptionSupport.FullWithStacktrace,
+                3 => WebGLExceptionSupport.FullWithoutStacktrace,
+                _ => AITDefaultSettings.GetDefaultExceptionSupport()
+            };
+        }
+
+#if UNITY_2023_3_OR_NEWER
+        /// <summary>
+        /// 설정 저장값을 WebGLPowerPreference enum으로 변환
+        /// 저장값(UI 순서): -1=자동, 0=Default, 1=HighPerformance, 2=LowPower
+        /// enum값: Default=0, LowPower=1, HighPerformance=2 — 1·2 순서가 반대라 직접 캐스팅 금지
+        /// </summary>
+        internal static WebGLPowerPreference ConvertToPowerPreference(int storedValue)
+        {
+            return storedValue switch
+            {
+                0 => WebGLPowerPreference.Default,
+                1 => WebGLPowerPreference.HighPerformance,
+                2 => WebGLPowerPreference.LowPower,
+                _ => AITDefaultSettings.GetDefaultPowerPreference()
+            };
+        }
+#endif
 
         /// <summary>
         /// 빌드 프로필 정보를 로그로 출력
@@ -331,16 +381,10 @@ namespace AppsInToss.Editor
                 _ => "자동"
             };
 
-            // Stripping Level 문자열 생성
-            string strippingStr = profile.managedStrippingLevel switch
-            {
-                0 => "Disabled",
-                1 => "Minimal",
-                2 => "Low",
-                3 => "Medium",
-                4 => "High",
-                _ => "자동 (High)"
-            };
+            // Stripping Level 문자열 생성 (실제 적용될 enum 기준)
+            string strippingStr = profile.managedStrippingLevel < 0
+                ? "자동 (High)"
+                : ConvertToManagedStrippingLevel(profile.managedStrippingLevel).ToString();
 
             Debug.Log("[AIT] ========================================");
             Debug.Log($"[AIT] 빌드 프로필: {profileName}");

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -358,15 +358,19 @@ namespace AppsInToss.Editor
             );
             profile.compressionFormat = compressionIndex == 0 ? -1 : compressionIndex - 1;
 
-            // Stripping Level
-            string[] strippingOptions = { "자동 (High)", "Disabled", "Minimal", "Low", "Medium", "High" };
-            int strippingIndex = profile.managedStrippingLevel < 0 ? 0 : profile.managedStrippingLevel + 1;
+            // Stripping Level — 저장값은 UI 순서(1=Minimal, 2=Low, 3=Medium, 4=High)이며
+            // 빌드 적용 시 AITBuildInitializer.ConvertToManagedStrippingLevel로 실제 enum에 매핑됨
+            // WebGL(IL2CPP)은 Disabled를 지원하지 않아 옵션에서 제외, 레거시 저장값 0(Disabled)은 Minimal로 정규화
+            if (profile.managedStrippingLevel == 0) profile.managedStrippingLevel = 1;
+            else if (profile.managedStrippingLevel > 4) profile.managedStrippingLevel = -1;
+            string[] strippingOptions = { "자동 (High)", "Minimal", "Low", "Medium", "High" };
+            int strippingIndex = profile.managedStrippingLevel < 0 ? 0 : profile.managedStrippingLevel;
             strippingIndex = EditorGUILayout.Popup(
                 new GUIContent("Managed Stripping", "코드 스트리핑 레벨 (낮을수록 빌드 속도 향상)"),
                 strippingIndex,
                 strippingOptions
             );
-            profile.managedStrippingLevel = strippingIndex == 0 ? -1 : strippingIndex - 1;
+            profile.managedStrippingLevel = strippingIndex == 0 ? -1 : strippingIndex;
 
             // 디버그 심볼
             profile.debugSymbolsExternal = EditorGUILayout.Toggle(
@@ -418,13 +422,10 @@ namespace AppsInToss.Editor
             };
             if (!string.IsNullOrEmpty(compression)) parts.Add(compression);
 
-            // Stripping
-            string stripping = profile.managedStrippingLevel switch
-            {
-                0 => "NoStrip",
-                1 => "Minimal",
-                _ => ""
-            };
+            // Stripping (실제 적용될 enum 기준)
+            string stripping = profile.managedStrippingLevel < 0
+                ? ""
+                : AITBuildInitializer.ConvertToManagedStrippingLevel(profile.managedStrippingLevel).ToString();
             if (!string.IsNullOrEmpty(stripping)) parts.Add(stripping);
 
             return parts.Count > 0 ? string.Join(", ", parts) : "(기본 설정)";
@@ -770,7 +771,7 @@ namespace AppsInToss.Editor
         private void DrawPowerPreferenceSetting()
         {
             WebGLPowerPreference defaultPower = AITDefaultSettings.GetDefaultPowerPreference();
-            bool isModified = config.powerPreference >= 0 && (WebGLPowerPreference)config.powerPreference != defaultPower;
+            bool isModified = config.powerPreference >= 0 && AITBuildInitializer.ConvertToPowerPreference(config.powerPreference) != defaultPower;
 
             EditorGUILayout.BeginHorizontal();
 
@@ -825,7 +826,7 @@ namespace AppsInToss.Editor
         private void DrawExceptionSupportSetting()
         {
             WebGLExceptionSupport defaultValue = AITDefaultSettings.GetDefaultExceptionSupport();
-            bool isModified = config.exceptionSupport >= 0 && (WebGLExceptionSupport)config.exceptionSupport != defaultValue;
+            bool isModified = config.exceptionSupport >= 0 && AITBuildInitializer.ConvertToExceptionSupport(config.exceptionSupport) != defaultValue;
 
             EditorGUILayout.BeginHorizontal();
 
@@ -1152,13 +1153,7 @@ namespace AppsInToss.Editor
             int effectiveMemory = config.memorySize > 0 ? config.memorySize : AITDefaultSettings.GetDefaultMemorySize();
             EditorGUILayout.LabelField($"  메모리: {effectiveMemory}MB");
 
-            WebGLCompressionFormat effectiveCompression = config.productionProfile.compressionFormat switch
-            {
-                0 => WebGLCompressionFormat.Disabled,
-                1 => WebGLCompressionFormat.Gzip,
-                2 => WebGLCompressionFormat.Brotli,
-                _ => AITDefaultSettings.GetDefaultCompressionFormat()
-            };
+            WebGLCompressionFormat effectiveCompression = AITBuildInitializer.ConvertToCompressionFormat(config.productionProfile.compressionFormat);
             EditorGUILayout.LabelField($"  압축: {effectiveCompression}");
 
             bool effectiveThreads = config.threadsSupport >= 0

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -27,7 +27,7 @@ namespace AppsInToss
         [Tooltip("압축 포맷: -1 = 자동, 0 = Disabled, 1 = Gzip, 2 = Brotli")]
         public int compressionFormat = -1;
 
-        [Tooltip("Managed Stripping Level: -1 = 자동 (High), 0 = Disabled, 1 = Minimal, 2 = Low, 3 = Medium, 4 = High")]
+        [Tooltip("Managed Stripping Level: -1 = 자동 (High), 1 = Minimal, 2 = Low, 3 = Medium, 4 = High (0 = 레거시 Disabled, Minimal로 처리)")]
         public int managedStrippingLevel = -1;
 
         [Tooltip("디버그 심볼을 외부 파일로 분리 (빌드 크기 감소)")]

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerInitIntegrationTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerInitIntegrationTests.cs
@@ -1,0 +1,160 @@
+// -----------------------------------------------------------------------
+// AITBuildInitializerInitIntegrationTests.cs - Init 실경로 통합 검증
+// Level 0: 변환 함수 단위(AITBuildProfileMappingTests)가 아니라 실제 빌드
+// 진입점 AITBuildInitializer.Init(profile)을 그대로 호출해 PlayerSettings에
+// 최종 반영되는 값을 검증한다.
+// NHN 제보 버그의 실경로 회귀 가드: 드롭다운 'High'(저장값 4) 선택 시
+// 직접 캐스팅으로 Minimal(=4)이 빌드에 적용되던 문제.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using AppsInToss;
+using AppsInToss.Editor;
+#if UNITY_6000_0_OR_NEWER
+using UnityEditor.Build;
+#endif
+
+[TestFixture]
+public class AITBuildInitializerInitIntegrationTests
+{
+    private PlayerSettingsSnapshot _backup;
+
+    // 스냅샷이 커버하지 않는 항목 수동 백업
+    private bool _useDefaultGraphicsAPIs;
+    private UnityEngine.Rendering.GraphicsDeviceType[] _graphicsAPIs;
+
+    // Init이 읽는 저장 설정(AITEditorScriptObject) 백업
+    private int _savedExceptionSupport;
+#if UNITY_2023_3_OR_NEWER
+    private int _savedPowerPreference;
+#endif
+
+    [SetUp]
+    public void Setup()
+    {
+        _backup = PlayerSettingsSnapshot.Capture();
+        _useDefaultGraphicsAPIs = PlayerSettings.GetUseDefaultGraphicsAPIs(BuildTarget.WebGL);
+        _graphicsAPIs = PlayerSettings.GetGraphicsAPIs(BuildTarget.WebGL);
+
+        var config = UnityUtil.GetEditorConf();
+        _savedExceptionSupport = config.exceptionSupport;
+#if UNITY_2023_3_OR_NEWER
+        _savedPowerPreference = config.powerPreference;
+#endif
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        var config = UnityUtil.GetEditorConf();
+        config.exceptionSupport = _savedExceptionSupport;
+#if UNITY_2023_3_OR_NEWER
+        config.powerPreference = _savedPowerPreference;
+#endif
+
+        PlayerSettings.SetUseDefaultGraphicsAPIs(BuildTarget.WebGL, _useDefaultGraphicsAPIs);
+        if (!_useDefaultGraphicsAPIs)
+        {
+            PlayerSettings.SetGraphicsAPIs(BuildTarget.WebGL, _graphicsAPIs);
+        }
+        _backup.Restore();
+    }
+
+    private static ManagedStrippingLevel GetAppliedStrippingLevel()
+    {
+#if UNITY_6000_0_OR_NEWER
+        return PlayerSettings.GetManagedStrippingLevel(NamedBuildTarget.WebGL);
+#else
+        return PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.WebGL);
+#endif
+    }
+
+    private static AITBuildProfile ProductionProfileWithStripping(int storedValue)
+    {
+        var profile = AITBuildProfile.CreateProductionProfile();
+        profile.managedStrippingLevel = storedValue;
+        return profile;
+    }
+
+    // =====================================================
+    // Managed Stripping: 저장값 → Init → PlayerSettings 최종 반영
+    // =====================================================
+
+    [Test]
+    public void Init_ProfileStoredHigh_AppliesManagedStrippingHigh()
+    {
+        AITBuildInitializer.Init(ProductionProfileWithStripping(4));
+
+        var applied = GetAppliedStrippingLevel();
+        Assert.AreEqual(ManagedStrippingLevel.High, applied,
+            "드롭다운 'High'(저장값 4)로 Init하면 PlayerSettings에 High가 반영되어야 함");
+        Assert.AreNotEqual(ManagedStrippingLevel.Minimal, applied,
+            "원래 버그: 저장값 4 직접 캐스팅으로 Minimal(=4)이 적용되던 회귀 방지");
+    }
+
+    [Test]
+    public void Init_ProfileStoredMinimal_AppliesManagedStrippingMinimal()
+    {
+        // 원래 버그: 저장값 1("Minimal") 직접 캐스팅으로 Low(=1)가 적용됨
+        AITBuildInitializer.Init(ProductionProfileWithStripping(1));
+
+        Assert.AreEqual(ManagedStrippingLevel.Minimal, GetAppliedStrippingLevel());
+    }
+
+    [Test]
+    public void Init_ProfileAuto_AppliesDefaultStripping()
+    {
+        AITBuildInitializer.Init(ProductionProfileWithStripping(-1));
+
+        Assert.AreEqual(AITDefaultSettings.GetDefaultManagedStrippingLevel(),
+            GetAppliedStrippingLevel());
+    }
+
+    // =====================================================
+    // Exception Support: 저장 설정 → Init → PlayerSettings 최종 반영
+    // =====================================================
+
+    [Test]
+    public void Init_ConfigExceptionSupportStored2_AppliesFullWithStacktrace()
+    {
+        // 원래 버그: 저장값 2("Full With Stacktrace") 직접 캐스팅으로
+        // FullWithoutStacktrace(=2)가 적용되어 Sentry 스택트레이스가 사라짐
+        UnityUtil.GetEditorConf().exceptionSupport = 2;
+
+        AITBuildInitializer.Init(AITBuildProfile.CreateProductionProfile());
+
+        Assert.AreEqual(WebGLExceptionSupport.FullWithStacktrace,
+            PlayerSettings.WebGL.exceptionSupport);
+    }
+
+    [Test]
+    public void Init_ConfigExceptionSupportStored3_AppliesFullWithoutStacktrace()
+    {
+        UnityUtil.GetEditorConf().exceptionSupport = 3;
+
+        AITBuildInitializer.Init(AITBuildProfile.CreateProductionProfile());
+
+        Assert.AreEqual(WebGLExceptionSupport.FullWithoutStacktrace,
+            PlayerSettings.WebGL.exceptionSupport);
+    }
+
+#if UNITY_2023_3_OR_NEWER
+    // =====================================================
+    // Power Preference: 저장 설정 → Init → PlayerSettings 최종 반영 (Unity 2023.3+)
+    // =====================================================
+
+    [Test]
+    public void Init_ConfigPowerPreferenceStored1_AppliesHighPerformance()
+    {
+        // 원래 버그: 저장값 1("HighPerformance") 직접 캐스팅으로 LowPower(=1)가 적용됨
+        UnityUtil.GetEditorConf().powerPreference = 1;
+
+        AITBuildInitializer.Init(AITBuildProfile.CreateProductionProfile());
+
+        Assert.AreEqual(WebGLPowerPreference.HighPerformance,
+            PlayerSettings.WebGL.powerPreference);
+    }
+#endif
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerInitIntegrationTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildInitializerInitIntegrationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b47e2d51c8a43f6b0d3a86f215c7e94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs
@@ -1,0 +1,215 @@
+// -----------------------------------------------------------------------
+// AITBuildProfileMappingTests.cs - 설정 저장값 → Unity enum 매핑 검증
+// Level 0: AITBuildInitializer.ConvertTo* 순수 변환 로직 검증
+// UI 저장값(드롭다운 순서)과 Unity enum 정수값의 순서 불일치로 인한
+// 오적용 회귀 방지 (Managed Stripping "High" 선택 시 Minimal이 적용되던 버그 등)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using UnityEditor;
+using AppsInToss;
+using AppsInToss.Editor;
+#if UNITY_6000_0_OR_NEWER
+using UnityEditor.Build;
+#endif
+
+[TestFixture]
+public class AITBuildProfileMappingTests
+{
+    // =====================================================
+    // Unity enum 레이아웃 가드
+    // 변환 함수가 전제하는 Unity enum 정수값이 바뀌면 여기서 먼저 실패해야 함
+    // =====================================================
+
+    [Test]
+    public void UnityEnumLayout_ManagedStrippingLevel_MatchesConversionAssumptions()
+    {
+        // Minimal은 나중에 추가되어 강도는 최약이지만 정수값은 4 — 이 비직관적 레이아웃이 원래 버그의 원인
+        Assert.AreEqual(0, (int)ManagedStrippingLevel.Disabled);
+        Assert.AreEqual(1, (int)ManagedStrippingLevel.Low);
+        Assert.AreEqual(2, (int)ManagedStrippingLevel.Medium);
+        Assert.AreEqual(3, (int)ManagedStrippingLevel.High);
+        Assert.AreEqual(4, (int)ManagedStrippingLevel.Minimal);
+    }
+
+    [Test]
+    public void UnityEnumLayout_WebGLExceptionSupport_MatchesConversionAssumptions()
+    {
+        Assert.AreEqual(0, (int)WebGLExceptionSupport.None);
+        Assert.AreEqual(1, (int)WebGLExceptionSupport.ExplicitlyThrownExceptionsOnly);
+        Assert.AreEqual(2, (int)WebGLExceptionSupport.FullWithoutStacktrace);
+        Assert.AreEqual(3, (int)WebGLExceptionSupport.FullWithStacktrace);
+    }
+
+#if UNITY_2023_3_OR_NEWER
+    [Test]
+    public void UnityEnumLayout_WebGLPowerPreference_MatchesConversionAssumptions()
+    {
+        Assert.AreEqual(0, (int)WebGLPowerPreference.Default);
+        Assert.AreEqual(1, (int)WebGLPowerPreference.LowPower);
+        Assert.AreEqual(2, (int)WebGLPowerPreference.HighPerformance);
+    }
+#endif
+
+    // =====================================================
+    // ConvertToManagedStrippingLevel 전수 매핑
+    // 저장값(UI 순서): -1=자동, 0=Disabled(레거시), 1=Minimal, 2=Low, 3=Medium, 4=High
+    // =====================================================
+
+    [TestCase(0, ManagedStrippingLevel.Minimal)]  // 레거시 Disabled — IL2CPP 미지원이라 Minimal로 폴백
+    [TestCase(1, ManagedStrippingLevel.Minimal)]
+    [TestCase(2, ManagedStrippingLevel.Low)]
+    [TestCase(3, ManagedStrippingLevel.Medium)]
+    [TestCase(4, ManagedStrippingLevel.High)]
+    public void ConvertToManagedStrippingLevel_Maps_StoredValue_To_ActualEnum(int stored, ManagedStrippingLevel expected)
+    {
+        Assert.AreEqual(expected, AITBuildInitializer.ConvertToManagedStrippingLevel(stored));
+    }
+
+    [TestCase(-1)]
+    [TestCase(99)]
+    public void ConvertToManagedStrippingLevel_OutOfRange_Falls_Back_To_Default(int stored)
+    {
+        Assert.AreEqual(AITDefaultSettings.GetDefaultManagedStrippingLevel(),
+            AITBuildInitializer.ConvertToManagedStrippingLevel(stored));
+    }
+
+    [Test]
+    public void ConvertToManagedStrippingLevel_High_Is_Not_Minimal_Regression()
+    {
+        // 원래 버그: 저장값 4("High")를 직접 캐스팅해 Minimal(=4)이 적용됨 (강도 역전)
+        Assert.AreEqual(ManagedStrippingLevel.High,
+            AITBuildInitializer.ConvertToManagedStrippingLevel(4),
+            "드롭다운 'High'(저장값 4)는 반드시 ManagedStrippingLevel.High로 매핑되어야 함");
+    }
+
+    [Test]
+    public void DevServerProfile_Default_Stripping_Applies_Minimal()
+    {
+        // Dev Server 프로필 기본값(저장값 1)은 주석("Minimal - 빌드 속도 우선")대로 Minimal이어야 함
+        // 원래 버그: 직접 캐스팅으로 Low가 적용됨
+        var profile = AITBuildProfile.CreateDevServerProfile();
+        Assert.AreEqual(ManagedStrippingLevel.Minimal,
+            AITBuildInitializer.ConvertToManagedStrippingLevel(profile.managedStrippingLevel));
+    }
+
+    // =====================================================
+    // ConvertToExceptionSupport 전수 매핑
+    // 저장값(UI 순서): -1=자동, 0=None, 1=ExplicitlyThrownOnly, 2=FullWithStacktrace, 3=FullWithoutStacktrace
+    // =====================================================
+
+    [TestCase(0, WebGLExceptionSupport.None)]
+    [TestCase(1, WebGLExceptionSupport.ExplicitlyThrownExceptionsOnly)]
+    [TestCase(2, WebGLExceptionSupport.FullWithStacktrace)]
+    [TestCase(3, WebGLExceptionSupport.FullWithoutStacktrace)]
+    public void ConvertToExceptionSupport_Maps_StoredValue_To_ActualEnum(int stored, WebGLExceptionSupport expected)
+    {
+        Assert.AreEqual(expected, AITBuildInitializer.ConvertToExceptionSupport(stored));
+    }
+
+    [TestCase(-1)]
+    [TestCase(99)]
+    public void ConvertToExceptionSupport_OutOfRange_Falls_Back_To_Default(int stored)
+    {
+        Assert.AreEqual(AITDefaultSettings.GetDefaultExceptionSupport(),
+            AITBuildInitializer.ConvertToExceptionSupport(stored));
+    }
+
+    [Test]
+    public void ConvertToExceptionSupport_FullWithStacktrace_Regression()
+    {
+        // 원래 버그: 저장값 2("FullWithStacktrace")를 직접 캐스팅해 FullWithoutStacktrace가 적용됨
+        // → Sentry 스택트레이스 목적으로 선택해도 실제로는 스택트레이스가 꺼졌음
+        Assert.AreEqual(WebGLExceptionSupport.FullWithStacktrace,
+            AITBuildInitializer.ConvertToExceptionSupport(2),
+            "드롭다운 'FullWithStacktrace'(저장값 2)는 반드시 FullWithStacktrace로 매핑되어야 함");
+    }
+
+#if UNITY_2023_3_OR_NEWER
+    // =====================================================
+    // ConvertToPowerPreference 전수 매핑 (Unity 2023.3+)
+    // 저장값(UI 순서): -1=자동, 0=Default, 1=HighPerformance, 2=LowPower
+    // =====================================================
+
+    [TestCase(0, WebGLPowerPreference.Default)]
+    [TestCase(1, WebGLPowerPreference.HighPerformance)]
+    [TestCase(2, WebGLPowerPreference.LowPower)]
+    public void ConvertToPowerPreference_Maps_StoredValue_To_ActualEnum(int stored, WebGLPowerPreference expected)
+    {
+        Assert.AreEqual(expected, AITBuildInitializer.ConvertToPowerPreference(stored));
+    }
+
+    [TestCase(-1)]
+    [TestCase(99)]
+    public void ConvertToPowerPreference_OutOfRange_Falls_Back_To_Default(int stored)
+    {
+        Assert.AreEqual(AITDefaultSettings.GetDefaultPowerPreference(),
+            AITBuildInitializer.ConvertToPowerPreference(stored));
+    }
+
+    [Test]
+    public void ConvertToPowerPreference_HighPerformance_Regression()
+    {
+        // 원래 버그: 저장값 1("HighPerformance")을 직접 캐스팅해 LowPower가 적용됨 (반전)
+        Assert.AreEqual(WebGLPowerPreference.HighPerformance,
+            AITBuildInitializer.ConvertToPowerPreference(1),
+            "드롭다운 'HighPerformance'(저장값 1)는 반드시 HighPerformance로 매핑되어야 함");
+    }
+#endif
+
+    // =====================================================
+    // ConvertToCompressionFormat 전수 매핑 (기존 정상 동작 가드)
+    // 저장값(UI 순서): -1=자동, 0=Disabled, 1=Gzip, 2=Brotli
+    // =====================================================
+
+    [TestCase(0, WebGLCompressionFormat.Disabled)]
+    [TestCase(1, WebGLCompressionFormat.Gzip)]
+    [TestCase(2, WebGLCompressionFormat.Brotli)]
+    public void ConvertToCompressionFormat_Maps_StoredValue_To_ActualEnum(int stored, WebGLCompressionFormat expected)
+    {
+        Assert.AreEqual(expected, AITBuildInitializer.ConvertToCompressionFormat(stored));
+    }
+
+    [Test]
+    public void ConvertToCompressionFormat_Auto_Falls_Back_To_Default()
+    {
+        Assert.AreEqual(AITDefaultSettings.GetDefaultCompressionFormat(),
+            AITBuildInitializer.ConvertToCompressionFormat(-1));
+    }
+
+    // =====================================================
+    // PlayerSettings 라운드트립 — WebGL 타깃이 변환 결과를 실제로 수용하는지
+    // =====================================================
+
+    [Test]
+    public void SetManagedStrippingLevel_RoundTrips_ConvertedMinimal()
+    {
+#if UNITY_6000_0_OR_NEWER
+        var original = PlayerSettings.GetManagedStrippingLevel(NamedBuildTarget.WebGL);
+        try
+        {
+            PlayerSettings.SetManagedStrippingLevel(NamedBuildTarget.WebGL,
+                AITBuildInitializer.ConvertToManagedStrippingLevel(1));
+            Assert.AreEqual(ManagedStrippingLevel.Minimal,
+                PlayerSettings.GetManagedStrippingLevel(NamedBuildTarget.WebGL));
+        }
+        finally
+        {
+            PlayerSettings.SetManagedStrippingLevel(NamedBuildTarget.WebGL, original);
+        }
+#else
+        var original = PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.WebGL);
+        try
+        {
+            PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL,
+                AITBuildInitializer.ConvertToManagedStrippingLevel(1));
+            Assert.AreEqual(ManagedStrippingLevel.Minimal,
+                PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.WebGL));
+        }
+        finally
+        {
+            PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL, original);
+        }
+#endif
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0251e3e8cf764baeb95e753ca1eb7ec6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 문제

AIT Configuration의 드롭다운 저장값(int, UI 순서)을 Unity enum으로 직접 캐스팅해 적용하고 있었는데, 아래 세 설정은 UI 순서와 Unity enum 정수값 순서가 달라 **선택한 것과 다른 값이 빌드에 적용**됐습니다.

### 1. Managed Stripping (빌드 프로필)

Unity enum은 `Disabled=0, Low=1, Medium=2, High=3, Minimal=4` — Minimal이 나중에 추가되어 표시 강도 순서와 정수값이 다릅니다.

| 드롭다운 선택 | 실제 적용 |
|---|---|
| Minimal | Low |
| Low | Medium |
| Medium | High |
| High | **Minimal (역전)** |

Dev Server 프로필 기본값(저장값 1, 주석 "Minimal")도 실제로는 Low가 적용되고 있었습니다. "자동 (High)"는 named enum을 반환해 영향 없음.

### 2. 예외 처리 모드 (WebGLExceptionSupport)

`FullWithStacktrace ↔ FullWithoutStacktrace` 반대 적용 — 스택트레이스 수집 목적으로 FullWithStacktrace를 선택해도 실제로는 꺼졌습니다.

### 3. Power Preference (Unity 2023.3+, WebGLPowerPreference)

`HighPerformance ↔ LowPower` 반대 적용.

## 수정

- 기존 `ConvertToCompressionFormat` 패턴대로 명시 변환 함수 3개 추가(`ConvertToManagedStrippingLevel` / `ConvertToExceptionSupport` / `ConvertToPowerPreference`) 후 적용부·빌드 로그·프로필 요약·isModified 표시등을 모두 변환 함수 경유로 통일
- 저장값 의미론(UI 순서)은 그대로 유지 — 기존 사용자 자산(AITConfig.asset) 마이그레이션 불필요
- 스트리핑 드롭다운에서 WebGL(IL2CPP) 미지원 "Disabled" 옵션 제거(Unity Player Settings UI와 동일 구성), 레거시 저장값 0은 Minimal로 정규화(self-healing)
- EditMode 회귀 테스트 23건 추가: 변환 전수 매핑 + Unity enum 레이아웃 가드 + PlayerSettings 라운드트립

## 영향

- 드롭다운을 수동 설정했던 프로젝트는 이번 수정으로 **선택한 값이 실제로 적용되기 시작**합니다 (산출물 크기/동작이 의도한 방향으로 변할 수 있음 — 릴리즈 노트 명시 필요)
- "자동" 설정 사용자는 변화 없음

## 검증

- 로컬 EditMode (Unity 2022.3.62f2): 1107개 통과 (신규 23건 포함)
- Unity enum 정수값은 UnityEditor.dll 역어셈블 및 enum 레이아웃 가드 테스트로 확인
