### PR TITLE
수정: cloudflared를 0.7.1로 고정하는 pnpm override

### DIFF
--- a/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
@@ -21,6 +21,10 @@ overrides:
   '@granite-js/plugin-core': 0.1.30
   find-my-way: '>=8.2.2'
   ip: '>=2.0.1'
+  # 일부 npm 미러/프록시 환경에서 cloudflared 0.7.3 타르볼이 404를 반환해 클라이언트
+  # SDK 빌드의 pnpm install이 실패하는 사례가 있다. 0.7.1은 동일 환경에서 정상 제공되고
+  # @apps-in-toss/devtools@3.0.3이 요구하는 범위(^0.7.1) 안이라 0.7.1로 고정한다.
+  cloudflared: 0.7.1
   # dependabot 취약점 대응(패치 존재분). granite 빌드 툴체인의 전이 의존이며
   # WebGL 산출물에 배포되지 않는다. 예기치 않은 상위 major 점프 차단 위해 캡.
   '@babel/core': '>=7.29.6 <8'


### PR DESCRIPTION
## 문제

일부 npm 미러/프록시 환경에서 `cloudflared-0.7.3.tgz` 타르بال 요청이 404를 반환해, 클라이언트 SDK 빌드의 `pnpm install`이 실패한다(0.7.1·0.7.0 타르볼은 동일 환경에서 정상 제공됨). `cloudflared`는 `@apps-in-toss/devtools@3.0.3`의 의존성(`^0.7.1`)으로 딸려 들어오며, pnpm이 satisfies 범위 내 최신(0.7.3)을 우선 해석하면서 발생한다.

## 조치

- `WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml`의 `overrides`에 `cloudflared: 0.7.1`을 추가해 해석 버전을 고정했다. 0.7.1은 `^0.7.1` 범위 안이라 semver 계약을 위반하지 않는다.
- lockfile(`pnpm-lock.yaml`)은 로컬에서 수동 편집하지 않고, GitHub Actions `Regenerate Lockfiles` 워크플로우로 재생성해 이 브랜치에 반영한다.

## 검증

- 재생성된 `WebGLTemplates/AITTemplate/BuildConfig~/pnpm-lock.yaml`에서 `cloudflared`가 `0.7.1`로 해석되는지 확인.
- `Regenerate Lockfiles` 워크플로우의 frozen-lockfile 검증 단계(실제 tarball 존재/무결성 확인)를 통과하는지 확인.
