### PR TITLE
개선: 데이터 캐싱 베타 설정 UI 숨김 및 자동 기본값 비활성화

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -1012,7 +1012,8 @@ namespace AppsInToss.Editor
         {
             config.memorySize = -1;
             config.threadsSupport = -1;
-            config.dataCaching = -1;
+            // dataCaching은 UI에서 숨겨진 베타 설정이라 리셋 대상에서도 제외 —
+            // 화면에 보이지 않는 값을 복원 버튼이 조용히 덮어쓰면 안 됨
             config.firstInteractiveLog = -1;
         }
 

--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -464,8 +464,8 @@ namespace AppsInToss.Editor
             // 스레딩 지원
             DrawThreadsSupportSetting();
 
-            // 데이터 캐싱
-            DrawDataCachingSetting();
+            // 데이터 캐싱: 베타 기능 — 정식 공개 전까지 설정 UI에서 제외
+            // (config.dataCaching 저장값과 빌드 적용 로직은 유지 — AITBuildInitializer 참조)
 
             // 파일 해싱
             config.nameFilesAsHashes = EditorGUILayout.Toggle("파일명 해싱", config.nameFilesAsHashes);
@@ -543,32 +543,6 @@ namespace AppsInToss.Editor
             if (isModified && DrawResetButton())
             {
                 config.threadsSupport = -1;
-            }
-
-            EditorGUILayout.EndHorizontal();
-        }
-
-        private void DrawDataCachingSetting()
-        {
-            bool defaultCaching = AITDefaultSettings.GetDefaultDataCaching();
-            bool isModified = config.dataCaching >= 0 && (config.dataCaching == 1) != defaultCaching;
-
-            EditorGUILayout.BeginHorizontal();
-
-            DrawModifiedIndicator(isModified);
-
-            string label = config.dataCaching < 0
-                ? $"데이터 캐싱 (자동: {(defaultCaching ? "활성화" : "비활성화")})"
-                : "데이터 캐싱";
-
-            string[] options = { $"자동 ({(defaultCaching ? "활성화" : "비활성화")})", "비활성화", "활성화" };
-            int currentIndex = config.dataCaching < 0 ? 0 : config.dataCaching + 1;
-            int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
-            config.dataCaching = newIndex == 0 ? -1 : newIndex - 1;
-
-            if (isModified && DrawResetButton())
-            {
-                config.dataCaching = -1;
             }
 
             EditorGUILayout.EndHorizontal();
@@ -1028,9 +1002,6 @@ namespace AppsInToss.Editor
             bool defaultThreads = AITDefaultSettings.GetDefaultThreadsSupport();
             if (config.threadsSupport >= 0 && (config.threadsSupport == 1) != defaultThreads) count++;
 
-            bool defaultCaching = AITDefaultSettings.GetDefaultDataCaching();
-            if (config.dataCaching >= 0 && (config.dataCaching == 1) != defaultCaching) count++;
-
             bool defaultFirstInteractive = AITDefaultSettings.GetDefaultFirstInteractiveLog();
             if (config.firstInteractiveLog >= 0 && (config.firstInteractiveLog == 1) != defaultFirstInteractive) count++;
 
@@ -1165,11 +1136,6 @@ namespace AppsInToss.Editor
                 ? config.threadsSupport == 1
                 : AITDefaultSettings.GetDefaultThreadsSupport();
             EditorGUILayout.LabelField($"  스레딩: {(effectiveThreads ? "활성화" : "비활성화")}");
-
-            bool effectiveCaching = config.dataCaching >= 0
-                ? config.dataCaching == 1
-                : AITDefaultSettings.GetDefaultDataCaching();
-            EditorGUILayout.LabelField($"  데이터 캐싱: {(effectiveCaching ? "활성화" : "비활성화")}");
 
             GUILayout.Space(10);
 

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -398,17 +398,13 @@ namespace AppsInToss
         }
 
         /// <summary>
-        /// 버전별 기본 데이터 캐싱 여부
-        /// - Unity 2021.3/2022.3: false
-        /// - Unity 6+: true (UnityVersion.md:401)
+        /// 기본 데이터 캐싱 여부
+        /// 베타 기능 미공개 상태라 전 버전 비활성화 — 플랫폼(WebView) 캐시 정책 검증 완료 후
+        /// 공개 시 Unity 6+ 기본 활성화(UnityVersion.md:401) 재검토
         /// </summary>
         public static bool GetDefaultDataCaching()
         {
-#if UNITY_2023_3_OR_NEWER
-            return true;  // Unity 6에서만 활성화 권장
-#else
             return false;
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
## 배경

"데이터 캐싱"(`PlayerSettings.WebGL.dataCaching`)은 플랫폼 WebView의 캐시 동작/퍼지 정책 검증이 끝나지 않은 **베타 기능**이라 설정 UI에 노출하지 않을 예정이었는데, WebGL 최적화 설정 섹션에 드롭다운이 노출되어 있었습니다. 또한 자동(-1) 기본값이 Unity 6+에서는 `true`로 되어 있어, 베타 기능이 Unity 6 사용자에게 기본으로 켜지는 상태였습니다.

## 변경

- **UI 숨김**: WebGL 최적화 설정의 "데이터 캐싱" 드롭다운, 변경 카운트, 프로젝트 정보의 설정 요약 표시 제거 (`DrawDataCachingSetting()` 삭제)
- **자동 기본값 통일**: `GetDefaultDataCaching()`이 전 버전에서 `false` 반환 (기존: Unity 2023.3+ `true`)
- **하위호환 유지**:
  - `config.dataCaching` 저장 필드와 빌드 적용 로직(`AITBuildInitializer`)은 유지
  - 이미 명시적으로 활성화(`1`)한 프로젝트는 기존 동작 그대로 유지
  - "모든 WebGL 설정 기본값으로 복원" 버튼이 숨겨진 값도 `-1`로 초기화

## 영향

- Unity 6+에서 자동(기본) 설정으로 빌드하던 프로젝트: `dataCaching`이 `true` → `false`로 변경 (베타 기능 비활성화 — 의도된 동작)
- Unity 2021.3/2022.3: 변화 없음

## 검증

- 로컬 EditMode (Unity 2022.3.62f2): 실패 0건


### 리뷰 후속 수정 (9c8b5696)

멀티에이전트 리뷰에서 확정된 결함 반영: `ResetWebGLSettings()`가 UI에서 숨겨진 dataCaching까지 -1로 초기화해, 명시적으로 켜둔 기존 사용자 값이 "모든 WebGL 설정 기본값으로 복원" 클릭 시 비가시적으로 지워지던 문제. 숨긴 설정은 리셋 대상에서도 제외.
