### PR TITLE
수정: Dev/Production Server의 granite bin 이름 충돌로 인한 즉시 크래시 해결

### DIFF
--- a/Editor/AppsInTossMenu.cs
+++ b/Editor/AppsInTossMenu.cs
@@ -641,16 +641,22 @@ namespace AppsInToss
             string logPrefix = GetProfileName(type);
             string suffix = openBrowser ? "" : " (서버만)";
 
+            // vite 단독 모드(web-framework 3.x) 여부 — granite 포트를 열지 않으므로
+            // 포트 가용성 검사와 Granite 관련 로그를 건너뛴다
+            bool viteOnly = DevServerCommandResolver.IsViteOnly(buildPath);
+
             // 서버 포트 해석 및 충돌 검사
             if (!PortResolver.TryResolveServerPorts(config,
                 out string graniteHost, out int granitePort,
-                out string viteHost, out int vitePort))
+                out string viteHost, out int vitePort,
+                skipGranitePortScan: viteOnly))
             {
                 return;
             }
 
-            Debug.Log($"AIT: {label} 서버 시작 중{suffix} (granite dev)... ({buildPath})");
-            Debug.Log($"AIT:   Granite: {graniteHost}:{granitePort}");
+            Debug.Log($"AIT: {label} 서버 시작 중{suffix}... ({buildPath})");
+            if (!viteOnly)
+                Debug.Log($"AIT:   Granite: {graniteHost}:{granitePort}");
             Debug.Log($"AIT:   Vite: {viteHost}:{vitePort}");
 
             // 캡처용 로컬 변수
@@ -668,23 +674,27 @@ namespace AppsInToss
                     { "AIT_VITE_PORT", finalVitePort.ToString() }
                 };
 
-                // granite dev 명령어에 --host, --port 인자로 granite 서버 설정 전달
-                string graniteCommand = "exec -- granite dev";
+                // web-framework 버전에 맞는 dev 서버 커맨드 해석
+                // (2.x: granite bin 파일을 node로 직접 실행 — .bin/granite 이름 충돌 우회, 3.x: vite)
+                string devCommand = DevServerCommandResolver.Resolve(buildPath, finalVitePort, out viteOnly);
+                int expectedPort = viteOnly ? finalVitePort : finalGranitePort;
+                Debug.Log($"AIT:   dev 커맨드: pnpm {devCommand}");
 
                 var processManager = new AITProcessTreeManager();
 
                 // 포트와 프로세스 관리자 저장 (상태는 변경하지 않음)
