### PR TITLE
기능: 유출 스캔을 metadata 표면(ref명·커밋/태그 메시지·경로·PR 제목/본문)까지 확장

### DIFF
--- a/.githooks/patterns.local.example
+++ b/.githooks/patterns.local.example
@@ -1,17 +1,26 @@
-# .githooks/patterns.local — 로컬 전용 내부호스트 denylist 템플릿
+# .githooks/patterns.local — 로컬 전용 denylist 템플릿 (내부 호스트 + 사설 프로젝트 식별자)
 #
 # 이 파일을 복사해 같은 디렉토리에 patterns.local 로 저장하세요:
 #     cp .githooks/patterns.local.example .githooks/patterns.local
 #
 # patterns.local 은 .gitignore 되어 있어 저장소(public)에 커밋되지 않습니다.
-# pre-push 훅이 여기 적힌 규칙으로 push 직전 트리/변경분을 검사해 내부 호스트명 유출을 차단합니다.
+# pre-push 훅이 여기 적힌 규칙으로 push 직전 (ref 이름 / 커밋·태그 메시지 / 파일 경로 / 변경 내용)을
+# 검사해 내부 인프라 정보 및 사설 프로젝트 식별자 유출을 차단합니다.
 #
 # 형식: 한 줄에 하나의 확장정규식(ERE). 빈 줄과 '#' 로 시작하는 줄은 무시됩니다.
-# 값은 CI의 STRING_CHECK_PATTERN secret 과 동일한 내부 호스트 규칙으로 채우세요.
+# 값은 CI의 STRING_CHECK_PATTERN secret 과 '동일한' 규칙 집합으로 채우세요(서버/클라 동기화).
 #
-# ⚠️ 실제 내부 도메인을 이 .example 파일(=커밋 대상)에는 절대 적지 마세요.
-#    아래는 자리표시자일 뿐입니다 — patterns.local 에서 실제 값으로 교체하세요.
+# ⚠️ 실제 값(내부 도메인 / 코드네임 / 클론 URL / 시크릿명)을 이 .example 파일(=커밋 대상)에는
+#    절대 적지 마세요. 실제 값은 오직 (1) patterns.local(git-ignored) 와 (2) STRING_CHECK_PATTERN
+#    secret 에만 존재해야 합니다. 아래는 카테고리 자리표시자일 뿐입니다.
 #
-# 예시(자리표시자):
+# ── 채워야 할 카테고리(각 줄을 patterns.local 에서 실제 ERE 로 교체) ──
+#   1) 내부 호스트/도메인            예: [a-z0-9.-]+\.corp\.example\.invalid
+#   2) 내부 레지스트리/자격증명 URL  예: \.internal-registry\.example\.invalid
+#   3) 사설 프로젝트 코드네임/식별자  예: (projectcodename-a|projectcodename-b)   ← 실제 코드네임으로
+#   4) 사설 클론 URL 형태            예: github\.example\.invalid[:/]org/private-repo
+#   5) 사설 시크릿/토큰 이름          예: (PRIVATE_[A-Z0-9_]+_TOKEN)
+#
+# 예시(자리표시자 — 그대로 두지 말고 patterns.local 에서 실제 값으로 교체):
 # \.internal-registry\.example\.invalid
 # [a-z0-9.-]+\.corp\.example\.invalid

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-# 내부 호스트명 / 자격증명 URL이 공개 원격으로 push되기 전에 차단하는 훅.
+# 내부 호스트명 / 자격증명 URL / 사설 프로젝트 식별자가 공개 원격으로 push되기 전에 차단하는 훅.
+#
+# 검사 표면(모두 push 경계, 노출 직전):
+#   (A) ref(브랜치/태그) 이름   (B) 커밋 메시지   (C) annotated 태그 메시지
+#   (D) 파일 경로명(파일명 자체)  (1) tip 트리 내용(경고)  (2) push 범위 추가 라인 내용(차단)
+#   — (A)(B)(C)(D)는 metadata 표면이라 파일 '내용' 스캔만으로는 잡히지 않던 유출 벡터다
+#     (예: 브랜치명/커밋 메시지/워크플로 파일명에 박힌 사설 프로젝트 코드네임).
 #
 # 배경: CI의 String Check(scan) 워크플로는 사후(push 이후) 탐지 계층이라, feature 브랜치를
 #       public 원격에 push하는 "노출 순간" 자체는 막지 못한다. 이 훅은 push 경계(노출 직전)에서
@@ -87,6 +93,18 @@ if [ "$have_org" = "0" ]; then
   printf "  STRING_CHECK_PATTERN 환경변수를 지정하세요 (템플릿: .githooks/patterns.local.example).\n" >&2
 fi
 
