### PR TITLE
개선: AITVersionInfo.json 안정화로 무변경 재빌드의 data 아카이브 재압축 제거

### DIFF
--- a/Editor/AITGitGuard.cs
+++ b/Editor/AITGitGuard.cs
@@ -59,6 +59,10 @@ namespace AppsInToss.Editor
             // 빌드 시 자동 생성되는 빌드 정보
             "Assets/StreamingAssets/build_info",
             "Assets/StreamingAssets/build_info.meta",
+            // 빌드 시 자동 생성·유지되는 버전 정보 (빌드 캐시 보존을 위해 빌드 후에도 유지됨 —
+            // 내용에 프로젝트 커밋 해시가 포함되어 커밋하면 매 커밋 후 빌드마다 churn 발생)
+            "Assets/Resources/AITVersionInfo.json",
+            "Assets/Resources/AITVersionInfo.json.meta",
         };
 
         /// <summary>
@@ -72,9 +76,11 @@ namespace AppsInToss.Editor
             ("Assets/WebGLTemplates/", true),
             ("Assets/StreamingAssets/build_info", false),
             ("Assets/StreamingAssets/build_info.meta", false),
+            ("Assets/Resources/AITVersionInfo.json", false),
+            ("Assets/Resources/AITVersionInfo.json.meta", false),
         };
 
