### PR TITLE
수정: 재빌드 시 정합인 기존 lockfile 보존으로 install 스킵 실효화

### DIFF
--- a/Editor/Package/BuildConfigMerger.cs
+++ b/Editor/Package/BuildConfigMerger.cs
@@ -152,7 +152,52 @@ namespace AppsInToss.Editor.Package
             }
             else if (File.Exists(pnpmLockSdk))
             {
-                CopyWithIoExceptionFallback(pnpmLockSdk, pnpmLockDst, "pnpm-lock.yaml (SDK에서 복사)");
+                // SDK lockfile은 프로젝트가 BuildConfig~/package.json으로 추가한 의존성을 모른다.
+                // 그런 프로젝트에서 무조건 덮어쓰면 이전 빌드의 install이 재생성한(= 병합 package.json과
+                // 정합인) lockfile이 매 빌드 stale 템플릿으로 되돌아가, frozen-lockfile이 항상 실패하고
+                // install 스킵 마커의 lockfileHash도 매번 갈려 스킵이 영원히 발동하지 못한다.
+                // 기존 산출물이 병합 package.json과 정합이면 보존한다 (MergePackageJson이 먼저 실행되어
+                // destPath/package.json은 이 시점에 항상 병합 완료 상태). 정합 판정이 실패하거나
+                // 예외가 나면 기존 동작(SDK 복사)으로 폴백한다 (Fix A의 stale lockfile 회귀 방지 유지).
+                if (IsExistingLockfileReusable(destPath, pnpmLockDst))
+                {
+                    Debug.Log("[AIT]   ✓ pnpm-lock.yaml (기존 빌드 산출물 유지 — 병합된 package.json과 정합)");
+                }
+                else
+                {
+                    CopyWithIoExceptionFallback(pnpmLockSdk, pnpmLockDst, "pnpm-lock.yaml (SDK에서 복사)");
+                }
+            }
+        }
+
+        /// <summary>
+        /// destPath의 기존 pnpm-lock.yaml이 병합된 package.json과 정합이어서 재사용해도 안전한지 판정한다.
+        /// 판정 불가(파일 없음, 파싱 실패, 예외)는 전부 false → SDK lockfile 복사로 폴백 (fail-closed).
+        /// </summary>
+        internal static bool IsExistingLockfileReusable(string destPath, string pnpmLockDst)
+        {
+            try
+            {
+                if (!File.Exists(pnpmLockDst))
+                {
+                    return false;
+                }
+                string mergedPackageJson = Path.Combine(destPath, "package.json");
+                if (!File.Exists(mergedPackageJson))
+                {
+                    return false;
+                }
+                if (LockfileValidator.IsLockfileInSync(mergedPackageJson, pnpmLockDst, out string mismatchSummary))
+                {
+                    return true;
+                }
+                Debug.Log($"[AIT] 기존 pnpm-lock.yaml 재사용 불가 (SDK lockfile로 대체): {mismatchSummary}");
+                return false;
+            }
+            catch (Exception e)
+            {
+                Debug.Log($"[AIT] 기존 pnpm-lock.yaml 재사용 판정 중 오류 (SDK lockfile로 대체): {e.Message}");
+                return false;
             }
         }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerLockfileFallbackTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/BuildConfigMergerLockfileFallbackTests.cs
@@ -39,6 +39,7 @@ namespace AppsInToss.Editor.Package.Tests
 
         private const string ProjectLockfileMarker = "PROJECT_LOCKFILE_MARKER";
         private const string SdkLockfileMarker = "SDK_LOCKFILE_MARKER";
