### PR TITLE
수정: web-framework 3.x 웹뷰 가드 메시지를 플랫폼 미지원으로 인식

### DIFF
--- a/Runtime/SDK/AITCore.cs
+++ b/Runtime/SDK/AITCore.cs
@@ -172,6 +172,12 @@ namespace AppsInToss
             if (string.IsNullOrEmpty(message)) return false;
             return message.Contains("__GRANITE_NATIVE_EMITTER") ||
                    message.Contains("ReactNativeWebView") ||
+                   // web-framework 3.x의 assertWebViewEnvironment 가드 메시지.
+                   // 가드 조건은 여전히 window.ReactNativeWebView 이지만 3.0.0-rc 부터
+                   // 메시지에서 그 단어가 빠지고 한국어 문장으로 바뀌었다
+                   // ("apps-in-toss 웹뷰 환경이 아니에요. 토스 앱 안에서만 호출할 수 있어요.").
+                   // 문장 뒷부분 변경에 견디도록 핵심 어구만 부분 매칭한다.
+                   message.Contains("웹뷰 환경이 아니") ||
                    message.Contains("is not a constant handler") ||
                    // WebGL JS 브리지 객체(window.AppsInToss)가 아직 초기화되지 않았을 때
                    // 발생하는 JS TypeError — 플랫폼 미지원과 동일하게 처리한다.

--- a/Tests~/E2E/SharedScripts/Runtime/RuntimeAPITester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/RuntimeAPITester.cs
@@ -44,7 +44,12 @@ public class RuntimeAPITester : MonoBehaviour
         // bridge-core 에러
         "is not a constant handler",                    // Constant API
         "__GRANITE_NATIVE_EMITTER is not available",    // Async API (emitter)
-        "ReactNativeWebView is not available",          // Native 통신
+        "ReactNativeWebView is not available",          // Native 통신 (~2.x)
+
+        // web-framework 3.x assertWebViewEnvironment 가드
+        // ("apps-in-toss 웹뷰 환경이 아니에요. 토스 앱 안에서만 호출할 수 있어요.")
+        // 가드 조건은 2.x와 동일하게 window.ReactNativeWebView 이지만 메시지만 바뀌었다.
+        "웹뷰 환경이 아니",
 
         // 플랫폼 미지원 에러
         "Platform not available",

--- a/sdk-runtime-generator~/src/templates/csharp-core.hbs
+++ b/sdk-runtime-generator~/src/templates/csharp-core.hbs
@@ -172,6 +172,12 @@ namespace AppsInToss
             if (string.IsNullOrEmpty(message)) return false;
             return message.Contains("__GRANITE_NATIVE_EMITTER") ||
                    message.Contains("ReactNativeWebView") ||
+                   // web-framework 3.x의 assertWebViewEnvironment 가드 메시지.
+                   // 가드 조건은 여전히 window.ReactNativeWebView 이지만 3.0.0-rc 부터
+                   // 메시지에서 그 단어가 빠지고 한국어 문장으로 바뀌었다
+                   // ("apps-in-toss 웹뷰 환경이 아니에요. 토스 앱 안에서만 호출할 수 있어요.").
+                   // 문장 뒷부분 변경에 견디도록 핵심 어구만 부분 매칭한다.
+                   message.Contains("웹뷰 환경이 아니") ||
                    message.Contains("is not a constant handler") ||
                    // WebGL JS 브리지 객체(window.AppsInToss)가 아직 초기화되지 않았을 때
                    // 발생하는 JS TypeError — 플랫폼 미지원과 동일하게 처리한다.

--- a/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
+++ b/sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden
@@ -172,6 +172,12 @@ namespace AppsInToss
             if (string.IsNullOrEmpty(message)) return false;
             return message.Contains("__GRANITE_NATIVE_EMITTER") ||
                    message.Contains("ReactNativeWebView") ||
