### PR TITLE
개선: Deploy (Test) 빌드 가속 — Gzip 압축·Minimal 스트리핑 오버라이드 및 단계별 시간 계측

### DIFF
--- a/Editor/AITConvertCore.cs
+++ b/Editor/AITConvertCore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using UnityEditor;
@@ -420,6 +421,12 @@ namespace AppsInToss
         /// AITDeployManager.RunDeploy(DeployKind.Test)가 이 값을 전달한다. 기본값 false는 Production
         /// 계열 호출부의 동작을 보존한다.
         /// </param>
+        /// <remarks>
+        /// onProgress/onComplete는 내부적으로 <see cref="PhaseTimingTracker"/>로 감싸여 BuildPhase 전환
+        /// 시점 기준 단계별 소요 시간을 계측한다 — Deploy (Test)/(Production)/Build &amp; Package/Dev Server 등
+        /// 이 메서드를 쓰는 모든 인터랙티브 경로에 공통 적용된다. 완료 시 "AIT: 단계별 소요 — ..." 요약
+        /// 1줄만 로그로 남기며(실패 시 실패 단계까지의 부분 요약 1줄), Sentry로는 전송하지 않는다.
+        /// </remarks>
         public static void DoExportAsync(
             bool buildWebGL,
             bool doPackaging,
@@ -456,11 +463,26 @@ namespace AppsInToss
             var snapshot = PlayerSettingsSnapshot.Capture();
             AITBuildSession.RecordPlayerSettingsSnapshot(snapshot);
 
+            // 단계별 시간 계측 — onProgress의 BuildPhase 전환 시점을 가로채 누적하고,
+            // onComplete 시점에 요약 1줄을 로그로 남긴다. 아래 두 래퍼를 거치지 않는 진입점
+            // (위 play mode/배치 모드의 조기 return)은 실제 빌드를 시작하지 않으므로 계측 대상이 아니다.
+            var phaseTiming = new PhaseTimingTracker();
+            Action<BuildPhase, float, string> trackedOnProgress = (phase, progress, status) =>
+            {
+                phaseTiming.EnterPhase(phase);
+                onProgress?.Invoke(phase, progress, status);
+            };
+            Action<AITExportError> trackedOnComplete = (result) =>
+            {
+                phaseTiming.LogSummary(result);
+                onComplete?.Invoke(result);
+            };
+
             try
             {
                 var editorConfig = PrepareExport(ref profile, ref profileName, fastBuild);
 
-                onProgress?.Invoke(BuildPhase.Preparing, 0.01f, "빌드 준비 중...");
+                trackedOnProgress(BuildPhase.Preparing, 0.01f, "빌드 준비 중...");
                 Debug.Log($"[AIT] 비동기 미니앱 변환 시작... (cleanBuild: {cleanBuild})");
 
                 if (editorConfig == null)
@@ -468,7 +490,7 @@ namespace AppsInToss
                     AITLog.Error("Apps in Toss 설정을 찾을 수 없습니다.", sentryCapture: false);
                     try { snapshot.Restore(); }
                     finally { AITBuildSession.EndBuild(); }
-                    onComplete?.Invoke(AITExportError.INVALID_APP_CONFIG);
+                    trackedOnComplete(AITExportError.INVALID_APP_CONFIG);
                     return;
                 }
 
@@ -477,7 +499,7 @@ namespace AppsInToss
                 {
                     try { snapshot.Restore(); }
                     finally { AITBuildSession.EndBuild(); }
-                    onComplete?.Invoke(AITExportError.CANCELLED);
+                    trackedOnComplete(AITExportError.CANCELLED);
                     return;
                 }
 
@@ -489,12 +511,12 @@ namespace AppsInToss
                         Debug.LogWarning("[AIT] 빌드가 취소되었습니다.");
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
-                        onComplete?.Invoke(AITExportError.CANCELLED);
+                        trackedOnComplete(AITExportError.CANCELLED);
                         return;
                     }
 
                     // Phase 0: BuildConfig 복사 + pnpm install 백그라운드 시작
-                    onProgress?.Invoke(BuildPhase.Preparing, 0.02f, "빌드 설정 파일 복사 및 pnpm install 준비 중...");
+                    trackedOnProgress(BuildPhase.Preparing, 0.02f, "빌드 설정 파일 복사 및 pnpm install 준비 중...");
                     string projectPath = UnityUtil.GetProjectPath();
 
                     var (earlyCtx, earlyError) = Editor.AITPackageBuilder.PrepareEarlyPackaging(projectPath, profile);
@@ -502,7 +524,7 @@ namespace AppsInToss
                     {
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
-                        onComplete?.Invoke(earlyError);
+                        trackedOnComplete(earlyError);
                         return;
                     }
 
