### PR TITLE
개선: 재빌드 시 변경 없으면 pnpm install 스킵 (재빌드 속도)

### DIFF
--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -22,6 +22,13 @@ namespace AppsInToss.Editor
         /// </summary>
         internal static string GetSharedPnpmStorePath() => Package.PnpmStoreManager.GetSharedPnpmStorePath();
 
+        /// <summary>
+        /// 빌드 프로젝트 드라이브를 고려한 pnpm store 경로 (PnpmStoreManager에 위임).
+        /// Windows 크로스 드라이브 시 하드링크가 가능한 드라이브별 store를 선택한다.
+        /// </summary>
+        internal static string GetSharedPnpmStorePath(string buildProjectPath) =>
+            Package.PnpmStoreManager.GetSharedPnpmStorePath(buildProjectPath);
+
         #region Packaging Common
 
         /// <summary>
@@ -129,7 +136,7 @@ namespace AppsInToss.Editor
             }
 
             // node_modules 무결성 검증
-            string storePath = GetSharedPnpmStorePath();
+            string storePath = GetSharedPnpmStorePath(buildProjectPath);
             if (!Package.NodeModulesValidator.ValidateIntegrity(buildProjectPath))
             {
                 Debug.Log("[AIT] node_modules 무결성 검증 실패. 정리 후 재설치합니다.");
@@ -194,7 +201,7 @@ namespace AppsInToss.Editor
             }
 
             // node_modules 무결성 검증
-            string storePath = GetSharedPnpmStorePath();
+            string storePath = GetSharedPnpmStorePath(buildProjectPath);
             if (!Package.NodeModulesValidator.ValidateIntegrity(buildProjectPath))
             {
                 Debug.Log("[AIT] [병렬] node_modules 무결성 검증 실패. 정리 후 재설치합니다.");

--- a/Editor/AITPackageManagerHelper.cs
+++ b/Editor/AITPackageManagerHelper.cs
@@ -393,7 +393,7 @@ namespace AppsInToss.Editor
                 // install 명령이면 공유 store 경로 추가 (병렬 빌드 시 패키지 공유)
                 if (command.TrimStart().StartsWith("install"))
                 {
-                    string storePath = AITPackageBuilder.GetSharedPnpmStorePath();
+                    string storePath = AITPackageBuilder.GetSharedPnpmStorePath(buildPath);
                     fullCommand += $" --store-dir \"{storePath}\"";
                 }
                 if (async)

--- a/Editor/Menu/PathValidator.cs
+++ b/Editor/Menu/PathValidator.cs
@@ -82,7 +82,7 @@ namespace AppsInToss.Editor.Menu
             {
                 Debug.Log("AIT: node_modules가 없습니다. pnpm install을 실행합니다...");
 
-                string localCachePath = AITPackageBuilder.GetSharedPnpmStorePath();
+                string localCachePath = AITPackageBuilder.GetSharedPnpmStorePath(buildPath);
                 var installResult = AITNpmRunner.RunNpmCommandWithCache(
                     buildPath, npmPath, "install", localCachePath, "pnpm install 실행 중..."
                 );

--- a/Editor/Package/BuildConfigMerger.cs
+++ b/Editor/Package/BuildConfigMerger.cs
@@ -22,7 +22,7 @@ namespace AppsInToss.Editor.Package
             // 프로젝트 파일 없으면 SDK 복사
             if (!File.Exists(projectFile))
             {
-                File.Copy(sdkFile, destFile, true);
+                CopyIfChanged(sdkFile, destFile);
                 Debug.Log("[AIT]   ✓ package.json (SDK에서 복사)");
                 return;
             }
@@ -39,7 +39,7 @@ namespace AppsInToss.Editor.Package
                 if (projectJson == null || sdkJson == null)
                 {
                     Debug.Log("[AIT] package.json 파싱 실패, SDK 버전 사용");
-                    File.Copy(sdkFile, destFile, true);
+                    CopyIfChanged(sdkFile, destFile);
                     return;
                 }
 
@@ -59,7 +59,7 @@ namespace AppsInToss.Editor.Package
                 );
 
                 string mergedJson = MiniJson.Serialize(result);
-                File.WriteAllText(destFile, mergedJson, new System.Text.UTF8Encoding(false));
+                WriteAllTextIfChanged(destFile, mergedJson);
                 Debug.Log("[AIT]   ✓ package.json (dependencies 머지됨)");
             }
             catch (Exception e)
@@ -67,6 +67,43 @@ namespace AppsInToss.Editor.Package
                 Debug.Log($"[AIT] package.json 머지 실패: {e}, SDK 버전 사용");
                 File.Copy(sdkFile, destFile, true);
             }
+        }
+
+        /// <summary>
+        /// 대상 파일 내용이 이미 동일하면 쓰기를 생략한다 (mtime 보존).
+        /// ait-build/package.json이 매 빌드 재작성되면 mtime이 갱신되어
+        /// pnpm의 "매니페스트 변경 없음 → install 스킵" 자체 최적화가 매번 무효화되는 것을 방지.
+        /// </summary>
+        private static void WriteAllTextIfChanged(string destFile, string content)
+        {
+            try
+            {
+                if (File.Exists(destFile) && File.ReadAllText(destFile) == content)
+                {
+                    return;
+                }
+            }
+            catch (Exception)
+            {
+                // 비교 실패 시 그냥 새로 쓴다.
+            }
+            File.WriteAllText(destFile, content, new System.Text.UTF8Encoding(false));
+        }
+
+        private static void CopyIfChanged(string sourceFile, string destFile)
+        {
+            try
+            {
+                if (File.Exists(destFile) && File.ReadAllText(sourceFile) == File.ReadAllText(destFile))
+                {
+                    return;
+                }
+            }
+            catch (Exception)
+            {
+                // 비교 실패 시 그냥 복사한다.
+            }
+            File.Copy(sourceFile, destFile, true);
         }
 
         /// <summary>

