### PR TITLE
빌드: 배포 워크플로에 건너뛴 버전 재배포 차단 가드 추가

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -146,6 +146,17 @@ jobs:
             exit 1
           fi
 
+          # --- 배포 제외 버전(denylist) 검사 — 건너뛴 버전의 실수 재배포 방지 ---
+          # dist-tag 입력도 위에서 이미 구체 버전으로 해석된 뒤이므로, dist-tag가
+          # 금지 버전을 가리키는 경우도 함께 걸러진다.
+          DENIED_VERSIONS=$(jq -r '(.deniedVersions // [])[]' sdk-policy.json)
+          for DENIED in $DENIED_VERSIONS; do
+            if [ "$NPM_VERSION" = "$DENIED" ] || [[ "$NPM_VERSION" == "$DENIED"-* ]]; then
+              echo "::error::배포가 제외된 버전입니다: ${NPM_VERSION} (거부 목록: ${DENIED})"
+              exit 1
+            fi
+          done
+
           # --- 채널 ref 가드 (stable 브랜치 금지) ---
           if [ -z "$CHANNEL_REF" ]; then
             echo "::error::channel_ref가 비어 있습니다."

--- a/.github/workflows/bulk-release.yml
+++ b/.github/workflows/bulk-release.yml
@@ -107,6 +107,21 @@ jobs:
           done
           VERSIONS=$(echo "$VERSIONS" | sed '/^$/d')
 
+          # 배포 제외 버전(denylist) 검사 — 건너뛴 버전의 실수 재배포 방지
+          DENIED_VERSIONS=$(jq -r '(.deniedVersions // [])[]' sdk-policy.json)
+          DENIED_HITS=""
+          for V in $VERSIONS; do
+            for DENIED in $DENIED_VERSIONS; do
+              if [ "$V" = "$DENIED" ] || [[ "$V" == "$DENIED"-* ]]; then
+                DENIED_HITS="${DENIED_HITS}${V}(거부 목록: ${DENIED}) "
+              fi
+            done
+          done
+          if [ -n "$DENIED_HITS" ]; then
+            echo "::error::배포가 제외된 버전이 포함되어 있습니다: ${DENIED_HITS}"
+            exit 1
+          fi
+
           # npm 사전 존재 체크 — npm에서 제거된(unpublish) web-framework 버전은
           # regenerate-sdk가 ERR_PNPM_NO_MATCHING_VERSION으로 반드시 실패하므로
           # 대상에서 미리 제외한다 (주로 수명이 끝난 beta 스냅샷 태그).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,7 @@ jobs:
       skip: ${{ steps.version.outputs.skip }}
 
     steps:
-      - name: Checkout (push 이벤트용)
-        if: github.event_name == 'push'
+      - name: Checkout
         uses: actions/checkout@v7
 
       - name: 버전 결정
@@ -105,6 +104,15 @@ jobs:
             echo "::error::올바른 버전 형식이 아닙니다: ${VERSION}"
             exit 1
           fi
+
+          # 배포 제외 버전(denylist) 검사 — 건너뛴 버전의 실수 재배포 방지
+          DENIED_VERSIONS=$(jq -r '(.deniedVersions // [])[]' sdk-policy.json)
+          for DENIED in $DENIED_VERSIONS; do
+            if [ "$VERSION" = "$DENIED" ] || [[ "$VERSION" == "$DENIED"-* ]]; then
+              echo "::error::배포가 제외된 버전입니다: ${VERSION} (거부 목록: ${DENIED})"
+              exit 1
+            fi
+          done
 
           echo "버전 검증 통과: ${VERSION}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -210,6 +210,20 @@ jobs:
           BRANCH_NAME="update/${VERSION}-${TIMESTAMP}"
           echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
+      - name: 배포 제외 버전(denylist) 확인
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # 건너뛴 버전의 실수 재배포 방지. workflow_dispatch로 명시 버전을 입력하면
+          # 위 감지 단계의 스킵 가드들이 우회되므로 여기서 반드시 걸러야 한다.
+          DENIED_VERSIONS=$(jq -r '(.deniedVersions // [])[]' sdk-policy.json)
+          for DENIED in $DENIED_VERSIONS; do
+            if [ "$VERSION" = "$DENIED" ] || [[ "$VERSION" == "$DENIED"-* ]]; then
+              echo "::error::배포가 제외된 버전입니다: ${VERSION} (거부 목록: ${DENIED})"
+              exit 1
+            fi
+          done
+
       - name: 스킵 판단
         id: check
         env:

--- a/sdk-policy.json
+++ b/sdk-policy.json
@@ -1,4 +1,5 @@
 {
   "schemaVersion": 1,
-  "minVersion": "2.4.0"
+  "minVersion": "2.4.0",
+  "deniedVersions": ["3.0.0"]
 }


### PR DESCRIPTION
## 배경

web-framework 3.0.0은 건너뛴 버전입니다(첫 3.0 stable은 3.0.1). 실수로 3.0.0 계열(3.0.0 정확히 + 3.0.0-beta.*/3.0.0-rc.* 프리릴리스)이 재배포되는 것을 워크플로 수준에서 차단합니다.

## 변경 사항

- `sdk-policy.json`에 `deniedVersions: ["3.0.0"]` 필드 추가 (schemaVersion은 1 유지 — `Editor/AITDeprecationChecker.cs`는 schemaVersion != 1이면 정책 전체를 거부하고, JsonUtility는 미지의 필드를 무시하므로 안전)
- 4개 워크플로에 denylist 체크 추가. 검사 대상 버전 V가 denylist 항목 D와 정확히 같거나 `D-`로 시작하면 차단:
  - `release.yml`: 체크아웃을 모든 이벤트(push/workflow_dispatch/workflow_call)에서 수행하도록 변경 후, semver 검증 직후 검사
  - `bulk-release.yml`: 버전 목록의 각 버전을 검사, 하나라도 걸리면 걸린 버전을 나열하고 전체 실패
  - `update.yml`: 버전 확정(`steps.version`) 직후 검사 — workflow_dispatch로 명시 버전을 입력하면 기존 스킵 가드들이 우회되는 경로도 포함
  - `beta-release.yml`: dist-tag → 구체 버전 해석 및 semver 형식 검증 직후 검사 (dist-tag가 금지 버전을 가리키는 경우도 포함)

## 한계

workflow_dispatch를 **가드가 없는 옛 ref에서** 실행하면 옛 워크플로 정의가 그대로 돌아 가드가 적용되지 않습니다. 이 가드는 main 등 가드가 포함된 ref에서의 dispatch만 보호합니다.

## 검증

- 4개 워크플로 YAML 파싱 확인, `actionlint` 실행 (신규 삽입 스크립트에서 새로운 오류 없음 — 기존에도 있던 style/info 수준 shellcheck 지적만 존재)
- denylist 매칭 로직을 로컬 셸에서 시뮬레이션: `3.0.0`→차단, `3.0.0-rc.4`→차단, `3.0.0-beta.abc123`→차단, `3.0.1`→통과, `2.10.8`→통과, `deniedVersions` 필드 없는 정책→통과
- `./run-local-tests.sh --validate`: npm 레지스트리 404(`@babel/generator` tarball) 인프라 이슈로 SDK Generator Unit Tests 스텝만 실패, 이번 변경과 무관 (구조 검증/Meta GUID 위생 등 나머지 스텝은 통과)