### PR TITLE
빌드: superpowers 플러그인 로컬 문서를 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,10 @@ Desktop.ini
 # Claude Code (로컬 설정은 커밋 제외)
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+# superpowers 플러그인이 로컬에 쌓는 기획/설계 메모.
+# 문서 루트는 Documentation~ 단일 루트이므로(#1015) 커밋 대상이 아니다.
+docs/superpowers/
+docs/superpowers.meta
 
 # Node modules
 node_modules/


### PR DESCRIPTION
## 문제

`git status` 에 `?? docs/` 가 계속 남아 있었다.

`#1015` 에서 문서 루트를 `Documentation~` 로 단일화하면서 `docs/` 와 `Docs~/` 를 저장소에서 제거했는데, 그 삭제 이후 로컬에는 추적되지 않는 `docs/superpowers/` 만 남았다. 이건 Claude Code `superpowers` 플러그인이 로컬에 쌓는 기획·설계 메모(plans 7개 + specs 7개, 4월 작성)로, 저장소 내용물이 아니다. Unity 가 스캔하면서 `.meta` 까지 붙여놨다.

## 변경

`.gitignore` 의 기존 "Claude Code (로컬 설정은 커밋 제외)" 섹션에 두 줄 추가.

```
docs/superpowers/
docs/superpowers.meta
```

파일은 로컬에 그대로 두고 추적에서만 제외한다. 삭제하지 않은 이유는 실제 기획 기록이라 없애면 복구가 안 되기 때문이다.

`docs/` 를 통째로 무시하지 않은 것은 의도적이다. 나중에 `docs/` 를 다시 쓰기로 하면 조용히 가려지므로 플러그인 경로만 정확히 지정했다.

## 검증

`git status --short` 출력이 비어 있는 것을 확인했다. `.gitignore` 외 변경 파일 없음.
