### PR TITLE
수정: INVALID_APP_CONFIG 안내 문구 정정 + E2E flaky 시그니처 문서 정정

### DIFF
--- a/Documentation~/internal/github-actions.md
+++ b/Documentation~/internal/github-actions.md
@@ -226,7 +226,19 @@ gh api repos/toss/apps-in-toss-unity-sdk/actions/runs/RUN_ID/rerun-failed-jobs -
   - 단, 라벨 핀된 단일 러너(예: `macos-1-1`=2021.3)의 라이선스가 실제로 깨진 경우는 transient가 아닙니다. `rerun-failed-jobs`를 반복해도 인프라나 사람이 라이선스를 고치기 전까지 매번 동일 시그니처로 실패합니다. 2026-06 베타 deploy probe에서 attempt #1~#3이 모두 macos-1-1의 동일 라이선스 시그니처로 실패했고, 시간 경과가 아니라 수동 라이선스 수복 후에야 attempt #4가 통과했습니다(자연 복구 아님). 동일 라이선스 시그니처가 **2회 연속**이면 transient로 보지 말고 러너 라이선스 수복 필요로 에스컬레이션하세요(반복 rerun으로 시간 낭비 금지).
 - **Windows artifact upload finalize transient** — `actions/upload-artifact@v7`가 `successfully finalized` 메시지 없이 종료합니다(~1.3% 빈도). 진단 step과 `continue-on-error`가 적용되어 있고 재실행으로 해결됩니다.
 - **Unity WebGL Brotli/Gzip 크래시** — `[BUSY Ns] Brotli webgl/Build/...unityweb` 직후 `exit code: 1`. self-hosted 러너 동시 빌드 시 리소스 경합입니다. 현재 E2E CI는 압축 비활성화(`AIT_COMPRESSION_FORMAT="0"`)로 압축 단계 자체를 건너뛰므로 신규 발생이 없습니다(E2E는 vite preview에서만 로드되며 배포되지 않아 압축 불필요). 로컬 재현은 [테스트 전략](testing.md)의 "로컬 CI 재현"을 참조하세요.
