### PR TITLE
수정: String Check push 스캔의 force-push 범위 폴백 추가

### DIFF
--- a/.github/workflows/string-check.yml
+++ b/.github/workflows/string-check.yml
@@ -155,18 +155,37 @@ jobs:
         run: |
           set -euo pipefail
           Z40=0000000000000000000000000000000000000000
-          # range 계산. PR 은 base..head(정확히 PR 커밋). push 기존 브랜치는 before..after.
-          # push 새 브랜치/태그(before=40-zero)는 '방금 푸시된 ref 를 제외한 다른 모든 remote
-          # 브랜치·태그' 를 기준으로 'after 에서만 도달 가능한' 커밋 — orphan/disjoint 히스토리의
+
+          # '방금 푸시된 ref 를 제외한 다른 모든 remote 브랜치·태그' 기준으로 EV_AFTER 에서만
+          # 도달 가능한 커밋 range 를 계산한다 — 신규 브랜치 최초 push 와 force-push before 유실
+          # 폴백이 공유하는 로직이라 함수로 공용화(중복 구현 금지). orphan/disjoint 히스토리의
           # 첫 푸시 커밋도 전부 포함(tip-only 아님, origin/main merge-base 아님).
+          others_fallback_range() {
+            local CUR OTHERS
+            if [ "$REF_TYPE" = "tag" ]; then CUR="refs/tags/$PUSH_REF"; else CUR="refs/remotes/origin/$PUSH_REF"; fi
+            OTHERS=$(git for-each-ref --format='%(refname)' refs/remotes/origin refs/tags | grep -vFx "$CUR" || true)
+            if [ -n "$OTHERS" ]; then echo "$EV_AFTER --not $OTHERS"; else echo "$EV_AFTER"; fi
+          }
+
+          # range 계산. PR 은 base..head(정확히 PR 커밋). push 기존 브랜치는 before..after 가 기본이나,
+          # 리베이스 force-push 시 EV_BEFORE(구 head)가 어떤 ref 에서도 도달 불가해 fetch-depth:0
+          # checkout 에도 없을 수 있다(방치 시 git log rc=128 로 fail-closed) — 로컬 존재 여부를 먼저
+          # 확인하고, 없으면 SHA 직접 fetch 를 한 번 시도한다(GitHub 은 SHA 직접 fetch 를 허용하므로
+          # force-push 직후 구 head 는 대체로 아직 fetch 가능). 그마저 실패하면(구 객체 만료 등) 신규
+          # 브랜치와 동일한 OTHERS 폴백으로 대체한다. push 새 브랜치/태그(before=40-zero)는 처음부터
+          # 이 OTHERS 폴백을 사용한다.
           if [ -n "${PR_HEAD:-}" ]; then
             RANGE="$PR_BASE..$PR_HEAD"
           elif [ "${EV_BEFORE:-$Z40}" != "$Z40" ]; then
-            RANGE="$EV_BEFORE..$EV_AFTER"
+            if git cat-file -e "$EV_BEFORE^{commit}" 2>/dev/null; then
+              RANGE="$EV_BEFORE..$EV_AFTER"
+            elif git fetch --quiet origin "$EV_BEFORE" 2>/dev/null; then
+              RANGE="$EV_BEFORE..$EV_AFTER"
+            else
+              RANGE="$(others_fallback_range)"
+            fi
           else
-            if [ "$REF_TYPE" = "tag" ]; then CUR="refs/tags/$PUSH_REF"; else CUR="refs/remotes/origin/$PUSH_REF"; fi
-            OTHERS=$(git for-each-ref --format='%(refname)' refs/remotes/origin refs/tags | grep -vFx "$CUR" || true)
-            if [ -n "$OTHERS" ]; then RANGE="$EV_AFTER --not $OTHERS"; else RANGE="$EV_AFTER"; fi
+            RANGE="$(others_fallback_range)"
           fi
 
           # (B) 커밋 메시지 — pathspec 없이 스캔(경로에 안 걸리는 orphan/메시지-only 유출 커밋 누락 방지).


### PR DESCRIPTION
## 결함