@@ -511,7 +533,7 @@ namespace AppsInToss
 
                     // Phase 1: WebGL Build (BLOCKING - 메인 스레드)
                     // 백그라운드 pnpm install은 독립 OS 프로세스이므로 이 동안 병렬 실행됨
-                    onProgress?.Invoke(BuildPhase.WebGLBuild, 0.05f, "WebGL 빌드 중... (pnpm install 병렬 실행 중)");
+                    trackedOnProgress(BuildPhase.WebGLBuild, 0.05f, "WebGL 빌드 중... (pnpm install 병렬 실행 중)");
 
                     AITBuildSession.SetStage(BuildStage.WebGLBuild);
                     var webglResult = Editor.AITWebGLBuilder.BuildWebGL(cleanBuild, profile);
@@ -521,7 +543,7 @@ namespace AppsInToss
                         AITBuildCancellation.SetCurrentEarlyContext(null);
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
-                        onComplete?.Invoke(webglResult);
+                        trackedOnComplete(webglResult);
                         return;
                     }
 
@@ -532,7 +554,7 @@ namespace AppsInToss
                         Debug.LogWarning("[AIT] 빌드가 취소되었습니다.");
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
-                        onComplete?.Invoke(AITExportError.CANCELLED);
+                        trackedOnComplete(AITExportError.CANCELLED);
                         return;
                     }
 
@@ -541,7 +563,7 @@ namespace AppsInToss
                     AITBuildCancellation.SetCurrentEarlyContext(null);
                     AITBuildSession.SetStage(BuildStage.Packaging);
                     Editor.AITPackageBuilder.CompletePackagingAfterWebGLBuild(
-                        earlyCtx, webglPath, profile, snapshot, onComplete, onProgress, skipGraniteBuild);
+                        earlyCtx, webglPath, profile, snapshot, trackedOnComplete, trackedOnProgress, skipGraniteBuild);
                 }
                 else if (buildWebGL)
                 {
@@ -551,11 +573,11 @@ namespace AppsInToss
                         Debug.LogWarning("[AIT] 빌드가 취소되었습니다.");
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
-                        onComplete?.Invoke(AITExportError.CANCELLED);
+                        trackedOnComplete(AITExportError.CANCELLED);
                         return;
                     }
 
-                    onProgress?.Invoke(BuildPhase.WebGLBuild, 0.05f, "WebGL 빌드 중... (Unity 제한으로 에디터가 일시 정지됩니다)");
+                    trackedOnProgress(BuildPhase.WebGLBuild, 0.05f, "WebGL 빌드 중... (Unity 제한으로 에디터가 일시 정지됩니다)");
 
                     AITBuildSession.SetStage(BuildStage.WebGLBuild);
                     var webglResult = Editor.AITWebGLBuilder.BuildWebGL(cleanBuild, profile);
@@ -563,7 +585,7 @@ namespace AppsInToss
                     {
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
-                        onComplete?.Invoke(webglResult);
+                        trackedOnComplete(webglResult);
                         return;
                     }
 
@@ -571,7 +593,7 @@ namespace AppsInToss
                     Debug.Log("[AIT] 비동기 미니앱 변환이 완료되었습니다!");
                     try { snapshot.Restore(); }
                     finally { AITBuildSession.EndBuild(); }
-                    onComplete?.Invoke(AITExportError.SUCCEED);
+                    trackedOnComplete(AITExportError.SUCCEED);
                 }
                 else if (doPackaging)
                 {
@@ -581,12 +603,12 @@ namespace AppsInToss
                         Debug.LogWarning("[AIT] 빌드가 취소되었습니다.");
                         try { snapshot.Restore(); }
                         finally { AITBuildSession.EndBuild(); }
-                        onComplete?.Invoke(AITExportError.CANCELLED);
+                        trackedOnComplete(AITExportError.CANCELLED);
                         return;
                     }
 
                     AITBuildSession.SetStage(BuildStage.Packaging);
-                    GenerateMiniAppPackageAsync(profile, snapshot, onComplete, onProgress, skipGraniteBuild);
+                    GenerateMiniAppPackageAsync(profile, snapshot, trackedOnComplete, trackedOnProgress, skipGraniteBuild);
                 }
                 else
                 {
@@ -594,7 +616,7 @@ namespace AppsInToss
                     Debug.Log("[AIT] 비동기 미니앱 변환이 완료되었습니다!");
                     try { snapshot.Restore(); }
                     finally { AITBuildSession.EndBuild(); }
-                    onComplete?.Invoke(AITExportError.SUCCEED);
+                    trackedOnComplete(AITExportError.SUCCEED);
                 }
             }
             catch (Exception e)
@@ -602,7 +624,7 @@ namespace AppsInToss
                 Debug.LogError($"[AIT] 변환 중 오류가 발생했습니다: {e}");
                 try { snapshot.Restore(); }
                 finally { AITBuildSession.EndBuild(); }