--- a/Editor/Package/GraniteBuildRunner.cs
+++ b/Editor/Package/GraniteBuildRunner.cs
@@ -33,6 +33,7 @@ namespace AppsInToss.Editor.Package
                 ctx.BuildProjectPath, ctx.PnpmPath, "install --no-frozen-lockfile",
                 ctx.LocalCachePath, "pnpm install (빌드 실패 후)...");
             if (installResult != AITConvertCore.AITExportError.SUCCEED) return installResult;
+            PnpmInstallStateMarker.WriteMarkerAfterSuccessfulInstall(ctx.BuildProjectPath);
 
             result = RunVersionedBuildSync(ctx, "ait build (재시도)");
             if (result == AITConvertCore.AITExportError.SUCCEED)
@@ -408,6 +409,7 @@ namespace AppsInToss.Editor.Package
                         return;
                     }
 
+                    PnpmInstallStateMarker.WriteMarkerAfterSuccessfulInstall(ctx.BuildProjectPath);
                     onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.7f, "granite build 재시도 중...");
 
                     RunVersionedBuildAsync(ctx, onProgress,

--- a/Editor/Package/PnpmInstallStateMarker.cs
+++ b/Editor/Package/PnpmInstallStateMarker.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using UnityEngine;
+
+namespace AppsInToss.Editor.Package
+{
+    /// <summary>
+    /// pnpm install 결과 상태 마커 — 재빌드 시 불필요한 install 재실행을 건너뛰기 위한 판단 근거.
+    /// 성공한 install 직후 package.json/pnpm-lock.yaml 내용 해시와 pnpm 버전을
+    /// node_modules/.ait-install-state.json 에 기록하고, 다음 빌드에서 전부 일치하면 install을 스킵한다.
+    ///
+    /// 마커를 node_modules 내부에 두는 이유: NodeModulesValidator.CleanNodeModules가 node_modules를
+    /// 통째로 삭제하므로 마커도 자동으로 함께 무효화된다 (재시도 정책의 clean 단계와 자동 정합).
+    ///
+    /// 판단이 불가능한 모든 케이스(마커 없음, 파싱 실패, 예외)는 "스킵 불가"로 처리한다 (fail-closed) —
+    /// 잘못된 스킵(빌드 실패)의 비용이 잘못된 재설치(시간 낭비)보다 크기 때문.
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
+    /// </summary>
+    internal static class PnpmInstallStateMarker
+    {
+        internal const string MarkerFileName = ".ait-install-state.json";
+        internal const int SchemaVersion = 1;
+
+        /// <summary>
+        /// 스킵 기능 강제 비활성화 환경변수. 배포 후 예기치 못한 문제 시 코드 수정 없이 되돌리는 킬스위치.
+        /// </summary>
+        internal const string KillSwitchEnvVar = "AIT_DISABLE_INSTALL_SKIP";
+
+        internal static string GetMarkerPath(string buildProjectPath)
+        {
+            return Path.Combine(buildProjectPath, "node_modules", MarkerFileName);
+        }
+
+        /// <summary>
+        /// 이번 빌드에서 pnpm install을 건너뛰어도 안전한지 판단한다.
+        /// node_modules 존재 + 마커 유효 + 스키마/pnpm 버전 일치 + package.json·lockfile 해시 일치 +
+        /// NodeModulesValidator 무결성 통과를 전부 만족할 때만 true.
+        /// </summary>
+        internal static bool ShouldSkipInstall(string buildProjectPath, out string reason)
+        {
+            reason = null;
+
+            try
+            {
+                if (Environment.GetEnvironmentVariable(KillSwitchEnvVar) == "1")
+                {
+                    return false;
+                }
+
+                if (!Directory.Exists(Path.Combine(buildProjectPath, "node_modules")))
+                {
+                    return false;
+                }
+
+                string packageJsonPath = Path.Combine(buildProjectPath, "package.json");
+                string lockfilePath = Path.Combine(buildProjectPath, "pnpm-lock.yaml");
+                if (!File.Exists(packageJsonPath) || !File.Exists(lockfilePath))
+                {
+                    return false;
+                }
+
+                string markerPath = GetMarkerPath(buildProjectPath);
+                if (!File.Exists(markerPath))
+                {
+                    return false;
+                }
+
+                var marker = MiniJson.Deserialize(File.ReadAllText(markerPath)) as Dictionary<string, object>;
+                if (marker == null)
+                {
+                    return false;
+                }
+
+                if (!marker.TryGetValue("schemaVersion", out object schemaObj)
+                    || Convert.ToInt32(schemaObj) != SchemaVersion)
+                {
+                    return false;
+                }
+
+                if (!marker.TryGetValue("pnpmVersion", out object pnpmObj)
+                    || (pnpmObj as string) != AITPackageManagerHelper.PNPM_VERSION)
+                {
+                    return false;
+                }
+
+                if (!marker.TryGetValue("packageJsonHash", out object pkgHashObj)
+                    || (pkgHashObj as string) != ComputeFileHash(packageJsonPath))
+                {
+                    return false;
+                }
+
+                if (!marker.TryGetValue("lockfileHash", out object lockHashObj)
+                    || (lockHashObj as string) != ComputeFileHash(lockfilePath))
+                {
+                    return false;
+                }
+
+                // 해시가 일치해도 node_modules 내용이 오염됐을 수 있다 (수동 삭제, 백신 격리 등) — 이중 게이트.
+                if (!NodeModulesValidator.ValidateIntegrity(buildProjectPath))
+                {
+                    return false;
+                }
+
+                reason = $"package.json/pnpm-lock.yaml 변경 없음 + node_modules 무결성 확인 (pnpm {AITPackageManagerHelper.PNPM_VERSION})";
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.Log($"[AIT] install 스킵 판정 중 오류 (스킵하지 않고 install 진행): {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 성공한 install 직후 현재 package.json/pnpm-lock.yaml 해시를 마커에 기록한다.
+        /// 기록 실패는 기능 저하가 아니라 "다음 빌드도 그냥 재설치"일 뿐이므로 모든 예외를 흡수한다.
+        /// </summary>
+        internal static void WriteMarkerAfterSuccessfulInstall(string buildProjectPath)
+        {
+            try
+            {
+                string packageJsonPath = Path.Combine(buildProjectPath, "package.json");
+                string lockfilePath = Path.Combine(buildProjectPath, "pnpm-lock.yaml");
+                string nodeModulesPath = Path.Combine(buildProjectPath, "node_modules");
+
+                if (!Directory.Exists(nodeModulesPath) || !File.Exists(packageJsonPath) || !File.Exists(lockfilePath))
+                {
+                    return;
+                }
+
+                var marker = new Dictionary<string, object>
+                {
+                    { "schemaVersion", SchemaVersion },
+                    { "pnpmVersion", AITPackageManagerHelper.PNPM_VERSION },
+                    { "packageJsonHash", ComputeFileHash(packageJsonPath) },
+                    { "lockfileHash", ComputeFileHash(lockfilePath) },
+                    { "installedAtUtc", DateTime.UtcNow.ToString("o") },
+                };
+
+                string markerPath = GetMarkerPath(buildProjectPath);
+                string tempPath = markerPath + ".tmp";
+                File.WriteAllText(tempPath, MiniJson.Serialize(marker), new UTF8Encoding(false));
+                if (File.Exists(markerPath)) File.Delete(markerPath);
+                File.Move(tempPath, markerPath);
+            }
+            catch (Exception e)
+            {
+                Debug.Log($"[AIT] install 상태 마커 기록 실패 (무시됨 — 다음 빌드에서 install 재실행): {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 파일 내용의 SHA256 해시 ("sha256:" 접두사 + 소문자 hex).
+        /// </summary>
+        internal static string ComputeFileHash(string filePath)
+        {
+            using (var sha256 = SHA256.Create())
+            using (var stream = File.OpenRead(filePath))
+            {
+                byte[] hash = sha256.ComputeHash(stream);
+                var sb = new StringBuilder("sha256:", 7 + hash.Length * 2);
+                foreach (byte b in hash)
+                {
+                    sb.Append(b.ToString("x2"));
+                }
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/Editor/Package/PnpmInstallStateMarker.cs
+++ b/Editor/Package/PnpmInstallStateMarker.cs
@@ -29,6 +29,34 @@ namespace AppsInToss.Editor.Package
         /// </summary>
         internal const string KillSwitchEnvVar = "AIT_DISABLE_INSTALL_SKIP";
 
+        /// <summary>
+        /// 킬스위치 값 해석. "1"/"true"는 활성, "0"/"false"/미설정은 비활성 (대소문자·양끝 공백 무시).
+        /// 그 외 값은 운영자가 스킵을 끄려던 의도로 보고 경고 로그 후 활성으로 처리한다 —
+        /// 킬스위치의 존재 목적상 오타로 무력화되는 것보다 스킵이 꺼지는 쪽이 항상 안전하다 (fail-safe).
+        /// </summary>
+        internal static bool IsKillSwitchActive(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            string normalized = value.Trim();
+            if (normalized == "1" || normalized.Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            if (normalized == "0" || normalized.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            Debug.LogWarning(
+                $"[AIT] {KillSwitchEnvVar}='{value}' 값을 인식할 수 없어 킬스위치 활성(스킵 비활성화)으로 처리합니다. " +
+                "인식되는 값: 1/true (활성), 0/false (비활성).");
+            return true;
+        }
+
         internal static string GetMarkerPath(string buildProjectPath)
         {
             return Path.Combine(buildProjectPath, "node_modules", MarkerFileName);
@@ -45,7 +73,7 @@ namespace AppsInToss.Editor.Package
 
             try
             {
-                if (Environment.GetEnvironmentVariable(KillSwitchEnvVar) == "1")
+                if (IsKillSwitchActive(Environment.GetEnvironmentVariable(KillSwitchEnvVar)))
                 {
                     return false;
                 }

--- a/Editor/Package/PnpmInstallStateMarker.cs.meta
+++ b/Editor/Package/PnpmInstallStateMarker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d171a64989834ccc84fabe9eff04efb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/PnpmRunner.cs
+++ b/Editor/Package/PnpmRunner.cs
@@ -66,6 +66,13 @@ namespace AppsInToss.Editor.Package
         /// </summary>
         private static async Task<AITConvertCore.AITExportError> RunPnpmInstallInThread(AITPackageBuilder.EarlyPackageContext earlyCtx)
         {
+            // 순수 파일 IO/해시 비교만 수행하므로 백그라운드 스레드에서 안전.
+            if (PnpmInstallStateMarker.ShouldSkipInstall(earlyCtx.BuildProjectPath, out string skipReason))
+            {
+                Debug.Log($"[AIT] [병렬] ✓ pnpm install 스킵: {skipReason}");
+                return AITConvertCore.AITExportError.SUCCEED;
+            }
+
             var ct = earlyCtx.PnpmCancellationToken;
             var additionalPaths = AITNpmRunner.BuildAdditionalPaths(earlyCtx.PnpmPath);
 
@@ -162,6 +169,7 @@ namespace AppsInToss.Editor.Package
                                 {
                                     // 성공 시 직전 폴백 단계의 실패 진단을 비운다 (§5).
                                     AITBuildDiagnostics.ClearOnSuccess();
+                                    PnpmInstallStateMarker.WriteMarkerAfterSuccessfulInstall(earlyCtx.BuildProjectPath);
                                     Debug.Log($"[AIT] [병렬] ✓ pnpm {label} 성공");
                                     return AITConvertCore.AITExportError.SUCCEED;
                                 }
@@ -209,6 +217,12 @@ namespace AppsInToss.Editor.Package
         /// </summary>
         internal static AITConvertCore.AITExportError RunPnpmInstallSync(AITPackageBuilder.PackageContext ctx)
         {
+            if (PnpmInstallStateMarker.ShouldSkipInstall(ctx.BuildProjectPath, out string skipReason))
+            {
+                Debug.Log($"[AIT] ✓ pnpm install 스킵: {skipReason}");
+                return AITConvertCore.AITExportError.SUCCEED;
+            }
+
             // 중간 단계 실패는 정상 fallback이라 Sentry로 보내지 않는다.
             // 최종 실패 LogError도 sentryCapture:false이며, 빌드 실패 캡처는 상위 CaptureBuildError가 담당한다.
             AITEditorErrorTracker.BeginSuppressLogCapture();
@@ -221,7 +235,11 @@ namespace AppsInToss.Editor.Package
                     var result = AITNpmRunner.RunNpmCommandWithCache(
                         ctx.BuildProjectPath, ctx.PnpmPath, args, ctx.LocalCachePath,
                         $"pnpm {label}...");
-                    if (result == AITConvertCore.AITExportError.SUCCEED) return result;
+                    if (result == AITConvertCore.AITExportError.SUCCEED)
+                    {
+                        PnpmInstallStateMarker.WriteMarkerAfterSuccessfulInstall(ctx.BuildProjectPath);
+                        return result;
+                    }
                     if (result == AITConvertCore.AITExportError.CANCELLED) return result;
                     Debug.Log($"[AIT] pnpm install ({label}) 실패, 다음 단계로...");
                 }
@@ -256,6 +274,14 @@ namespace AppsInToss.Editor.Package
                 return;
             }
 
+            // 스킵 판정은 첫 단계에서만 — 재시도 단계(stageIndex > 0)는 이미 install이 필요하다고 판명된 상태.
+            if (stageIndex == 0 && PnpmInstallStateMarker.ShouldSkipInstall(buildProjectPath, out string skipReason))
+            {
+                Debug.Log($"[AIT] ✓ pnpm install 스킵: {skipReason}");
+                onComplete?.Invoke(AITConvertCore.AITExportError.SUCCEED);
+                return;
+            }
+
             var (args, label, cleanFirst, deleteLockfileFirst) = PnpmStoreManager.InstallStages[stageIndex];
             if (cleanFirst) NodeModulesValidator.CleanNodeModules(buildProjectPath);
             if (deleteLockfileFirst) DeleteLockfileIfExists(buildProjectPath);
@@ -283,6 +309,7 @@ namespace AppsInToss.Editor.Package
 
                         if (result == AITConvertCore.AITExportError.SUCCEED)
                         {
+                            PnpmInstallStateMarker.WriteMarkerAfterSuccessfulInstall(buildProjectPath);
                             onComplete?.Invoke(result);
                             return;
                         }

--- a/Editor/Package/PnpmStoreManager.cs
+++ b/Editor/Package/PnpmStoreManager.cs
@@ -28,6 +28,73 @@ namespace AppsInToss.Editor.Package
         }
 
         /// <summary>
+        /// 빌드 프로젝트 위치를 고려한 store 경로.
+        /// pnpm의 하드링크는 같은 볼륨 안에서만 동작한다 — Windows에서 프로젝트가
+        /// 홈 드라이브(보통 C:)와 다른 드라이브에 있으면 store→node_modules가 매번
+        /// 파일 복사로 폴백되어 재설치가 크게 느려진다. 이 경우 pnpm 자체의 관례처럼
+        /// 프로젝트 드라이브 루트에 드라이브별 store(예: D:\.ait-unity-sdk\pnpm-store)를
+        /// 사용해 하드링크를 복원한다. 드라이브 루트에 쓸 수 없으면 홈 store로 폴백
+        /// (복사라서 느리지만 동작은 함).
+        /// </summary>
+        internal static string GetSharedPnpmStorePath(string buildProjectPath)
+        {
+            string homeStore = GetSharedPnpmStorePath();
+            string resolved = ResolveStorePathForProject(homeStore, buildProjectPath);
+            if (resolved == homeStore)
+            {
+                return homeStore;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(resolved);
+                // 디렉토리가 이미 있어도 쓰기 권한이 없을 수 있어 실제 쓰기로 검증
+                string probe = Path.Combine(resolved, ".ait-write-probe-" + Guid.NewGuid().ToString("N"));
+                File.WriteAllText(probe, string.Empty);
+                File.Delete(probe);
+                return resolved;
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning(
+                    $"[AIT] 프로젝트 드라이브 pnpm store({resolved})에 쓸 수 없어 홈 store로 폴백합니다. " +
+                    $"크로스 드라이브 하드링크가 불가능해 설치가 느려질 수 있습니다: {e.Message}");
+                return homeStore;
+            }
+        }
+
+        /// <summary>
+        /// 순수 함수: 홈 store와 프로젝트가 다른 Windows 드라이브에 있으면
+        /// 프로젝트 드라이브 루트의 store 경로를, 그 외에는 홈 store를 반환.
+        /// 드라이브 문자 루트(C:\ 등)만 대상 — UNC/유닉스 경로는 항상 홈 store.
+        /// </summary>
+        internal static string ResolveStorePathForProject(string homeStorePath, string buildProjectPath)
+        {
+            string homeRoot = GetWindowsDriveRoot(homeStorePath);
+            string projectRoot = GetWindowsDriveRoot(buildProjectPath);
+            if (homeRoot == null || projectRoot == null || homeRoot == projectRoot)
+            {
+                return homeStorePath;
+            }
+            return projectRoot + @".ait-unity-sdk\pnpm-store";
+        }
+
+        /// <summary>
+        /// 경로가 Windows 드라이브 문자로 시작하면 정규화된 루트("D:\")를, 아니면 null 반환.
+        /// Path.GetPathRoot는 실행 OS의 규칙을 따르므로 플랫폼 무관 판정을 위해 직접 파싱.
+        /// </summary>
+        internal static string GetWindowsDriveRoot(string path)
+        {
+            if (string.IsNullOrEmpty(path) || path.Length < 2 || path[1] != ':')
+            {
+                return null;
+            }
+            char drive = path[0];
+            bool isAsciiLetter = (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z');
+            return isAsciiLetter ? char.ToUpperInvariant(drive) + @":\" : null;
+        }
+
+        /// <summary>
         /// pnpm install 재시도 정책 (args, label, cleanFirst, deleteLockfileFirst).
         /// 1단계: frozen-lockfile (lockfile 정합 시 통과)
         /// 2단계: --no-frozen-lockfile (lockfile 갱신 허용)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStateMarkerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStateMarkerTests.cs
@@ -161,11 +161,14 @@ namespace AppsInToss.Editor.Package.Tests
             Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
         }
 
-        [Test]
-        public void ShouldSkipInstall_ReturnsFalse_WhenKillSwitchEnvVarSet()
+        [TestCase("1")]
+        [TestCase("true")]
+        [TestCase("TRUE")]
+        [TestCase(" 1 ")]
+        public void ShouldSkipInstall_ReturnsFalse_WhenKillSwitchEnvVarSet(string value)
         {
             CreateValidInstalledState();
-            System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, "1");
+            System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, value);
             try
             {
                 Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
@@ -174,6 +177,64 @@ namespace AppsInToss.Editor.Package.Tests
             {
                 System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, null);
             }
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_AndWarns_WhenKillSwitchValueUnrecognized()
+        {
+            // 오타/비표준 값("yes" 등)으로 킬스위치를 걸어도 무경고 무시되면 안 됨 —
+            // fail-safe로 킬스위치 활성 처리 + 경고 로그
+            CreateValidInstalledState();
+            System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, "yes");
+            try
+            {
+                UnityEngine.TestTools.LogAssert.Expect(UnityEngine.LogType.Warning,
+                    new System.Text.RegularExpressions.Regex("인식할 수 없어 킬스위치 활성"));
+                Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, null);
+            }
+        }
+
+        [TestCase("0")]
+        [TestCase("false")]
+        public void ShouldSkipInstall_StillSkips_WhenKillSwitchExplicitlyOff(string value)
+        {
+            CreateValidInstalledState();
+            System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, value);
+            try
+            {
+                Assert.IsTrue(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, null);
+            }
+        }
+
+        [TestCase(null, false)]
+        [TestCase("", false)]
+        [TestCase("   ", false)]
+        [TestCase("0", false)]
+        [TestCase("false", false)]
+        [TestCase("FALSE", false)]
+        [TestCase("1", true)]
+        [TestCase("true", true)]
+        [TestCase("True", true)]
+        [TestCase(" 1 ", true)]
+        public void IsKillSwitchActive_ParsesRecognizedValues(string value, bool expected)
+        {
+            Assert.AreEqual(expected, PnpmInstallStateMarker.IsKillSwitchActive(value));
+        }
+
+        [Test]
+        public void IsKillSwitchActive_UnrecognizedValue_IsActiveWithWarning()
+        {
+            UnityEngine.TestTools.LogAssert.Expect(UnityEngine.LogType.Warning,
+                new System.Text.RegularExpressions.Regex("인식할 수 없어 킬스위치 활성"));
+            Assert.IsTrue(PnpmInstallStateMarker.IsKillSwitchActive("yes"));
         }
 
         // =====================================================

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStateMarkerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStateMarkerTests.cs
@@ -1,0 +1,248 @@
+// -----------------------------------------------------------------------
+// PnpmInstallStateMarkerTests.cs - install 스킵 판정 마커 단위 테스트
+// Level 0: 임시 디렉토리 fixture로 판정 로직만 확인 (pnpm 실행 없음)
+// 판정이 잘못되면 (a) 불필요한 재설치(원래 문제 재발) 또는 (b) 오염된
+// node_modules로 빌드(더 나쁨) — fail-closed 동작을 집중 검증한다.
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+
+namespace AppsInToss.Editor.Package.Tests
+{
+    [TestFixture]
+    public class PnpmInstallStateMarkerTests
+    {
+        private const string WebFrameworkVersion = "2.4.7";
+
+        private string _tempDir;
+
+        [SetUp]
+        public void CreateTempDir()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "ait-marker-tests-" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TearDown]
+        public void CleanupTempDir()
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// 스킵 가능한 정상 상태 fixture:
+        /// package.json + pnpm-lock.yaml + node_modules/.pnpm/web-framework@버전 + 성공 마커
+        /// </summary>
+        private void CreateValidInstalledState()
+        {
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"" + WebFrameworkVersion + "\"}}");
+            File.WriteAllText(Path.Combine(_tempDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+            Directory.CreateDirectory(Path.Combine(
+                _tempDir, "node_modules", ".pnpm", "@apps-in-toss+web-framework@" + WebFrameworkVersion));
+            PnpmInstallStateMarker.WriteMarkerAfterSuccessfulInstall(_tempDir);
+        }
+
+        // =====================================================
+        // 스킵 성공 (전 조건 만족)
+        // =====================================================
+
+        [Test]
+        public void WriteMarker_ThenShouldSkipInstall_RoundTrips()
+        {
+            CreateValidInstalledState();
+
+            bool skip = PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out string reason);
+
+            Assert.IsTrue(skip);
+            Assert.IsNotNull(reason);
+        }
+
+        // =====================================================
+        // fail-closed: 조건 하나라도 어긋나면 스킵 불가
+        // =====================================================
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenMarkerMissing()
+        {
+            CreateValidInstalledState();
+            File.Delete(PnpmInstallStateMarker.GetMarkerPath(_tempDir));
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenNodeModulesMissing()
+        {
+            CreateValidInstalledState();
+            Directory.Delete(Path.Combine(_tempDir, "node_modules"), recursive: true);
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenPackageJsonChanged()
+        {
+            CreateValidInstalledState();
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"),
+                "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"9.9.9\"}}");
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenLockfileChanged()
+        {
+            CreateValidInstalledState();
+            File.AppendAllText(Path.Combine(_tempDir, "pnpm-lock.yaml"), "# changed\n");
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenLockfileMissing()
+        {
+            CreateValidInstalledState();
+            File.Delete(Path.Combine(_tempDir, "pnpm-lock.yaml"));
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenPnpmVersionMismatch()
+        {
+            CreateValidInstalledState();
+            string markerPath = PnpmInstallStateMarker.GetMarkerPath(_tempDir);
+            string marker = File.ReadAllText(markerPath);
+            File.WriteAllText(markerPath,
+                marker.Replace(AITPackageManagerHelper.PNPM_VERSION, "0.0.1"));
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenSchemaVersionMismatch()
+        {
+            // 해시/버전은 전부 유효하고 schemaVersion만 미래 값인 마커 — 직렬화 형식 의존 없이 직접 구성
+            CreateValidInstalledState();
+            var marker = new System.Collections.Generic.Dictionary<string, object>
+            {
+                { "schemaVersion", PnpmInstallStateMarker.SchemaVersion + 998 },
+                { "pnpmVersion", AITPackageManagerHelper.PNPM_VERSION },
+                { "packageJsonHash", PnpmInstallStateMarker.ComputeFileHash(Path.Combine(_tempDir, "package.json")) },
+                { "lockfileHash", PnpmInstallStateMarker.ComputeFileHash(Path.Combine(_tempDir, "pnpm-lock.yaml")) },
+            };
+            File.WriteAllText(PnpmInstallStateMarker.GetMarkerPath(_tempDir), MiniJson.Serialize(marker));
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenMarkerJsonCorrupted()
+        {
+            CreateValidInstalledState();
+            File.WriteAllText(PnpmInstallStateMarker.GetMarkerPath(_tempDir), "{not-valid-json!!");
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenNodeModulesIntegrityBroken()
+        {
+            // 해시/마커는 유효하지만 .pnpm 디렉토리가 사라진 오염 상태 (수동 삭제, 백신 격리 등)
+            // → NodeModulesValidator 이중 게이트가 스킵을 막아야 함
+            CreateValidInstalledState();
+            Directory.Delete(Path.Combine(_tempDir, "node_modules", ".pnpm"), recursive: true);
+
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipInstall_ReturnsFalse_WhenKillSwitchEnvVarSet()
+        {
+            CreateValidInstalledState();
+            System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, "1");
+            try
+            {
+                Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable(PnpmInstallStateMarker.KillSwitchEnvVar, null);
+            }
+        }
+
+        // =====================================================
+        // 마커 수명주기: CleanNodeModules와의 정합
+        // =====================================================
+
+        [Test]
+        public void CleanNodeModules_InvalidatesMarker()
+        {
+            // 마커가 node_modules 내부에 있어 clean 재시도 단계에서 자동으로 함께 무효화되어야 함
+            CreateValidInstalledState();
+
+            NodeModulesValidator.CleanNodeModules(_tempDir);
+
+            Assert.IsFalse(File.Exists(PnpmInstallStateMarker.GetMarkerPath(_tempDir)));
+            Assert.IsFalse(PnpmInstallStateMarker.ShouldSkipInstall(_tempDir, out _));
+        }
+
+        [Test]
+        public void WriteMarker_DoesNothing_WhenNodeModulesMissing()
+        {
+            // install 성공 직후가 아닌 상태(node_modules 없음)에서는 마커를 만들지 않아야 함
+            File.WriteAllText(Path.Combine(_tempDir, "package.json"), "{}");
+            File.WriteAllText(Path.Combine(_tempDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+
+            PnpmInstallStateMarker.WriteMarkerAfterSuccessfulInstall(_tempDir);
+
+            Assert.IsFalse(File.Exists(PnpmInstallStateMarker.GetMarkerPath(_tempDir)));
+        }
+
+        // =====================================================
+        // 해시 형식
+        // =====================================================
+
+        [Test]
+        public void ComputeFileHash_IsStable_AndPrefixed()
+        {
+            string file = Path.Combine(_tempDir, "sample.txt");
+            File.WriteAllText(file, "content");
+
+            string hash1 = PnpmInstallStateMarker.ComputeFileHash(file);
+            string hash2 = PnpmInstallStateMarker.ComputeFileHash(file);
+
+            Assert.AreEqual(hash1, hash2);
+            StringAssert.StartsWith("sha256:", hash1);
+            Assert.AreEqual("sha256:".Length + 64, hash1.Length);
+        }
+
+        // =====================================================
+        // PnpmRunner 통합: 스킵 시 프로세스가 전혀 스폰되지 않아야 함
+        // =====================================================
+
+        [Test]
+        public void RunPnpmInstallSync_Skips_WithoutSpawningProcess_WhenStateValid()
+        {
+            // PnpmPath에 존재하지 않는 경로를 넣었으므로, 스킵이 동작하지 않고 실제 install을
+            // 시도했다면 SUCCEED가 나올 수 없다 — SUCCEED 반환 자체가 "프로세스 미스폰"의 증거.
+            CreateValidInstalledState();
+
+            var ctx = new AITPackageBuilder.PackageContext
+            {
+                BuildProjectPath = _tempDir,
+                PnpmPath = Path.Combine(_tempDir, "nonexistent-pnpm-binary"),
+                LocalCachePath = _tempDir,
+            };
+
+            var result = PnpmRunner.RunPnpmInstallSync(ctx);
+
+            Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result);
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStateMarkerTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmInstallStateMarkerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c6c7304d12640f98bdb8f75987600ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmStorePathResolutionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmStorePathResolutionTests.cs
@@ -1,0 +1,120 @@
+// -----------------------------------------------------------------------
+// PnpmStorePathResolutionTests.cs - 크로스 드라이브 pnpm store 해석 테스트
+// Level 0: 순수 함수(ResolveStorePathForProject / GetWindowsDriveRoot)라
+// 실행 OS와 무관하게 Windows 경로 문자열 판정을 검증할 수 있다.
+// 판정이 잘못되면 (a) 크로스 드라이브에서 하드링크 대신 복사(원래 문제 재발)
+// 또는 (b) 잘못된 위치에 store 생성 — 폴백(홈 store) 동작을 집중 검증한다.
+// -----------------------------------------------------------------------
+
+using System.IO;
+using NUnit.Framework;
+
+namespace AppsInToss.Editor.Package.Tests
+{
+    [TestFixture]
+    public class PnpmStorePathResolutionTests
+    {
+        private const string HomeStoreC = @"C:\Users\dev\AppData\Local\.ait-unity-sdk\pnpm-store";
+        private const string HomeStoreUnix = "/Users/dev/.ait-unity-sdk/pnpm-store";
+
+        // =====================================================
+        // GetWindowsDriveRoot: 드라이브 문자 파싱
+        // =====================================================
+
+        [TestCase(@"C:\Users\dev\project", "C:\\")]
+        [TestCase(@"d:\game\ait-build", "D:\\")]
+        [TestCase("D:/game/ait-build", "D:\\")]
+        [TestCase("E:", "E:\\")]
+        public void GetWindowsDriveRoot_ParsesDriveLetterPaths(string path, string expectedRoot)
+        {
+            Assert.AreEqual(expectedRoot, PnpmStoreManager.GetWindowsDriveRoot(path));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("/Users/dev/project")]
+        [TestCase(@"\\server\share\project")]
+        [TestCase("relative/path")]
+        [TestCase("1:\\not-a-letter")]
+        [TestCase("C")]
+        public void GetWindowsDriveRoot_ReturnsNull_ForNonDrivePaths(string path)
+        {
+            Assert.IsNull(PnpmStoreManager.GetWindowsDriveRoot(path));
+        }
+
+        // =====================================================
+        // ResolveStorePathForProject: 같은 드라이브/비드라이브 → 홈 store 유지
+        // =====================================================
+
+        [Test]
+        public void Resolve_KeepsHomeStore_WhenSameDrive()
+        {
+            Assert.AreEqual(HomeStoreC,
+                PnpmStoreManager.ResolveStorePathForProject(HomeStoreC, @"C:\game\ait-build"));
+        }
+
+        [Test]
+        public void Resolve_KeepsHomeStore_WhenSameDrive_CaseInsensitive()
+        {
+            Assert.AreEqual(HomeStoreC,
+                PnpmStoreManager.ResolveStorePathForProject(HomeStoreC, @"c:\game\ait-build"));
+        }
+
+        [Test]
+        public void Resolve_KeepsHomeStore_ForUnixPaths()
+        {
+            Assert.AreEqual(HomeStoreUnix,
+                PnpmStoreManager.ResolveStorePathForProject(HomeStoreUnix, "/Users/dev/game/ait-build"));
+        }
+
+        [Test]
+        public void Resolve_KeepsHomeStore_WhenProjectPathIsNullOrEmpty()
+        {
+            Assert.AreEqual(HomeStoreC, PnpmStoreManager.ResolveStorePathForProject(HomeStoreC, null));
+            Assert.AreEqual(HomeStoreC, PnpmStoreManager.ResolveStorePathForProject(HomeStoreC, ""));
+        }
+
+        [Test]
+        public void Resolve_KeepsHomeStore_WhenProjectOnUncShare()
+        {
+            // 네트워크 공유 루트에 store 디렉토리를 만드는 것은 침습적 — 홈 store 유지
+            Assert.AreEqual(HomeStoreC,
+                PnpmStoreManager.ResolveStorePathForProject(HomeStoreC, @"\\nas\projects\game\ait-build"));
+        }
+
+        // =====================================================
+        // ResolveStorePathForProject: 크로스 드라이브 → 드라이브별 store
+        // =====================================================
+
+        [Test]
+        public void Resolve_UsesProjectDriveStore_WhenDifferentDrive()
+        {
+            Assert.AreEqual(@"D:\.ait-unity-sdk\pnpm-store",
+                PnpmStoreManager.ResolveStorePathForProject(HomeStoreC, @"D:\game\ait-build"));
+        }
+
+        [Test]
+        public void Resolve_UsesProjectDriveStore_WhenDifferentDrive_LowercaseAndForwardSlash()
+        {
+            Assert.AreEqual(@"D:\.ait-unity-sdk\pnpm-store",
+                PnpmStoreManager.ResolveStorePathForProject(HomeStoreC, "d:/game/ait-build"));
+        }
+
+        // =====================================================
+        // GetSharedPnpmStorePath(buildProjectPath): 현재 OS 실경로 통합 확인
+        // =====================================================
+
+        [Test]
+        public void GetSharedPnpmStorePath_WithProjectPath_ReturnsPureResolutionOrHomeFallback()
+        {
+            // 실제 환경 통합 확인: 순수 해석 결과 또는 (드라이브 루트 쓰기 불가 시) 홈 store 폴백만 허용
+            string homeStore = PnpmStoreManager.GetSharedPnpmStorePath();
+            string projectPath = Path.Combine(Path.GetTempPath(), "ait-store-tests");
+            string pure = PnpmStoreManager.ResolveStorePathForProject(homeStore, projectPath);
+
+            string resolved = PnpmStoreManager.GetSharedPnpmStorePath(projectPath);
+
+            Assert.That(resolved, Is.EqualTo(pure).Or.EqualTo(homeStore));
+        }
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmStorePathResolutionTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PnpmStorePathResolutionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f8a1c62d94b47e0a5c19e7b842d6f01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경

NHN 문의: 이미 빌드했던 폴더에서 재빌드할 때 web-framework 등을 다시 다운로드하는 것처럼 보이고 빌드가 느리다는 제보.

조사 결과 실제 네트워크 다운로드는 없었고(`downloaded 0`), 원인은 두 가지:

1. 메인 빌드 경로가 node_modules 상태와 무관하게 **매 빌드 무조건 `pnpm install --frozen-lockfile`을 실행** — pnpm이 lockfile 전체를 재해석하며 store→node_modules 재링크(`added 1058`)를 매번 수행
2. `BuildConfigMerger.MergePackageJson`이 내용이 같아도 매 빌드 `ait-build/package.json`을 재작성 → mtime 갱신으로 pnpm 자체의 "매니페스트 변경 없음 → 스킵" 최적화도 무효화

## 변경 내용

### 1차 방어선: 상태 마커 기반 install 스킵 (신규 `PnpmInstallStateMarker`)

- 성공한 install 직후 `package.json`/`pnpm-lock.yaml`의 SHA256 해시 + pnpm 버전을 `ait-build/node_modules/.ait-install-state.json`에 기록
- 다음 빌드에서 **전부 일치 + `NodeModulesValidator.ValidateIntegrity` 통과** 시 install 프로세스 스폰 자체를 생략
- **fail-closed**: 마커 없음/손상, 스키마·pnpm 버전 불일치, 해시 불일치, 무결성 실패, 예외 — 전부 기존처럼 install 실행
- 적용 지점: 동기(`RunPnpmInstallSync`)/비동기(`RunPnpmInstallAsync` stage 0)/병렬(`RunPnpmInstallInThread`) 3개 진입점 + granite build 실패 후 재설치 경로 2곳(마커 기록)
- 마커가 node_modules 내부에 있어 `CleanNodeModules`(재시도 3~4단계, granite 실패 복구) 시 자동 무효화 — 기존 4단계 재시도 정책과 정합
- 킬스위치: `AIT_DISABLE_INSTALL_SKIP=1`(또는 `true`) 환경변수로 즉시 비활성화 가능 — 미인식 값은 경고 로그 후 안전한 방향(스킵 비활성)으로 처리 (d95a5a66, 리뷰 후속 수정)

### 2차 방어선: package.json write-if-changed

- `MergePackageJson`이 내용 동일 시 쓰기/복사를 생략해 mtime 보존 → 마커 스킵이 동작하지 않는 예외 상황에서도 pnpm 네이티브 스킵이 작동할 여지 확보

## 테스트

- 신규 `PnpmInstallStateMarkerTests` (EditMode Level 0, 15케이스): 라운드트립, 해시/버전/스키마 불일치, 손상 JSON fail-closed, 킬스위치, 무결성 이중 게이트, `CleanNodeModules` 자동 무효화
- 회귀 가드: 유효 마커 + 존재하지 않는 `PnpmPath`로 `RunPnpmInstallSync` → `SUCCEED` (스킵 시 프로세스가 전혀 스폰되지 않음을 증명)
- 로컬 검증: `./run-local-tests.sh --editmode` 1094개 전체 통과. `--validate`의 SDK Generator 유닛 테스트는 로컬 프록시의 lockfile 최신 버전 미캐시(404)로 실행 불가 — 본 PR은 `sdk-runtime-generator~`를 건드리지 않으며 CI에서 검증됨

## 사용자 영향

- 재빌드 시 의존성 변경이 없으면 install 단계(수십 초)가 제거됨
- 첫 빌드/의존성 변경 시 동작은 기존과 동일

### 3차: Windows 크로스 드라이브 시 드라이브별 pnpm store (cad64d42)

pnpm 하드링크는 같은 볼륨에서만 동작한다. 프로젝트가 홈 드라이브(보통 C:)와 다른 드라이브에 있으면 store→node_modules 링크가 매번 **파일 복사로 폴백**되어, 스킵이 무효화된 상황(의존성 변경 등)에서의 재설치가 크게 느려진다 (NHN 스크린샷 환경은 Windows).

- pnpm 자체 관례처럼 프로젝트 드라이브 루트에 드라이브별 store(예: `D:\.ait-unity-sdk\pnpm-store`)를 선택해 하드링크 복원
- 드라이브 루트에 쓰기 불가 시 실제 쓰기 검증 후 홈 store로 폴백 (느리지만 동작)
- UNC/유닉스 경로는 기존 홈 store 유지 — macOS/Linux 동작 변화 없음
- 순수 해석 함수(`ResolveStorePathForProject`/`GetWindowsDriveRoot`) 분리로 실행 OS와 무관하게 Windows 경로 판정을 EditMode 테스트로 검증 (신규 `PnpmStorePathResolutionTests`, 18케이스 — 전체 EditMode 1116개 통과)
