### PR TITLE
수정: SDK Update 워크플로우의 자매 패키지 lockstep 가정 제거

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -235,18 +235,45 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: 동반 패키지 버전 결정
+        if: steps.check.outputs.skip != 'true'
+        id: family
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # 3.0부터 web-framework와 자매 패키지(web-analytics/bridge-core)는 lockstep으로
+          # publish되지 않는다(web-framework@3.0.1은 자매 패키지 의존 선언 자체가 제거됨).
+          # 요청 버전이 해당 패키지에 실제로 존재하면 그대로 쓰고(lockstep 복원 시 자동 동기화),
+          # 없으면 그 패키지의 latest를 쓴다 — release/v3.0.0-rc.4가 검증한 조합과 같은 방식.
+          resolve() {
+            local PKG="$1"
+            if npm view "${PKG}" versions --json --registry https://registry.npmjs.org \
+              | jq -e --arg v "$VERSION" '[.] | flatten | index($v) != null' > /dev/null; then
+              echo "${VERSION}"
+            else
+              npm view "${PKG}" dist-tags.latest --registry https://registry.npmjs.org
+            fi
+          }
+
+          ANALYTICS_VERSION=$(resolve "@apps-in-toss/web-analytics")
+          BRIDGE_CORE_VERSION=$(resolve "@apps-in-toss/bridge-core")
+          echo "web-analytics: ${ANALYTICS_VERSION} / bridge-core: ${BRIDGE_CORE_VERSION}"
+          echo "analytics_version=${ANALYTICS_VERSION}" >> $GITHUB_OUTPUT
+          echo "bridge_core_version=${BRIDGE_CORE_VERSION}" >> $GITHUB_OUTPUT
+
       - name: web-framework 버전 업데이트 및 SDK 재생성
         if: steps.check.outputs.skip != 'true'
         id: generate
         working-directory: sdk-runtime-generator~
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          ANALYTICS_VERSION="${{ steps.family.outputs.analytics_version }}"
 
-          echo "=== web-framework, web-analytics v${VERSION} 업데이트 ==="
+          echo "=== web-framework v${VERSION}, web-analytics v${ANALYTICS_VERSION} 업데이트 ==="
 
           # 캐시 정리 후 강제 업데이트 (캐시로 인한 오래된 버전 문제 방지)
           pnpm store prune
-          pnpm update "@apps-in-toss/web-framework@${VERSION}" "@apps-in-toss/web-analytics@${VERSION}" --force --registry https://registry.npmjs.org
+          pnpm update "@apps-in-toss/web-framework@${VERSION}" "@apps-in-toss/web-analytics@${ANALYTICS_VERSION}" --force --registry https://registry.npmjs.org
 
           # 설치된 버전 검증
           INSTALLED_VERSION=$(pnpm list @apps-in-toss/web-framework --json | jq -r '.[0].dependencies["@apps-in-toss/web-framework"].version')
@@ -301,20 +328,22 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          ANALYTICS_VERSION="${{ steps.family.outputs.analytics_version }}"
+          BRIDGE_CORE_VERSION="${{ steps.family.outputs.bridge_core_version }}"
           BUILDCONFIG_PKG="WebGLTemplates/AITTemplate/BuildConfig~/package.json"
 
           # BuildConfig의 @apps-in-toss 패밀리 버전 동기화
-          # web-framework/web-analytics/bridge-core는 lockstep으로 publish되므로 동일 VERSION으로 정렬한다.
+          # 자매 패키지 버전은 "동반 패키지 버전 결정" 단계가 패키지별로 해석한다 (3.0부터 lockstep publish 아님).
           # bridge-core는 직접 의존성으로 존재할 때만 갱신 — 향후 직접 핀이 제거되어도 phantom 키를 다시 만들지 않도록 조건부 처리.
-          jq --arg v "$VERSION" '
-            .dependencies["@apps-in-toss/web-framework"] = $v |
-            .dependencies["@apps-in-toss/web-analytics"] = $v |
+          jq --arg fw "$VERSION" --arg wa "$ANALYTICS_VERSION" --arg bc "$BRIDGE_CORE_VERSION" '
+            .dependencies["@apps-in-toss/web-framework"] = $fw |
+            .dependencies["@apps-in-toss/web-analytics"] = $wa |
             (if .dependencies["@apps-in-toss/bridge-core"]
-             then .dependencies["@apps-in-toss/bridge-core"] = $v
+             then .dependencies["@apps-in-toss/bridge-core"] = $bc
              else . end)
           ' "$BUILDCONFIG_PKG" > tmp.json
           mv tmp.json "$BUILDCONFIG_PKG"
-          echo "BuildConfig web-framework/web-analytics/bridge-core 버전: ${VERSION}"
+          echo "BuildConfig 버전 — web-framework: ${VERSION}, web-analytics: ${ANALYTICS_VERSION}, bridge-core: ${BRIDGE_CORE_VERSION}"
 
           # 확인
           cat "$BUILDCONFIG_PKG" | jq '.dependencies'


### PR DESCRIPTION
## 배경

업스트림 `@apps-in-toss/web-framework@3.0.1`이 stable로 배포되면서(`latest` 태그 이동), 3.0부터 자매 패키지(`web-analytics`, `bridge-core`)는 더 이상 lockstep으로 publish되지 않습니다. 3.0.1의 `dependencies`에서 자매 패키지 의존 선언 자체가 제거됐고, 두 패키지의 `latest`는 여전히 `2.10.8`입니다.

이로 인해 SDK Update 워크플로우를 `version: 3.0.1`로 dispatch한 실행이 `sdk-runtime-generator~`에서 `pnpm update "@apps-in-toss/web-analytics@3.0.1"`을 시도하다 `ERR_PNPM_NO_MATCHING_VERSION`으로 실패했습니다.

실패 run: https://github.com/toss/apps-in-toss-unity-sdk/actions/runs/30782318878

## 수정 내용 (`.github/workflows/update.yml`)

1. **"동반 패키지 버전 결정" 단계 신설** (`id: family`) — 요청 버전이 해당 패키지(`web-analytics`, `bridge-core`)에 실제 존재하면 그대로 쓰고(향후 lockstep이 복원되면 자동으로 동기화됨), 없으면 그 패키지의 `dist-tags.latest`로 해석합니다. `release/v3.0.0-rc.4`가 이미 검증한 조합(framework 3.x + 자매 패키지 2.10.8)과 동일한 방식입니다.
2. **생성기 업데이트 단계**: `web-analytics`를 고정 `${VERSION}` 대신 위 단계에서 해석된 버전으로 설치하도록 변경.
3. **BuildConfig 동기화 단계**: `web-analytics`/`bridge-core`를 각각 해석된 버전으로 핀. "lockstep으로 publish되므로" 라는 낡은 주석도 현재 상황에 맞게 갱신.

## 검증

- 해석 로직을 로컬에서 실제 npm 레지스트리로 검증: `VERSION=3.0.1` → analytics/bridge-core `2.10.8` 폴백, `VERSION=2.10.8`(향후 lockstep 복원 케이스) → `2.10.8` 그대로 유지.
- `actionlint`로 확인 — 기존 파일 전반과 동일한 info 수준 shellcheck 스타일 지적만 있고 신규 오류 없음.