-                onComplete?.Invoke(AITExportError.BUILD_WEBGL_FAILED);
+                trackedOnComplete(AITExportError.BUILD_WEBGL_FAILED);
             }
         }
 
@@ -656,6 +678,137 @@ namespace AppsInToss
                 onProgress: onProgress,
                 skipGraniteBuild: skipGraniteBuild
             );
+        }
+
+        #endregion
+
+        #region Phase Timing (Deploy 가속 계측)
+
+        /// <summary>
+        /// DoExportAsync 진행 중 BuildPhase 전환 시점을 기준으로 각 단계의 소요 시간을 누적한다.
+        /// 동일 단계에 여러 번 재진입해도(GraniteBuildRunner의 pnpm 재설치 → granite 재시도 경로 등)
+        /// 시간을 합산한다. Preparing/Complete/Failed/Cancelled/None은 순간적인 마커라 별도 버킷을
+        /// 만들지 않는다(그 구간에 흐른 시간은 요약에서 빠지지만, 총 소요 시간은 overall 스톱워치가
+        /// 별도로 잡으므로 정보 손실이 실질적으로 없다 — 준비 단계는 보통 1초 미만).
+        /// </summary>
+        private sealed class PhaseTimingTracker
+        {
+            private static readonly HashSet<BuildPhase> TrackedPhases = new HashSet<BuildPhase>
+            {
+                BuildPhase.WebGLBuild,
+                BuildPhase.CopyingFiles,
+                BuildPhase.PnpmInstall,
+                BuildPhase.GraniteBuild,
+            };
+
+            private readonly System.Diagnostics.Stopwatch _overallStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            private readonly System.Diagnostics.Stopwatch _phaseStopwatch = new System.Diagnostics.Stopwatch();
+            private readonly List<BuildPhase> _phaseOrder = new List<BuildPhase>();
+            private readonly Dictionary<BuildPhase, double> _phaseSeconds = new Dictionary<BuildPhase, double>();
+            private BuildPhase? _currentPhase;
+            private bool _summaryLogged;
+
+            /// <summary>
+            /// onProgress가 새 phase를 보고할 때마다 호출한다. phase가 실제로 바뀐 경우에만
+            /// 직전 phase의 경과 시간을 버킷에 반영하고 스톱워치를 재시작한다 — 같은 phase가
+            /// 여러 번(진행률 갱신마다) 불려도 시간이 끊기지 않는다.
+            /// </summary>
+            public void EnterPhase(BuildPhase phase)
+            {
+                if (_currentPhase.HasValue && _currentPhase.Value != phase)
+                {
+                    FlushCurrentPhase();
+                }
+                if (!_currentPhase.HasValue || _currentPhase.Value != phase)
+                {
+                    _currentPhase = phase;
+                    _phaseStopwatch.Restart();
+                }
+            }
+
+            private void FlushCurrentPhase()
+            {
+                if (!_currentPhase.HasValue) return;
+                double seconds = _phaseStopwatch.Elapsed.TotalSeconds;
+                var phase = _currentPhase.Value;
+                if (!TrackedPhases.Contains(phase)) return;
+
+                if (!_phaseSeconds.ContainsKey(phase))
+                {
+                    _phaseSeconds[phase] = 0;
+                    _phaseOrder.Add(phase);
+                }
+                _phaseSeconds[phase] += seconds;
+            }
+
+            /// <summary>
+            /// 빌드 완료(성공/실패/취소) 시 1회 호출. 요약 로그 1줄을 남긴다. 중복 호출은 무시한다
+            /// (일부 실패 경로가 콜백을 여러 겹으로 감쌀 가능성에 대비한 방어).
+            /// </summary>
+            public void LogSummary(AITExportError result)
+            {
+                if (_summaryLogged) return;
+                _summaryLogged = true;
+
+                FlushCurrentPhase();
+                _overallStopwatch.Stop();
+
+                // 단계 진입 전 즉시 종료(예: 설정 오류로 즉시 실패)된 경우 요약할 내용이 없다.
+                if (_phaseOrder.Count == 0) return;
+
+                var phaseTimings = new List<(string label, double seconds)>(_phaseOrder.Count);
+                foreach (var phase in _phaseOrder)
+                {
+                    phaseTimings.Add((PhaseTimingLabel(phase), _phaseSeconds[phase]));
+                }
+
+                double totalSeconds = _overallStopwatch.Elapsed.TotalSeconds;
+                string failedAtLabel = result == AITExportError.SUCCEED || !_currentPhase.HasValue
+                    ? null
+                    : PhaseTimingLabel(_currentPhase.Value);
+
+                Debug.Log(FormatPhaseTimings(phaseTimings, totalSeconds, failedAtLabel));
+            }
+        }
+
+        /// <summary>
+        /// 단계별 시간 요약 로그에 쓰는 한국어 라벨. AITDeployManager.GetPhaseText(진행률 다이얼로그용)와는
+        /// 별개 — GraniteBuild는 여기서 "vite/ait build"로 표기해 실제 실행되는 CLI를 드러낸다.
+        /// </summary>
+        private static string PhaseTimingLabel(BuildPhase phase)
+        {
+            switch (phase)
+            {
+                case BuildPhase.WebGLBuild: return "WebGL 빌드";
+                case BuildPhase.CopyingFiles: return "파일 복사";
+                case BuildPhase.PnpmInstall: return "pnpm install";
+                case BuildPhase.GraniteBuild: return "vite/ait build";
+                default: return phase.ToString();
+            }
+        }
+
+        /// <summary>
+        /// 단계별 소요 시간 요약을 "AIT: " 로그 컨벤션에 맞는 한 줄 문자열로 조립한다.
+        /// Stopwatch/시각 의존이 없는 순수 함수 — 유닛 테스트로 포맷을 고정할 수 있다.
+        /// 예: "AIT: 단계별 소요 — WebGL 빌드 87.3s · 파일 복사 2.1s · pnpm install 0.4s · vite/ait build 41.2s (총 131.0s)"
+        /// failedAtLabel이 주어지면(성공하지 못한 경우) 실패 시점까지의 부분 요약으로 표기한다.
+        /// </summary>
+        internal static string FormatPhaseTimings(IReadOnlyList<(string label, double seconds)> phaseTimings, double totalSeconds, string failedAtLabel = null)
+        {
+            var segments = new List<string>(phaseTimings?.Count ?? 0);
+            if (phaseTimings != null)
+            {
+                foreach (var (label, seconds) in phaseTimings)
+                {
+                    segments.Add($"{label} {seconds.ToString("F1", CultureInfo.InvariantCulture)}s");
+                }
+            }
+            string body = string.Join(" · ", segments);
+            string totalStr = totalSeconds.ToString("F1", CultureInfo.InvariantCulture);
+
+            return string.IsNullOrEmpty(failedAtLabel)
+                ? $"AIT: 단계별 소요 — {body} (총 {totalStr}s)"
+                : $"AIT: 단계별 소요(실패: {failedAtLabel}) — {body} (실패까지 {totalStr}s)";
         }
 
         #endregion

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -67,6 +67,37 @@ namespace AppsInToss
                 debugSymbolsExternal = true
             };
         }