-                stateManager.SetExpectedPortAndProcess(processManager, finalGranitePort);
+                stateManager.SetExpectedPortAndProcess(processManager, expectedPort);
 
                 StartServerProcessWithPortDetection(
                     processManager,
-                    buildPath, npmPath, graniteCommand, logPrefix, envVars, finalGranitePort,
+                    buildPath, npmPath, devCommand, logPrefix, envVars, expectedPort,
                     onServerStarted: (detectedPort) =>
                     {
-                        // 감지된 포트(Granite)를 저장하여 ValidateState에서 올바르게 확인할 수 있도록 함
+                        // 감지된 포트를 저장하여 ValidateState에서 올바르게 확인할 수 있도록 함
                         stateManager.OnServerStarted(detectedPort);
                         Debug.Log($"AIT: {label} 서버가 시작되었습니다{suffix}");
-                        Debug.Log($"AIT:   Granite (Metro): http://{graniteHost}:{finalGranitePort}");
+                        if (!viteOnly)
+                            Debug.Log($"AIT:   Granite (Metro): http://{graniteHost}:{finalGranitePort}");
                         Debug.Log($"AIT:   Vite: http://{viteHost}:{finalVitePort}");
                         if (openBrowser)
                             AITBrowserLauncher.OpenBrowser(finalVitePort, type);

--- a/Editor/Menu/DevServerCommandResolver.cs
+++ b/Editor/Menu/DevServerCommandResolver.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using AppsInToss.Editor.Package;
+
+namespace AppsInToss.Editor.Menu
+{
+    /// <summary>
+    /// Dev/Production Server가 실행할 dev 서버 커맨드(pnpm 인자)를 web-framework 버전에 맞춰 해석합니다.
+    ///
+    /// "granite"라는 bin 이름을 pnpm exec로 resolve하면 안 되는 이유:
+    /// - 2.x: 전이 의존성 @granite-js/react-native도 같은 이름의 granite bin을 선언하므로,
+    ///   설치 그래프에 따라 node_modules/.bin/granite가 RN Metro CLI로 링크될 수 있다.
+    ///   그 CLI는 web용 granite.config.ts의 pluginHooks를 요구해 즉시 종료한다 (bin collision).
+    /// - 3.x: granite bin과 @granite-js/* 의존성이 트리에서 제거됐고, ait CLI에도 dev
+    ///   서브커맨드가 없다.
+    /// 따라서 2.x는 web-framework 패키지 자신의 granite bin 파일을 node로 직접 실행하고
+    /// (bin 이름 resolve 우회), 3.x는 vite dev 서버를 직접 실행한다
+    /// (<see cref="GraniteBuildRunner"/>의 3.x 빌드가 vite build를 직접 호출하는 것과 대칭).
+    /// internal 멤버는 Editor/AssemblyInfo.cs 의 InternalsVisibleTo 를 통해 테스트 어셈블리에서 접근됩니다.
+    /// </summary>
+    internal static class DevServerCommandResolver
+    {
+        /// <summary>ait-build 기준 web-framework 패키지 상대 경로 (node는 Windows에서도 / 구분자 허용)</summary>
+        internal const string WebFrameworkPackagePath = "node_modules/@apps-in-toss/web-framework";
+
+        /// <summary>bin 파일 해석 실패 시에만 쓰는 기존 명령 (bin 이름 resolve — collision에 노출)</summary>
+        internal const string LegacyGraniteCommand = "exec -- granite dev";
+
+        /// <summary>
+        /// dev 서버가 vite 단독으로 동작하는지 (web-framework 3.x — granite/Metro 레이어 없음).
+        /// 이 경우 granite 포트는 전혀 사용되지 않으므로, 포트 해석 단계에서 granite 포트
+        /// 가용성 검사를 건너뛰어야 합니다 (점유 시 vite 단독 기동까지 차단되는 것을 방지).
+        /// </summary>
+        internal static bool IsViteOnly(string buildProjectPath)
+        {
+            return GraniteBuildRunner.GetWebFrameworkMajor(buildProjectPath) >= 3;
+        }
+
+        /// <summary>
+        /// dev 서버 기동용 pnpm 인자 문자열을 반환합니다.
+        /// viteOnly가 true면 서버는 vite 포트만 열므로 포트 감지/중지도 vite 포트를 기준으로 해야 합니다.
+        /// </summary>
+        internal static string Resolve(string buildProjectPath, int vitePort, out bool viteOnly)
+        {
+            if (IsViteOnly(buildProjectPath))
+            {
+                viteOnly = true;
+                return $"exec -- vite --host --port {vitePort}";
+            }
+
+            viteOnly = false;
+            string binRelPath = ResolveGraniteBinRelPath(buildProjectPath);
+            if (binRelPath == null)
+            {
+                Debug.LogWarning("[AIT] web-framework granite bin 경로 해석 실패 — 기존 granite dev 명령으로 폴백합니다.");
+                return LegacyGraniteCommand;
+            }
+            return $"exec -- node {binRelPath} dev";
+        }
+
+        /// <summary>
+        /// web-framework package.json의 bin 맵에서 granite 진입 파일의 (ait-build 기준) 상대 경로를 해석합니다.
+        /// 해석 불가·검증 실패 시 null (호출부가 기존 명령으로 폴백).
+        /// </summary>
+        internal static string ResolveGraniteBinRelPath(string buildProjectPath)
+        {
+            try
+            {
+                string pkgDir = Path.Combine(buildProjectPath, WebFrameworkPackagePath);
+                string pkgJsonPath = Path.Combine(pkgDir, "package.json");
+                if (!File.Exists(pkgJsonPath)) return null;
+
+                var pkg = MiniJson.Deserialize(File.ReadAllText(pkgJsonPath)) as Dictionary<string, object>;
+                var bin = pkg != null && pkg.ContainsKey("bin") ? pkg["bin"] as Dictionary<string, object> : null;
+                if (bin == null || !bin.ContainsKey("granite")) return null;
+
+                string binFile = bin["granite"] as string;
+                if (string.IsNullOrEmpty(binFile)) return null;
+                if (binFile.StartsWith("./")) binFile = binFile.Substring(2);
+
+                // 셸 명령 문자열에 인용 없이 삽입되므로 허용 문자만 통과시킨다 (allowlist).
+                // 영숫자·'.'·'_'·'-'·'/' 외의 문자(공백, 따옴표, ;&|<> 등 bash/cmd 메타문자 일체)가
+                // 하나라도 있으면 거부. 추가로 경로 탈출('..')과 절대 경로도 차단.
+                if (!IsSafeBinRelPath(binFile))
+                {
+                    return null;
+                }
+
+                if (!File.Exists(Path.Combine(pkgDir, binFile))) return null;
+
+                return WebFrameworkPackagePath + "/" + binFile;
+            }
+            catch (Exception e)
+            {
+                Debug.Log($"[AIT] granite bin 경로 해석 중 오류 (기존 명령으로 폴백): {e.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>bin 상대 경로가 셸 명령에 무인용 삽입해도 안전한 문자로만 구성됐는지 검사합니다.</summary>
+        private static bool IsSafeBinRelPath(string binFile)
+        {
+            if (string.IsNullOrEmpty(binFile) || binFile.Contains("..") || Path.IsPathRooted(binFile))
+            {
+                return false;
+            }
+            foreach (char c in binFile)
+            {
+                bool allowed = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+                    || c == '.' || c == '_' || c == '-' || c == '/';
+                if (!allowed)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/Editor/Menu/DevServerCommandResolver.cs.meta
+++ b/Editor/Menu/DevServerCommandResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bb261d8ba0d4be79a51a08b4e351c6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Menu/PortResolver.cs
+++ b/Editor/Menu/PortResolver.cs
@@ -201,12 +201,16 @@ namespace AppsInToss.Editor.Menu
         }
 
         /// <summary>
-        /// 서버 포트 설정 해석 및 충돌 검사
+        /// 서버 포트 설정 해석 및 충돌 검사.
+        /// skipGranitePortScan이 true면 granite 포트 가용성 검사를 건너뛴다
+        /// (web-framework 3.x vite 단독 모드 — granite 포트를 열지 않으므로, 8081 계열이
+        /// 다른 프로세스에 점유되어 있어도 서버 기동을 차단하면 안 된다).
         /// </summary>
         internal static bool TryResolveServerPorts(
             AITEditorScriptObject config,
             out string graniteHost, out int granitePort,
-            out string viteHost, out int vitePort)
+            out string viteHost, out int vitePort,
+            bool skipGranitePortScan = false)
         {
             graniteHost = !string.IsNullOrEmpty(config.graniteHost) ? config.graniteHost : "0.0.0.0";
             granitePort = config.granitePort > 0 ? config.granitePort : 8081;
@@ -231,7 +235,7 @@ namespace AppsInToss.Editor.Menu
             }
 
             // Granite 포트 충돌 확인 및 자동 탐지
-            if (!IsPortAvailable(granitePort))
+            if (!skipGranitePortScan && !IsPortAvailable(granitePort))
             {
                 int availablePort = FindAvailablePort(granitePort);
                 if (availablePort > 0)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/DevServerCommandResolverTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/DevServerCommandResolverTests.cs
@@ -1,0 +1,207 @@
+// -----------------------------------------------------------------------
+// DevServerCommandResolverTests.cs
+// Level 0: DevServerCommandResolver — dev 서버 커맨드 해석 검증
+// (2.x: web-framework granite bin 직접 실행 / 3.x: vite / 해석 실패: 기존 명령 폴백)
+// -----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using AppsInToss.Editor.Menu;
+
+[TestFixture]
+public class DevServerCommandResolverTests
+{
+    private string tempDir;
+
+    [SetUp]
+    public void SetUp()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), "ait-test-devcmd-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(tempDir))
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private void WriteBuildPackageJson(string webFrameworkVersion)
+    {
+        File.WriteAllText(Path.Combine(tempDir, "package.json"),
+            "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"" + webFrameworkVersion + "\"}}");
+    }
+
+    private void WriteWebFrameworkPackage(string binJson, string binFileToCreate = null)
+    {
+        string pkgDir = Path.Combine(tempDir, DevServerCommandResolver.WebFrameworkPackagePath);
+        Directory.CreateDirectory(pkgDir);
+        File.WriteAllText(Path.Combine(pkgDir, "package.json"),
+            "{\"name\":\"@apps-in-toss/web-framework\"" + (binJson != null ? ",\"bin\":" + binJson : "") + "}");
+        if (binFileToCreate != null)
+        {
+            string binPath = Path.Combine(pkgDir, binFileToCreate);
+            Directory.CreateDirectory(Path.GetDirectoryName(binPath));
+            File.WriteAllText(binPath, "// bin");
+        }
+    }
+
+    [Test]
+    public void Resolve_2x_WithGraniteBin_ReturnsNodeDirectInvocation()
+    {
+        WriteBuildPackageJson("2.10.7");
+        WriteWebFrameworkPackage("{\"ait\":\"./ait.js\",\"granite\":\"./bin.js\"}", "bin.js");
+
+        string cmd = DevServerCommandResolver.Resolve(tempDir, 5174, out bool viteOnly);
+
+        Assert.IsFalse(viteOnly);
+        Assert.AreEqual("exec -- node node_modules/@apps-in-toss/web-framework/bin.js dev", cmd);
+    }
+
+    [Test]
+    public void Resolve_3x_ReturnsViteCommand()
+    {
+        WriteBuildPackageJson("3.0.0-rc.0");
+        // 3.x는 granite bin이 없으므로 web-framework 패키지 유무와 무관하게 vite 경로
+
+        string cmd = DevServerCommandResolver.Resolve(tempDir, 5174, out bool viteOnly);
+
+        Assert.IsTrue(viteOnly);
+        Assert.AreEqual("exec -- vite --host --port 5174", cmd);
+    }
+
+    [Test]
+    public void Resolve_3xBetaVersion_ReturnsViteCommand()
+    {
+        WriteBuildPackageJson("^3.0.0-beta.283cb36");
+
+        string cmd = DevServerCommandResolver.Resolve(tempDir, 5175, out bool viteOnly);
+
+        Assert.IsTrue(viteOnly);
+        Assert.AreEqual("exec -- vite --host --port 5175", cmd);
+    }
+
+    [Test]
+    public void Resolve_2x_WebFrameworkPackageMissing_FallsBackToLegacyCommand()
+    {
+        WriteBuildPackageJson("2.10.7");
+        // node_modules/@apps-in-toss/web-framework 자체가 없음
+
+        string cmd = DevServerCommandResolver.Resolve(tempDir, 5174, out bool viteOnly);
+
+        Assert.IsFalse(viteOnly);
+        Assert.AreEqual(DevServerCommandResolver.LegacyGraniteCommand, cmd);
+    }
+
+    [Test]
+    public void Resolve_2x_NoGraniteBinDeclared_FallsBackToLegacyCommand()
+    {
+        WriteBuildPackageJson("2.10.7");
+        WriteWebFrameworkPackage("{\"ait\":\"./bin/ait.js\"}");
+
+        string cmd = DevServerCommandResolver.Resolve(tempDir, 5174, out bool viteOnly);
+
+        Assert.AreEqual(DevServerCommandResolver.LegacyGraniteCommand, cmd);
+    }
+
+    [Test]
+    public void Resolve_2x_BinFileMissingOnDisk_FallsBackToLegacyCommand()
+    {
+        WriteBuildPackageJson("2.10.7");
+        WriteWebFrameworkPackage("{\"granite\":\"./bin.js\"}", binFileToCreate: null);
+
+        string cmd = DevServerCommandResolver.Resolve(tempDir, 5174, out bool viteOnly);
+
+        Assert.AreEqual(DevServerCommandResolver.LegacyGraniteCommand, cmd);
+    }
+
+    [Test]
+    public void Resolve_NoBuildPackageJson_FallsBackToLegacyCommand()
+    {
+        // package.json 없음 → GetWebFrameworkMajor는 2 반환 → bin 해석도 실패 → 폴백
+
+        string cmd = DevServerCommandResolver.Resolve(tempDir, 5174, out bool viteOnly);
+
+        Assert.IsFalse(viteOnly);
+        Assert.AreEqual(DevServerCommandResolver.LegacyGraniteCommand, cmd);
+    }
+
+    [Test]
+    public void ResolveGraniteBinRelPath_NestedBinPath_ReturnsForwardSlashRelPath()
+    {
+        WriteBuildPackageJson("2.10.7");
+        WriteWebFrameworkPackage("{\"granite\":\"./dist/cli/bin.js\"}", "dist/cli/bin.js");
+
+        string rel = DevServerCommandResolver.ResolveGraniteBinRelPath(tempDir);
+
+        Assert.AreEqual("node_modules/@apps-in-toss/web-framework/dist/cli/bin.js", rel);
+    }
+
+    // allowlist(영숫자·._-/) 밖의 문자·경로 탈출·절대 경로는 모두 거부되어야 한다.
+    // 셸 무인용 삽입 컨텍스트이므로 bash(공백 " ' $ ` ; & | < > 개행)와
+    // cmd.exe(% ^ & | < >) 메타문자를 실사용 인젝션 형태로 직접 커버한다.
+    [TestCase("./bin with space.js")]
+    [TestCase("../escape.js")]
+    [TestCase("bin\\win.js")]
+    [TestCase("bin\"quote.js")]
+    [TestCase("bin'quote.js")]
+    [TestCase("bin$var.js")]
+    [TestCase("bin`tick.js")]
+    [TestCase("bin.js;rm -rf x")]
+    [TestCase("bin.js&&curl x")]
+    [TestCase("bin.js|sh")]
+    [TestCase("bin.js<input")]
+    [TestCase("bin.js>output")]
+    [TestCase("bin%PATH%.js")]
+    [TestCase("bin^caret.js")]
+    [TestCase("bin\ttab.js")]
+    [TestCase("bin\nnewline.js")]
+    [TestCase("/abs/path/bin.js")]
+    public void ResolveGraniteBinRelPath_UnsafeBinPath_ReturnsNull(string unsafeBin)
+    {
+        WriteBuildPackageJson("2.10.7");
+        // JSON 문자열로 안전하게 직렬화 (역슬래시·따옴표·제어문자 이스케이프)
+        string escaped = unsafeBin.Replace("\\", "\\\\").Replace("\"", "\\\"")
+            .Replace("\t", "\\t").Replace("\n", "\\n");
+        WriteWebFrameworkPackage("{\"granite\":\"" + escaped + "\"}");
+
+        Assert.IsNull(DevServerCommandResolver.ResolveGraniteBinRelPath(tempDir));
+    }
+
+    [Test]
+    public void ResolveGraniteBinRelPath_AllowlistChars_DigitsDashUnderscore_Resolves()
+    {
+        WriteBuildPackageJson("2.10.7");
+        WriteWebFrameworkPackage("{\"granite\":\"./dist/bin-2.x_v1.js\"}", "dist/bin-2.x_v1.js");
+
+        Assert.AreEqual(
+            "node_modules/@apps-in-toss/web-framework/dist/bin-2.x_v1.js",
+            DevServerCommandResolver.ResolveGraniteBinRelPath(tempDir));
+    }
+
+    [Test]
+    public void IsViteOnly_3x_ReturnsTrue_2x_ReturnsFalse()
+    {
+        WriteBuildPackageJson("3.0.0-rc.0");
+        Assert.IsTrue(DevServerCommandResolver.IsViteOnly(tempDir),
+            "3.x는 granite 포트를 사용하지 않으므로 vite 단독 모드여야 함 (granite 포트 스캔 생략 근거)");
+
+        WriteBuildPackageJson("2.10.7");
+        Assert.IsFalse(DevServerCommandResolver.IsViteOnly(tempDir));
+    }
+
+    [Test]
+    public void ResolveGraniteBinRelPath_MalformedPackageJson_ReturnsNull()
+    {
+        WriteBuildPackageJson("2.10.7");
+        string pkgDir = Path.Combine(tempDir, DevServerCommandResolver.WebFrameworkPackagePath);
+        Directory.CreateDirectory(pkgDir);
+        File.WriteAllText(Path.Combine(pkgDir, "package.json"), "{ not valid json");
+
+        Assert.IsNull(DevServerCommandResolver.ResolveGraniteBinRelPath(tempDir));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/DevServerCommandResolverTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Menu/DevServerCommandResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25b0bfcccce140a785a9f54fe59623b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -649,6 +649,79 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
 
 
   // -------------------------------------------------------------------------
+  // Test 2b: SDK dev 서버 커맨드 스모크 (granite bin collision 회귀 방지)
+  // -------------------------------------------------------------------------
+  // Unity Editor의 Dev/Production Server 메뉴는 vite가 아니라 web-framework의
+  // granite CLI 파일을 node로 직접 실행한다 (DevServerCommandResolver —
+  // node_modules/.bin/granite 이름 충돌 우회). test 2의 vite 경로는 이 커맨드를
+  // 전혀 거치지 않으므로, 실제 커맨드가 즉사하지 않고 리슨 포트를 여는지만
+  // 짧게 검증한다 (Unity 로드 검증은 test 2가 담당).
+  test('2b. SDK dev server command (granite bin direct) should boot', async () => {
+    test.setTimeout(90000);
+
+    expect(directoryExists(AIT_BUILD), 'ait-build/ should exist').toBe(true);
+
+    const wfPkgPath = path.resolve(AIT_BUILD, 'node_modules/@apps-in-toss/web-framework/package.json');
+    test.skip(!fs.existsSync(wfPkgPath), 'web-framework not installed in ait-build');
+
+    const wfPkg = JSON.parse(fs.readFileSync(wfPkgPath, 'utf8'));
+    const graniteBin = wfPkg.bin && wfPkg.bin.granite;
+    // 3.x: granite bin 없음 — Editor는 vite 경로를 쓰므로 test 2가 커버
+    test.skip(!graniteBin, 'web-framework has no granite bin (3.x) — vite path covered by test 2');
+
+    const binRel = path.join('node_modules/@apps-in-toss/web-framework', graniteBin.replace(/^\.\//, ''));
+    console.log(`🚀 Booting SDK dev command: node ${binRel} dev`);
+
+    // Editor 커맨드(pnpm exec -- node <bin> dev)와 동일한 실행 (pnpm exec는 PATH 추가뿐)
+    const child = spawn(process.execPath, [binRel, 'dev'], {
+      cwd: AIT_BUILD,
+      stdio: 'pipe',
+      env: { ...process.env, CI: 'true', NODE_OPTIONS: '' }
+    });
+
+    let output = '';
+    const seenPorts = new Set();
+    const result = await new Promise((resolve) => {
+      let settled = false;
+      const settle = (value) => {
+        if (!settled) {
+          settled = true;
+          resolve(value);
+        }
+      };
+      const onData = (data) => {
+        const clean = data.toString().replace(/\x1B\[[0-9;]*[mGKH]/g, '');
+        output += clean;
+        for (const m of clean.matchAll(/(?:localhost|0\.0\.0\.0|127\.0\.0\.1|\[::1?\]):(\d+)/g)) {
+          seenPorts.add(parseInt(m[1], 10));
+        }
+        if (seenPorts.size > 0) {
+          settle('listening');
+        }
+      };
+      child.stdout.on('data', onData);
+      child.stderr.on('data', onData);
+      child.on('exit', (code) => settle(`exited:${code}`));
+      setTimeout(() => settle('timeout'), 60000);
+    });
+
+    // 정리: 프로세스 트리 + 감지된 포트(Metro가 띄운 vite 자식 포함) + Metro 기본 포트
+    await killServerProcess(child, [...seenPorts, 8081]);
+
+    console.log(`SDK dev command result: ${result}, ports: ${[...seenPorts].join(',')}`);
+    expect(
+      result,
+      `SDK dev command should open a listen port, got: ${result}\n--- output tail ---\n${output.slice(-2000)}`
+    ).toBe('listening');
+
+    testResults.tests['2b_sdk_dev_command'] = {
+      passed: true,
+      ports: [...seenPorts]
+    };
+  });
+
+
+  // -------------------------------------------------------------------------
   // Tests 3-5: Production Server + Runtime Tests (세션 공유)
   // -------------------------------------------------------------------------
   test.describe.serial('Production Tests (shared session)', () => {


### PR DESCRIPTION
## 문제

AIT 메뉴의 **Dev Server / Production Server**가 기동 직후 즉시 크래시한다.

- **web-framework 2.x**: 서버 기동 명령이 `pnpm exec -- granite dev`인데, pnpm의 `.bin/granite`이 `@apps-in-toss/web-framework`의 `granite` bin이 아니라 **전이 의존성 `@granite-js/react-native`의 Metro CLI로 잘못 링크**될 수 있다. 이 CLI는 granite dev 설정(`config.pluginHooks`)을 기대하며 구조 분해 시점에 즉시 크래시한다.
- **web-framework 3.x**: `granite` bin 자체가 존재하지 않는다 (`bin: {"ait": ...}`만 제공, `ait`에는 `dev` 서브커맨드 없음). `pnpm exec -- granite dev`는 명령을 찾지 못해 실패한다.

즉, 현행 명령은 2.x에서는 비결정적으로(설치 레이아웃에 따라), 3.x에서는 항상 깨진다.

## 수정

`Editor/Menu/DevServerCommandResolver.cs` (신규)가 빌드 프로젝트의 web-framework major를 읽어 실행 커맨드를 해석한다:

| 상황 | 해석 결과 |
|---|---|
| **3.x** | `pnpm exec -- vite --host --port <vitePort>` (granite/Metro 레이어 없음 — vite 단독) |
| **2.x** (bin 해석 성공) | `pnpm exec -- node node_modules/@apps-in-toss/web-framework/<bin> dev` — `.bin` 셔틀을 우회해 **패키지가 선언한 bin 파일을 node로 직접 실행** |
| **2.x** (bin 해석 실패) | 기존 명령 `pnpm exec -- granite dev` 폴백 (동작 저하 없음) |

- major 판별은 기존 `GraniteBuildRunner.GetWebFrameworkMajor()` 재사용 (fail-closed: 판별 불가 시 2).
- bin 경로는 `node_modules/@apps-in-toss/web-framework/package.json`의 `bin` 맵에서 `granite` 항목을 MiniJson으로 파싱. **allowlist(영숫자·`.`·`_`·`-`·`/`) 검증** — 공백·따옴표·`;`·`&`·`|`·`<`·`>`·`%`·`^` 등 bash/cmd 메타문자가 하나라도 있으면 거부하고 폴백 (셸 무인용 삽입 안전성), `..`/절대경로 차단 + 실제 파일 존재 확인.
- 3.x는 Metro 포트가 없으므로 포트 감지 기대 포트를 vite 포트로 전환 (`viteOnly`).
- **3.x vite 단독 모드에서는 granite 포트(8081 계열) 가용성 스캔을 생략** — 사용하지도 않는 포트가 점유됐다는 이유로 서버 기동이 차단되던 경로 제거. 시작 전 `Granite:` 로그도 함께 생략해 로그와 실제 동작을 일치시킴.

## 검증

- **EditMode 테스트 28개 추가** (`DevServerCommandResolverTests.cs`): 2.x 정상 해석 / 3.x(vite) / 폴백 4경로 / 중첩 bin 경로 / 비안전 경로 17종 거부 (bash·cmd 메타문자 포함) / allowlist 정상 문자 / IsViteOnly / malformed JSON — 전체 스위트 1206개 통과.
- `./run-local-tests.sh --validate` 통과.
- **실커맨드 스모크 (2.x)**: web-framework 2.10.7 실설치에서 해석된 명령(`node .../bin.js dev`)으로 서버 기동 → Metro(8081) + vite ready 확인.
- **실커맨드 스모크 (3.x)**: web-framework 3.0.0-rc.0 + vite 8.1.4(BuildConfig~ 템플릿 핀과 동일) 실설치에서 3종 확인 — (a) `.bin`에 granite 부재 (`ait`/`vite`만 존재), (b) 기존 명령 `pnpm exec -- granite dev` → `[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "granite" not found` 실패 재현 (수정 전 코드가 3.x에서 항상 깨짐을 실증), (c) 해석된 명령 `pnpm exec -- vite --host --port 5199` → `VITE v8.1.4 ready in 517 ms` + `--host` 바인딩 + HTTP 200 응답.
- **E2E 테스트 추가** (`2b. SDK dev server command`): 실제 ait-build에서 해석된 bin을 직접 기동해 listening 확인 (3.x 빌드에서는 skip).

## 영향 범위

- `Editor/AppsInTossMenu.cs`의 `LaunchServerProcess`만 명령 문자열 결정부가 변경 — spawn/포트감지/종료 처리 로직은 불변.
- 빌드 파이프라인(granite build / ait build)은 변경 없음.