### PR TITLE
기능: 배포 메모에 배포 시각 및 타임존 표기 추가

### DIFF
--- a/Editor/Menu/AITDeployManager.cs
+++ b/Editor/Menu/AITDeployManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -302,7 +303,11 @@ namespace AppsInToss.Editor.Menu
                 return;
             }
 
-            string memo = BuildDeployMemo(kind, config.appName, config.version);
+            // 다이얼로그에는 타임스탬프 없는 미리보기만 보여준다 — 이 다이얼로그는 사용자 확인을
+            // 기다리는 모달이라 실제 배포까지 임의의 시간이 걸릴 수 있고, 여기서 memo를 확정해버리면
+            // 표시된 시각과 실제 ait deploy 실행 시각이 어긋난다. 최종 memo(타임스탬프 포함)는
+            // 확인 이후 명령을 조립하는 시점에 BuildDeployMemo로 다시 만든다.
+            string memoPreview = BuildDeployMemoPreview(kind, config.appName, config.version);
             string profileName = ProfileNameFor(kind);
 
             // Deploy (Test)는 빠른 빌드(IL2CPP Debug + Code Generation OptimizeSize) 산출물이라
@@ -313,7 +318,7 @@ namespace AppsInToss.Editor.Menu
 
             bool confirmed = AITPlatformHelper.ShowConfirmDialog(
                 "배포 확인",
-                $"Apps in Toss에 배포하시겠습니까? ({profileName})\n\n프로젝트: {config.appName}\n버전: {config.version}\nMemo: {memo}{fastBuildNotice}",
+                $"Apps in Toss에 배포하시겠습니까? ({profileName})\n\n프로젝트: {config.appName}\n버전: {config.version}\nMemo: {memoPreview} (+ 배포 시각 자동 첨부){fastBuildNotice}",
                 "배포",
                 "취소",
                 autoApprove: true
@@ -322,6 +327,10 @@ namespace AppsInToss.Editor.Menu
             if (!confirmed) return;
 
             Debug.Log($"AIT: Apps in Toss 배포 시작... ({profileName})");
+
+            // ait deploy 명령을 조립하는 이 시점에 memo를 확정한다 — 실제 배포(CLI 실행) 시각과
+            // memo에 찍히는 타임스탬프가 일치하도록.
+            string memo = BuildDeployMemo(kind, config.appName, config.version);
 
             try
             {
@@ -455,16 +464,144 @@ namespace AppsInToss.Editor.Menu
         }
 
         /// <summary>
-        /// 배포 memo 자동 생성: "[Test] {appName} v{version} · Unity SDK {AITVersion.Version}"
-        /// (Production은 [Production] 접두사). 셸 인용을 깨는 문자를 소스에서 무해화한 뒤
-        /// CLI의 -m/--memo 최대 길이(1000자)에 맞춰 잘라낸다(무해화는 길이를 늘리지 않으므로
-        /// 절단 후 재팽창이 없다).
+        /// 배포 memo 자동 생성: "[Test] {appName} v{version} · Unity SDK {AITVersion.Version} · {배포 시각} {TZ 약어}"
+        /// (Production은 [Production] 접두사). 배포가 실행된 로컬 시각 + 타임존 약어를 덧붙인 뒤
+        /// 셸 인용을 깨는 문자를 소스에서 무해화하고 CLI의 -m/--memo 최대 길이(1000자)에 맞춰
+        /// 잘라낸다(무해화는 길이를 늘리지 않으므로 절단 후 재팽창이 없다). 타임스탬프 첨부가 실패해도
+        /// (예: 알 수 없는 TimeZoneInfo 상태) 예외를 삼키고 타임스탬프 없는 memo로 폴백한다
+        /// (<see cref="AppendDeployTimestamp"/> 참조) — 배포 자체가 이 때문에 죽으면 안 된다.
         /// </summary>
         internal static string BuildDeployMemo(DeployKind kind, string appName, string version)
         {
-            string prefix = kind == DeployKind.Production ? "[Production]" : "[Test]";
-            string memo = SanitizeMemo($"{prefix} {appName} v{version} · Unity SDK {AITVersion.Version}");
+            string baseMemo = BuildDeployMemoBase(kind, appName, version);
+            string withTimestamp = AppendDeployTimestamp(baseMemo);
+            string memo = SanitizeMemo(withTimestamp);
             return memo.Length > MaxMemoLength ? memo.Substring(0, MaxMemoLength) : memo;
+        }
+
+        /// <summary>
+        /// 배포 확인 다이얼로그에 보여줄 memo 미리보기 — 타임스탬프 없이 기본 memo만 무해화해 표시한다.
+        /// 실제 배포 시 첨부되는 memo(<see cref="BuildDeployMemo"/>)와는 타임스탬프 유무만 다르다.
+        /// </summary>
+        private static string BuildDeployMemoPreview(DeployKind kind, string appName, string version)
+        {
+            return SanitizeMemo(BuildDeployMemoBase(kind, appName, version));
+        }
+
+        /// <summary>
+        /// 타임스탬프를 제외한 memo 본문: "[Test] {appName} v{version} · Unity SDK {AITVersion.Version}"
+        /// </summary>
+        private static string BuildDeployMemoBase(DeployKind kind, string appName, string version)
+        {
+            string prefix = kind == DeployKind.Production ? "[Production]" : "[Test]";
+            return $"{prefix} {appName} v{version} · Unity SDK {AITVersion.Version}";
+        }
+
+        /// <summary>
+        /// baseMemo에 "현재 로컬 시각 + 타임존 약어"를 " · " 구분자로 덧붙인다.
+        /// TimeZoneInfo.Local / DateTime.Now 조회 및 그 조합 과정에서 어떤 예외가 나더라도
+        /// 배포 흐름 자체를 막지 않도록 여기서 삼키고, 실패 시 타임스탬프 없는 baseMemo를 반환한다.
+        /// </summary>
+        private static string AppendDeployTimestamp(string baseMemo)
+        {
+            try
+            {
+                TimeZoneInfo tz = TimeZoneInfo.Local;
+                DateTime now = DateTime.Now;
+                TimeSpan utcOffset = tz.GetUtcOffset(now);
+                string tzName = tz.IsDaylightSavingTime(now) ? tz.DaylightName : tz.StandardName;
+                string abbreviation = ResolveTimeZoneAbbreviation(tz.Id, utcOffset, tzName);
+                string timestamp = FormatDeployTimestamp(now, abbreviation);
+                return $"{baseMemo} · {timestamp}";
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"AIT: 배포 memo에 타임스탬프를 추가하지 못했습니다 ({e.Message}). 타임스탬프 없이 진행합니다.");
+                return baseMemo;
+            }
+        }
+
+        // IANA(예: Asia/Seoul) / Windows(예: Korea Standard Time) id를 함께 등록한다 — 플랫폼에 따라
+        // TimeZoneInfo.Local.Id가 둘 중 하나로 오기 때문. DST가 있는 타임존은 약어가 계절에 따라
+        // 바뀌므로(예: 미국 동부 EST/EDT) 여기서는 의도적으로 다루지 않는다 — 아래 오프셋 폴백으로 처리.
+        private static readonly Dictionary<string, string> KnownTimeZoneAbbreviations =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Asia/Seoul", "KST" },
+                { "Korea Standard Time", "KST" },
+                { "Etc/UTC", "UTC" },
+                { "UTC", "UTC" },
+                { "Asia/Tokyo", "JST" },
+                { "Tokyo Standard Time", "JST" },
+                { "Asia/Shanghai", "CST" },
+                { "China Standard Time", "CST" },
+                { "Asia/Taipei", "CST" },
+                { "Taipei Standard Time", "CST" },
+                { "Asia/Singapore", "SGT" },
+                { "Singapore Standard Time", "SGT" },
+                { "Asia/Hong_Kong", "HKT" },
+                { "Hong Kong Standard Time", "HKT" },
+                { "Hong Kong SAR Standard Time", "HKT" },
+            };
+
+        /// <summary>
+        /// 타임존 id/오프셋/이름으로부터 사람이 읽을 약어를 3단계로 해석한다.
+        /// 1) known 매핑 (IANA + Windows id, DST 없는 아시아권 위주)
+        /// 2) tzName이 이미 2~5자 대문자 약어 형태면 그대로 사용 (일부 플랫폼은 CultureInfo와 무관하게
+        ///    약어를 준다)
+        /// 3) UTC 오프셋 폴백 ("UTC+9", "UTC-5", "UTC+5:30", 오프셋 0은 "UTC")
+        /// 순수 함수 — 시스템 TimeZoneInfo 조회(FindSystemTimeZoneById 등)에 의존하지 않아 테스트 가능.
+        /// </summary>
+        internal static string ResolveTimeZoneAbbreviation(string tzId, TimeSpan utcOffset, string tzName)
+        {
+            if (!string.IsNullOrEmpty(tzId))
+            {
+                if (KnownTimeZoneAbbreviations.TryGetValue(tzId, out string known))
+                {
+                    return known;
+                }
+
+                // "Hong Kong Standard Time" / "Hong Kong SAR Standard Time" 등 Windows 표기 변형 계열.
+                if (tzId.IndexOf("Hong Kong", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return "HKT";
+                }
+            }
+
+            if (!string.IsNullOrEmpty(tzName) && Regex.IsMatch(tzName, "^[A-Z]{2,5}$"))
+            {
+                return tzName;
+            }
+
+            return FormatUtcOffsetAbbreviation(utcOffset);
+        }
+
+        /// <summary>
+        /// UTC 오프셋을 "UTC+9" / "UTC-5" / "UTC+5:30" 형식으로 포맷한다. 분이 0이면 시(hour)만
+        /// 표기하고, 오프셋이 0이면 "UTC"만 반환한다.
+        /// </summary>
+        private static string FormatUtcOffsetAbbreviation(TimeSpan utcOffset)
+        {
+            if (utcOffset == TimeSpan.Zero) return "UTC";
+
+            string sign = utcOffset < TimeSpan.Zero ? "-" : "+";
+            TimeSpan abs = utcOffset.Duration();
+            string result = $"UTC{sign}{abs.Hours}";
+            if (abs.Minutes != 0)
+            {
+                result += $":{abs.Minutes:D2}";
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// 배포 시각을 "yyyy-MM-dd HH:mm {약어}" 형식으로 포맷한다. CultureInfo.InvariantCulture를
+        /// 사용해 Editor/테스트 러너의 문화권 설정과 무관하게 항상 동일한 출력을 보장한다.
+        /// 순수 함수 — 테스트 가능성을 위해 시스템 시계/타임존 조회와 분리했다.
+        /// </summary>
+        internal static string FormatDeployTimestamp(DateTime localNow, string abbreviation)
+        {
+            return $"{localNow.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} {abbreviation}";
         }
 
         /// <summary>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployMemoTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployMemoTests.cs
@@ -12,6 +12,9 @@
 //   해당 어셈블리는 InternalsVisibleTo로 internal AITDeployManager/DeployKind에 접근 가능하다.
 // -----------------------------------------------------------------------
 
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using AppsInToss.Editor.Menu;  // AITDeployManager, DeployKind (internal, .Menu 하위 네임스페이스)
 
@@ -122,6 +125,112 @@ public class DeployMemoTests
     {
         Assert.IsNull(AITDeployManager.SanitizeMemo(null));
         Assert.AreEqual(string.Empty, AITDeployManager.SanitizeMemo(string.Empty));
+    }
+
+    // =====================================================
+    // ResolveTimeZoneAbbreviation: 순수 함수 — 시스템 TimeZoneInfo 조회 없이 문자열/TimeSpan만으로 검증.
+    // TimeZoneInfo.FindSystemTimeZoneById 등 시스템 존 조회는 Windows CI에서 실패할 수 있어 사용하지 않는다.
+    // =====================================================
+
+    [Test]
+    public void ResolveTimeZoneAbbreviation_AsiaSeoulId_ReturnsKst()
+    {
+        string abbr = AITDeployManager.ResolveTimeZoneAbbreviation("Asia/Seoul", TimeSpan.FromHours(9), "대한민국 표준시");
+        Assert.AreEqual("KST", abbr);
+    }
+
+    [Test]
+    public void ResolveTimeZoneAbbreviation_KoreaStandardTimeWindowsId_ReturnsKst()
+    {
+        string abbr = AITDeployManager.ResolveTimeZoneAbbreviation("Korea Standard Time", TimeSpan.FromHours(9), "대한민국 표준시");
+        Assert.AreEqual("KST", abbr);
+    }
+
+    [Test]
+    public void ResolveTimeZoneAbbreviation_EtcUtcId_ReturnsUtc()
+    {
+        string abbr = AITDeployManager.ResolveTimeZoneAbbreviation("Etc/UTC", TimeSpan.Zero, "UTC");
+        Assert.AreEqual("UTC", abbr);
+    }
+
+    [Test]
+    public void ResolveTimeZoneAbbreviation_UnknownId_ShortUppercaseTzName_UsesTzNameAsIs()
+    {
+        // 1단계 known 매핑에 없는 id라도 tzName이 이미 2~5자 대문자 약어 형태면 2단계 휴리스틱으로 그대로 사용.
+        string abbr = AITDeployManager.ResolveTimeZoneAbbreviation("Europe/Paris", TimeSpan.FromHours(1), "CET");
+        Assert.AreEqual("CET", abbr);
+    }
+
+    [Test]
+    public void ResolveTimeZoneAbbreviation_UnknownId_LocalizedLongName_FallsBackToPositiveOffset()
+    {
+        // known 매핑도 없고 tzName도 약어 형태가 아니면(로컬라이즈된 긴 이름) 3단계 오프셋 폴백.
+        string abbr = AITDeployManager.ResolveTimeZoneAbbreviation("Unknown/Zone", TimeSpan.FromHours(9), "일본 표준시");
+        Assert.AreEqual("UTC+9", abbr);
+    }
+
+    [Test]
+    public void ResolveTimeZoneAbbreviation_UnknownId_LocalizedLongName_FallsBackToNegativeOffset()
+    {
+        string abbr = AITDeployManager.ResolveTimeZoneAbbreviation("Unknown/Zone", TimeSpan.FromHours(-5), "Eastern Standard Time (Localized)");
+        Assert.AreEqual("UTC-5", abbr);
+    }
+
+    [Test]
+    public void ResolveTimeZoneAbbreviation_UnknownId_HalfHourOffset_FallsBackWithMinutes()
+    {
+        string abbr = AITDeployManager.ResolveTimeZoneAbbreviation("Unknown/Zone", new TimeSpan(5, 30, 0), "Indian Standard Time (Localized)");
+        Assert.AreEqual("UTC+5:30", abbr);
+    }
+
+    [Test]
+    public void ResolveTimeZoneAbbreviation_UnknownId_ZeroOffset_FallsBackToUtc()
+    {
+        string abbr = AITDeployManager.ResolveTimeZoneAbbreviation("Unknown/Zone", TimeSpan.Zero, "Greenwich Mean Time (Localized)");
+        Assert.AreEqual("UTC", abbr);
+    }
+
+    // =====================================================
+    // FormatDeployTimestamp: 고정 DateTime + InvariantCulture — 테스트 러너 문화권과 무관해야 함.
+    // =====================================================
+
+    [Test]
+    public void FormatDeployTimestamp_FixedDateTime_FormatsAsExpected()
+    {
+        var fixedDateTime = new DateTime(2026, 8, 13, 14, 5, 0);
+        string formatted = AITDeployManager.FormatDeployTimestamp(fixedDateTime, "KST");
+        Assert.AreEqual("2026-08-13 14:05 KST", formatted);
+    }
+
+    [Test]
+    public void FormatDeployTimestamp_UsesInvariantCulture_RegardlessOfCurrentCulture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            // 일부 문화권(예: fr-FR)은 날짜 구분자·자릿수 표기가 달라진다 — InvariantCulture 강제 검증.
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var fixedDateTime = new DateTime(2026, 1, 5, 9, 3, 0);
+            string formatted = AITDeployManager.FormatDeployTimestamp(fixedDateTime, "UTC");
+            Assert.AreEqual("2026-01-05 09:03 UTC", formatted);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    // =====================================================
+    // BuildDeployMemo: 타임스탬프 첨부 (기존 memo 조립 파이프라인과의 결합)
+    // =====================================================
+
+    [Test]
+    public void BuildDeployMemo_EndsWithSeparatorAndTimestampPattern()
+    {
+        string memo = AITDeployManager.BuildDeployMemo(DeployKind.Test, "MyGame", "1.2.3");
+
+        Assert.IsTrue(Regex.IsMatch(memo, @" · \d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$"),
+            $"memo는 ' · ' 구분자 + 타임스탬프 패턴으로 끝나야 함. 실제: {memo}");
     }
 
     // =====================================================


### PR DESCRIPTION
## 요약

배포 메모(`ait deploy -m`)에 **배포가 실행된 시각**을 로컬 타임존 약어와 함께 덧붙입니다.

**형식 예시**
```
[Test] MyGame v1.2.3 · Unity SDK 3.0.1 · 2026-08-13 14:05 KST
```

## 스탬프 시점 결정

`BuildDeployMemo`의 호출 지점을 추적한 결과, 배포 흐름은 `RunDeploy`(확인 다이얼로그 → Unity 빌드(수 분)) → `ExecuteDeploy`(ait deploy 실행) 순서였고, 기존 코드는 `BuildDeployMemo`를 `ExecuteDeploy` 진입 직후 **한 번만** 호출해 그 결과를 (1) 확인 다이얼로그 텍스트와 (2) 실제 CLI 명령 조립 양쪽에 그대로 재사용하고 있었습니다.

확인 다이얼로그는 사용자 입력을 기다리는 모달이라 여기서 memo(타임스탬프 포함)를 확정해버리면, 사용자가 다이얼로그를 오래 붙잡고 있을 경우 memo에 찍힌 시각과 실제 `ait deploy` 실행 시각이 어긋납니다.

**선택한 방법**: 다이얼로그에는 타임스탬프 없는 미리보기(`BuildDeployMemoPreview`)만 보여주고 "배포 시각 자동 첨부" 안내 문구를 붙였습니다. 최종 memo(`BuildDeployMemo`, 타임스탬프 포함)는 사용자 확인 이후 `ait deploy` 명령을 실제로 조립하는 시점에 다시 호출해 확정합니다. 다이얼로그 재조립 없이 가장 단순하게 실제 배포 시각과 memo 시각을 일치시키는 방법이라 판단했습니다.

## 타임존 약어 해석 (3단계, 순수 함수)

`ResolveTimeZoneAbbreviation(tzId, utcOffset, tzName)` — 시스템 `TimeZoneInfo` 조회 없이 문자열/TimeSpan만으로 동작해 테스트 가능:

1. **known 매핑** (IANA + Windows id 병기, DST 없는 아시아권 위주): `Asia/Seoul`/`Korea Standard Time`→`KST`, `Etc/UTC`/`UTC`→`UTC`, `Asia/Tokyo`/`Tokyo Standard Time`→`JST`, `Asia/Shanghai`·`Asia/Taipei`/`China Standard Time`·`Taipei Standard Time`→`CST`, `Asia/Singapore`/`Singapore Standard Time`→`SGT`, `Asia/Hong_Kong`/`Hong Kong (SAR) Standard Time` 계열→`HKT`
2. **휴리스틱**: `tzName`이 이미 2~5자 대문자 약어 형태(`^[A-Z]{2,5}$`)면 그대로 사용
3. **오프셋 폴백**: `UTC+9` / `UTC-5` / `UTC+5:30` 형식 (오프셋 0은 `UTC`)

`FormatDeployTimestamp(localNow, abbreviation)`는 `CultureInfo.InvariantCulture`로 `yyyy-MM-dd HH:mm {약어}` 포맷을 고정해 Editor/테스트 러너의 문화권 설정과 무관하게 동일한 출력을 보장합니다.

실제 호출부(`AppendDeployTimestamp`)는 `TimeZoneInfo.Local` + `DateTime.Now`로 위 두 함수를 조합하며, 전체를 try/catch로 감싸 어떤 예외가 나도 타임스탬프만 생략하고(`Debug.LogWarning` 1줄) 배포 자체는 계속 진행됩니다.

## 기존 파이프라인과의 결합

타임스탬프는 `BuildDeployMemo` 내부에서 memo 본문에 append된 뒤 기존 `SanitizeMemo` → 1000자 절단 흐름을 그대로 통과합니다. 타임스탬프 문자열 자체는 셸 특수문자를 포함하지 않아 `SanitizeMemo`/`EscapeMemoForShell` 계층은 수정하지 않았습니다.

## 검증

- `./run-local-tests.sh --validate`: 통과. (`sdk-runtime-generator~`의 `pnpm install`이 `ERR_PNPM_TARBALL_INTEGRITY`로 실패했는데, 알려진 사내 레지스트리 미러 노이즈이며 이 건 하나만 실패 — Meta GUID Hygiene 등 나머지는 정상 통과)
- Unity 2022.3.62f2 EditMode 전체 실행 (격리 프로젝트, `manifest.json`의 `file:` 경로를 이 브랜치 워크트리로 임시 지정 후 복원): **1225 total / 1211 passed / 0 failed / 1 inconclusive(기존 `BuildFileSelectionTests.FindFileInBuild_DeleteFails_FallsBackAndLogs_Windows`, macOS에서 정상적으로 inconclusive) / 13 skipped**. 신규 추가한 `DeployMemoTests`의 `ResolveTimeZoneAbbreviation_*`(8건) · `FormatDeployTimestamp_*`(2건) · `BuildDeployMemo_EndsWithSeparatorAndTimestampPattern`(1건) 전부 Passed, 기존 `DeployMemoTests` 19건도 모두 회귀 없이 Passed.
- `git diff`로 변경 파일이 `Editor/Menu/AITDeployManager.cs`, `Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployMemoTests.cs` 두 개뿐임을 확인.

## 변경 파일

- `Editor/Menu/AITDeployManager.cs`: `BuildDeployMemo`에 타임스탬프 append, `BuildDeployMemoPreview`/`BuildDeployMemoBase`/`AppendDeployTimestamp`/`ResolveTimeZoneAbbreviation`/`FormatUtcOffsetAbbreviation`/`FormatDeployTimestamp` 추가, `ExecuteDeploy`의 memo 조립 시점을 확인 다이얼로그 이후로 이동
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployMemoTests.cs`: 신규 순수 함수 테스트 11건 추가