+
+        /// <summary>
+        /// Deploy (Test) 전용 오버라이드 프로필 생성.
+        /// baseProfile(보통 productionProfile)의 나머지 필드는 그대로 복사한 "새 인스턴스"에
+        /// 압축 포맷/Managed Stripping Level만 빌드 가속용 값으로 덮어쓴다.
+        /// </summary>
+        /// <remarks>
+        /// baseProfile 인스턴스는 절대 변형하지 않는다 — config.productionProfile은 ScriptableObject로
+        /// 영속화되므로 여기서 원본 필드를 바꾸면 사용자가 Configuration에서 설정한 Production 값이
+        /// 디스크(AITConfig.asset)에 그대로 오염된다. 그래서 Clone() 뒤 필드를 대입하는 대신, object
+        /// initializer로 완전히 새 인스턴스를 만들어 baseProfile을 읽기 전용으로만 사용한다.
+        ///
+        /// 오버라이드 값의 근거(저장값 컨벤션): AITBuildInitializer.ConvertToCompressionFormat/
+        /// ConvertToManagedStrippingLevel 주석 — compressionFormat 1=Gzip, managedStrippingLevel 1=Minimal.
+        /// Production(-1=자동)은 Brotli·High로 변환되므로, Test만 Gzip·Minimal로 갈라진다.
+        /// </remarks>
+        internal static AITBuildProfile CreateTestDeployProfile(AITBuildProfile baseProfile)
+        {
+            if (baseProfile == null)
+                baseProfile = CreateProductionProfile();
+
+            return new AITBuildProfile
+            {
+                enableDebugConsole = baseProfile.enableDebugConsole,
+                developmentBuild = baseProfile.developmentBuild,
+                enableLZ4Compression = baseProfile.enableLZ4Compression,
+                compressionFormat = 1,  // Gzip — Deploy (Test) 가속: 압축 시간 단축(Production은 Brotli 유지)
+                managedStrippingLevel = 1,  // Minimal — Deploy (Test) 가속: 스트리핑 시간 단축(Production은 High 유지)
+                debugSymbolsExternal = baseProfile.debugSymbolsExternal
+            };
+        }
     }
 
     /// <summary>

--- a/Editor/Menu/AITDeployManager.cs
+++ b/Editor/Menu/AITDeployManager.cs
@@ -90,6 +90,13 @@ namespace AppsInToss.Editor.Menu
                 var (cleanBuild, fastBuild) = GetBuildFlags(kind);
                 string il2cppMode = fastBuild ? "Debug/OptimizeSize" : "기본";
 
