### PR TITLE
개선: 샘플 프로젝트 BuildConfig~ 스캐폴드 산출물 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ logs/
 !**/BuildConfig~
 !**/BuildConfig~/**
 **/BuildConfig~/node_modules/
+# 샘플 프로젝트에 빌드 시 스캐폴드되는 SDK 템플릿 사본 (AITTemplateManager.UpdateConfigFileWithMarkers)
+Tests~/E2E/*UnityProject-*/Assets/WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts
+Tests~/E2E/*UnityProject-*/Assets/WebGLTemplates/AITTemplate/BuildConfig~/granite.config.ts
 
 # Legacy folders (replaced with ~ suffix versions)
 BuildTemplate/


### PR DESCRIPTION
## 배경

로컬에서 E2E 샘플 프로젝트를 빌드하면 `AITTemplateManager.UpdateConfigFileWithMarkers`가 SDK 템플릿의 `vite.config.ts`·`granite.config.ts`를 프로젝트의 `Assets/WebGLTemplates/AITTemplate/BuildConfig~/`에 스캐폴드합니다(없으면 생성, 있으면 USER_CONFIG 영역만 보존하고 SDK 최신으로 갱신). 사용자 프로젝트 입장에서는 의도된 동작이지만, 이 저장소의 샘플 프로젝트에서는 빌드할 때마다 untracked 파일로 남습니다.

- 어떤 샘플 프로젝트도 이 두 파일을 커밋하지 않음 (추적 대상은 `.env.example`, `.gitignore`, `package.json`, `src/main.ts`)
- 최상위 `.gitignore`의 `!**/BuildConfig~/**` 재포함 규칙이 하위 `.gitignore`보다 우선하므로, 재포함 뒤에 명시적 제외를 추가해야 함 (기존 `**/BuildConfig~/node_modules/`와 동일한 방식)

## 변경

샘플 프로젝트(`Tests~/E2E/*UnityProject-*`) 한정으로 두 스캐폴드 파일을 ignore. SDK 원본 템플릿(`WebGLTemplates/AITTemplate/BuildConfig~/`)과 기존 추적 파일에는 영향 없음 (`git check-ignore`로 검증).

## 검증

- `git check-ignore -v`: 샘플·Heavy 프로젝트의 두 파일 ignore 판정 확인
- SDK 원본 `WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts` → ignore 안 됨
- 샘플의 추적 파일 `BuildConfig~/package.json` → 영향 없음
- TODO.md 관련 항목 없음