+# --- shallow clone 가드 ---------------------------------------------------------
+# 얕은(shallow) 클론에서는 range 기반 스캔(커밋 메시지 / 경로 / diff)이 조상 커밋 부재로 조용히
+# 잘려 fail-open 될 수 있다. STRICT 면 거부, 아니면 강하게 경고한다(서버 CI String Check 가 백스톱).
+if git rev-parse --is-shallow-repository 2>/dev/null | grep -qx true; then
+  if [ "${PREPUSH_STRICT:-0}" = "1" ]; then
+    printf "${RED}[pre-push] STRICT: 얕은(shallow) 클론이라 range 스캔이 불완전할 수 있어 push를 거부합니다.${NC}\n" >&2
+    printf "  'git fetch --unshallow' 후 다시 시도하세요.\n" >&2
+    exit 1
+  fi
+  printf "${YEL}[pre-push] 경고: 얕은(shallow) 클론입니다 — range 기반 스캔이 불완전할 수 있습니다. 'git fetch --unshallow' 권장.${NC}\n" >&2
+fi
+
 # --- push되는 각 ref 검사 ----------------------------------------------------
 # 새 브랜치 range 스캔은 '이 push의 대상 원격'을 기준으로 한정한다. bare '--not --remotes'는
 # 다른 원격(사설 미러/포크/stale ref)에 있는 커밋까지 제외해 유출을 놓칠 수 있으므로, 대상 원격이
@@ -98,10 +116,104 @@ else
   NOT_REMOTES="--remotes"
 fi
 
+# 참고(메타 self-block 회피): 이 훅/워크플로의 denylist '동작'을 서술하는 커밋 메시지·경로에는
+# 실제 내부 호스트/자격증명/사설 IP 리터럴을 넣지 않는다(넣으면 아래 (A)(B)(D) 스캔이 자기 자신을
+# 차단한다). 내용 스캔(1)(2)만 pathspec 으로 정의 파일을 제외할 수 있고, 이름/메시지 스캔은 제외 불가.
+
 fail=0
 while read -r localref localsha remoteref remotesha; do
   [ -z "${localsha:-}" ] && continue
   [ "$localsha" = "$z40" ] && continue   # 삭제 push: 스캔할 tip 없음