+                // Deploy (Test)만 압축 Gzip + 스트리핑 Minimal로 오버라이드한 새 프로필을 사용한다.
+                // config.productionProfile 자체는 절대 변형하지 않는다(CreateTestDeployProfile 참조) —
+                // Deploy (Production)/Build & Package는 이 분기에 들어오지 않으므로 한 글자도 영향받지 않는다.
+                AITBuildProfile deployProfile = kind == DeployKind.Test
+                    ? AITBuildProfile.CreateTestDeployProfile(config.productionProfile)
+                    : config.productionProfile;
+
                 Debug.Log($"AIT: {profileName} 빌드 시작 (cleanBuild={cleanBuild}, fastBuild={fastBuild}, IL2CPP={il2cppMode})...");
                 _buildStopwatch.Restart();
 
@@ -102,7 +109,7 @@ namespace AppsInToss.Editor.Menu
                     buildWebGL: true,
                     doPackaging: true,
                     cleanBuild: cleanBuild,
-                    profile: config.productionProfile,
+                    profile: deployProfile,
                     profileName: profileName,
                     onComplete: (result) => tcs.TrySetResult(result),
                     onProgress: (phase, progress, status) =>
@@ -305,10 +312,12 @@ namespace AppsInToss.Editor.Menu
             string memo = BuildDeployMemo(kind, config.appName, config.version);
             string profileName = ProfileNameFor(kind);
 
-            // Deploy (Test)는 빠른 빌드(IL2CPP Debug + Code Generation OptimizeSize) 산출물이라
-            // 런타임 성능이 실제 출시 빌드와 다르다 — QR로 성능을 재는 테스터가 오해하지 않도록 고지.
+            // Deploy (Test)는 빠른 빌드(IL2CPP Debug + Code Generation OptimizeSize) 산출물이고
+            // 압축 Gzip + 스트리핑 Minimal 오버라이드까지 적용되어 런타임 성능·산출물 크기가 실제
+            // 출시 빌드와 다르다 — QR로 성능을 재는 테스터가 오해하지 않도록 고지.
             string fastBuildNotice = kind == DeployKind.Test
-                ? "\n\n⚠ Deploy (Test)는 빠른 빌드(IL2CPP Debug/OptimizeSize)로 생성되어 런타임 성능이 실제 출시 빌드와 다릅니다."
+                ? "\n\n⚠ Deploy (Test)는 빠른 빌드(IL2CPP Debug/OptimizeSize)로 생성되어 런타임 성능이 실제 출시 빌드와 다릅니다." +
+                  "\n⚠ 압축 Gzip(출시 빌드는 Brotli — 다운로드 크기 소폭 증가) + 코드 스트리핑 Minimal(출시 빌드는 High)이 적용됩니다."
                 : "";
 
             bool confirmed = AITPlatformHelper.ShowConfirmDialog(

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs
@@ -181,6 +181,76 @@ public class AITBuildProfileMappingTests
     // PlayerSettings 라운드트립 — WebGL 타깃이 변환 결과를 실제로 수용하는지
     // =====================================================
 
+    // =====================================================
+    // AITBuildProfile.CreateTestDeployProfile — Deploy (Test) 전용 압축/스트리핑 오버라이드
+    // baseProfile(보통 productionProfile)을 절대 변형하지 않고 새 인스턴스를 만들어야 한다.
+    // =====================================================
+
+    [Test]
+    public void CreateTestDeployProfile_Overrides_CompressionAndStripping()
+    {
+        var baseProfile = AITBuildProfile.CreateProductionProfile();
+
+        var testProfile = AITBuildProfile.CreateTestDeployProfile(baseProfile);
+
+        Assert.AreEqual(1, testProfile.compressionFormat, "Deploy (Test)는 압축 포맷 저장값 1(Gzip)이어야 함.");
+        Assert.AreEqual(1, testProfile.managedStrippingLevel, "Deploy (Test)는 Stripping 저장값 1(Minimal)이어야 함.");
+        Assert.AreEqual(WebGLCompressionFormat.Gzip, AITBuildInitializer.ConvertToCompressionFormat(testProfile.compressionFormat));
+        Assert.AreEqual(ManagedStrippingLevel.Minimal, AITBuildInitializer.ConvertToManagedStrippingLevel(testProfile.managedStrippingLevel));
+    }
+
+    [Test]
+    public void CreateTestDeployProfile_PreservesRemainingFields_FromBaseProfile()
+    {
+        var baseProfile = new AITBuildProfile
+        {
+            enableDebugConsole = true,
+            developmentBuild = true,
+            enableLZ4Compression = false,
+            compressionFormat = 2,          // Brotli — 오버라이드 대상이 아님을 증명하기 위한 값
+            managedStrippingLevel = 4,       // High — 오버라이드 대상이 아님을 증명하기 위한 값
+            debugSymbolsExternal = false
+        };
+
+        var testProfile = AITBuildProfile.CreateTestDeployProfile(baseProfile);
+
+        Assert.AreEqual(baseProfile.enableDebugConsole, testProfile.enableDebugConsole);
+        Assert.AreEqual(baseProfile.developmentBuild, testProfile.developmentBuild);
+        Assert.AreEqual(baseProfile.enableLZ4Compression, testProfile.enableLZ4Compression);
+        Assert.AreEqual(baseProfile.debugSymbolsExternal, testProfile.debugSymbolsExternal);
+
+        // 압축/스트리핑만 오버라이드되고 나머지는 baseProfile 값을 그대로 물려받아야 함
+        Assert.AreEqual(1, testProfile.compressionFormat);
+        Assert.AreEqual(1, testProfile.managedStrippingLevel);
+    }
+
+    [Test]
+    public void CreateTestDeployProfile_DoesNotMutate_BaseProfileInstance()
+    {
+        var baseProfile = new AITBuildProfile
+        {
+            compressionFormat = 2,   // Brotli
+            managedStrippingLevel = 4 // High
+        };
+
+        AITBuildProfile.CreateTestDeployProfile(baseProfile);
+
+        Assert.AreEqual(2, baseProfile.compressionFormat,
+            "CreateTestDeployProfile은 baseProfile 인스턴스를 절대 변형하면 안 됨(압축).");
+        Assert.AreEqual(4, baseProfile.managedStrippingLevel,
+            "CreateTestDeployProfile은 baseProfile 인스턴스를 절대 변형하면 안 됨(스트리핑).");
+    }
+
+    [Test]
+    public void CreateTestDeployProfile_ReturnsDifferentInstance_FromBaseProfile()
+    {
+        var baseProfile = AITBuildProfile.CreateProductionProfile();
+
+        var testProfile = AITBuildProfile.CreateTestDeployProfile(baseProfile);
+
+        Assert.AreNotSame(baseProfile, testProfile, "반환 인스턴스는 baseProfile과 다른 참조여야 함.");
+    }
+
     [Test]
     public void SetManagedStrippingLevel_RoundTrips_ConvertedMinimal()
     {
@@ -211,5 +281,77 @@ public class AITBuildProfileMappingTests
             PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL, original);
         }
 #endif
