### PR TITLE
문서: BuildProfiles.md에 Deploy (Test) Gzip·Minimal 오버라이드 반영

### DIFF
--- a/Documentation~/BuildProfiles.md
+++ b/Documentation~/BuildProfiles.md
@@ -19,10 +19,10 @@
 |------|:-----------:|:-----------------:|:----------:|:---------------:|:--------:|:-----------:|
 | **Dev Server** | ✅ 활성화 | ✅ 활성화 | Disabled | Minimal | ✅ 활성화 | Embedded |
 | **Build & Package** | ❌ 비활성화 | ❌ 비활성화 | 자동 (Brotli) | 자동 (High) | ✅ 활성화 | External |
-| **Deploy (Test)** | ❌ 비활성화 | ❌ 비활성화 | 자동 (Brotli) | 자동 (High) | ✅ 활성화 | External |
+| **Deploy (Test)** | ❌ 비활성화 | ❌ 비활성화 | Gzip (오버라이드) | Minimal (오버라이드) | ✅ 활성화 | External |
 | **Deploy (Production)** | ❌ 비활성화 | ❌ 비활성화 | 자동 (Brotli) | 자동 (High) | ✅ 활성화 | External |
 
-Deploy (Test)와 Deploy (Production)은 같은 프로덕션 프로필을 쓰므로 위 설정값은 동일합니다. 둘의 차이는 이 표에 없는 **빌드 범위**(증분 vs 클린)와 **배포 memo 접두사**(`-m "[Test] …"` / `-m "[Production] …"`)입니다 — 콘솔에서 이 접두사로 두 배포를 구분합니다.
+Deploy (Test)는 production 프로필의 복제본에 압축(Gzip)·스트리핑(Minimal) 오버라이드를 적용해 배포 속도를 높입니다(`AITEditorScriptObject.CreateTestDeployProfile`) — Brotli 대비 다운로드 크기가 소폭 늘고 Minimal 스트리핑은 산출물 크기가 커질 수 있으니, 테스트 배포 결과를 성능·크기 측정 기준으로 삼지 마세요. 여기에 더해 증분 빌드 + IL2CPP Debug/OptimizeSize 빠른 빌드(fastBuild)도 함께 적용됩니다(`AITDeployManager.RunDeploy`). Deploy (Production)과 Build & Package는 이런 오버라이드 없이 `config.productionProfile` 원본 그대로 사용합니다. 둘의 나머지 차이는 이 표에 없는 **빌드 범위**(증분 vs 클린)와 **배포 memo 접두사**(`-m "[Test] …"` / `-m "[Production] …"`)입니다 — 콘솔에서 이 접두사로 두 배포를 구분합니다.
 
 > `Mock 브릿지`는 빌드 프로필 항목이 아닙니다. `devtools`(`@apps-in-toss/devtools`)는 별도 절 참고.
 
@@ -65,7 +65,7 @@ Unity의 Development Build 옵션입니다.
 | Gzip | Gzip 압축 |
 | Brotli | Brotli 압축 (최고 압축률) |
 
-Dev Server만 빌드 속도를 위해 Disabled이고, 나머지 프로필은 자동(Brotli)입니다.
+Dev Server는 빌드 속도를 위해 Disabled, Deploy (Test)는 배포 가속을 위해 Gzip으로 오버라이드됩니다(Brotli 대비 다운로드 크기 소폭 증가 — 성능·크기 측정 기준으로 쓰지 마세요). 나머지(Build & Package, Deploy (Production))는 자동(Brotli)입니다.
 
 ### Stripping Level
 
@@ -79,7 +79,7 @@ Dev Server만 빌드 속도를 위해 Disabled이고, 나머지 프로필은 자
 | Medium | 중간 수준의 코드 제거 |
 | High | 적극적으로 코드 제거 (최소 빌드 크기) |
 
-Dev Server만 빌드 속도를 위해 Minimal이고, 나머지는 자동(High)입니다.
+Dev Server와 Deploy (Test)는 빌드 속도를 위해 Minimal이고(Deploy (Test)는 오버라이드 — High 대비 산출물 크기가 커질 수 있습니다), 나머지(Build & Package, Deploy (Production))는 자동(High)입니다.
 
 > **참고**: Disabled는 WebGL(IL2CPP)에서 지원되지 않아 옵션에서 제외되었으며, 이전 버전에서 Disabled로 저장된 값은 Minimal로 정규화됩니다. 리플렉션으로만 참조되는 타입이 High에서 제거될 수 있으니, 스트리핑 이후 동작이 달라지면 `link.xml`로 보존 대상을 지정하세요.
 


### PR DESCRIPTION
## 배경

#1072(`a9c03a4c`)로 **Deploy (Test)** 메뉴가 production 프로필의 복제본에 두 가지 오버라이드를 적용하도록 바뀌었습니다:

- `compressionFormat = 1` (Gzip) — 기존 production은 자동(Brotli)
- `managedStrippingLevel = 1` (Minimal) — 기존 High

`Documentation~/BuildProfiles.md`의 "Deploy (Test)와 Deploy (Production)이 같은 프로덕션 프로필/설정을 쓴다"는 서술이 이 변경으로 stale해져 실제 동작 기준으로 정정했습니다.

## 변경 요지

- 프로필 매트릭스 표: Deploy (Test) 행의 WebGL 압축/Stripping Level을 `Gzip (오버라이드)` / `Minimal (오버라이드)`로 수정 (기존: `자동 (Brotli)` / `자동 (High)`)
- 표 아래 설명 문단: Deploy (Test)가 production 프로필 기반 + Gzip·Minimal 오버라이드 + 증분 빌드 + IL2CPP Debug/OptimizeSize fastBuild로 동작함을 명시. Deploy (Production)/Build & Package는 오버라이드 없이 `productionProfile` 원본 그대로임을 명시
- "WebGL 압축", "Stripping Level" 절: Deploy (Test)의 오버라이드와 트레이드오프(Gzip은 Brotli 대비 다운로드 크기 소폭 증가, Minimal 스트리핑은 산출물 크기 증가 가능 — 테스트 배포 결과를 성능/크기 측정 기준으로 삼지 말 것) 반영

## 근거 코드

- `Editor/AITEditorScriptObject.cs` `CreateTestDeployProfile(AITBuildProfile baseProfile)`
- `Editor/Menu/AITDeployManager.cs` `RunDeploy`(`kind == DeployKind.Test` 분기), `ExecuteDeploy`의 `fastBuildNotice`

## 범위

`Documentation~/BuildProfiles.md` 1개 파일만 수정했습니다. Unity 실행/빌드 없음, `Documentation~`는 `~` 접미 디렉토리라 `.meta` 불필요합니다.