-        private const string PREFS_KEY_GITIGNORE_CHECKED = "AIT_GitIgnore_Checked_v5";
+        private const string PREFS_KEY_GITIGNORE_CHECKED = "AIT_GitIgnore_Checked_v6";
 
         static AITGitGuard()
         {

--- a/Editor/AITWebGLBuilder.cs
+++ b/Editor/AITWebGLBuilder.cs
@@ -10,7 +10,7 @@ namespace AppsInToss.Editor
     /// <summary>
     /// Unity WebGL 빌드 실행부 (AITConvertCore에서 분리).
     /// 빌드 캐시 유효성 검증, BuildPipeline 실행, 빌드 마커 기록,
-    /// 버전 정보 JSON 기록/정리를 한 곳에서 관리한다.
+    /// 버전 정보 JSON 기록을 한 곳에서 관리한다.
     /// AITConvertCore의 빌드 파이프라인(DoExport/DoExportAsync)이 이 클래스를 호출하며 동작은 기존과 동일하다.
     /// </summary>
     internal static class AITWebGLBuilder
@@ -160,21 +160,9 @@ namespace AppsInToss.Editor
 
             // 빌드 직전: Resources JSON으로 Version/CommitHash/ReleaseDateTime 기록
             // .cs 파일 수정과 달리 .json은 스크립트 컴파일을 유발하지 않으므로 도메인 리로드 없음
-            bool versionInfoWritten = WriteVersionInfoJson(out bool createdResourcesDir);
+            WriteVersionInfoJson();
 
-            UnityEditor.Build.Reporting.BuildReport result;
-            try
-            {
-                result = BuildPipeline.BuildPlayer(buildPlayerOptions);
-            }
-            finally
-            {
-                // 빌드 완료 후 (성공/실패 무관) 생성한 JSON 제거 — 사용자 프로젝트에 산출물 남기지 않음
-                if (versionInfoWritten)
-                {
-                    RemoveVersionInfoJson(createdResourcesDir);
-                }
-            }
+            var result = BuildPipeline.BuildPlayer(buildPlayerOptions);
 
             // 빌드 리포트를 에러 리포터에 저장 (Issue 신고 시 사용)
             AITErrorReporter.SetBuildReport(result);
@@ -256,61 +244,103 @@ namespace AppsInToss.Editor
 
         // Unity Resources 폴더는 사용자 프로젝트 소유 — SDK 패키지(UPM Git 설치 시 immutable)가 아니라
         // 여기에 쓰면 설치 방식에 무관하게 쓰기 가능. 플레이어 번들은 Resources/ 를 자동 포함함.
+        // 이 파일은 빌드 후에도 삭제하지 않고 유지한다 — 매 빌드 삭제/재생성하면 .meta GUID가
+        // 갱신되어 내용이 같아도 data 아카이브가 dirty 판정되고, 무변경 재빌드마다 아카이브
+        // 재빌드+재압축(대형 프로젝트에서 수 분)이 발생하기 때문이다.
         private const string VersionInfoAssetPath = "Assets/Resources/AITVersionInfo.json";
 
         /// <summary>
         /// 빌드 직전 Assets/Resources/AITVersionInfo.json 에 Version/CommitHash/ReleaseDateTime 기록.
         /// .cs 파일 수정과 달리 .json은 스크립트 컴파일/도메인 리로드를 유발하지 않는다.
+        ///
+        /// 내용이 실제로 달라질 때(SDK 버전/커밋 변경)만 다시 기록한다. 같은 내용을 매 빌드
+        /// 다시 쓰거나 삭제/재생성하면 asset dirty 판정으로 data 아카이브 증분 캐시가 무효화된다
+        /// (판단 로직은 <see cref="BuildVersionInfoJson"/> 참조).
         /// </summary>
-        /// <param name="createdResourcesDir">
-        /// 이번 호출에서 Assets/Resources/ 폴더를 새로 생성했는지. 파일 쓰기까지 성공한 경우에만
-        /// true 로 설정되어, cleanup 단계가 "우리가 만든 빈 폴더" 만 지우고 사용자의 기존
-        /// Resources/ 는 보존하도록 한다.
-        /// </param>
-        /// <returns>파일을 성공적으로 기록했으면 true (빌드 후 정리 대상)</returns>
-        private static bool WriteVersionInfoJson(out bool createdResourcesDir)
+        private static void WriteVersionInfoJson()
         {
-            createdResourcesDir = false;
             try
             {
-                // AITVersion.Version은 EnsureLoaded 경로에 따라 "unknown"으로 초기화될 수 있어
-                // 패키지의 권위 있는 소스인 package.json 에서 직접 읽는다.
-                var payload = new AITVersion.VersionInfoPayload
-                {
-                    version = ResolveSdkVersion(),
-                    releaseDateTime = DateTime.UtcNow.ToString("yyyyMMdd_HHmm"),
-                    commitHash = GetGitCommitHash(),
-                };
-
-                // JsonUtility.ToJson 으로 직렬화 — 수동 문자열 보간의 이스케이프 누락을 방지.
-                // 필드명은 VersionInfoPayload 의 public field 이름과 런타임 read 경로가 공유.
-                string json = JsonUtility.ToJson(payload, prettyPrint: true);
-
                 string projectPath = UnityUtil.GetProjectPath();
                 string absolutePath = Path.Combine(projectPath, VersionInfoAssetPath);
+                string existingJson = File.Exists(absolutePath) ? File.ReadAllText(absolutePath) : null;
+
+                // AITVersion.Version은 EnsureLoaded 경로에 따라 "unknown"으로 초기화될 수 있어
+                // 패키지의 권위 있는 소스인 package.json 에서 직접 읽는다.
+                string version = ResolveSdkVersion();
+                string commitHash = GetGitCommitHash();
+                string json = BuildVersionInfoJson(
+                    existingJson, version, commitHash,
+                    DateTime.UtcNow.ToString("yyyyMMdd_HHmm"),
+                    out bool changed);
+
+                if (!changed)
+                {
+                    Debug.Log("[AIT] 버전 정보 JSON 변경 없음 — 기존 파일 유지 (data 빌드 캐시 보존)");
+                    return;
+                }
+
                 string directory = Path.GetDirectoryName(absolutePath);
-                bool directoryCreated = false;
                 if (!Directory.Exists(directory))
                 {
                     Directory.CreateDirectory(directory);
-                    directoryCreated = true;
                 }
-
                 File.WriteAllText(absolutePath, json);
-                // 파일 쓰기까지 성공한 후에야 "우리가 만든 폴더" 로 확정 — 쓰기 실패 시 폴더가
-                // 남더라도 caller 는 정리하지 않아 시스템이 일관된 상태를 유지.
-                createdResourcesDir = directoryCreated;
 
                 // Resources로 인식시키기 위해 임포트 (스크립트가 아니므로 도메인 리로드 없음)
                 AssetDatabase.ImportAsset(VersionInfoAssetPath, ImportAssetOptions.ForceSynchronousImport);
-                Debug.Log($"[AIT] 버전 정보 JSON 기록: Version={payload.version}, CommitHash={payload.commitHash}, ReleaseDateTime={payload.releaseDateTime}");
-                return true;
+                Debug.Log($"[AIT] 버전 정보 JSON 기록: Version={version}, CommitHash={commitHash}");
             }
             catch (Exception e)
             {
                 Debug.LogWarning($"[AIT] 버전 정보 JSON 기록 실패 (무시됨): {e.Message}");
-                return false;
             }
+        }
+
+        /// <summary>
+        /// 기록할 버전 정보 JSON(canonical 형태)을 만들고 기존 파일 내용과 비교해
+        /// 재기록 필요 여부를 판단한다. 순수 함수 — 파일 IO 없음 (EditMode 테스트 대상).
+        ///
+        /// version/commitHash가 기존 파일과 같으면 기존 releaseDateTime을 재사용한다.
+        /// releaseDateTime은 분 단위 wall-clock이라 이를 매 빌드 갱신하면 그것만으로
+        /// 내용이 달라져 data 아카이브가 무효화된다. 소비처(<see cref="AITVersion.FullVersion"/>,
+        /// Sentry 태그)는 표시용이므로 "이 버전/커밋 조합을 처음 빌드한 시각" 의미로 충분하다.
+        /// </summary>
+        /// <returns>기록할 canonical JSON. changed가 false면 기존 파일과 동일하므로 기록 불필요.</returns>
+        internal static string BuildVersionInfoJson(
+            string existingJson, string version, string commitHash, string nowStamp, out bool changed)
+        {
+            var payload = new AITVersion.VersionInfoPayload
+            {
+                version = version,
+                releaseDateTime = nowStamp,
+                commitHash = commitHash,
+            };
+
+            if (!string.IsNullOrEmpty(existingJson))
+            {
+                try
+                {
+                    var existing = JsonUtility.FromJson<AITVersion.VersionInfoPayload>(existingJson);
+                    if (existing != null
+                        && existing.version == version
+                        && existing.commitHash == commitHash
+                        && !string.IsNullOrEmpty(existing.releaseDateTime))
+                    {
+                        payload.releaseDateTime = existing.releaseDateTime;
+                    }
+                }
+                catch
+                {
+                    // 손상된 기존 파일 → 새 값으로 canonical 재기록
+                }
+            }
+
+            // JsonUtility.ToJson 으로 직렬화 — 수동 문자열 보간의 이스케이프 누락을 방지.
+            // 필드명은 VersionInfoPayload 의 public field 이름과 런타임 read 경로가 공유.
+            string json = JsonUtility.ToJson(payload, prettyPrint: true);
+            changed = !string.Equals(existingJson, json, StringComparison.Ordinal);
+            return json;
         }
 
         /// <summary>
@@ -337,46 +367,6 @@ namespace AppsInToss.Editor
             catch
             {
                 return AITVersion.Version;
-            }
-        }
-
-        /// <summary>
-        /// 빌드 후 Assets/Resources/AITVersionInfo.json 및 .meta 파일을 제거해
-        /// 사용자 프로젝트에 산출물이 남지 않도록 한다.
-        /// </summary>
-        /// <param name="createdResourcesDir">
-        /// 같은 빌드에서 WriteVersionInfoJson 이 Resources/ 폴더를 새로 생성했는지.
-        /// true 인 경우 빈 폴더도 함께 정리한다 (사용자가 원래 사용 중이던 Resources/ 는 보존).
-        /// </param>
-        private static void RemoveVersionInfoJson(bool createdResourcesDir)
-        {
-            try
-            {
-                // AssetDatabase.DeleteAsset이 파일과 .meta를 함께 삭제 (스크립트 아님 → 리로드 없음)
-                if (!AssetDatabase.DeleteAsset(VersionInfoAssetPath))
-                {
-                    return;
-                }
-
-                Debug.Log("[AIT] 버전 정보 JSON 제거 완료");
-
-                // 우리가 생성한 빈 Resources/ 폴더 정리 (Finder 등이 만든 .DS_Store 같은 hidden
-                // 파일이 있으면 Directory.GetFileSystemEntries 가 0 이 아니므로 보존되는데, 이는
-                // 안전한 방향의 기본값).
-                if (createdResourcesDir)
-                {
-                    string projectPath = UnityUtil.GetProjectPath();
-                    string resourcesAbs = Path.Combine(projectPath, "Assets/Resources");
-                    if (Directory.Exists(resourcesAbs)
-                        && Directory.GetFileSystemEntries(resourcesAbs).Length == 0)
-                    {
-                        AssetDatabase.DeleteAsset("Assets/Resources");
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Debug.LogWarning($"[AIT] 버전 정보 JSON 제거 실패 (무시됨): {e.Message}");
             }
         }
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/VersionInfoJsonStabilityTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/VersionInfoJsonStabilityTests.cs
@@ -1,0 +1,108 @@
+// -----------------------------------------------------------------------
+// VersionInfoJsonStabilityTests.cs
+// Level 0: AITWebGLBuilder.BuildVersionInfoJson — 버전 정보 JSON 안정화 검증
+// (version+commitHash 불변 시 기존 releaseDateTime 재사용 → 내용 불변 → 재기록 스킵
+//  → 파일/.meta 안정 → 무변경 재빌드에서 data 아카이브 재빌드+재압축 방지)
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor;
+
+[TestFixture]
+public class VersionInfoJsonStabilityTests
+{
+    [Test]
+    public void NoExistingFile_ProducesJsonWithGivenValues_Changed()
+    {
+        string json = AITWebGLBuilder.BuildVersionInfoJson(
+            null, "1.9.0", "abc1234", "20260725_1200", out bool changed);
+
+        Assert.IsTrue(changed);
+        StringAssert.Contains("\"version\": \"1.9.0\"", json);
+        StringAssert.Contains("\"releaseDateTime\": \"20260725_1200\"", json);
+        StringAssert.Contains("\"commitHash\": \"abc1234\"", json);
+    }
+
+    [Test]
+    public void SameVersionAndCommit_ReusesExistingStamp_NotChanged()
+    {
+        string first = AITWebGLBuilder.BuildVersionInfoJson(
+            null, "1.9.0", "abc1234", "20260725_1200", out _);
+
+        // 다음 빌드: wall-clock은 달라졌지만 버전·커밋은 그대로
+        string second = AITWebGLBuilder.BuildVersionInfoJson(
+            first, "1.9.0", "abc1234", "20260725_1830", out bool changed);
+
+        Assert.IsFalse(changed, "버전·커밋 불변이면 재기록 없이 기존 내용 유지 (data 캐시 보존의 핵심)");
+        Assert.AreEqual(first, second, "재사용 시 기존 파일과 바이트 동일한 canonical JSON이어야 함");
+        StringAssert.Contains("\"releaseDateTime\": \"20260725_1200\"", second);
+    }
+
+    [Test]
+    public void DifferentCommitHash_UsesFreshStamp_Changed()
+    {
+        string first = AITWebGLBuilder.BuildVersionInfoJson(
+            null, "1.9.0", "abc1234", "20260725_1200", out _);
+
+        string second = AITWebGLBuilder.BuildVersionInfoJson(
+            first, "1.9.0", "def5678", "20260726_0900", out bool changed);
+
+        Assert.IsTrue(changed, "커밋이 바뀌면 재기록 (그때의 data 재빌드는 정당한 비용)");
+        StringAssert.Contains("\"commitHash\": \"def5678\"", second);
+        StringAssert.Contains("\"releaseDateTime\": \"20260726_0900\"", second);
+    }
+
+    [Test]
+    public void DifferentVersion_UsesFreshStamp_Changed()
+    {
+        string first = AITWebGLBuilder.BuildVersionInfoJson(
+            null, "1.9.0", "abc1234", "20260725_1200", out _);
+
+        string second = AITWebGLBuilder.BuildVersionInfoJson(
+            first, "1.10.0", "abc1234", "20260726_0900", out bool changed);
+
+        Assert.IsTrue(changed);
+        StringAssert.Contains("\"version\": \"1.10.0\"", second);
+        StringAssert.Contains("\"releaseDateTime\": \"20260726_0900\"", second);
+    }
+
+    [Test]
+    public void MalformedExistingJson_RewritesCanonical_Changed()
+    {
+        string json = AITWebGLBuilder.BuildVersionInfoJson(
+            "{ not valid json", "1.9.0", "abc1234", "20260725_1200", out bool changed);
+
+        Assert.IsTrue(changed);
+        StringAssert.Contains("\"version\": \"1.9.0\"", json);
+    }
+
+    [Test]
+    public void ExistingWithEmptyStamp_UsesFreshStamp_Changed()
+    {
+        string existing = "{\"version\":\"1.9.0\",\"releaseDateTime\":\"\",\"commitHash\":\"abc1234\"}";
+
+        string json = AITWebGLBuilder.BuildVersionInfoJson(
+            existing, "1.9.0", "abc1234", "20260725_1200", out bool changed);
+
+        Assert.IsTrue(changed);
+        StringAssert.Contains("\"releaseDateTime\": \"20260725_1200\"", json);
+    }
+
+    [Test]
+    public void NonCanonicalFormatting_SameValues_RewrittenOnce_ThenStable()
+    {
+        // 값은 같지만 포맷이 다른(비 prettyPrint) 기존 파일 → 1회 canonical 재기록
+        string nonCanonical = "{\"version\":\"1.9.0\",\"releaseDateTime\":\"20260725_1200\",\"commitHash\":\"abc1234\"}";
+
+        string rewritten = AITWebGLBuilder.BuildVersionInfoJson(
+            nonCanonical, "1.9.0", "abc1234", "20260726_0900", out bool changedFirst);
+
+        Assert.IsTrue(changedFirst, "포맷이 다르면 canonical 형태로 1회 재기록");
+        StringAssert.Contains("\"releaseDateTime\": \"20260725_1200\"", rewritten);
+
+        // 이후 빌드부터는 안정
+        AITWebGLBuilder.BuildVersionInfoJson(
+            rewritten, "1.9.0", "abc1234", "20260727_1500", out bool changedSecond);
+        Assert.IsFalse(changedSecond);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/VersionInfoJsonStabilityTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/VersionInfoJsonStabilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47e476ff27c34514928eb8531a372bb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 문제

무변경 재빌드인데도 **매 빌드 data 아카이브 전체가 재빌드 + 재압축**된다. 대형 프로젝트 실측(Heavy 픽스처, 78MB data.unityweb, Brotli)에서는 무변경 Production 재기동 251.6s 중 **약 230s가 이 재압축**이었다.

원인은 `AITWebGLBuilder`의 버전 정보 기록 방식 두 가지가 겹친 것:

1. **매 빌드 삭제/재생성**: 빌드 직전 `Assets/Resources/AITVersionInfo.json`을 쓰고 빌드 후 `finally`에서 삭제한다. 다음 빌드에서 재생성되면 **`.meta` GUID가 매번 새로 발급**되어, 내용이 같아도 Unity가 자산을 새 자산으로 취급한다.
2. **분 단위 wall-clock**: `releaseDateTime = DateTime.UtcNow("yyyyMMdd_HHmm")`이라 내용 자체도 사실상 매 빌드 달라진다.

→ 매 빌드 `Rebuilding Data files because Assets/Resources/AITVersionInfo.json is dirty (hash)` → data 아카이브 재빌드 + Brotli/Gzip 재압축.

## 수정

- **파일을 빌드 후 삭제하지 않고 유지** — `.meta` GUID가 안정되어 내용이 같으면 dirty 판정이 나지 않는다. (`RemoveVersionInfoJson` 및 `createdResourcesDir` 정리 로직 제거)
- **내용이 실제로 달라질 때만 기록**: `version`/`commitHash`가 기존 파일과 같으면 기존 `releaseDateTime`을 재사용해 canonical JSON을 만들고, 기존 내용과 동일하면 기록/임포트를 스킵한다. 판단 로직은 순수 함수 `BuildVersionInfoJson`으로 분리 (EditMode 테스트 대상).
- 버전 업그레이드·새 커밋처럼 **실제 변경이 있으면 기존대로 재기록**된다 (그때의 1회 재빌드는 정당한 비용). `commitHash`(Sentry `ait.commit_hash` 태그)와 `releaseDateTime`(표시용 — `FullVersion`, Sentry `ait.sdk_version` 태그) 소비처 의미는 그대로다.

### 동작 변화 (의도된 정책 변경)

`Assets/Resources/AITVersionInfo.json`(+`.meta`)이 빌드 후 사용자 프로젝트에 남는다. 기존 "산출물을 남기지 않는다" 정책보다 **증분 빌드 캐시 보존을 우선**한 결정이다 (남는 파일은 0.1KB 텍스트 1개).

파일 내용에 프로젝트 커밋 해시가 포함되므로 사용자가 이 파일을 실수로 커밋하면 커밋마다 재기록 churn이 생길 수 있다. 이를 막기 위해 **`AITGitGuard` 안전망에 통합** — `build_info`와 동일하게 사용자 프로젝트 `.gitignore`에 자동 패턴 추가 + tracked 상태 감지 대상에 포함 (세션 키 v5→v6 bump로 기존 세션에서도 재적용). 이 저장소의 E2E 샘플 프로젝트들은 이미 `Assets/Resources/`가 gitignore되어 있어 변경 불필요.

### 2.x / 3.x 호환

이 파일은 Unity WebGL 빌드 단계(granite/web-framework 이전)에서만 다뤄지므로 web-framework 2.x/3.x 어느 쪽에도 동일하게 적용되며 버전 분기가 없다.

## 검증

씬을 매번 재생성하는 E2E 러너 대신, 기존 씬 그대로 `AITWebGLBuilder.BuildWebGL`만 2회 실행하는 격리 실험 (Unity 2022.3.62f2, Brotli, SampleUnityProject):

- **수정 전 2회차(무변경) 빌드 로그**:
  - `Rebuilding Data files because Assets/Resources/AITVersionInfo.json is dirty (hash)` — 유일한 재빌드 사유
  - `Start importing Assets/Resources/AITVersionInfo.json using Guid(6d93d550…)` — 빌드마다 새 GUID 발급 확인
  - Brotli 압축 5회 실행
- **수정 후 2회차 빌드 로그**:
  - `[AIT] 버전 정보 JSON 변경 없음 — 기존 파일 유지 (data 빌드 캐시 보존)`
  - `Rebuilding Data files` 라인 **0건**, Brotli **0회**
- **EditMode 테스트 7종 추가** (`VersionInfoJsonStabilityTests.cs`): 최초 기록 / 버전·커밋 불변 시 스킵(스탬프 재사용) / 커밋 변경·버전 변경·손상 파일·빈 스탬프·비정형 포맷 재기록 — 전체 스위트 `result="Failed"` 0건.
- `./run-local-tests.sh --validate` 통과.