+    }
+
+    // =====================================================
+    // AITConvertCore.FormatPhaseTimings — 단계별 소요 시간 요약 로그 포맷
+    // Stopwatch/시각 의존이 없는 순수 함수이므로 고정 입력으로 문자열을 그대로 검증한다.
+    // =====================================================
+
+    [Test]
+    public void FormatPhaseTimings_SuccessCase_MatchesExpectedFormat()
+    {
+        var phaseTimings = new System.Collections.Generic.List<(string label, double seconds)>
+        {
+            ("WebGL 빌드", 87.34),
+            ("파일 복사", 2.06),
+            ("pnpm install", 0.4),
+            ("vite/ait build", 41.2),
+        };
+
+        string formatted = AITConvertCore.FormatPhaseTimings(phaseTimings, 131.0);
+
+        Assert.AreEqual(
+            "AIT: 단계별 소요 — WebGL 빌드 87.3s · 파일 복사 2.1s · pnpm install 0.4s · vite/ait build 41.2s (총 131.0s)",
+            formatted);
+    }
+
+    [Test]
+    public void FormatPhaseTimings_FailureCase_IncludesFailedPhaseLabel()
+    {
+        var phaseTimings = new System.Collections.Generic.List<(string label, double seconds)>
+        {
+            ("WebGL 빌드", 12.5),
+        };
+
+        string formatted = AITConvertCore.FormatPhaseTimings(phaseTimings, 12.5, "WebGL 빌드");
+
+        Assert.AreEqual(
+            "AIT: 단계별 소요(실패: WebGL 빌드) — WebGL 빌드 12.5s (실패까지 12.5s)",
+            formatted);
+    }
+
+    [Test]
+    public void FormatPhaseTimings_EmptyPhaseList_StillProducesTotal()
+    {
+        var phaseTimings = new System.Collections.Generic.List<(string label, double seconds)>();
+
+        string formatted = AITConvertCore.FormatPhaseTimings(phaseTimings, 3.0);
+
+        Assert.AreEqual("AIT: 단계별 소요 —  (총 3.0s)", formatted);
+    }
+
+    [Test]
+    public void FormatPhaseTimings_UsesInvariantCulture_ForDecimalSeparator()
+    {
+        // 소수점 구분자가 시스템 로케일(예: 콤마 사용 로케일)에 흔들리지 않고 항상 '.'이어야 함.
+        var previousCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("de-DE");
+            var phaseTimings = new System.Collections.Generic.List<(string label, double seconds)>
+            {
+                ("WebGL 빌드", 1000.5),
+            };
+
+            string formatted = AITConvertCore.FormatPhaseTimings(phaseTimings, 1000.5);
+
+            StringAssert.Contains("1000.5s", formatted);
+            StringAssert.DoesNotContain(",5s", formatted);
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = previousCulture;
+        }
     }
 }