+
+  # ref 종류/이름 도출. ref 이름 자체가 토큰일 수 있으므로 $ref_name 은 어떤 경우에도 출력하지 않는다.
+  case "$localref" in
+    refs/tags/*) is_tag=1 ;;
+    *)           is_tag=0 ;;
+  esac
+  ref_name="${localref#refs/heads/}"
+  ref_name="${ref_name#refs/tags/}"
+
+  # push 범위 계산(이하 (B) 메시지 / (D) 경로 / (2) diff 스캔이 공유). origin/main 에 의존하지 않는다.
+  #   --full-history: pathspec(-- .)로 인한 history simplification 이 --no-ff 머지에서 정리된
+  #   side-branch 유출 커밋을 walk에서 누락시키는 것을 방지.
+  if [ "$remotesha" != "$z40" ]; then
+    RANGE="$remotesha..$localsha"                 # 기존 브랜치 업데이트: 정확한 범위
+  else
+    RANGE="$localsha --not $NOT_REMOTES"          # 새 브랜치/태그: 대상 원격에 없는 모든 커밋
+  fi
+
+  # (A) ref(브랜치/태그) 이름 스캔 — 차단. 이름은 metadata 라 기존 어떤 스캔도 보지 않던 표면이며
+  #     이름 자체가 노출 대상이므로 매치해도 내용을 출력하지 않는다.
+  #     grep 종료코드: 0=매치, 1=미매치, >=2=오류(fail-closed).
+  if printf '%s' "$ref_name" | grep -qiE "$PATTERNS"; then
+    printf "${RED}[pre-push] 차단: ref(브랜치/태그) 이름에 금지 패턴이 있습니다 (tip %s).${NC}\n" "${localsha:0:12}" >&2
+    printf "  이름 자체가 노출 대상이라 내용을 출력하지 않습니다. 브랜치/태그명을 바꿔 다시 시도하세요.\n" >&2
+    fail=1
+  elif [ "$?" -ge 2 ]; then
+    printf "${RED}[pre-push] 오류: ref 이름 스캔 실패(grep rc>=2). 안전을 위해 push를 중단합니다.${NC}\n" >&2
+    fail=1
+  fi
+
+  # (B) 커밋 메시지 스캔 — 차단. git log -p 의 '^+' 필터는 메시지 라인을 못 보므로 별도 스캔한다.
+  #     pathspec/exclude 를 쓰지 않는다(경로에 안 걸리는 orphan/메시지-only 유출 커밋 누락 방지).
+  #     새 브랜치/태그(before=40-zero)도 위 $RANGE 의 '--not $NOT_REMOTES' 로 첫 푸시 커밋까지 포함.
+  #     매치 시 메시지 원문은 비출력, 건수만 보고.
+  # shellcheck disable=SC2086
+  mlog="$(git log --no-color --format=%B $RANGE 2>/dev/null)"
+  mrc=$?
+  if [ "$mrc" -ne 0 ]; then
+    printf "${RED}[pre-push] 오류: 커밋 메시지 범위 스캔 실패(git log rc=%s). 안전을 위해 push를 중단합니다.${NC}\n" "$mrc" >&2
+    fail=1
+  else
+    mhits="$(printf '%s\n' "$mlog" | grep -icE "$PATTERNS")"
+    mghrc=$?
+    if [ "$mghrc" -ge 2 ]; then
+      printf "${RED}[pre-push] 오류: 커밋 메시지 스캔 실패(grep rc>=2). 안전을 위해 push를 중단합니다.${NC}\n" >&2
+      fail=1
+    elif [ "${mhits:-0}" -gt 0 ] 2>/dev/null; then
+      printf "${RED}[pre-push] 차단: push 범위 커밋 메시지에서 금지 패턴 %s건 감지 (tip %s).${NC}\n" "$mhits" "${localsha:0:12}" >&2
+      fail=1
+    fi
+  fi
+
+  # (C) annotated 태그 메시지 스캔 — 차단. 태그 객체 메시지는 커밋 walk(git log)로는 안 보인다
+  #     (이 저장소는 release/beta-release 에서 'git tag -m' 로 annotated 태그를 만든다).
+  if [ "$is_tag" = "1" ]; then
+    tmsg="$(git for-each-ref --format='%(contents)' "refs/tags/$ref_name" 2>/dev/null)"
+    tfrc=$?
+    if [ "$tfrc" -ne 0 ]; then
+      printf "${RED}[pre-push] 오류: 태그 메시지 조회 실패(git for-each-ref rc=%s). 안전을 위해 push를 중단합니다.${NC}\n" "$tfrc" >&2
+      fail=1
+    else
+      thits="$(printf '%s\n' "$tmsg" | grep -icE "$PATTERNS")"
+      tghrc=$?
+      if [ "$tghrc" -ge 2 ]; then
+        printf "${RED}[pre-push] 오류: 태그 메시지 스캔 실패(grep rc>=2). 안전을 위해 push를 중단합니다.${NC}\n" >&2
+        fail=1
+      elif [ "${thits:-0}" -gt 0 ] 2>/dev/null; then
+        printf "${RED}[pre-push] 차단: annotated 태그 메시지에서 금지 패턴 %s건 감지 (tip %s).${NC}\n" "$thits" "${localsha:0:12}" >&2
+        fail=1
+      fi
+    fi
+  fi
+
+  # (D) 파일 경로명 스캔 — 차단. 경로(파일명) 자체가 토큰인 유출(#718: 워크플로 파일명)은
+  #     내용 grep(-r 은 매치 '내용'만 경로로 prefix)도 diff '^+' 필터('+++ b/path' 제외)도 못 잡는다.
+  #     경로가 곧 토큰이므로 매치 경로를 절대 출력하지 않고 정적 마커만 낸다. git 오류는 grep 전에 fail-closed.
+  # shellcheck disable=SC2086
+  nlog="$(git log --name-only --format= -m --full-history $RANGE 2>/dev/null)"
+  nrc=$?
+  if [ "$nrc" -ne 0 ]; then
+    printf "${RED}[pre-push] 오류: 경로명 범위 스캔 실패(git log rc=%s). 안전을 위해 push를 중단합니다.${NC}\n" "$nrc" >&2
+    fail=1
+  elif printf '%s\n' "$nlog" | grep -qiE "$PATTERNS"; then
+    printf "${RED}[pre-push] 차단: push 범위에서 금지 패턴을 포함한 파일 경로가 감지되었습니다 (tip %s).${NC}\n" "${localsha:0:12}" >&2
+    printf "  경로 자체가 노출 대상이라 경로를 출력하지 않습니다. 파일명/경로를 바꿔 다시 시도하세요.\n" >&2
+    fail=1
+  elif [ "$?" -ge 2 ]; then
+    printf "${RED}[pre-push] 오류: 경로명 스캔 실패(grep rc>=2). 안전을 위해 push를 중단합니다.${NC}\n" >&2
+    fail=1
+  fi
 
   # (1) tip tree 스캔 — 경고 전용. tip 트리 '전체'를 훑기 때문에 이미 공개된 내용까지 매치할 수
   #     있어(예: 오래전 머지된 문서의 사설 IP 예시) 여기서 차단하면 무관한 push가 영구히 막힌다.
@@ -120,36 +232,29 @@ while read -r localref localsha remoteref remotesha; do
     printf "  이미 공개된 내용이면 정리를 권장합니다. (이 항목만으로는 push를 막지 않습니다.)\n" >&2
   fi
 
-  # (2) push 범위 커밋별 추가 라인 스캔 — 차단의 핵심. 중간 커밋에서 add된 뒤 tip에서 지워졌더라도
-  #     그 커밋 객체는 push되어 공개되므로 함께 검사. origin/main 에 의존하지 않도록 '대상 원격에
-  #     아직 없는 커밋'을 --not $NOT_REMOTES 로 정의(shallow/orphan/비-main 기본브랜치 안전).
-  #     --full-history: pathspec(-- .)로 인한 history simplification 이 --no-ff 머지에서 정리된
-  #     side-branch 유출 커밋을 walk에서 누락시키는 것을 방지.
-  if [ "$remotesha" != "$z40" ]; then
-    RANGE="$remotesha..$localsha"                 # 기존 브랜치 업데이트: 정확한 범위
-  else
-    RANGE="$localsha --not $NOT_REMOTES"          # 새 브랜치: 대상 원격에 없는 모든 커밋
-  fi
+  # (2) push 범위 커밋별 추가 라인(내용) 스캔 — 차단의 핵심. 중간 커밋에서 add된 뒤 tip에서 지워졌더라도
+  #     그 커밋 객체는 push되어 공개되므로 함께 검사. merge 커밋의 충돌 해소 내용도 보도록 -m 추가
+  #     (-m 은 부모별 2-way diff 라 '^+'/'+++ ' 필터가 그대로 유효; 과다 카운트는 안전한 방향).
   # shellcheck disable=SC2086  # RANGE/NOT_REMOTES 는 의도적으로 여러 토큰으로 분리
-  plog="$(git log -p --no-color --full-history $RANGE -- . "$EXC1" "$EXC2" 2>/dev/null)"
+  plog="$(git log -p -m --no-color --full-history $RANGE -- . "$EXC1" "$EXC2" 2>/dev/null)"
   lrc=$?
   if [ "$lrc" -ne 0 ]; then
-    printf "${RED}[pre-push] 오류: 범위 스캔 실패(git log rc=%s). 안전을 위해 push를 중단합니다.${NC}\n" "$lrc" >&2
+    printf "${RED}[pre-push] 오류: 범위 diff 스캔 실패(git log rc=%s). 안전을 위해 push를 중단합니다.${NC}\n" "$lrc" >&2
     fail=1
   else
     # 추가된 실제 내용 라인만 검사: '^+' 중 diff 헤더('+++ b/path')는 제외해, 파일 경로가 패턴과
     # 겹치는 것만으로 오탐하지 않게 한다.
     dhits="$(printf '%s\n' "$plog" | grep -E "^\+" | grep -vE "^\+\+\+ " | grep -icE "$PATTERNS")"
     if [ "${dhits:-0}" -gt 0 ] 2>/dev/null; then
-      printf "${RED}[pre-push] 차단: push 범위 커밋에서 추가된 내부 호스트 패턴 %s건 감지 (tip %s).${NC}\n" "$dhits" "${localsha:0:12}" >&2
+      printf "${RED}[pre-push] 차단: push 범위 커밋에서 추가된 금지 패턴 %s건 감지 (tip %s).${NC}\n" "$dhits" "${localsha:0:12}" >&2
       fail=1
     fi
   fi
 done
 
 if [ "$fail" != "0" ]; then
-  printf "${RED}[pre-push] push를 중단했습니다.${NC} 위 파일에서 내부 호스트명을 제거한 뒤 다시 시도하세요.\n" >&2
-  printf "  이 차단은 public 저장소로의 내부 인프라 정보 유출을 막기 위한 것입니다. --no-verify 우회 금지.\n" >&2
+  printf "${RED}[pre-push] push를 중단했습니다.${NC} 위에 표시된 표면(이름/메시지/경로/내용)에서 금지 패턴을 제거한 뒤 다시 시도하세요.\n" >&2
+  printf "  이 차단은 public 저장소로의 내부 인프라 정보 / 사설 프로젝트 식별자 유출을 막기 위한 것입니다. --no-verify 우회 금지.\n" >&2
   exit 1
 fi
 

--- a/.githooks/setup.sh
+++ b/.githooks/setup.sh
@@ -1,26 +1,58 @@
 #!/bin/bash
 
 # Git hooks 설정 스크립트
-# 저장소를 클론한 후 한 번 실행하면 됩니다.
+# 저장소를 클론한 후(그리고 새 worktree 를 만든 후) 한 번 실행하면 됩니다.
 
+set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
 echo "Git hooks 설정 중..."
+# core.hooksPath 를 '상대경로' .githooks 로 지정한다. 상대경로는 각 worktree 의 top-level 기준으로
+# 해석되므로, worktree 마다 자기 자신의 .githooks 를 사용한다(절대경로로 넣으면 특정 worktree 에
+# 고정되어 다른 worktree 에서 잘못된 훅이 돌 수 있음).
 git -C "$REPO_ROOT" config core.hooksPath .githooks
 
-echo "✓ Git hooks가 .githooks 디렉토리로 설정되었습니다."
+# (c) 검증 가능한 설치 마커 — 실제로 어떤 경로/worktree 에 적용됐는지 눈으로 확인.
+RESOLVED="$(git -C "$REPO_ROOT" config --get core.hooksPath 2>/dev/null || echo '(미설정)')"
+TOP="$(git -C "$REPO_ROOT" rev-parse --show-toplevel 2>/dev/null || echo '?')"
+echo "✓ Git hooks 설정 완료: core.hooksPath=${RESOLVED}  (worktree top-level=${TOP})"
+echo "  확인: git config --get core.hooksPath  →  .githooks (이 worktree 의 .githooks 해석)"
 echo ""
 echo "활성화된 hooks:"
 ls -1 "$SCRIPT_DIR" 2>/dev/null | grep -vE '^(setup\.sh|patterns\.local.*)$' | sed 's/^/  - /' || echo "  (없음)"
 
-# pre-push 훅(내부 호스트명 유출 차단)용 로컬 denylist 안내
+# (b) 원격 추적 ref 최신화 — pre-push 의 range 스캔(--not --remotes)이 오래된 remote ref 때문에
+#     불필요하게 커지거나 부정확해지는 것을 예방. 오프라인/권한없음이어도 설치는 실패시키지 않는다.
+echo ""
+echo "원격 ref 최신화(fetch --prune) 시도 중... (실패해도 설치에는 영향 없음)"
+git -C "$REPO_ROOT" fetch --quiet --prune 2>/dev/null && echo "  ✓ fetch 완료" || echo "  ℹ fetch 건너뜀(오프라인/권한). 나중에 'git fetch --prune' 권장."
+
+# pre-push 훅용 로컬 denylist(patterns.local) 안내
 echo ""
 if [ -f "$SCRIPT_DIR/patterns.local" ]; then
-  echo "✓ pre-push denylist: .githooks/patterns.local 감지됨 (내부 호스트 검사 활성)."
+  echo "✓ pre-push denylist: .githooks/patterns.local 감지됨 (내부 호스트 + 사설 식별자 검사 활성)."
 else
-  echo "ℹ pre-push 훅은 내부 호스트명 유출을 차단합니다. 완전한 보호를 위해 로컬 denylist를 만드세요:"
-  echo "    cp .githooks/patterns.local.example .githooks/patterns.local"
-  echo "  그런 다음 patterns.local 에 조직 내부 호스트 규칙(CI STRING_CHECK_PATTERN과 동일)을 채우세요."
-  echo "  (patterns.local 은 .gitignore되어 커밋되지 않습니다.)"
+  echo "⚠ pre-push denylist(.githooks/patterns.local)가 없습니다 — 지금은 내장 '일반' 패턴만 검사합니다."
+  echo "  (내부 도메인 / 사설 프로젝트 코드네임 / 클론 URL / 시크릿명은 아직 검사되지 않습니다.)"
+  echo "  완전한 보호를 위해:"
+  echo "    1) cp .githooks/patterns.local.example .githooks/patterns.local"
+  echo "    2) patterns.local 을 실제 규칙으로 채우세요. 실제 값은 저장소에 없으므로,"
+  echo "       팀 보안 시크릿 저장소(사내 secrets manager / 자격증명 볼트 등)에 보관된"
+  echo "       'STRING_CHECK_PATTERN 규칙 세트'를 담당자에게 받아 그대로 반영하세요."
+  echo "       (patterns.local 은 .gitignore 되어 커밋되지 않습니다. 실제 값을 .example 에는 절대 넣지 마세요.)"
 fi
+
+# (d)(e) STRICT 모드 & 영속화 안내
+echo ""
+echo "권장: 조직 denylist 미설정 시 '경고'가 아닌 'push 거부(fail-closed)'로 강제하려면 PREPUSH_STRICT=1."
+if [ "${PREPUSH_STRICT:-0}" = "1" ]; then
+  echo "  현재 셸: PREPUSH_STRICT=1 (활성)."
+else
+  echo "  현재 셸: PREPUSH_STRICT 미설정."
+fi
+echo "  ⚠ 한 번의 'export PREPUSH_STRICT=1' 은 새 셸에서 사라집니다. 셸 프로파일에 '영속화'하세요:"
+echo "      echo 'export PREPUSH_STRICT=1' >> ~/.zshrc   # 또는 ~/.bashrc / direnv"
+echo ""
+echo "설치 검증: 합성 canary(실제 코드네임 아님)를 patterns.local 에 넣고 그 문자열을 담은 브랜치명/"
+echo "커밋 메시지/파일 경로로 test push 를 시도하면 pre-push 가 차단해야 합니다(내용은 비표시)."

--- a/.github/workflows/string-check.yml
+++ b/.github/workflows/string-check.yml
@@ -14,6 +14,9 @@ on:
       - '**'
   pull_request:
     branches: [main]
+    # 기본 타입(opened/synchronize/reopened)에 edited 를 더해 PR '제목/본문 수정' 시에도 재스캔한다
+    # — open 이후의 제목 rename 이 재검사되지 않아 코드네임이 제목으로 새는 갭을 닫는다.
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   scan:
@@ -31,6 +34,11 @@ jobs:
       - name: Checkout
         if: env.IS_BOT_PR != 'true'
         uses: actions/checkout@v7
+        with:
+          # 커밋 메시지 / 파일 경로 range 스캔에 전체 히스토리 + 원격 브랜치/태그 ref 가 필요하다.
+          # fetch-depth:0 은 모든 브랜치·태그를 가져와, 새 브랜치 첫 푸시(before=40-zero)의 range 를
+          # '방금 푸시된 ref 를 제외한 다른 모든 ref' 기준으로 계산할 수 있게 한다.
+          fetch-depth: 0
 
       - name: Skip scan for bot PR
         if: env.IS_BOT_PR == 'true'
@@ -106,3 +114,140 @@ jobs:
           done
           [ "$BAD" = "0" ] || exit 1
           echo "lockfile scan OK"
+
+      # ── 아래 스텝들은 파일 '내용' 외의 metadata 표면(ref 이름 / 커밋·태그 메시지 / 파일 경로 /
+      #    PR 제목·본문)을 검사한다. 모두 Guard 뒤에 두어(빈 PATTERN 이면 Guard 가 이미 job 을 중단)
+      #    fork PR 의 빈 정규식이 전부 매치되는 false-fail 을 원천 차단한다. grep rc: 0=매치, 1=미매치,
+      #    2+=오류(fail-closed). 매치 시 이름/경로/메시지 '원문'은 절대 출력하지 않는다(공개 Actions
+      #    로그는 비인증 열람 가능 — 경로/이름 자체가 토큰일 수 있음).
+
+      - name: Scan ref name
+        if: env.IS_BOT_PR != 'true'
+        env:
+          LC_ALL: C
+          # push 는 github.ref_name(브랜치/태그 short), PR 은 소스 브랜치 github.head_ref.
+          REF_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          set +e
+          printf '%s' "$REF_NAME" | grep -qiE "$PATTERN"
+          RC=$?
+          set -e
+          if [ "$RC" -eq 0 ]; then
+            echo "::error::ref(브랜치/태그) 이름에서 금지 패턴이 감지되었습니다(이름 비표시). 이름을 바꿔 다시 push 하세요."
+            exit 1
+          elif [ "$RC" -ge 2 ]; then
+            echo "::error::ref 이름 스캔 실패(grep rc=$RC). 안전을 위해 실패 처리합니다."
+            exit 1
+          fi
+          echo "ref-name scan OK"
+
+      - name: Scan commit messages and file paths
+        if: env.IS_BOT_PR != 'true'
+        env:
+          LC_ALL: C
+          EV_BEFORE: ${{ github.event.before }}
+          EV_AFTER: ${{ github.sha }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          REF_TYPE: ${{ github.ref_type }}
+          PUSH_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          Z40=0000000000000000000000000000000000000000
+          # range 계산. PR 은 base..head(정확히 PR 커밋). push 기존 브랜치는 before..after.
+          # push 새 브랜치/태그(before=40-zero)는 '방금 푸시된 ref 를 제외한 다른 모든 remote
+          # 브랜치·태그' 를 기준으로 'after 에서만 도달 가능한' 커밋 — orphan/disjoint 히스토리의
+          # 첫 푸시 커밋도 전부 포함(tip-only 아님, origin/main merge-base 아님).
+          if [ -n "${PR_HEAD:-}" ]; then
+            RANGE="$PR_BASE..$PR_HEAD"
+          elif [ "${EV_BEFORE:-$Z40}" != "$Z40" ]; then
+            RANGE="$EV_BEFORE..$EV_AFTER"
+          else
+            if [ "$REF_TYPE" = "tag" ]; then CUR="refs/tags/$PUSH_REF"; else CUR="refs/remotes/origin/$PUSH_REF"; fi
+            OTHERS=$(git for-each-ref --format='%(refname)' refs/remotes/origin refs/tags | grep -vFx "$CUR" || true)
+            if [ -n "$OTHERS" ]; then RANGE="$EV_AFTER --not $OTHERS"; else RANGE="$EV_AFTER"; fi
+          fi
+
+          # (B) 커밋 메시지 — pathspec 없이 스캔(경로에 안 걸리는 orphan/메시지-only 유출 커밋 누락 방지).
+          set +e
+          # shellcheck disable=SC2086  # $RANGE 는 'SHA --not ref1 ref2' 형태로 의도적 워드분할
+          MSGS=$(git log --no-color --format=%B $RANGE 2>/dev/null); GRC=$?
+          set -e
+          [ "$GRC" -eq 0 ] || { echo "::error::커밋 메시지 범위 조회 실패(git log rc=$GRC). 안전을 위해 실패 처리합니다."; exit 1; }
+          set +e
+          printf '%s\n' "$MSGS" | grep -qiE "$PATTERN"; MRC=$?
+          set -e
+          if [ "$MRC" -eq 0 ]; then
+            echo "::error::push 범위 커밋 메시지에서 금지 패턴이 감지되었습니다(내용 비표시)."
+            exit 1
+          elif [ "$MRC" -ge 2 ]; then
+            echo "::error::커밋 메시지 스캔 실패(grep rc=$MRC). 안전을 위해 실패 처리합니다."
+            exit 1
+          fi
+
+          # (D) 파일 경로명 — 경로(파일명) 자체가 토큰인 유출(#718 워크플로 파일명)은 내용/‘^+’ diff
+          #     스캔이 못 잡는다. 경로가 곧 토큰이므로 매치 경로/라인을 절대 출력하지 않고 정적 마커만.
+          #     git 오류는 grep 전에 fail-closed. merge 커밋 경로도 보도록 -m.
+          set +e
+          # shellcheck disable=SC2086  # $RANGE 는 'SHA --not ref1 ref2' 형태로 의도적 워드분할
+          PATHS=$(git log --name-only --format= -m $RANGE 2>/dev/null); PRC=$?
+          set -e
+          [ "$PRC" -eq 0 ] || { echo "::error::경로명 범위 조회 실패(git log rc=$PRC). 안전을 위해 실패 처리합니다."; exit 1; }
+          set +e
+          printf '%s\n' "$PATHS" | grep -qiE "$PATTERN"; NRC=$?
+          set -e
+          if [ "$NRC" -eq 0 ]; then
+            echo "::error::push 범위에서 금지 패턴을 포함한 파일 경로가 감지되었습니다(경로 비표시)."
+            exit 1
+          elif [ "$NRC" -ge 2 ]; then
+            echo "::error::경로명 스캔 실패(grep rc=$NRC). 안전을 위해 실패 처리합니다."
+            exit 1
+          fi
+          echo "commit-message + path scan OK"
+
+      - name: Scan annotated tag message
+        if: env.IS_BOT_PR != 'true' && github.ref_type == 'tag'
+        env:
+          LC_ALL: C
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # annotated 태그 객체 메시지는 커밋 walk(git log)로는 안 보인다(이 저장소는 release/
+          # beta-release 에서 'git tag -m' 로 생성). lightweight 태그는 %(contents)가 비어 무매치.
+          MSG=$(git for-each-ref --format='%(contents)' "refs/tags/$TAG_REF" 2>/dev/null) || {
+            echo "::error::태그 메시지 조회 실패. 안전을 위해 실패 처리합니다."; exit 1; }
+          set +e
+          printf '%s\n' "$MSG" | grep -qiE "$PATTERN"; RC=$?
+          set -e
+          if [ "$RC" -eq 0 ]; then
+            echo "::error::annotated 태그 메시지에서 금지 패턴이 감지되었습니다(내용 비표시)."
+            exit 1
+          elif [ "$RC" -ge 2 ]; then
+            echo "::error::태그 메시지 스캔 실패(grep rc=$RC). 안전을 위해 실패 처리합니다."
+            exit 1
+          fi
+          echo "tag-message scan OK"
+
+      - name: Scan PR title and body
+        if: env.IS_BOT_PR != 'true' && github.event_name == 'pull_request'
+        env:
+          LC_ALL: C
+          # 인젝션 안전: 제목/본문을 셸에 직접 보간하지 않고 env 로만 전달한다.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          # 참고: 제목 rename 은 이 스텝이 돌기 전 이미 타임라인 이벤트로 기록된다 —
+          # 따라서 이 검사는 '예방'이 아니라 '탐지 + 머지 차단'이다(권한 있는 대응이 뒤따라야 함).
+          set +e
+          printf '%s\n%s\n' "$PR_TITLE" "${PR_BODY:-}" | grep -qiE "$PATTERN"; RC=$?
+          set -e
+          if [ "$RC" -eq 0 ]; then
+            echo "::error::PR 제목/본문에서 금지 패턴이 감지되었습니다(내용 비표시). 제목/본문을 수정하세요."
+            exit 1
+          elif [ "$RC" -ge 2 ]; then
+            echo "::error::PR 제목/본문 스캔 실패(grep rc=$RC). 안전을 위해 실패 처리합니다."
+            exit 1
+          fi
+          echo "pr title/body scan OK"


### PR DESCRIPTION
## 배경

public 저장소로의 비공개 식별자(내부 호스트 / 사설 프로젝트 코드네임 / 클론 URL / 시크릿명) 유출을 막는 두 장치가 이미 있다 — 서버 측 `String Check`(CI)와 로컬 `pre-push` 훅. 그러나 **둘 다 파일 '내용'만 검사**하고 다음 **metadata 표면은 검사하지 않는** 구조적 갭이 있었다:

- ref(브랜치/태그) 이름
- 커밋 메시지
- annotated 태그 메시지 (`git tag -m`)
- 파일 경로명(파일명 자체 — 내용이 아니라 경로에만 토큰이 있는 경우)
- PR 제목/본문

내용 스캔만으로는 예컨대 **브랜치명·커밋 메시지·워크플로 파일명에 박힌 사설 프로젝트 코드네임**을 잡지 못한다. 이 PR은 그 갭을 닫는다.

## 변경 요약

| 표면 | 로컬 `pre-push` (예방, push 직전 차단) | 서버 `String Check` (탐지, 머지 차단) |
|---|---|---|
| 파일 내용 | 기존 유지 (+merge 커밋 `-m`) | 기존 유지 |
| ref 이름 | **신규 차단** | **신규 탐지** |
| 커밋 메시지 | **신규 차단** | **신규 탐지** |
| annotated 태그 메시지 | **신규 차단** | **신규 탐지** |
| 파일 경로명 | **신규 차단** | **신규 탐지** |
| PR 제목/본문 | (로컬에서 접근 불가) | **신규 탐지** (`edited` 포함) |

## 안전 설계

- **비표시(redaction)**: 매치 시 이름/경로/메시지 원문을 절대 출력하지 않는다 — 경로/이름 자체가 토큰일 수 있고, 공개 Actions 로그는 비인증 열람이 가능하기 때문. (커밋/태그 메시지는 건수만, 경로/이름은 정적 마커만.)
- **fail-closed**: 모든 신규 스캔은 `grep rc>=2`(정규식/엔진 오류)와 git 명령 실패 시 통과가 아니라 **차단**한다. `LC_ALL=C` 바이트 매칭 유지.
- **fork PR 안전**: 신규 스텝은 모두 기존 `Guard` 뒤에 둔다. fork PR은 secret 미접근이라 Guard가 먼저 job을 중단시키므로, 빈 정규식이 전부 매치되는 false-fail이 발생하지 않는다. bot PR skip도 유지.
- **새 브랜치 첫 푸시(before=40-zero) range 정확도**: 서버에선 push 시점에 이미 원격에 해당 ref가 존재하므로, '방금 푸시된 ref를 제외한 다른 모든 remote 브랜치/태그' 기준으로 range를 계산한다 — orphan/disjoint 히스토리와 첫-푸시 커밋도 누락 없이 스캔(tip-only 아님, `origin/main` merge-base 아님). 로컬 pre-push는 push 전이라 `--not <대상 원격>` 로 동일 보장.
- **shallow 클론 가드**: 로컬에서 얕은 클론이면 range 스캔이 잘릴 수 있어 `PREPUSH_STRICT=1` 시 차단(아니면 경고).

## 검증

합성 canary(실제 코드네임 아님)로:
- 로컬 `pre-push` 8/8 — clean 통과, (A)ref명·(B)커밋 메시지·(C)태그 메시지·(D)경로명·내용 차단, bad-regex/STRICT fail-closed, 출력에 canary 무유출.
- 서버 range 로직 9/9 — 새 브랜치(원격에 이미 push된 조건)·기존 브랜치·PR·clean·orphan range + 4개 표면.

## 남은 작업 (이 PR 밖, repo에 커밋 불가한 데이터/설정)

1. **denylist 데이터**: 실제 규칙(내부 도메인/코드네임/클론 URL/시크릿명)을 `STRING_CHECK_PATTERN` secret(서버)과 git-ignored `.githooks/patterns.local`(클라)에 등록해야 신규 스캔이 코드네임 클래스를 잡는다. 값은 저장소에 넣지 않는다(`patterns.local.example`엔 카테고리 자리표시자만 추가함).
2. **훅 활성화**: `.githooks/setup.sh` 재실행으로 `core.hooksPath`를 상대경로로 교정(현재 절대경로라 특정 worktree 고정) + 각 머신에 `patterns.local` 배치 + `PREPUSH_STRICT=1` 셸 프로파일 영속화.