### PR TITLE
문서: Stripping Disabled 옵션 제거 및 pnpm install 스킵 동작 반영

### DIFF
--- a/Docs~/BuildProfiles.md
+++ b/Docs~/BuildProfiles.md
@@ -107,13 +107,13 @@ Unity의 Development Build 옵션을 활성화합니다.
 | 값 | 설명 |
 |-----|------|
 | 자동 | High 사용 (기본값) |
-| Disabled | 코드 제거 없음 |
 | Minimal | 최소한의 코드만 제거 |
 | Low | 낮은 수준의 코드 제거 |
 | Medium | 중간 수준의 코드 제거 |
 | High | 적극적으로 코드 제거 (최소 빌드 크기) |
 
 > **참고**: Dev Server는 빌드 속도를 위해 Minimal, 나머지 프로필은 자동(High)이 기본값입니다.
+> Disabled는 WebGL(IL2CPP)에서 지원되지 않아 옵션에서 제외되었으며, 이전 버전에서 Disabled로 저장된 값은 Minimal로 정규화됩니다.
 
 ### LZ4 압축
 

--- a/docs/claude/build-pipeline.md
+++ b/docs/claude/build-pipeline.md
@@ -20,8 +20,10 @@ SDK는 **2단계 빌드 시스템**을 사용합니다:
 3. **WebGL 빌드를 적절한 구조로 복사**:
    - `index.html` → 프로젝트 루트 (Unity 플레이스홀더 치환 적용)
    - `Build/`, `TemplateData/`, `Runtime/` → `public/` 폴더
-4. **npm install 실행** (`node_modules/`가 없는 경우에만)
-5. **`npm run build` 실행** (`granite build` 실행):
+4. **pnpm install 실행** — 재빌드 시 `node_modules/.ait-install-state.json` 마커(`PnpmInstallStateMarker`) 기준으로
+   package.json/pnpm-lock.yaml 해시·pnpm 버전이 일치하고 node_modules 무결성 검증을 통과하면 install을 스킵
+   (판정 불가 시 fail-closed로 재설치, 킬스위치: `AIT_DISABLE_INSTALL_SKIP=1`)
+5. **`pnpm run build` 실행** (`granite build` 실행):
    - `ait-build/dist/`에 최종 배포 가능 패키지 생성
 
 ## 플레이스홀더 치환


### PR DESCRIPTION
## 변경 내용

코드 변경 없이 문서 2건을 현행 동작에 맞게 갱신한다.

### `Docs~/BuildProfiles.md`
- Stripping Level 표에서 **Disabled 행 제거** — #1001에서 WebGL(IL2CPP)이 지원하지 않는 Disabled를 드롭다운에서 제외했고, 이전 버전에서 Disabled(0)로 저장된 값은 Minimal로 정규화됨. 참고 문구에 정규화 안내 추가.

### `docs/claude/build-pipeline.md`
- "npm install 실행 (`node_modules/`가 없는 경우에만)" stale 문구를 #1003/#1005의 실제 동작으로 갱신: 마커(`.ait-install-state.json`) 기반 해시·버전 일치 + 무결성 통과 시 스킵, fail-closed, 킬스위치 `AIT_DISABLE_INSTALL_SKIP=1`.
- `npm run build` → `pnpm run build` 표기 정정.