### PR DESCRIPTION
## 요약

Deploy (Test) 배포 경로만 빌드 가속용으로 압축 포맷·Managed Stripping Level을 오버라이드하고, `DoExportAsync`를 쓰는 모든 인터랙티브 빌드 경로에 단계별 소요 시간 계측 로그를 추가합니다.

| 진입점 | 압축 포맷 | Managed Stripping | 단계별 시간 로그 |
|---|---|---|---|
| Deploy (Test) | **Gzip로 오버라이드** (기존: Production과 동일 설정 상속) | **Minimal로 오버라이드** (기존: Production과 동일 설정 상속) | 추가됨 |
| Deploy (Production) | 무변경 (`config.productionProfile` 그대로) | 무변경 | 추가됨 |
| Build & Package | 무변경 | 무변경 | 추가됨 |
| Dev Server | 무변경 | 무변경 | 추가됨 |

## 변경 내용

1. **`Editor/AITEditorScriptObject.cs`** — `AITBuildProfile.CreateTestDeployProfile(baseProfile)` 추가. `baseProfile`(보통 `config.productionProfile`)의 나머지 필드는 그대로 복사한 **새 인스턴스**를 object initializer로 생성하고, `compressionFormat`/`managedStrippingLevel`만 오버라이드합니다. `Clone()` + 필드 대입 방식을 쓰지 않은 이유는 원본 `baseProfile` 인스턴스(ScriptableObject로 `AITConfig.asset`에 영속화됨)를 절대 건드리지 않기 위해서입니다 — 이 함수는 baseProfile을 읽기 전용으로만 사용합니다.

   오버라이드 값 근거 (`Editor/AITBuildInitializer.cs`의 저장값→enum 변환 주석):
   - `ConvertToCompressionFormat`: `저장값: -1=자동, 0=Disabled, 1=Gzip, 2=Brotli` → Gzip = **1**
   - `ConvertToManagedStrippingLevel`: `저장값(UI 순서): -1=자동, 0=Disabled(레거시), 1=Minimal, 2=Low, 3=Medium, 4=High` → Minimal = **1**

2. **`Editor/Menu/AITDeployManager.cs`** — `RunDeploy(DeployKind kind)`에서 `kind == DeployKind.Test`일 때만 `AITBuildProfile.CreateTestDeployProfile(config.productionProfile)`로 만든 새 프로필을 `DoExportAsync`에 전달합니다. Production 분기는 기존과 동일하게 `config.productionProfile`을 그대로 사용하므로 한 글자도 영향받지 않습니다. 또한 `ExecuteDeploy`의 사전 확인 다이얼로그에 Deploy (Test) 산출물이 압축 Gzip(Production은 Brotli)·스트리핑 Minimal(Production은 High)로 생성된다는 고지 문구를 추가해, QR로 성능을 측정하는 테스터가 오해하지 않도록 했습니다.

3. **`Editor/AITConvertCore.cs`** — `DoExportAsync` 내부에 `PhaseTimingTracker`를 추가해 `onProgress`로 전달되는 `BuildPhase` 전환 시점을 가로채 단계별(WebGL 빌드/파일 복사/pnpm install/vite·ait build) 누적 소요 시간을 계측합니다. `onComplete` 시점에 요약 1줄을 `Debug.Log`로 남깁니다. 래핑된 콜백(`trackedOnProgress`/`trackedOnComplete`)을 `AITPackageBuilder.CompletePackagingAfterWebGLBuild`/`GenerateMiniAppPackageAsync` 등 중첩 호출에도 그대로 전달해, 호출 체인 전체의 단계 전환을 놓치지 않습니다. 이 계측은 `DoExportAsync`를 쓰는 모든 인터랙티브 진입점(Deploy Test/Production, Build & Package, Dev Server)에 공통 적용되는 사이드 이펙트이며, 그 외 동작은 전혀 바꾸지 않습니다.

   실제 로그 포맷 예시(성공):
   ```
   AIT: 단계별 소요 — WebGL 빌드 87.3s · 파일 복사 2.1s · pnpm install 0.4s · vite/ait build 41.2s (총 131.0s)
   ```
   실패 시(예: WebGL 빌드 단계 도중 실패):
   ```
   AIT: 단계별 소요(실패: WebGL 빌드) — WebGL 빌드 12.5s (실패까지 12.5s)
   ```
   포맷 생성 로직은 순수 함수 `internal static string FormatPhaseTimings(...)`로 분리해 테스트 가능하게 했고, `CultureInfo.InvariantCulture`로 소수점 로케일 문제를 방지했습니다.