+        private const string DestLockfileMarker = "DEST_LOCKFILE_MARKER";
 
         private static string MakePackageJson(string webFrameworkSpec)
         {
@@ -129,6 +130,85 @@ namespace AppsInToss.Editor.Package.Tests
 
             Assert.IsFalse(File.Exists(Path.Combine(_destDir, "pnpm-lock.yaml")),
                 "양쪽 lockfile이 모두 없을 때 dest에 lockfile이 생성되면 안 된다");
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_PreservesExistingDestLockfile_WhenInSyncWithMergedPackageJson()
+        {
+            // 프로젝트가 의존성을 추가한 시나리오: 이전 빌드의 install이 재생성한 dest lockfile은
+            // 병합 package.json(9.9.9)과 정합이고, SDK 템플릿 lockfile(2.4.7)은 이를 모른다.
+            // 무조건 SDK 복사로 되돌리면 frozen-lockfile 실패 + install 스킵 마커 해시 불일치가
+            // 매 빌드 반복되므로, 정합인 기존 산출물은 보존되어야 한다.
+            File.WriteAllText(Path.Combine(_destDir, "package.json"), MakePackageJson("9.9.9"));
+            File.WriteAllText(Path.Combine(_destDir, "pnpm-lock.yaml"), MakeLockfile("9.9.9", DestLockfileMarker));
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string result = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(DestLockfileMarker, result,
+                "병합 package.json과 정합인 기존 dest lockfile은 보존되어야 한다");
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_OverwritesDestLockfile_WhenOutOfSyncWithMergedPackageJson()
+        {
+            // package.json이 변경되어(9.9.9→2.4.7) 기존 dest lockfile(9.9.9)이 더 이상 정합이 아니면
+            // 기존 동작대로 SDK lockfile로 되돌린다 (Fix A의 stale lockfile 회귀 방지 유지).
+            File.WriteAllText(Path.Combine(_destDir, "package.json"), MakePackageJson("2.4.7"));
+            File.WriteAllText(Path.Combine(_destDir, "pnpm-lock.yaml"), MakeLockfile("9.9.9", DestLockfileMarker));
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string result = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(SdkLockfileMarker, result,
+                "정합이 깨진 dest lockfile은 SDK lockfile로 교체되어야 한다");
+            Assert.IsFalse(result.Contains(DestLockfileMarker));
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_OverwritesDestLockfile_WhenMergedPackageJsonMissing()
+        {
+            // 병합 package.json이 없으면 정합 판정 불가 → fail-closed로 SDK 복사.
+            File.WriteAllText(Path.Combine(_destDir, "pnpm-lock.yaml"), MakeLockfile("9.9.9", DestLockfileMarker));
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string result = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(SdkLockfileMarker, result);
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_OverwritesDestLockfile_WhenDestLockfileCorrupted()
+        {
+            // dest lockfile이 lockfile 형식이 아니면(파싱 불가) 보존하지 않고 SDK 복사 (fail-closed).
+            File.WriteAllText(Path.Combine(_destDir, "package.json"), MakePackageJson("2.4.7"));
+            File.WriteAllText(Path.Combine(_destDir, "pnpm-lock.yaml"), "not a lockfile");
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string result = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(SdkLockfileMarker, result);
+        }
+
+        [Test]
+        public void CopyPnpmLockfileWithFallback_ProjectLockfileStillWins_OverExistingDestLockfile()
+        {
+            // 정합인 프로젝트 lockfile(사용자의 명시적 핀)은 기존 dest lockfile보다 항상 우선한다.
+            File.WriteAllText(Path.Combine(_projectDir, "package.json"), MakePackageJson("2.4.7"));
+            File.WriteAllText(Path.Combine(_projectDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", ProjectLockfileMarker));
+            File.WriteAllText(Path.Combine(_destDir, "package.json"), MakePackageJson("9.9.9"));
+            File.WriteAllText(Path.Combine(_destDir, "pnpm-lock.yaml"), MakeLockfile("9.9.9", DestLockfileMarker));
+            File.WriteAllText(Path.Combine(_sdkDir, "pnpm-lock.yaml"), MakeLockfile("2.4.7", SdkLockfileMarker));
+
+            BuildConfigMerger.CopyPnpmLockfileWithFallback(_projectDir, _sdkDir, _destDir);
+
+            string result = File.ReadAllText(Path.Combine(_destDir, "pnpm-lock.yaml"));
+            StringAssert.Contains(ProjectLockfileMarker, result,
+                "정합인 프로젝트 lockfile이 기존 dest lockfile을 덮어써야 한다");
         }
 
         /// <summary>


### PR DESCRIPTION
## 배경

#1003의 pnpm install 스킵은 마커의 package.json/lockfile 해시 일치를 전제로 한다. 그런데 프로젝트가 `BuildConfig~/package.json`으로 의존성을 추가하는 경우(E2E 샘플 프로젝트 포함), 병합된 package.json이 SDK 템플릿 lockfile과 항상 불일치하여:

1. `CopyPnpmLockfileWithFallback`이 매 빌드 SDK 템플릿 lockfile을 무조건 재복사 → 이전 install이 재생성한 정합 lockfile이 stale 템플릿으로 회귀
2. `pnpm install --frozen-lockfile`이 매 빌드 `ERR_PNPM_OUTDATED_LOCKFILE`로 실패 후 `--no-frozen-lockfile` 재해석
3. 스킵 마커의 lockfileHash가 매번 갈려 **install 스킵이 영원히 발동 불가**

## 수정

SDK lockfile 폴백 분기에서, 기존 `ait-build/pnpm-lock.yaml`이 병합된 package.json과 정합(`LockfileValidator.IsLockfileInSync`)이면 보존한다.

- 판정 불가·파싱 실패·예외는 전부 기존 동작(SDK 복사)으로 폴백 (fail-closed, Fix A의 stale lockfile 회귀 방지 유지)
- 정합인 프로젝트 lockfile(사용자 명시 핀)의 우선순위는 변하지 않음
- 재사용 거부 시 사유를 로그로 남겨 진단 가능

## 실측 (2022.3 샘플, 의존성 추가 프로젝트)

| 시나리오 | 결과 |
|---|---|
| 에디터 재빌드 (ait-build 보존) | 보존 발동 → `✓ pnpm install 스킵` → frozen 실패 소음 해소, 17s (콜드 65~81s) |
| `AIT_DISABLE_INSTALL_SKIP=true` | 스킵 차단 + `pnpm install --frozen-lockfile` 실행·성공 (킬스위치 실효) |
| package.json 변경 시 | 정합 깨짐 → SDK 복사 → 재설치 (기존 동작 유지, 테스트로 검증) |

참고: E2E 하니스(`scripts~/test-unity-build.sh`)는 매 빌드 전 `rm -rf ait-build`로 콜드 스타트를 강제하므로 스킵 경로가 실행되지 않는다 — 스킵 실측은 에디터 재빌드와 동일한 직접 호출로 수행했다.

## 테스트

- EditMode 1176개 통과 (신규 5건: 정합 보존 / 비정합 SDK 교체 / package.json 부재 fail-closed / 손상 lockfile fail-closed / 프로젝트 lockfile 우선)
- `./run-local-tests.sh --validate` 4/4 통과