-- **E2E warm-reload `unityInstance` 타임아웃** — `Tests~/E2E/tests/e2e-full-pipeline.test.js`의 test 3-1(`3-1. Page reload should not crash (cache warm)`)에서 `page.waitForFunction(() => window['unityInstance'] !== undefined, {timeout:120000})`(line ~795)가 120s 예산을 초과합니다. reload 자체는 200 성공(line 793 통과) 후 Unity WASM의 warm 재초기화가 CI 부하 편차로 예산 내 미완료 → `unityInstance` 미설정이 원인입니다. E2E TEST 잡은 격리된 GitHub-hosted `ubuntu-latest`에서 실행되어 self-hosted 경합과 무관합니다. **비결정적**입니다 — 동일 코드가 실행마다 랜덤하게 다른 macOS leg에서 실패(2022.3↔2021.3 이동)하므로 특정 커밋이나 버전의 결정적 회귀가 아닙니다(2026-07 #929 검증 중 확인 — run 28743857273=2022.3 실패, run 28802654528=2021.3 실패, 89e353f/run 28802966012=5/5 통과). **처리**: E2E Tests는 non-required라 머지를 차단하지 않습니다. 단일 leg 랜덤 실패면 transient로 보고 `rerun-failed-jobs`로 실패 leg만 재실행합니다.
+- **E2E warm-reload `unityInstance` 타임아웃** — `Tests~/E2E/tests/e2e-full-pipeline.test.js`의 test 3-1(`3-1. Page reload should not crash (cache warm)`)에서 리로드 후 `window['unityInstance']`가 예산 내 설정되지 않습니다. 대기 로직은 `waitForUnityBounded`(정의 L926, 호출 L980)이며 **75초 예산을 최대 3회 재시도**합니다(`maxAttempts = 3`, L871). 예산을 넘기면 L993이 다음 문자열을 던지므로, 로그 검색은 이 문자열로 하세요.
+
+  ```text
+  [3-1] attempt 1/3 reload status=200 after 180ms
+  [3-1] attempt 1/3 FAILED after 75666ms: unityInstance not set within 75s budget (evalThrows=2)
+  [3-1] harness connection-drop classified (server dropped webgl.data stream) — retrying reload
+  ```
+
+  reload 자체는 매 시도 200으로 성공합니다. 재시도 사유가 `harness connection-drop classified`(L1011)로 찍히면 원인은 warm 재초기화 지연이 아니라 **서버가 `webgl.data` 스트림 연결을 끊은 것**입니다(판정은 `hadHarnessDrop()`, L903). 진짜 크래시 시그니처(`CRASH_RE`, L869 — `webglcontextlost`/`Aborted(`/`RuntimeError`/`out of bounds`/`memory access`)는 재시도 없이 즉시 hard-fail하므로(L998), 재시도 로그가 보인다면 크래시가 아닙니다. E2E TEST 잡은 격리된 GitHub-hosted `ubuntu-latest`에서 실행되어 self-hosted 경합과 무관합니다.
+
+  **비결정적**입니다 — 실행마다 다른 macOS leg 조합이 걸립니다(run 30412296776=6000.2+6000.3, run 30606499460=6000.3+6000.0). **1개가 아니라 2개 leg이 동시에 걸리는 경우가 있으니 "단일 leg만 flaky"로 가정하지 마세요.** **처리**: E2E Tests는 non-required라 머지를 차단하지 않습니다. `rerun-failed-jobs`로 실패 leg만 재실행하면 통과합니다(run 30606499460은 코드 변경 없이 attempt 2에서 E2E 10개 leg 전부 통과).
+  - 버전 bump를 범인으로 지목하기 전에 **대조군부터** 확인하세요. 2026-07 `@playwright/test` 1.61.1 → 1.62.0 직후 이 실패가 났을 때, bump **이전** run 30412296776(로그에 `+ @playwright/test 1.61.1`)에 동일 시그니처(75s×3 예산, connection-drop 분류)가 이미 존재해 회귀 가설이 기각됐습니다. 실패 코드 경로는 playwright API가 아니라 테스트 하네스 자체 워치독이므로, playwright 회귀라면 나올 시그니처(strict mode violation, `Executable doesn't exist`, `browserType.launch` 실패)를 먼저 grep해 0건임을 확인하는 것이 빠릅니다.
+  - 근본 원인 미규명 — `webgl.data` 스트림이 왜 끊기는지는 확인되지 않았습니다. 동일 시그니처가 2개 이상 leg에서 **반복** 재현되면 transient로 넘기지 말고 별건 조사로 승격하세요.
   - 비인과적 red herring 주의 — 같은 3-1 창에 찍히는 vite `Pre-transform error: Failed to load /unity-bridge.ts`·`/src/main.ts`(404), `net::ERR_CONNECTION_CLOSED`, `wasm streaming compile failed`, 다수의 `AppsInToss 존재: false` 폴링, `createUnityInstance` 사이클은 통과 leg에도 카운트가 동일하므로 원인이 아닙니다. 로그 끝의 `vite preview ... SIGKILL (Forced termination)`은 타임아웃 후 Playwright teardown의 정리 동작입니다(원인이 아니라 결과). 실제 차이는 `unityInstance set/ready` 마커뿐입니다(통과 leg 9회 / 실패 leg 0회).
 
 ## Library/Bee 캐시 무효화 정책

--- a/Editor/AITExportErrorCatalog.cs
+++ b/Editor/AITExportErrorCatalog.cs
@@ -36,11 +36,11 @@ namespace AppsInToss.Editor
                            "4. File > Build Settings > WebGL에서 직접 빌드 시도";
 
                 case AITExportError.INVALID_APP_CONFIG:
-                    return "앱 설정이 올바르지 않습니다.\n\n" +
+                    return "Apps in Toss 설정을 불러오지 못했습니다.\n\n" +
                            "해결 방법:\n" +
-                           "1. Apps in Toss > Build & Deploy Window 열기\n" +
-                           "2. 설정 섹션에서 아이콘 URL 입력 (필수)\n" +
-                           "3. 앱 ID, 버전 등 기본 정보 확인";
+                           "1. AIT > Configuration 메뉴로 설정 창을 열어 값이 정상 표시되는지 확인\n" +
+                           "2. Assets/AppsInToss/Editor/AITConfig.asset 이 존재하고 읽기 전용이 아닌지 확인\n" +
+                           "3. 프로젝트 폴더 쓰기 권한 확인 후 Unity 재시작";
 
                 case AITExportError.NETWORK_ERROR:
                     return "네트워크 오류가 발생했습니다.\n\n" +
@@ -148,7 +148,7 @@ namespace AppsInToss.Editor
                     return "Unity WebGL 빌드 중 오류가 발생했습니다.\n" +
                            "Console 창에서 컴파일 오류나 스택 트레이스를 확인해주세요.";
                 case AITExportError.INVALID_APP_CONFIG:
-                    return "앱 설정이 올바르지 않거나 필수 필드(App ID, 아이콘 URL 등)가 누락되었습니다.\n" +
+                    return "Apps in Toss 설정 애셋(Assets/AppsInToss/Editor/AITConfig.asset)을 불러오거나 생성하지 못했습니다.\n" +
                            "AIT > Configuration 창에서 설정을 확인해주세요.";
                 case AITExportError.NETWORK_ERROR:
                     return "빌드 과정에서 네트워크 요청에 실패했습니다.\n" +

--- a/TODO.md
+++ b/TODO.md
@@ -10,11 +10,7 @@
 
 ## 코드 결함
 
-- **P2 — `AITExportErrorCatalog`의 `INVALID_APP_CONFIG` 안내가 사실과 다름**: 두 곳 모두 존재하지 않는 메뉴와 잘못된 필수 조건을 안내한다. 사용자가 그대로 따라가면 막힌다.
-  - `Editor/AITExportErrorCatalog.cs:41` — "Apps in Toss > Build & Deploy Window 열기". 그런 `[MenuItem]`은 없고 실제 메뉴는 `AIT > Configuration`이다.
-  - `Editor/AITExportErrorCatalog.cs:42` — "아이콘 URL 입력 (필수)". 아이콘 URL은 선택 항목이다. `Editor/AITConfigurationWindow.cs:134` 주석이 "선택 사항"이라고 명시하고, 입력한 경우에만 `http://`/`https://` 형식을 검사한다.
-  - `Editor/AITExportErrorCatalog.cs:150` — "필수 필드(App ID, 아이콘 URL 등)". 같은 오류 반복.
-  - 실제 필수 항목은 앱 ID 하나. 공개 문서(`Documentation~/Troubleshooting.md`)는 이미 정정했으므로 콘솔 문구만 맞추면 된다.
+- **P3 — `AITEditorScriptObject.IsReadyForDeploy()`가 죽은 코드**: `Editor/AITEditorScriptObject.cs:273`. `IsIconUrlValid`/`IsAppNameValid`/`IsVersionValid` 셋을 묶지만 어디서도 호출되지 않는다(`Editor/AITCredentials.cs:82`의 동명 static은 별개 메서드이고 이쪽도 호출처가 없다). Configuration 창은 `IsAppNameValid()`를 직접 호출해 빌드 버튼을 게이팅하므로(`Editor/AITConfigurationWindow.cs:1139`) 기능 공백은 없다. 제거하거나, 빌드 진입 경로의 실제 게이트로 승격할지 결정 필요.
 
 - **P3 — 생성기가 파라미터 이름을 `args_0`/`args_1`로 내보냄**: `Runtime/SDK/AIT.Storage.cs:34` 등. 상위 `.d.ts`의 `@param` 이름을 살리지 못해 XML 주석과 IntelliSense가 무의미해진다. `sdk-runtime-generator~/src/parser/`에서 파라미터 이름을 보존하도록 수정 필요. 문서 이슈가 아니라 생성기 이슈.
 


### PR DESCRIPTION
## 요약

`AITExportErrorCatalog`의 `INVALID_APP_CONFIG` 안내가 사실과 달라 정정한다. 함께 발견한 런북 문서의 stale 시그니처도 코드 기준으로 맞춘다.

## 1. `INVALID_APP_CONFIG` 안내 정정 (TODO.md P2)

기존 문구는 세 곳이 틀렸고, 사용자가 그대로 따라가면 막힌다.

| 기존 | 실제 |
|---|---|
| `Apps in Toss > Build & Deploy Window 열기` | 그런 `[MenuItem]`은 없다. Configuration 창을 여는 메뉴는 `AIT/Configuration` 하나 (`Editor/AppsInTossMenu.cs:411`) |
| `아이콘 URL 입력 (필수)` | 선택 항목이다. `Editor/AITConfigurationWindow.cs:134` 주석이 "선택 사항"이라 명시하고, 값이 있을 때만 `http://`/`https://` 형식을 검사한다 |
| `필수 필드(App ID, 아이콘 URL 등)가 누락` | 이 오류의 조건 자체가 아니다 (아래) |

**TODO.md 항목의 전제도 일부 틀렸다.** TODO는 "실제 필수 항목은 앱 ID 하나이니 콘솔 문구만 맞추면 된다"고 적혀 있었으나, 코드상 `INVALID_APP_CONFIG`는 필드 검증과 무관하다:

- 반환 지점은 `Editor/AITConvertCore.cs:318`, `:453` 두 곳뿐이고, 조건은 `PrepareExport(...) == null`이다.
- `PrepareExport`(`:223`)는 `UnityUtil.GetEditorConf()`를 그대로 반환한다.
- `GetEditorConf()`(`Editor/AITFileUtils.cs:33`)는 `AITConfig.asset`이 없으면 **새로 생성해서** 반환한다.

즉 이 오류는 "필드 누락"이 아니라 **설정 애셋 로드/생성 실패**일 때만 난다. 문구를 그 사실에 맞추고, 조치 절차도 실재하는 메뉴와 애셋 경로로 바꿨다.

## 2. E2E flaky 시그니처 문서 정정

`Documentation~/internal/github-actions.md`의 warm-reload 항목이 실제 테스트 코드와 어긋나 있어, 문서의 시그니처로 grep하면 실제 로그와 매칭되지 않았다.

| 문서 기재 | 실제 (`Tests~/E2E/tests/e2e-full-pipeline.test.js`) |
|---|---|
| `waitForFunction(..., {timeout:120000})` 120초 단일 대기, line ~795 | `waitForUnityBounded(75000)` — 75초 예산 × 최대 3회 재시도 (L871/926/980) |
| (없음) | 실패 문자열 `unityInstance not set within 75s budget (evalThrows=N)` (L993) |
| (없음) | 재시도 분류 `harness connection-drop classified (server dropped webgl.data stream)` (L1011), 판정은 `hadHarnessDrop()` (L903) |
| (없음) | 진짜 크래시(`CRASH_RE`, L869)는 재시도 없이 즉시 hard-fail (L998) |
| "**단일** leg 랜덤 이동" | 2개 leg이 동시에 걸리는 경우가 있다 (run 30412296776=6000.2+6000.3, run 30606499460=6000.3+6000.0) |

추가로 두 가지를 명시했다.

- **버전 bump를 범인으로 지목하기 전 대조군을 보라** — playwright 1.61.1 → 1.62.0 직후 이 실패가 났을 때, bump 이전 run 30412296776 로그(`+ @playwright/test 1.61.1`)에 동일 시그니처가 이미 존재해 회귀 가설이 기각됐다.
- **근본 원인 미규명** — `webgl.data` 스트림이 왜 끊기는지는 확인되지 않았다. 2개 이상 leg에서 반복 재현되면 transient로 넘기지 말고 별건으로 승격할 것.

## 3. TODO.md

- 위 P2 항목 제거 (이 PR로 해결).
- 조사 중 발견한 죽은 코드를 P3로 등록 — `AITEditorScriptObject.IsReadyForDeploy()`(`:273`)는 검증 셋을 묶지만 어디서도 호출되지 않는다. Configuration 창은 `IsAppNameValid()`를 직접 호출해 빌드 버튼을 게이팅하므로(`:1139`) 기능 공백은 없다.

## 검증

- `./run-local-tests.sh --validate` — E2E 파일 구조 / Playwright 설정 / Meta GUID 위생 통과.
- ⚠️ **SDK Generator 유닛 테스트는 로컬에서 완주하지 못했다.** 로컬 개발 환경의 npm 프록시가 `baseline-browser-mapping@2.11.6`(#1033이 오늘 들여온 신규 전이 의존)을 아직 서빙하지 못해 `pnpm install`이 404로 실패한다. npmjs 원본은 정상 응답하고, main(af60c019)의 `validate` 워크플로도 success이므로 lockfile 결함이 아니라 로컬 환경 제약이다. 이 PR의 변경은 생성기 입력·`Runtime/SDK`·jslib를 건드리지 않으므로 해당 테스트 표면과 무관하며, CI가 검증한다.
- C# 변경은 문자열 리터럴 교체만이라 제어 흐름 변화가 없다.