4. **`Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs`** — 신규 테스트 8종 추가:
   - `CreateTestDeployProfile_Overrides_CompressionAndStripping`
   - `CreateTestDeployProfile_PreservesRemainingFields_FromBaseProfile`
   - `CreateTestDeployProfile_DoesNotMutate_BaseProfileInstance`
   - `CreateTestDeployProfile_ReturnsDifferentInstance_FromBaseProfile`
   - `FormatPhaseTimings_SuccessCase_MatchesExpectedFormat`
   - `FormatPhaseTimings_FailureCase_IncludesFailedPhaseLabel`
   - `FormatPhaseTimings_EmptyPhaseList_StillProducesTotal`
   - `FormatPhaseTimings_UsesInvariantCulture_ForDecimalSeparator`

   모두 Pass. 기존 `GetBuildFlags` 관련 테스트(`DeployMemoTests.cs`)도 무변경으로 계속 통과합니다.

## 트레이드오프

- **다운로드 크기**: Gzip은 Brotli보다 압축률이 낮아 Deploy (Test) 산출물의 다운로드 크기가 소폭 증가합니다. 배포 확인 다이얼로그에 고지 문구를 추가했습니다. Production 배포는 그대로 Brotli를 사용하므로 최종 사용자에게 전달되는 산출물은 영향받지 않습니다.
- **Managed Stripping 관련 버그 재현 범위 축소**: Deploy (Test)가 Minimal 스트리핑으로 바뀌면서, High 스트리핑에서만 재현되는 코드 스트리핑 관련 버그(예: 리플렉션 대상 누락)는 이제 Deploy (Production) 또는 로컬에서 Production 프로필로 직접 빌드해야만 재현됩니다. Deploy (Test)만으로는 더 이상 이 클래스의 버그를 잡을 수 없습니다.

## decompressionFallback / 빌드 파이프라인 정합성

압축 포맷을 Gzip으로 바꿔도 다운스트림 파이프라인 수정이 필요 없음을 코드로 확인했습니다:

- `PlayerSettings.WebGL.decompressionFallback`은 `compressionFormat`과 독립적인 별도 축(`Editor/AITBuildInitializer.cs`)이며 기본값 `true`입니다. `decompressionFallback == true`일 때는 확장자와 무관하게 `.unityweb` 산출물이 생성되고, `Editor/AITBuildValidator.cs`의 `GetFilePatterns`가 이를 인지해 파일 패턴을 반환합니다.
- `Editor/Package/WebGLBuildCopier.cs`는 이 패턴을 소비하며, 정확한 확장자 매치가 실패해도 와일드카드 폴백을 갖고 있어 Gzip/Brotli 어느 쪽이든 안전하게 동작합니다.
- `WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts`의 `unity-web-content-encoding` 플러그인(`detectUnityWebCompression`)은 파일 헤더의 매직 스트링(`'(brotli)'`/`'(gzip)'`)을 직접 스니핑해 실제 압축 알고리즘을 판별하므로, 애초에 압축 포맷에 대해 알고리즘 비의존적으로 설계되어 있습니다. Gzip은 이미 1급으로 지원되는 포맷입니다.

즉, 이번 변경은 프로필 값 자체만 바꾸며 빌드 파이프라인의 나머지 구간은 수정 없이 그대로 호환됩니다.

## 테스트

- `./run-local-tests.sh --validate`: 4개 중 3개 통과. 유일한 실패는 `sdk-runtime-generator~`의 `pnpm install` 단계에서 발생한 `ERR_PNPM_TARBALL_INTEGRITY`(복수의 `@apps-in-toss/*` 패키지 체크섬 불일치)로, 미러 네트워크 이슈에 의한 기지의 노이즈이며 이번 변경과 무관합니다.
- Unity EditMode 전체 테스트(격리된 프로젝트 사본에서 실행): **total=1222, passed=1208, failed=0, inconclusive=1, skipped=13**. `inconclusive=1`은 기존에도 존재하던 `BuildFileSelectionTests.FindFileInBuild_DeleteFails_FallsBackAndLogs_Windows`(Windows 전용 케이스, 현재 macOS 실행 환경에서는 항상 inconclusive)로 이번 변경과 무관합니다. 신규 테스트 8종 전부 Pass 포함.
- `Runtime/SDK/`, pnpm lockfile, `.meta` 파일에는 변경 없음(`git diff --stat`로 확인, 변경 파일은 위 4개뿐).

## 문서

`Documentation~/BuildProfiles.md`의 "Test/Production 동일 설정" 서술이 이번 변경으로 stale해집니다. **저장소 규칙상 `*.md` 파일은 사용자의 명시적 허락 없이 수정할 수 없어 이번 PR에서는 문서를 갱신하지 않았습니다. BuildProfiles.md 문서 갱신 필요 — 별도 승인 대기.**
