### PR TITLE
문서: CLAUDE.md 인시던트 상세를 docs/claude/로 이전

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,24 +104,15 @@
 - PR 번호 사용 시 `target_ref`에 숫자만 입력 (# 접두사 불필요)
 
 ### E2E 테스트 실패 대응
-- E2E 실패 시 먼저 **코드 변경과 무관한 인프라 이슈인지** 판별
+- E2E 실패 시 먼저 **코드 변경과 무관한 인프라 이슈인지** 판별 — 알려진 flaky 패턴(Unity 라이선스 충돌 / Windows artifact finalize / Brotli·Gzip 크래시 / warm-reload `unityInstance` 120s 타임아웃)의 시그니처·판별 상세와 red herring 목록은 `docs/claude/github-actions.md`의 "E2E 알려진 flaky 패턴 (상세)"를 Read 후 대조
 - **인프라 기인 실패 시**: `rerun-failed-jobs`로 실패한 job만 재실행 (전체 재실행보다 성공률 높음 — self-hosted runner 리소스 경합 감소)
   ```bash
   gh api repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs -X POST
   ```
-- **알려진 flaky 패턴** (대부분 인프라 기인, 코드 변경 없이 재실행으로 해결 — Unity 라이선스 결함은 예외, 아래 참조):
-  - **Unity 라이선스 충돌** — `Code 8 (또는 Code 10) while verifying Licensing Client signature` / `No ULF license found` / `Token not found in cache` / handshake / IPC 에러 (exit code 42). self-hosted runner는 현재 `unity-<version>` 라벨로 1:1 핀 고정되어 차단 중. 재발 시 라벨이 빠진 머신이 있는지 확인 (`docs/claude/github-actions.md`).
-    - ⚠️ **단, 라벨 핀된 단일 러너(예: `macos-1-1`=2021.3)의 라이선스가 실제로 깨진 경우는 transient가 아니다** — `rerun-failed-jobs`를 반복해도 인프라/사람이 라이선스를 고치기 전까지 매번 동일 시그니처로 실패한다. (2026-06 베타 deploy probe에서 attempt #1~#3이 모두 macos-1-1의 동일 라이선스 시그니처로 실패했고, **시간 경과가 아니라 수동 라이선스 수복 후에야** attempt #4가 통과했다 — 자연 복구 아님.) 동일 라이선스 시그니처가 **2회 연속**이면 transient로 보지 말고 러너 라이선스 수복 필요로 **에스컬레이션**(반복 rerun으로 시간 낭비 금지).
-  - **Windows artifact upload finalize transient** — `actions/upload-artifact@v7`가 `successfully finalized` 메시지 없이 종료 (~1.3% 빈도). 진단 step + `continue-on-error`가 적용되어 있고 재실행으로 해결됨
-  - **Unity WebGL Brotli/Gzip 크래시** — `[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`. self-hosted runner 동시 빌드 시 리소스 경합. **현재 E2E CI는 압축 비활성화(`AIT_COMPRESSION_FORMAT="0"`)** 로 압축 단계 자체를 건너뛰므로 신규 발생 없음 (E2E는 vite preview에서만 로드되며 배포되지 않아 압축 불필요). 로컬 재현은 아래 "로컬 CI 재현" 가이드 참조
-  - **E2E warm-reload `unityInstance` 120s 타임아웃** — `Tests~/E2E/tests/e2e-full-pipeline.test.js`의 test 3-1(`3-1. Page reload should not crash (cache warm)`)에서 `page.waitForFunction(() => window['unityInstance'] !== undefined, {timeout:120000})`(line ~795)가 120s 예산을 초과. reload 자체는 200 성공(line 793 통과) 후 **Unity WASM의 warm 재초기화가 CI 부하 편차로 예산 내 미완료** → `unityInstance` 미설정이 원인. E2E TEST 잡은 **격리된 GitHub-hosted `ubuntu-latest`** 에서 실행되어 self-hosted 경합과 무관. **비결정적**: 동일 코드가 실행마다 랜덤하게 다른 macOS leg에서 실패(2022.3↔2021.3 이동)하므로 특정 커밋/버전의 결정적 회귀가 아님 (2026-07 #929 검증 중 확인 — run 28743857273=2022.3 실패, run 28802654528=2021.3 실패, 89e353f/run 28802966012=5/5 통과). **처리**: E2E Tests는 non-required라 머지 차단 안 함 — 단일 leg 랜덤 실패면 transient로 보고 `rerun-failed-jobs`로 실패 leg만 재실행.
-    - ⚠️ **비인과적 red herring 주의**: 같은 3-1 창에 찍히는 vite `Pre-transform error: Failed to load /unity-bridge.ts`·`/src/main.ts`(404), `net::ERR_CONNECTION_CLOSED`, `wasm streaming compile failed`, 다수의 `AppsInToss 존재: false` 폴링, `createUnityInstance` 사이클은 **통과 leg에도 카운트가 동일**하므로 원인이 아니다. 로그 끝의 `vite preview ... SIGKILL (Forced termination)`은 타임아웃 후 Playwright teardown의 정리 동작(원인이 아니라 결과). 실제 차이는 `unityInstance set/ready` 마커뿐(통과 leg 9회 / 실패 leg 0회).
+- ⚠️ **동일 Unity 라이선스 시그니처가 2회 연속이면 transient가 아니다** — 라벨 핀된 단일 러너의 라이선스가 실제로 깨진 경우로, 수동 수복 전까지 매번 동일 시그니처로 실패한다. 반복 rerun으로 시간 낭비 금지, 러너 라이선스 수복 필요로 **에스컬레이션**
+- **E2E Tests는 non-required라 머지 차단 안 함** — 단일 leg 랜덤 실패면 transient로 보고 실패 leg만 재실행
 - **Sentry 노이즈 패턴 추가**는 자동화(`auto-resolve`)가 처리하므로 수동 PR 불필요 — `Editor/ErrorTracker/AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 자동 흡수됨
-- **Sentry 자동 resolve는 "머지 시점"이 아니라 "다음 릴리즈 시점"에 발생 (release-gated)** — auto-resolve PR body의 `Fixes APPS-IN-TOSS-UNITY-SDK-XX` 키워드는 squash 머지 커밋에 그대로 들어가지만, 이슈가 실제로 closed 되는 건 **다음 `apps-in-toss.unity@X.Y.Z` 릴리즈가 cut될 때**다. `release.yml`의 `sentry-release` job(`getsentry/action-release@v3`, `set_commits: auto`, PR #657)이 릴리즈에 커밋 범위를 연결하고, 그 커밋의 `Fixes` trailer가 참조한 이슈를 Sentry가 resolve한다. 따라서 **머지 직후에는 대상 이슈가 여전히 `unresolved`로 보이는 게 정상**이다 (버그 아님, 2026-06 PR #703에서 확인).
-  - **즉시 닫아야 할 때만 수동 resolve** (릴리즈를 기다리지 않거나, 아래 잔여 이벤트처럼 미래 릴리즈 커밋 범위에 안 잡히는 경우):
-    1. 상태 확인 — Sentry MCP `get_sentry_resource(resourceType='issue', organizationSlug='toss', resourceId='APPS-IN-TOSS-UNITY-SDK-XX')` 또는 `search_issues`
-    2. `unresolved`이면 직접 resolve — Sentry MCP `update_issue(organizationSlug='toss', issueId='APPS-IN-TOSS-UNITY-SDK-XX', status='resolved', reason='노이즈 패턴 PR #N 머지로 현행 SDK가 드롭 — 릴리즈 전 즉시 resolve')`
-  - **이미 현행 main에 커버된 잔여 이벤트**(구버전 SDK에서 유입, 코드/PR 변경 없음)는 미래 릴리즈 커밋 범위에 `Fixes`가 없어 자동 resolve되지 않으므로 **항상 수동 resolve**로 정리한다.
+- **Sentry 자동 resolve는 "머지 시점"이 아니라 "다음 릴리즈 시점"에 발생 (release-gated)** — 머지 직후 대상 이슈가 `unresolved`로 보이는 게 정상 (버그 아님). 즉시 닫아야 하는 경우와 잔여 이벤트(미래 릴리즈 커밋 범위 밖 — 항상 수동 resolve)의 Sentry MCP 절차는 `docs/claude/sentry-known-issues.md`의 "자동 resolve는 release-gated" 참조
 
 ### 테스트 관련
 - E2E 테스트 전 빌드 필요: `./run-local-tests.sh --all` (빌드+테스트) vs `--e2e` (테스트만)
@@ -151,32 +142,11 @@ SDK 생성기 작업을 포함하는 변경사항을 커밋/푸시하기 전, **
 
 ### 로컬 CI 재현 (압축 포맷 / 리소스 경합)
 
-E2E CI는 현재 압축이 **Disabled**(`AIT_COMPRESSION_FORMAT="0"`)이므로 신규 빌드에서 Brotli/Gzip 크래시는 발생하지 않음. 다만 이전 빌드 분석이나 압축별 동작 검증이 필요하면 `--compression`과 `--parallel`을 조합:
-
-```bash
-# E2E CI와 동일한 경로(압축 비활성화)
-./run-local-tests.sh --unity-build --compression disabled --unity-version 6000.2
-
-# Gzip / Brotli 강제 (압축 단계 flaky 재현용)
-./run-local-tests.sh --unity-build --compression gzip --unity-version 6000.2
-./run-local-tests.sh --unity-build --compression brotli --unity-version 6000.2
-
-# 동시 빌드로 리소스 경합 재현 (모든 버전 병렬)
-./run-local-tests.sh --unity-build --parallel --compression brotli
-```
-
-**압축 포맷 값**: `auto` | `disabled` | `gzip` | `brotli` (`run-local-tests.sh` 참조).
-**주의**: self-hosted runner의 리소스 경합 자체(CPU/메모리/디스크 경합)는 로컬 머신 스펙에 따라 재현이 보장되지 않음. 로컬에서 통과해도 CI flaky가 재현되지 않을 수 있으며, 이 경우 `rerun-failed-jobs` 경로를 사용 (위 "E2E 테스트 실패 대응" 참조).
+E2E CI는 현재 압축 비활성화(`AIT_COMPRESSION_FORMAT="0"`)로 실행되어 신규 빌드에서 Brotli/Gzip 크래시 없음. 압축별 동작 검증·병렬 리소스 경합 재현 명령(`--compression`/`--parallel` 조합)은 `docs/claude/testing.md`의 "로컬 CI 재현" 섹션 참조.
 
 ### Library/Bee 캐시 동작
 
-CI Unity 빌드의 `Library/Bee` 캐시 무효화 정책:
-- **SDK/asmdef/jslib 변경 있음** → `Library/Bee` 삭제 (full rebuild — stale ref.dll 차단)
-- **변경 없음** → 캐시 보존 (incremental rebuild로 빌드 시간 단축)
-- **fallback** (`git diff` 실패, 얕은 fetch 등) → 보수적으로 Bee 삭제
-- **escape hatch**: workflow_dispatch에서 `clean_library=true`로 강제 풀 클린 가능 (`docs/claude/github-actions.md` 참조)
-
-캐시가 의심되는 빌드 실패가 있으면 먼저 `clean_library=true`로 재트리거 후 재현 여부 확인.
+CI Unity 빌드는 SDK/asmdef/jslib 변경 시 `Library/Bee` 삭제(full rebuild — stale ref.dll 차단), 무변경 시 캐시 보존(incremental), 판별 실패 시 보수적으로 삭제한다. 캐시가 의심되는 빌드 실패는 먼저 workflow_dispatch `clean_library=true`로 재트리거해 재현 확인 (상세: `docs/claude/github-actions.md`의 "Library/Bee 캐시 무효화 정책").
 
 ## 빠른 참조: 주요 명령어
 

--- a/docs/claude/github-actions.md
+++ b/docs/claude/github-actions.md
@@ -193,3 +193,24 @@ gh api repos/toss/apps-in-toss-unity-sdk/actions/runs \
 2. **Preview 다중 타겟**: 여러 Unity 버전을 빌드할 때 쉼표로 구분하여 한 번에 트리거 (N번 호출 금지)
 3. **concurrency 그룹**: 같은 PR에 대해 동시 실행 시 이전 실행이 취소될 수 있음
 4. **GraphQL 차단**: `gh workflow run` 명령 사용 불가, REST API 사용 필수
+
+## E2E 알려진 flaky 패턴 (상세)
+
+대부분 인프라 기인으로, 코드 변경 없이 `rerun-failed-jobs` 재실행으로 해결 — Unity 라이선스 결함은 예외(아래 참조).
+
+- **Unity 라이선스 충돌** — `Code 8 (또는 Code 10) while verifying Licensing Client signature` / `No ULF license found` / `Token not found in cache` / handshake / IPC 에러 (exit code 42). self-hosted runner는 현재 `unity-<version>` 라벨로 1:1 핀 고정되어 차단 중. 재발 시 라벨이 빠진 머신이 있는지 확인 (위 "워크플로우 ID 참조" 및 runner 라우팅은 `docs/claude/testing.md` 참조).
+  - ⚠️ **단, 라벨 핀된 단일 러너(예: `macos-1-1`=2021.3)의 라이선스가 실제로 깨진 경우는 transient가 아니다** — `rerun-failed-jobs`를 반복해도 인프라/사람이 라이선스를 고치기 전까지 매번 동일 시그니처로 실패한다. (2026-06 베타 deploy probe에서 attempt #1~#3이 모두 macos-1-1의 동일 라이선스 시그니처로 실패했고, **시간 경과가 아니라 수동 라이선스 수복 후에야** attempt #4가 통과했다 — 자연 복구 아님.) 동일 라이선스 시그니처가 **2회 연속**이면 transient로 보지 말고 러너 라이선스 수복 필요로 **에스컬레이션**(반복 rerun으로 시간 낭비 금지).
+- **Windows artifact upload finalize transient** — `actions/upload-artifact@v7`가 `successfully finalized` 메시지 없이 종료 (~1.3% 빈도). 진단 step + `continue-on-error`가 적용되어 있고 재실행으로 해결됨
+- **Unity WebGL Brotli/Gzip 크래시** — `[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`. self-hosted runner 동시 빌드 시 리소스 경합. **현재 E2E CI는 압축 비활성화(`AIT_COMPRESSION_FORMAT="0"`)** 로 압축 단계 자체를 건너뛰므로 신규 발생 없음 (E2E는 vite preview에서만 로드되며 배포되지 않아 압축 불필요). 로컬 재현은 `docs/claude/testing.md`의 "로컬 CI 재현" 참조
+- **E2E warm-reload `unityInstance` 120s 타임아웃** — `Tests~/E2E/tests/e2e-full-pipeline.test.js`의 test 3-1(`3-1. Page reload should not crash (cache warm)`)에서 `page.waitForFunction(() => window['unityInstance'] !== undefined, {timeout:120000})`(line ~795)가 120s 예산을 초과. reload 자체는 200 성공(line 793 통과) 후 **Unity WASM의 warm 재초기화가 CI 부하 편차로 예산 내 미완료** → `unityInstance` 미설정이 원인. E2E TEST 잡은 **격리된 GitHub-hosted `ubuntu-latest`** 에서 실행되어 self-hosted 경합과 무관. **비결정적**: 동일 코드가 실행마다 랜덤하게 다른 macOS leg에서 실패(2022.3↔2021.3 이동)하므로 특정 커밋/버전의 결정적 회귀가 아님 (2026-07 #929 검증 중 확인 — run 28743857273=2022.3 실패, run 28802654528=2021.3 실패, 89e353f/run 28802966012=5/5 통과). **처리**: E2E Tests는 non-required라 머지 차단 안 함 — 단일 leg 랜덤 실패면 transient로 보고 `rerun-failed-jobs`로 실패 leg만 재실행.
+  - ⚠️ **비인과적 red herring 주의**: 같은 3-1 창에 찍히는 vite `Pre-transform error: Failed to load /unity-bridge.ts`·`/src/main.ts`(404), `net::ERR_CONNECTION_CLOSED`, `wasm streaming compile failed`, 다수의 `AppsInToss 존재: false` 폴링, `createUnityInstance` 사이클은 **통과 leg에도 카운트가 동일**하므로 원인이 아니다. 로그 끝의 `vite preview ... SIGKILL (Forced termination)`은 타임아웃 후 Playwright teardown의 정리 동작(원인이 아니라 결과). 실제 차이는 `unityInstance set/ready` 마커뿐(통과 leg 9회 / 실패 leg 0회).
+
+## Library/Bee 캐시 무효화 정책 (상세)
+
+CI Unity 빌드의 `Library/Bee` 캐시 무효화 정책:
+- **SDK/asmdef/jslib 변경 있음** → `Library/Bee` 삭제 (full rebuild — stale ref.dll 차단)
+- **변경 없음** → 캐시 보존 (incremental rebuild로 빌드 시간 단축)
+- **fallback** (`git diff` 실패, 얕은 fetch 등) → 보수적으로 Bee 삭제
+- **escape hatch**: workflow_dispatch에서 `clean_library=true`로 강제 풀 클린 가능 (위 "Library 캐시 정리 옵션" 참조)
+
+캐시가 의심되는 빌드 실패가 있으면 먼저 `clean_library=true`로 재트리거 후 재현 여부 확인.

--- a/docs/claude/sentry-known-issues.md
+++ b/docs/claude/sentry-known-issues.md
@@ -67,3 +67,18 @@ minVersion 비정상, 태그 자동 감지 실패 등). 이 컨벤션은 일괄 
 두 메커니즘은 독립적이라 한쪽이 실패해도 다른 쪽이 보완한다. strict 게이트가
 SDK 결함을 false negative로 드롭하면 §"무시해도 되는 이슈 패턴" 모니터링에서
 포착 → `IsAitRelated` 화이트리스트 또는 `SdkMessagePatterns` 키워드 추가로 복구.
+
+## 자동 resolve는 release-gated (머지 시점 아님)
+
+**Sentry 자동 resolve는 "머지 시점"이 아니라 "다음 릴리즈 시점"에 발생한다** — auto-resolve PR body의 `Fixes APPS-IN-TOSS-UNITY-SDK-XX` 키워드는 squash 머지 커밋에 그대로 들어가지만, 이슈가 실제로 closed 되는 건 **다음 `apps-in-toss.unity@X.Y.Z` 릴리즈가 cut될 때**다. `release.yml`의 `sentry-release` job(`getsentry/action-release@v3`, `set_commits: auto`, PR #657)이 릴리즈에 커밋 범위를 연결하고, 그 커밋의 `Fixes` trailer가 참조한 이슈를 Sentry가 resolve한다. 따라서 **머지 직후에는 대상 이슈가 여전히 `unresolved`로 보이는 게 정상**이다 (버그 아님, 2026-06 PR #703에서 확인).
+
+### 즉시 닫아야 할 때만 수동 resolve
+
+릴리즈를 기다리지 않거나, 아래 잔여 이벤트처럼 미래 릴리즈 커밋 범위에 안 잡히는 경우:
+
+1. 상태 확인 — Sentry MCP `get_sentry_resource(resourceType='issue', organizationSlug='toss', resourceId='APPS-IN-TOSS-UNITY-SDK-XX')` 또는 `search_issues`
+2. `unresolved`이면 직접 resolve — Sentry MCP `update_issue(organizationSlug='toss', issueId='APPS-IN-TOSS-UNITY-SDK-XX', status='resolved', reason='노이즈 패턴 PR #N 머지로 현행 SDK가 드롭 — 릴리즈 전 즉시 resolve')`
+
+### 잔여 이벤트는 항상 수동 resolve
+
+**이미 현행 main에 커버된 잔여 이벤트**(구버전 SDK에서 유입, 코드/PR 변경 없음)는 미래 릴리즈 커밋 범위에 `Fixes`가 없어 자동 resolve되지 않으므로 **항상 수동 resolve**로 정리한다.

--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -86,3 +86,22 @@ npm test
 - `2`: 전체 실행 (~14분, 기본값)
 
 `test_level=0/1`이면 `e2e-*` 잡은 skipped 처리되고 결과는 `build-*` 결과로 폴백.
+
+## 로컬 CI 재현 (압축 포맷 / 리소스 경합)
+
+E2E CI는 현재 압축이 **Disabled**(`AIT_COMPRESSION_FORMAT="0"`)이므로 신규 빌드에서 Brotli/Gzip 크래시는 발생하지 않음. 다만 이전 빌드 분석이나 압축별 동작 검증이 필요하면 `--compression`과 `--parallel`을 조합:
+
+```bash
+# E2E CI와 동일한 경로(압축 비활성화)
+./run-local-tests.sh --unity-build --compression disabled --unity-version 6000.2
+
+# Gzip / Brotli 강제 (압축 단계 flaky 재현용)
+./run-local-tests.sh --unity-build --compression gzip --unity-version 6000.2
+./run-local-tests.sh --unity-build --compression brotli --unity-version 6000.2
+
+# 동시 빌드로 리소스 경합 재현 (모든 버전 병렬)
+./run-local-tests.sh --unity-build --parallel --compression brotli
+```
+
+**압축 포맷 값**: `auto` | `disabled` | `gzip` | `brotli` (`run-local-tests.sh` 참조).
+**주의**: self-hosted runner의 리소스 경합 자체(CPU/메모리/디스크 경합)는 로컬 머신 스펙에 따라 재현이 보장되지 않음. 로컬에서 통과해도 CI flaky가 재현되지 않을 수 있으며, 이 경우 `rerun-failed-jobs` 경로를 사용 (`docs/claude/github-actions.md`의 "E2E 알려진 flaky 패턴" 참조).


### PR DESCRIPTION
## 요약
항상 로드되는 CLAUDE.md에서 인시던트 forensic 상세를 기존 `docs/claude/` 문서로 이전하고, CLAUDE.md에는 판단 규칙과 Read 포인터만 상주시킨다. CLAUDE.md 18,791자 → 13,789자 (세션당 약 1.25k est. 토큰 절감).

## 변경 내용
- **CLAUDE.md**: E2E flaky 시그니처 상세·red herring 목록, Sentry release-gated 메커니즘·수동 resolve 절차, 로컬 CI 재현 명령, Library/Bee 캐시 상세를 이동. 판단 규칙(인프라 판별 → `rerun-failed-jobs`, 동일 라이선스 시그니처 2회 연속 → 에스컬레이션, E2E non-required 처리, 머지 직후 unresolved 정상)은 상주 유지하고 각 위치에 Read 포인터 추가
- **docs/claude/github-actions.md**: "E2E 알려진 flaky 패턴 (상세)" / "Library/Bee 캐시 무효화 정책 (상세)" 섹션 추가
- **docs/claude/sentry-known-issues.md**: "자동 resolve는 release-gated (머지 시점 아님)" 섹션 추가 (수동 resolve MCP 절차 포함)
- **docs/claude/testing.md**: "로컬 CI 재현 (압축 포맷 / 리소스 경합)" 섹션 추가
- 신규 파일 없음 — 기존 문서에만 병합이라 `.meta` 변경 없음

## 검증
- 문서 전용 변경 (코드/생성물 무관)
- TODO.md 확인 완료 — 이번 변경으로 완료되는 항목 없음