+                   // web-framework 3.x의 assertWebViewEnvironment 가드 메시지.
+                   // 가드 조건은 여전히 window.ReactNativeWebView 이지만 3.0.0-rc 부터
+                   // 메시지에서 그 단어가 빠지고 한국어 문장으로 바뀌었다
+                   // ("apps-in-toss 웹뷰 환경이 아니에요. 토스 앱 안에서만 호출할 수 있어요.").
+                   // 문장 뒷부분 변경에 견디도록 핵심 어구만 부분 매칭한다.
+                   message.Contains("웹뷰 환경이 아니") ||
                    message.Contains("is not a constant handler") ||
                    // WebGL JS 브리지 객체(window.AppsInToss)가 아직 초기화되지 않았을 때
                    // 발생하는 JS TypeError — 플랫폼 미지원과 동일하게 처리한다.


### PR DESCRIPTION
## 배경

`@apps-in-toss/web-framework` 3.0.0-rc 부터 `assertWebViewEnvironment` 가드의 에러 메시지가 바뀌었다.

```js
// 3.0.0-rc.4 / dist/index.js
function assertWebViewEnvironment() {
  if (typeof window === "undefined" || window.ReactNativeWebView == null)
    throw new Error("apps-in-toss 웹뷰 환경이 아니에요. 토스 앱 안에서만 호출할 수 있어요.");
}
```

가드 **조건**은 2.x와 동일하게 `window.ReactNativeWebView` 이지만, 메시지에서 `ReactNativeWebView` 라는 단어가 빠지고 한국어 문장으로 바뀌었다. 에러 코드나 전용 에러 클래스는 없고 평범한 `Error` 라서 문자열 매칭 외에 판별 수단이 없다.

## 문제

`AITCore.CheckPlatformUnavailable` 이 이 메시지를 인식하지 못해 `AITException.IsPlatformUnavailable` 이 `false` 가 된다. 그 결과:

- 브라우저(비-토스 환경)에서 네이티브 게이팅된 API 호출이 "플랫폼 미지원"이 아니라 일반 예외로 분류된다.
- `AITSentryContextEnricher` 의 플랫폼 미지원 억제 로직이 동작하지 않아, 3.x 채택 시 Sentry로 정상 동작(=토스 앱 밖에서의 호출)이 에러로 쏟아진다.

영향 API 20개: `GetNetworkStatus`, `AppLogin`, `GetClipboardText`, `SetClipboardText`, `CloseView`, `OpenURL`, `Share`, `FetchContacts`, `EventLog`, `GetPermission`, `RequestPermission`, `OpenPermissionDialog`, `GetCurrentLocation`, `GenerateHapticFeedback`, `SetIosSwipeGestureEnabled`, `SetScreenAwakeMode`, `SetSecureScreen`, `CheckoutPayment`, `FetchAlbumPhotos`, `OpenCamera`

## 변경

- `sdk-runtime-generator~/src/templates/csharp-core.hbs` — 가드 메시지 패턴 `"웹뷰 환경이 아니"` 추가. 문장 뒷부분이 또 바뀌어도 견디도록 핵심 어구만 부분 매칭한다. 기존 2.x 패턴(`ReactNativeWebView is not available`)은 그대로 두어 두 버전을 모두 지원한다.
- `Runtime/SDK/AITCore.cs` — `pnpm generate` 재생성 산출물 (직접 수정 아님).
- `sdk-runtime-generator~/tests/fixtures/golden/AITCore.cs.golden` — 골든 파일 동기화.
- `Tests~/E2E/SharedScripts/Runtime/RuntimeAPITester.cs` — `EXPECTED_ERROR_PATTERNS` 에 동일 패턴 추가.

## 검증

- 로컬: `./run-local-tests.sh --validate` → 4/4 suite, 57/57 test 통과.
- CI: 이 브랜치를 `source_ref` 로 Beta Release 를 돌려 실증했다.
  - 수정 전 → 베타 E2E (macOS) **0/5** 실패
  - 수정 후 → 빌드 10/10 + E2E 10/10 (macOS·Windows × Unity 2021.3/2022.3/6000.0/6000.2/6000.3) 전부 통과, `베타 ait deploy 검증(게시 게이트)` 통과
  - 해당 실행으로 beta 채널이 `3.0.0-rc.4` 로 갱신되고 `release/v3.0.0-rc.4` 스냅샷 태그·prerelease 가 생성됐다.