`.github/workflows/string-check.yml`의 `scan` job, "Scan commit messages and file paths" 스텝의 push 이벤트 range 계산에서, 기존 브랜치 push는 `RANGE="$EV_BEFORE..$EV_AFTER"`를 사용했다.

**리베이스 force-push** 시 `EV_BEFORE`(구 head)가 어떤 remote ref/tag 에서도 도달 불가능해지는데, `fetch-depth: 0` checkout으로도 이 커밋 객체는 받아지지 않는다 → `git log $RANGE` 가 `rc=128`로 실패 → 기존 fail-closed 정책에 의해 job 자체가 실패한다. 2026-08-17 세 PR 브랜치를 리베이스했을 때 실제로 셋 다 이 경로로 required check(`scan`)가 blocked됐다.

신규 브랜치 최초 push(before=all-zero) 경로는 이미 "방금 푸시된 ref를 제외한 다른 모든 remote 브랜치·태그 기준 도달 가능한 커밋" 폴백(OTHERS 로직)을 갖고 있었지만, force-push 경로에는 동일한 안전장치가 없었다.

## 수정

같은 스텝의 range 계산부만 수정했다(다른 스텝·트리거·시크릿 처리 로직은 변경 없음):

1. PR 이벤트: 기존과 동일하게 `PR_BASE..PR_HEAD`.
2. push + before가 all-zero가 아닌 경우: `git cat-file -e "$EV_BEFORE^{commit}"`로 로컬 존재를 먼저 확인. 없으면 `git fetch --quiet origin "$EV_BEFORE"`를 한 번 시도(GitHub은 SHA 직접 fetch를 허용하므로 force-push 직후의 구 head는 대체로 아직 fetch 가능). 성공하면 기존과 동일하게 `EV_BEFORE..EV_AFTER` 사용.
3. fetch도 실패하면(구 객체 만료 등) 신규 브랜치와 **동일한 OTHERS 폴백**을 사용한다. 이 로직은 새 브랜치 케이스와 셸 함수로 공용화해 중복 구현하지 않았다.
4. 그 외 git 오류는 기존과 동일하게 fail-closed 유지(완화하지 않음 — 이 워크플로의 설계 원칙은 "오류=차단").
5. 스텝 상단 range 계산 주석을 새 동작(force-push 폴백 포함)에 맞게 갱신.

## 검증 (이 PR 브랜치에서 end-to-end 실행)

push 이벤트는 push된 ref의 워크플로 사본을 실행하므로, 이 수정 자체를 이 브랜치에서 실검증했다.

1. **정상 push** (신규 브랜치 최초 push, before=all-zero → 기존 OTHERS 폴백 경로): scan **success**.
   - https://github.com/toss/apps-in-toss-unity-sdk/actions/runs/32105705661
   - `Scan commit messages and file paths` 스텝 conclusion: success
2. **force-push 시나리오** (`git commit --amend --no-edit` 후 서명 유지, `git push --force-with-lease`): 새 push 이벤트에서 `before`가 리라이트 전 구 head SHA로 오는데, 이 SHA는 push 직후 어떤 remote ref/tag에서도 도달 불가능함을 별도로 확인했다(`git merge-base --is-ancestor` 전 remote ref/tag 순회, 매치 없음). 수정 전이라면 `git log rc=128`로 fail-closed 실패했을 이 시나리오에서 scan이 **success**로 완료됨을 확인.
   - https://github.com/toss/apps-in-toss-unity-sdk/actions/runs/32105759759
   - `Scan commit messages and file paths` 스텝 conclusion: success, 로그에 `commit-message + path scan OK` 출력 확인(스킵이 아닌 실제 실행 완료)
3. `actionlint`(로컬 설치본) 통과 — 워크플로 문법 및 임베디드 셸 스크립트 이상 없음.

## 영향 범위

`.github/workflows/string-check.yml` 1개 파일, "Scan commit messages and file paths" 스텝의 range 계산 로직만 변경. 다른 스텝(Guard, Scan tree, Scan lockfiles, Scan ref name, Scan annotated tag message, Scan PR title and body)과 트리거·시크릿 처리는 무변경.