### PR TITLE
개선: 공개 문서 참조를 GitBook 포털 URL로 전환

### DIFF
--- a/.github/workflows/sdk-update-rebase.yml
+++ b/.github/workflows/sdk-update-rebase.yml
@@ -319,18 +319,6 @@ jobs:
           pnpm install --no-frozen-lockfile
           echo "BuildConfig pnpm-lock.yaml 업데이트 완료"
 
-      - name: Documentation~/GettingStarted.md 설치 가이드 업데이트
-        if: steps.author-check.outputs.skip != 'true'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG_NAME="release/v${VERSION}"
-
-          # Documentation~/GettingStarted.md의 Git URL을 최신 릴리즈 태그로 업데이트
-          sed -i 's|https://github.com/toss/apps-in-toss-unity-sdk\.git\(#[^"]*\)\?|https://github.com/toss/apps-in-toss-unity-sdk.git#'"${TAG_NAME}"'|g' Documentation~/GettingStarted.md
-
-          echo "Documentation~/GettingStarted.md 업데이트 완료: #${TAG_NAME}"
-          grep -n "apps-in-toss-unity-sdk.git" Documentation~/GettingStarted.md || true
-
       - name: 기존 브랜치에 force-push
         if: steps.author-check.outputs.skip != 'true'
         id: push
@@ -364,7 +352,6 @@ jobs:
           - main 브랜치 최신 상태 기반 리베이스
           - package.json 버전 동기화
           - BuildConfig package.json web-framework/web-analytics/bridge-core 버전 동기화
-          - Documentation~/GettingStarted.md 설치 가이드 업데이트
 
           자동 생성: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -376,20 +376,6 @@ jobs:
           pnpm install --no-frozen-lockfile
           echo "BuildConfig pnpm-lock.yaml 업데이트 완료"
 
-      - name: Documentation~/GettingStarted.md 설치 가이드 업데이트
-        if: steps.check.outputs.skip != 'true'
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG_NAME="release/v${VERSION}"
-
-          # Documentation~/GettingStarted.md의 Git URL을 최신 릴리즈 태그로 업데이트
-          # 패턴: https://github.com/toss/apps-in-toss-unity-sdk.git 또는
-          #       https://github.com/toss/apps-in-toss-unity-sdk.git#release/vX.X.X
-          sed -i 's|https://github.com/toss/apps-in-toss-unity-sdk\.git\(#[^"]*\)\?|https://github.com/toss/apps-in-toss-unity-sdk.git#'"${TAG_NAME}"'|g' Documentation~/GettingStarted.md
-
-          echo "Documentation~/GettingStarted.md 업데이트 완료: #${TAG_NAME}"
-          grep -n "apps-in-toss-unity-sdk.git" Documentation~/GettingStarted.md || true
-
       - name: 브랜치 생성 및 커밋
         if: steps.check.outputs.skip != 'true'
         id: commit
@@ -415,7 +401,6 @@ jobs:
           - package.json 버전 동기화
           - BuildConfig package.json web-framework/web-analytics/bridge-core 버전 동기화
           - unity-bridge.ts 자동 생성
-          - Documentation~/GettingStarted.md 설치 가이드 업데이트
 
           자동 생성: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ review-fix-loop 등 자동화 skill이 파싱하는 규약 섹션. 각 항목은
 
 ## 상세 문서
 
-`Documentation~/`가 문서 루트다. 인덱스는 `Documentation~/README.md`.
+`Documentation~/`가 문서 루트다. 공개 문서 정본은 포털(https://developers-apps-in-toss.toss.im/documentation/unity)이며, 저장소의 공개 문서 사본 11종(README/GettingStarted/APIUsagePatterns/Troubleshooting/Advertising/Metrics/SentryIntegration/BuildProfiles/BuildCustomization/LoadingScreenCustomization/BuildProcess)은 제거 예정 — 그때까지 편집 동결.
 
 **내부 런북** (`Documentation~/internal/`) — 저장소 운영용, 필요할 때 Read로 가져가서 참조:
 
@@ -165,10 +165,9 @@ review-fix-loop 등 자동화 skill이 파싱하는 규약 섹션. 각 항목은
 - `sentry-known-issues.md` — 무시 가능 이슈 목록, environment 분리, fallback warning 컨벤션, 이중 안전망, 릴리즈 게이트 resolve
 - `build-session-recovery.md` — `AITBuildSessionRecovery` 수동 재현 절차 (`.cs` 저장 / 강제 종료 / Stale 세션 / Idle gate)
 
-**공개 문서** (`Documentation~/`) — 제품 동작의 정본. 내부 런북은 여기를 링크만 한다:
+**저장소 잔류 문서** (`Documentation~/`) — 이관 대상이 아니라 계속 저장소에서 관리:
 
-- `BuildProcess.md` — 2단계 빌드 파이프라인, 플레이스홀더 치환, 에러 코드, 내장 Node/pnpm
-- `BuildProfiles.md` — 프로필 4종, 환경 변수 오버라이드
-- `BuildCustomization.md` — 사용자 영역 마커, 외부 라이브러리 추가
-- `APIUsagePatterns.md` — async/await, `AITException.ErrorCode`, 타임아웃, Mock 브릿지, IAP 지급 승인
 - `Contributing.md` — 개발 환경, git hooks, `run-local-tests.sh`, 커밋·PR 규칙
+- `ManualIntegration.md` — SDK 없이 수동으로 WebGL 빌드하는 방법
+- `BetaChannel.md` / `PerfBetaChannel.md` — 파일럿 전용 옵트인 채널 가이드
+- `changelog/` — 릴리즈별 변경 이력

--- a/Documentation~/BetaChannel.md
+++ b/Documentation~/BetaChannel.md
@@ -28,7 +28,7 @@
 }
 ```
 
-Package Manager의 `Add package from git URL...`에 같은 URL을 넣어도 됩니다. 설치 ref를 다루는 방법 전반은 [시작하기](GettingStarted.md)의 설치 ref 관리 절에 정리되어 있습니다.
+Package Manager의 `Add package from git URL...`에 같은 URL을 넣어도 됩니다. 설치 ref를 다루는 방법 전반은 [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started)의 설치 ref 관리 절에 정리되어 있습니다.
 
 특정 베타 스냅샷에 고정하려면 이동 브랜치 대신 스냅샷 태그(`#release/v3.0.0-beta.<해시>`)를 쓰세요. 베타 릴리즈 목록은 [GitHub Releases](https://github.com/toss/apps-in-toss-unity-sdk/releases)에서 `prerelease` 표시로 확인할 수 있습니다.
 
@@ -36,7 +36,7 @@ Package Manager의 `Add package from git URL...`에 같은 URL을 넣어도 됩�
 
 자동 업데이트 프롬프트가 뜨지 않으므로, 새 베타 안내를 받으면 직접 최신 `beta` HEAD를 다시 당겨와야 합니다. UPM이 커밋 해시를 `packages-lock.json`에 잠가 두기 때문에 Unity를 다시 여는 것만으로는 갱신되지 않습니다.
 
-구체적인 두 가지 방법(패키지 제거 후 재추가 / lock 해제)은 [시작하기](GettingStarted.md)의 설치 ref 관리 절에 있습니다. 베타 채널이라서 다른 것은 없고, 이동 ref를 쓰는 모든 경우에 같은 절차가 적용됩니다.
+구체적인 두 가지 방법(패키지 제거 후 재추가 / lock 해제)은 [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started)의 설치 ref 관리 절에 있습니다. 베타 채널이라서 다른 것은 없고, 이동 ref를 쓰는 모든 경우에 같은 절차가 적용됩니다.
 
 ## stable 로 복귀
 
@@ -54,10 +54,10 @@ stable 태그로 핀하면 자동 업데이터가 다시 해당 ref를 추적합
 - **재현 가능한 빌드**: `beta`는 force-push로 갱신되는 이동 ref입니다. 같은 산출물을 다시 만들어야 한다면 스냅샷 태그로 핀하세요.
 - **Latest 아님**: 베타 릴리즈는 항상 prerelease로 표시되며 stable의 Latest 표시에 영향을 주지 않습니다.
 - **메이저 변경**: 빌드·배포 동작이 stable과 다를 수 있습니다. 파일럿 중 발견한 이슈는 안내받은 채널로 즉시 공유해 주세요.
-- **Sentry 분리**: 베타 빌드의 에러는 `environment:beta`로 분리 수집되어 stable triage를 오염시키지 않습니다. 자세한 내용은 [Sentry 연동](SentryIntegration.md)을 참고하세요.
+- **Sentry 분리**: 베타 빌드의 에러는 `environment:beta`로 분리 수집되어 stable triage를 오염시키지 않습니다. 자세한 내용은 [Sentry 연동](https://developers-apps-in-toss.toss.im/documentation/unity/add-features/sentry-integration)을 참고하세요.
 
 ## 관련 문서
 
-- [시작하기](GettingStarted.md) — 설치 ref 관리 공통 절차
+- [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started) — 설치 ref 관리 공통 절차
 - [perf 베타 채널](PerfBetaChannel.md) — 콜드 로드 최적화 파일럿 채널
-- [문제 해결](Troubleshooting.md) — 문제가 생겼을 때
+- [FAQ](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/faq) — 문제가 생겼을 때

--- a/Documentation~/Contributing.md
+++ b/Documentation~/Contributing.md
@@ -2,7 +2,7 @@
 
 SDK 자체를 고칠 때 필요한 개발 환경 설정과 규칙입니다.
 
-> **대상**: SDK 기여자. SDK를 사용하기만 한다면 [시작하기](GettingStarted.md)로 가세요.
+> **대상**: SDK 기여자. SDK를 사용하기만 한다면 [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started)로 가세요.
 
 ## 개발 환경 설정
 
@@ -139,6 +139,6 @@ feat: Add user authentication API    영어 사용
 
 ## 관련 문서
 
-- [시작하기](GettingStarted.md) — SDK 사용자 관점의 설치와 설정
-- [빌드 파이프라인](BuildProcess.md) — 빌드가 실제로 하는 일
-- [문제 해결](Troubleshooting.md) — 빌드가 막혔을 때
+- [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started) — SDK 사용자 관점의 설치와 설정
+- [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process) — 빌드가 실제로 하는 일
+- [FAQ](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/faq) — 빌드가 막혔을 때

--- a/Documentation~/ManualIntegration.md
+++ b/Documentation~/ManualIntegration.md
@@ -1,10 +1,10 @@
 # 수동 연동
 
-> **참고**: Apps in Toss Unity SDK 사용을 권장합니다. 수동 연동 방식은 JS Bridge, WebGL 빌드 설정, 패키징을 모두 직접 구현해야 합니다. 특별한 이유가 없다면 [SDK를 사용한 자동 연동](GettingStarted.md)을 사용하세요.
+> **참고**: Apps in Toss Unity SDK 사용을 권장합니다. 수동 연동 방식은 JS Bridge, WebGL 빌드 설정, 패키징을 모두 직접 구현해야 합니다. 특별한 이유가 없다면 [SDK를 사용한 자동 연동](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started)을 사용하세요.
 
 Apps in Toss에 Unity 게임을 배포하려면 Unity 프로젝트를 WebGL로 빌드해야 합니다. 이 문서는 SDK 없이 Unity에서 WebGL 빌드를 만드는 지점까지를 설명합니다. 웹 프로젝트로 감싸 배포 가능한 패키지로 만드는 작업(Vite 구성, `.ait` 패키징)은 다루지 않습니다 — 아래 "5. 결과물 확인" 절 참고.
 
-SDK를 사용하면 이 과정 전체(WebGL 빌드부터 `.ait` 패키징까지)가 자동화됩니다. 자동화된 과정의 내부 동작은 [빌드 파이프라인](BuildProcess.md)에 정리되어 있습니다.
+SDK를 사용하면 이 과정 전체(WebGL 빌드부터 `.ait` 패키징까지)가 자동화됩니다. 자동화된 과정의 내부 동작은 [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process)에 정리되어 있습니다.
 
 ## 1. WebGL 모듈 설치
 
@@ -29,7 +29,7 @@ Edit > Project Settings > Player 메뉴에서 다음 항목을 설정합니다.
 - Publishing Settings
   - Compression Format: `Brotli`로 설정
 
-> **참고**: SDK를 사용한 자동 연동에서도 Production Server, Build & Package, Publish 프로필은 압축 포맷을 자동으로 Brotli로 설정합니다. Dev Server 프로필만 빌드 속도를 위해 압축을 비활성화합니다. 프로필별 매트릭스는 [빌드 프로필](BuildProfiles.md)을 참고하세요.
+> **참고**: SDK를 사용한 자동 연동에서도 Build & Package, Deploy (Test), Deploy (Production) 프로필은 압축 포맷을 자동으로 Brotli로 설정합니다. Dev Server 프로필만 빌드 속도를 위해 압축을 비활성화합니다. 프로필별 매트릭스는 [빌드 프로필](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-profiles)을 참고하세요.
 
 ## 4. 빌드하기
 
@@ -43,10 +43,10 @@ Edit > Project Settings > Player 메뉴에서 다음 항목을 설정합니다.
 
 이 폴더들을 Vite 등으로 구성한 웹 프로젝트에 포함시키면 정적 웹페이지 형태로 띄울 수 있습니다. Vite 프로젝트를 구성하는 방법과, 그 결과물을 배포 가능한 `.ait` 패키지로 만드는 방법은 이 문서의 범위를 벗어납니다.
 
-SDK를 사용한 자동 연동에서는 이 부분을 [빌드 파이프라인](BuildProcess.md)의 Phase 2 패키징 단계가 대신합니다 — WebGL 산출물을 웹 프로젝트 구조로 재배치하고, 플레이스홀더를 치환하고, `granite build`로 `.ait` 패키지를 생성합니다.
+SDK를 사용한 자동 연동에서는 이 부분을 [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process)의 Phase 2 패키징 단계가 대신합니다 — WebGL 산출물을 웹 프로젝트 구조로 재배치하고, 플레이스홀더를 치환하고, `granite build`로 `.ait` 패키지를 생성합니다.
 
 ## 관련 문서
 
-- [시작하기](GettingStarted.md) — SDK를 사용한 자동 연동
-- [빌드 파이프라인](BuildProcess.md) — SDK가 WebGL 빌드부터 패키징까지 자동화하는 방식
-- [빌드 프로필](BuildProfiles.md) — 프로필별 압축 포맷 등 설정 차이
+- [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started) — SDK를 사용한 자동 연동
+- [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process) — SDK가 WebGL 빌드부터 패키징까지 자동화하는 방식
+- [빌드 프로필](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-profiles) — 프로필별 압축 포맷 등 설정 차이

--- a/Documentation~/PerfBetaChannel.md
+++ b/Documentation~/PerfBetaChannel.md
@@ -31,7 +31,7 @@ WebGL 콜드 로드 시간을 줄이는 실험적 최적화 레버를 미리 적
 }
 ```
 
-설치 ref를 다루는 방법 전반과, 이동 ref를 최신으로 다시 당겨오는 절차는 [시작하기](GettingStarted.md)의 설치 ref 관리 절에 정리되어 있습니다. perf 베타 채널이라서 다른 점은 없습니다.
+설치 ref를 다루는 방법 전반과, 이동 ref를 최신으로 다시 당겨오는 절차는 [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started)의 설치 ref 관리 절에 정리되어 있습니다. perf 베타 채널이라서 다른 점은 없습니다.
 
 특정 스냅샷에 고정하려면 이동 브랜치 대신 스냅샷 태그(`#release/vX.Y.Z-beta.<해시>`)를 쓰세요.
 
@@ -90,7 +90,7 @@ WebGL 콜드 로드 시간을 줄이는 실험적 최적화 레버를 미리 적
 3. 콜드 로드 시간(첫 프레임 표시까지)과 초기 다운로드 페이로드 크기를 두 빌드 사이에서 비교합니다.
 4. 어느 번들이 어느 채널 것인지는 `window.AITLoading.buildVariant === "perf"`로 구분합니다.
 
-첫 프레임 시각은 SDK가 자동 수집하는 `unity_first_interactive` 이벤트로도 얻을 수 있습니다. 자세한 내용은 [SDK 이벤트 로깅](Metrics.md)을 참고하세요.
+첫 프레임 시각은 SDK가 자동 수집하는 `unity_first_interactive` 이벤트로도 얻을 수 있습니다. 자세한 내용은 [SDK 이벤트 로깅](https://developers-apps-in-toss.toss.im/documentation/unity/add-features/metrics)을 참고하세요.
 
 ## stable 로 복귀
 
@@ -113,7 +113,7 @@ stable로 돌아가면 위 레버와 설정 필드가 함께 사라집니다. `A
 
 ## 관련 문서
 
-- [시작하기](GettingStarted.md) — 설치 ref 관리 공통 절차
+- [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started) — 설치 ref 관리 공통 절차
 - [베타 채널](BetaChannel.md) — web-framework 메이저 업그레이드 파일럿 채널
-- [SDK 이벤트 로깅](Metrics.md) — 첫 프레임 시각 계측
-- [빌드 프로필](BuildProfiles.md) — stable에도 있는 압축·스트리핑 설정
+- [SDK 이벤트 로깅](https://developers-apps-in-toss.toss.im/documentation/unity/add-features/metrics) — 첫 프레임 시각 계측
+- [빌드 프로필](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-profiles) — stable에도 있는 압축·스트리핑 설정

--- a/Documentation~/internal/build-session-recovery.md
+++ b/Documentation~/internal/build-session-recovery.md
@@ -67,4 +67,4 @@ Unity에 무한 컴파일 루프를 유도하기 어려우므로 단위 테스�
 
 - [테스트 전략](testing.md) — 자동화된 테스트 층위
 - [구현 지점 색인](implementation-details.md) — 세션 복원 구현 위치
-- [빌드 파이프라인](../BuildProcess.md) — Packaging 단계가 하는 일
+- [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process) — Packaging 단계가 하는 일

--- a/Documentation~/internal/implementation-details.md
+++ b/Documentation~/internal/implementation-details.md
@@ -2,7 +2,7 @@
 
 "이 동작은 어느 파일에 있나"를 빠르게 찾기 위한 색인입니다. 동작 자체의 설명은 공개 문서에 있고, 여기에는 코드 위치만 둡니다.
 
-> **대상**: SDK 기여자. 빌드가 무엇을 하는지는 [빌드 파이프라인](../BuildProcess.md)을 보세요.
+> **대상**: SDK 기여자. 빌드가 무엇을 하는지는 [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process)을 보세요.
 
 ## 빌드
 
@@ -22,7 +22,7 @@
 
 SDK의 `WebGLTemplates/AITTemplate/`이 원본이고, `Editor/AITTemplateManager.cs`가 프로젝트의 `Assets/WebGLTemplates/`로 복사합니다. `AITBuildInitializer`가 `PlayerSettings.WebGL.template`을 `PROJECT:AITTemplate`으로 지정합니다.
 
-사용자가 편집하는 영역과 마커 계약은 [빌드 커스터마이징](../BuildCustomization.md)에 있습니다.
+사용자가 편집하는 영역과 마커 계약은 [빌드 커스터마이징](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization)에 있습니다.
 
 ## 내장 Node.js
 
@@ -51,7 +51,7 @@ SDK의 `WebGLTemplates/AITTemplate/`이 원본이고, `Editor/AITTemplateManager
 
 배포 자격증명은 별도 에셋(`Assets/AppsInToss/Editor/AITCredentials.asset`)에 분리되어 있고 `Editor/AITGitGuard.cs`가 커밋되지 않도록 감시합니다.
 
-> **참고**: 필수 입력은 앱 ID 하나입니다. 검증 규칙은 `Editor/AITBuildValidator.cs`가 단일 출처이며, 사용자 관점 설명은 [문제 해결](../Troubleshooting.md)에 있습니다.
+> **참고**: 필수 입력은 앱 ID 하나입니다. 검증 규칙은 `Editor/AITBuildValidator.cs`가 단일 출처이며, 사용자 관점 설명은 [FAQ](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/faq)에 있습니다.
 
 devtools(`@apps-in-toss/devtools`) 설정은 빌드 프로필이 아니라 `AITConfig.asset`의 `AITDevtoolsSettings` 필드입니다. 활성화 게이트와 Vite 환경 변수 주입은 `Editor/Menu/DevtoolsSupport.cs`(`ShouldEnable`, `AddEnvVars`)가 단일 출처입니다.
 
@@ -79,7 +79,7 @@ devtools(`@apps-in-toss/devtools`) 설정은 빌드 프로필이 아니라 `AITC
 
 ## 관련 문서
 
-- [빌드 파이프라인](../BuildProcess.md) — 빌드 단계와 에러 코드
-- [빌드 프로필](../BuildProfiles.md) — 프로필별 설정과 환경 변수 오버라이드
+- [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process) — 빌드 단계와 에러 코드
+- [빌드 프로필](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-profiles) — 프로필별 설정과 환경 변수 오버라이드
 - [프로젝트 구조](project-structure.md) — 디렉터리 전체 지도
 - [기여 가이드](../Contributing.md) — 개발 환경 설정

--- a/Documentation~/internal/project-structure.md
+++ b/Documentation~/internal/project-structure.md
@@ -2,7 +2,7 @@
 
 저장소에서 무엇이 어디에 있는지에 대한 지도입니다.
 
-> **대상**: SDK 기여자. SDK를 사용하는 관점의 안내는 [시작하기](../GettingStarted.md)에 있습니다.
+> **대상**: SDK 기여자. SDK를 사용하는 관점의 안내는 [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started)에 있습니다.
 
 ## 최상위
 
@@ -95,7 +95,7 @@ WebGLTemplates/AITTemplate/
     └── package.json
 ```
 
-빌드 시 무엇이 언제 복사·병합되는지는 [빌드 파이프라인](../BuildProcess.md)에 있습니다.
+빌드 시 무엇이 언제 복사·병합되는지는 [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process)에 있습니다.
 
 ## Tests~
 
@@ -113,5 +113,5 @@ Tests~/E2E/
 
 - [SDK 런타임 생성기](sdk-generator.md) — `Runtime/SDK/`가 만들어지는 방식
 - [테스트 전략](testing.md) — `Tests~/` 구조와 실행
-- [빌드 파이프라인](../BuildProcess.md) — `Editor/`와 `WebGLTemplates/`가 실제로 하는 일
+- [빌드 파이프라인](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-process) — `Editor/`와 `WebGLTemplates/`가 실제로 하는 일
 - [기여 가이드](../Contributing.md) — 개발 환경과 커밋 규칙

--- a/Documentation~/internal/sdk-generator.md
+++ b/Documentation~/internal/sdk-generator.md
@@ -41,7 +41,7 @@
 
 `src/parser/jsdoc-extractor.ts`가 상위 `.d.ts`의 JSDoc을 C# XML 주석으로 옮깁니다. 그래서 개별 API 설명은 마크다운에 옮겨 적지 않아도 IntelliSense에 그대로 뜨고, 상위 문서가 갱신되면 다음 `pnpm generate`에서 자동으로 따라옵니다.
 
-> **중요**: API 설명을 마크다운 문서에 복사하지 마세요. 상위는 SDK 업데이트마다 재생성되지만 마크다운은 아니라서 확정적으로 어긋납니다. 공개 문서는 상위에 없는 것만 다룹니다 — [API 사용 패턴](../APIUsagePatterns.md) 참조.
+> **중요**: API 설명을 마크다운 문서에 복사하지 마세요. 상위는 SDK 업데이트마다 재생성되지만 마크다운은 아니라서 확정적으로 어긋납니다. 공개 문서는 상위에 없는 것만 다룹니다 — [API 사용 패턴](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns) 참조.
 
 ## 문서 링크가 생성물로 들어가는 지점
 
@@ -65,5 +65,5 @@ catch (AITException ex)
 ## 관련 문서
 
 - [기여 가이드](../Contributing.md) — 생성기 실행 명령과 검증 순서
-- [API 사용 패턴](../APIUsagePatterns.md) — 생성된 API를 쓰는 쪽 관점
+- [API 사용 패턴](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns) — 생성된 API를 쓰는 쪽 관점
 - [프로젝트 구조](project-structure.md) — 생성물이 놓이는 위치

--- a/Documentation~/internal/sentry-known-issues.md
+++ b/Documentation~/internal/sentry-known-issues.md
@@ -2,7 +2,7 @@
 
 Sentry에 뜨는 이슈 중 조치가 필요 없는 것과, 노이즈를 막는 장치에 대한 내부 메모입니다.
 
-> **대상**: SDK 기여자. 사용자 프로젝트에서 Sentry를 붙이는 방법은 [Sentry 연동](../SentryIntegration.md)에 있습니다.
+> **대상**: SDK 기여자. 사용자 프로젝트에서 Sentry를 붙이는 방법은 [Sentry 연동](https://developers-apps-in-toss.toss.im/documentation/unity/add-features/sentry-integration)에 있습니다.
 
 ## 무시해도 되는 이슈 패턴
 
@@ -82,6 +82,6 @@ SDK 정상 흐름의 fallback이나 timeout, 예측된 분기에서 나는 warni
 
 ## 관련 문서
 
-- [Sentry 연동](../SentryIntegration.md) — 사용자 프로젝트 관점의 Sentry 설정
+- [Sentry 연동](https://developers-apps-in-toss.toss.im/documentation/unity/add-features/sentry-integration) — 사용자 프로젝트 관점의 Sentry 설정
 - [GitHub Actions 워크플로](github-actions.md) — 릴리즈 워크플로
 - [테스트 전략](testing.md) — 통합 테스트가 도는 위치

--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ Unity 2021.3 이상을 지원하며, Unity 6 이상을 권장합니다.
 
 ## 문서
 
+전체 문서는 [Apps in Toss 개발자 문서 포털](https://developers-apps-in-toss.toss.im/documentation/unity/overview)에 있습니다.
+
 | 문서 | 내용 |
 |------|------|
-| [시작하기](Documentation~/GettingStarted.md) | 설치, 설치 ref 관리, 설정, 첫 번째 빌드 |
-| [API 사용 패턴](Documentation~/APIUsagePatterns.md) | async/await, 에러 처리, Mock 브릿지 |
-| [빌드 프로필](Documentation~/BuildProfiles.md) | Dev Server, Production Server, Build & Package, Publish |
-| [빌드 커스터마이징](Documentation~/BuildCustomization.md) | 웹 진입점 수정, 외부 라이브러리 추가 |
-| [문제 해결](Documentation~/Troubleshooting.md) | 자주 막히는 지점과 해결 방법 |
+| [시작하기](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/getting-started) | 설치, 설치 ref 관리, 설정, 첫 번째 빌드 |
+| [API 사용 패턴](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns) | async/await, 에러 처리, Mock 브릿지 |
+| [빌드 프로필](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-profiles) | Dev Server, Build & Package, Deploy (Test), Deploy (Production) |
+| [빌드 커스터마이징](https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization) | 웹 진입점 수정, 외부 라이브러리 추가 |
+| [FAQ](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/faq) | 자주 막히는 지점과 해결 방법 |
 
-광고 연동, 로딩 화면 커스터마이징, Sentry 연동, 기여 가이드를 포함한 전체 목록은 [문서 인덱스](Documentation~/README.md)에 있습니다.
+광고 연동, 로딩 화면 커스터마이징, Sentry 연동은 포털에서 확인할 수 있고, 기여 가이드는 [저장소 문서](Documentation~/Contributing.md)에 있습니다.
 
 ## 베타 채널 (파일럿 전용)
 

--- a/Runtime/SDK/AIT.Types.IAP.cs
+++ b/Runtime/SDK/AIT.Types.IAP.cs
@@ -75,7 +75,8 @@ namespace AppsInToss
         /// </para>
         /// <para>
         /// <c>false</c>는 정말로 이 상품을 줄 수 없을 때만 반환한다 — true가 아닌 응답은
-        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Documentation~/APIUsagePatterns.md의
+        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Apps in Toss 개발자 문서 포털
+        /// (https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns)의
         /// "인앱결제: 지급 승인과 서버 검증" 절 참고.
         /// </para>
         /// </remarks>
@@ -200,7 +201,8 @@ namespace AppsInToss
         /// </para>
         /// <para>
         /// <c>false</c>는 정말로 이 상품을 줄 수 없을 때만 반환한다 — true가 아닌 응답은
-        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Documentation~/APIUsagePatterns.md의
+        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Apps in Toss 개발자 문서 포털
+        /// (https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns)의
         /// "인앱결제: 지급 승인과 서버 검증" 절 참고.
         /// </para>
         /// </remarks>

--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,6 @@
 
 ## 문서
 
-- **P3 — 미문서 public API 약 65개**: 문서 통합 정리(2026-07)에서 의도적으로 범위 제외. 개별 API 설명은 상위 `@apps-in-toss/web-framework` JSDoc이 생성기를 통해 C# XML 주석으로 자동 이관되므로, 마크다운 레퍼런스를 만들면 상위의 수기 포크가 되어 확정적으로 드리프트한다. 현재는 `Documentation~/APIUsagePatterns.md`의 "API 원문은 어디에 있나" 절이 IntelliSense와 클라이언트 SDK 공식 문서로 안내한다. 이 정책이 충분한지 사용자 피드백으로 재검토.
+- **P3 — 미문서 public API 약 65개**: 문서 통합 정리(2026-07)에서 의도적으로 범위 제외. 개별 API 설명은 상위 `@apps-in-toss/web-framework` JSDoc이 생성기를 통해 C# XML 주석으로 자동 이관되므로, 마크다운 레퍼런스를 만들면 상위의 수기 포크가 되어 확정적으로 드리프트한다. 현재는 [API 사용 패턴](https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns)의 "API 원문은 어디에 있나" 절이 IntelliSense와 클라이언트 SDK 공식 문서로 안내한다. 이 정책이 충분한지 사용자 피드백으로 재검토.
 
 - **P3 — `PAYMENT_COMPLETED` 주문 상태 미검증**: 이전 `Troubleshooting.md`가 인용하던 값인데 이 저장소의 C# 타입 어디에도 없다. 플랫폼 측 상태값으로 추정되나 확인되지 않아 리라이트에서 제거했다. 실재 여부를 확인하고, 실재한다면 IAP 문서에 정식으로 반영.

--- a/Tests~/E2E/HeavySampleUnityProject-2021.3/Assets/AppsInToss/loading.html
+++ b/Tests~/E2E/HeavySampleUnityProject-2021.3/Assets/AppsInToss/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/Tests~/E2E/HeavySampleUnityProject-2021.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
+++ b/Tests~/E2E/HeavySampleUnityProject-2021.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
@@ -3,7 +3,7 @@
 // - 튜토리얼 #1: canvas-confetti — Unity와 무관한 외부 라이브러리 번들링 예시
 // - 튜토리얼 #2: Firebase Analytics — 환경변수 기반 초기화 예시
 //
-// 자세한 내용: Documentation~/BuildCustomization.md
+// 자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization
 
 import confetti from 'canvas-confetti';
 import { initializeApp } from 'firebase/app';

--- a/Tests~/E2E/HeavySampleUnityProject-6000.0/Assets/AppsInToss/loading.html
+++ b/Tests~/E2E/HeavySampleUnityProject-6000.0/Assets/AppsInToss/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/Tests~/E2E/HeavySampleUnityProject-6000.0/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
+++ b/Tests~/E2E/HeavySampleUnityProject-6000.0/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
@@ -3,7 +3,7 @@
 // - 튜토리얼 #1: canvas-confetti — Unity와 무관한 외부 라이브러리 번들링 예시
 // - 튜토리얼 #2: Firebase Analytics — 환경변수 기반 초기화 예시
 //
-// 자세한 내용: Documentation~/BuildCustomization.md
+// 자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization
 
 import confetti from 'canvas-confetti';
 import { initializeApp } from 'firebase/app';

--- a/Tests~/E2E/HeavySampleUnityProject-6000.3/Assets/AppsInToss/loading.html
+++ b/Tests~/E2E/HeavySampleUnityProject-6000.3/Assets/AppsInToss/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/Tests~/E2E/HeavySampleUnityProject-6000.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
+++ b/Tests~/E2E/HeavySampleUnityProject-6000.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
@@ -3,7 +3,7 @@
 // - 튜토리얼 #1: canvas-confetti — Unity와 무관한 외부 라이브러리 번들링 예시
 // - 튜토리얼 #2: Firebase Analytics — 환경변수 기반 초기화 예시
 //
-// 자세한 내용: Documentation~/BuildCustomization.md
+// 자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization
 
 import confetti from 'canvas-confetti';
 import { initializeApp } from 'firebase/app';

--- a/Tests~/E2E/SampleUnityProject-2021.3/Assets/AppsInToss/loading.html
+++ b/Tests~/E2E/SampleUnityProject-2021.3/Assets/AppsInToss/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/Tests~/E2E/SampleUnityProject-2021.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
+++ b/Tests~/E2E/SampleUnityProject-2021.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
@@ -3,7 +3,7 @@
 // - 튜토리얼 #1: canvas-confetti — Unity와 무관한 외부 라이브러리 번들링 예시
 // - 튜토리얼 #2: Firebase Analytics — 환경변수 기반 초기화 예시
 //
-// 자세한 내용: Documentation~/BuildCustomization.md
+// 자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization
 
 import confetti from 'canvas-confetti';
 import { initializeApp } from 'firebase/app';

--- a/Tests~/E2E/SampleUnityProject-2022.3/Assets/AppsInToss/loading.html
+++ b/Tests~/E2E/SampleUnityProject-2022.3/Assets/AppsInToss/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/Tests~/E2E/SampleUnityProject-2022.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
+++ b/Tests~/E2E/SampleUnityProject-2022.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
@@ -3,7 +3,7 @@
 // - 튜토리얼 #1: canvas-confetti — Unity와 무관한 외부 라이브러리 번들링 예시
 // - 튜토리얼 #2: Firebase Analytics — 환경변수 기반 초기화 예시
 //
-// 자세한 내용: Documentation~/BuildCustomization.md
+// 자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization
 
 import confetti from 'canvas-confetti';
 import { initializeApp } from 'firebase/app';

--- a/Tests~/E2E/SampleUnityProject-6000.0/Assets/AppsInToss/loading.html
+++ b/Tests~/E2E/SampleUnityProject-6000.0/Assets/AppsInToss/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/Tests~/E2E/SampleUnityProject-6000.0/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
+++ b/Tests~/E2E/SampleUnityProject-6000.0/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
@@ -3,7 +3,7 @@
 // - 튜토리얼 #1: canvas-confetti — Unity와 무관한 외부 라이브러리 번들링 예시
 // - 튜토리얼 #2: Firebase Analytics — 환경변수 기반 초기화 예시
 //
-// 자세한 내용: Documentation~/BuildCustomization.md
+// 자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization
 
 import confetti from 'canvas-confetti';
 import { initializeApp } from 'firebase/app';

--- a/Tests~/E2E/SampleUnityProject-6000.2/Assets/AppsInToss/loading.html
+++ b/Tests~/E2E/SampleUnityProject-6000.2/Assets/AppsInToss/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/Tests~/E2E/SampleUnityProject-6000.2/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
+++ b/Tests~/E2E/SampleUnityProject-6000.2/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
@@ -3,7 +3,7 @@
 // - 튜토리얼 #1: canvas-confetti — Unity와 무관한 외부 라이브러리 번들링 예시
 // - 튜토리얼 #2: Firebase Analytics — 환경변수 기반 초기화 예시
 //
-// 자세한 내용: Documentation~/BuildCustomization.md
+// 자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization
 
 import confetti from 'canvas-confetti';
 import { initializeApp } from 'firebase/app';

--- a/Tests~/E2E/SampleUnityProject-6000.3/Assets/AppsInToss/loading.html
+++ b/Tests~/E2E/SampleUnityProject-6000.3/Assets/AppsInToss/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/Tests~/E2E/SampleUnityProject-6000.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
+++ b/Tests~/E2E/SampleUnityProject-6000.3/Assets/WebGLTemplates/AITTemplate/BuildConfig~/src/main.ts
@@ -3,7 +3,7 @@
 // - 튜토리얼 #1: canvas-confetti — Unity와 무관한 외부 라이브러리 번들링 예시
 // - 튜토리얼 #2: Firebase Analytics — 환경변수 기반 초기화 예시
 //
-// 자세한 내용: Documentation~/BuildCustomization.md
+// 자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization
 
 import confetti from 'canvas-confetti';
 import { initializeApp } from 'firebase/app';

--- a/Tests~/E2E/tests/e2e-full-pipeline.test.js
+++ b/Tests~/E2E/tests/e2e-full-pipeline.test.js
@@ -1502,7 +1502,7 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
     // -------------------------------------------------------------------------
     // Test 6: Build Customization Tutorial #1 — canvas-confetti
     // BuildConfig~/src/main.ts 가 번들링되어 confetti 가 발사되었는지 검증
-    // (Documentation~/BuildCustomization.md 튜토리얼 #1)
+    // (https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization 튜토리얼 #1)
     // -------------------------------------------------------------------------
     test('6. Tutorial #1: canvas-confetti should fire after page load', async () => {
       test.setTimeout(30000);
@@ -1525,7 +1525,7 @@ test.describe('Apps in Toss Unity SDK E2E Pipeline', () => {
     // -------------------------------------------------------------------------
     // Test 7: Build Customization Tutorial #2 — Firebase
     // VITE_FIREBASE_* 환경변수가 주입되어 firebase/app 이 초기화되었는지 검증
-    // (Documentation~/BuildCustomization.md 튜토리얼 #2)
+    // (https://developers-apps-in-toss.toss.im/documentation/unity/build/build-customization 튜토리얼 #2)
     //
     // 환경변수가 없으면(로컬 개발) 초기화 시도를 건너뛰므로 skip 처리.
     // CI 에서는 GitHub Secret 으로 주입되어 모든 단계가 통과해야 한다.

--- a/WebGLTemplates/AITTemplate/loading.html
+++ b/WebGLTemplates/AITTemplate/loading.html
@@ -16,7 +16,7 @@
     - AITLoading.appInfo: 앱 정보 (iconUrl, displayName, primaryColor)
     - AITLoading.hide(): 로딩 화면 숨기기
 
-    자세한 내용: Documentation~/LoadingScreenCustomization.md
+    자세한 내용: https://developers-apps-in-toss.toss.im/documentation/unity/build/loading-screen-customization
 -->
 
 <style>

--- a/sdk-runtime-generator~/src/generators/csharp/field-docs.ts
+++ b/sdk-runtime-generator~/src/generators/csharp/field-docs.ts
@@ -38,7 +38,8 @@ const FIELD_DOC_OVERRIDES: Record<string, string> = {
         /// </para>
         /// <para>
         /// <c>false</c>는 정말로 이 상품을 줄 수 없을 때만 반환한다 — true가 아닌 응답은
-        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Documentation~/APIUsagePatterns.md의
+        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Apps in Toss 개발자 문서 포털
+        /// (https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns)의
         /// "인앱결제: 지급 승인과 서버 검증" 절 참고.
         /// </para>
         /// </remarks>

--- a/sdk-runtime-generator~/tests/fixtures/golden/AIT.Types.IAP.cs.golden
+++ b/sdk-runtime-generator~/tests/fixtures/golden/AIT.Types.IAP.cs.golden
@@ -75,7 +75,8 @@ namespace AppsInToss
         /// </para>
         /// <para>
         /// <c>false</c>는 정말로 이 상품을 줄 수 없을 때만 반환한다 — true가 아닌 응답은
-        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Documentation~/APIUsagePatterns.md의
+        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Apps in Toss 개발자 문서 포털
+        /// (https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns)의
         /// "인앱결제: 지급 승인과 서버 검증" 절 참고.
         /// </para>
         /// </remarks>
@@ -200,7 +201,8 @@ namespace AppsInToss
         /// </para>
         /// <para>
         /// <c>false</c>는 정말로 이 상품을 줄 수 없을 때만 반환한다 — true가 아닌 응답은
-        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Documentation~/APIUsagePatterns.md의
+        /// 사용자에게 환불 안내 페이지를 띄운다. 자세한 절차는 Apps in Toss 개발자 문서 포털
+        /// (https://developers-apps-in-toss.toss.im/documentation/unity/first-steps/api-usage-patterns)의
         /// "인앱결제: 지급 승인과 서버 검증" 절 참고.
         /// </para>
         /// </remarks>


### PR DESCRIPTION
## 배경

공개 문서 11종(README/GettingStarted/APIUsagePatterns/Troubleshooting/Advertising/Metrics/SentryIntegration/BuildProfiles/BuildCustomization/LoadingScreenCustomization/BuildProcess)이 개발자 포털(GitBook)로 이관되어 라이브 상태입니다. 이 PR은 저장소가 해당 문서들을 가리키던 참조를 포털 URL로 전환합니다. **문서 본문 삭제는 하지 않으며**, 삭제는 changelog 이관·pages 정리와 함께 후속 PR에서 진행합니다.

## 변경 내용

- **생성기**: `sdk-runtime-generator~/src/generators/csharp/field-docs.ts`의 `Documentation~/APIUsagePatterns.md` 인용 → 포털 URL. `pnpm generate`로 `Runtime/SDK/AIT.Types.IAP.cs` 재생성 + golden fixture 갱신
- **루트 README.md**: 이관 문서 5링크 + 문서 인덱스 → 포털 URL, 옛 빌드 프로필명(Production Server/Publish) → 현행(Deploy (Test)/(Production))으로 갱신. 베타/perf 베타/기여 가이드 링크는 저장소 상대링크 유지
- **CLAUDE.md**: 공개 문서 정본이 포털임을 명시, 저장소 사본은 제거 예정(그때까지 편집 동결) 안내
- **internal 런북 5종 + 잔류 문서 4종**(Contributing/ManualIntegration/BetaChannel/PerfBetaChannel): 이관 문서로 가는 상대링크 → 포털 URL (Troubleshooting 링크 텍스트는 포털 제목 "FAQ"로)
- **워크플로**: `update.yml`·`sdk-update-rebase.yml`의 GettingStarted.md 설치 가이드 sed 업데이트 스텝 제거 (이관으로 무의미)
- **WebGLTemplates 마스터 `loading.html` + E2E 샘플 8종 사본, 샘플 `main.ts` 8종, E2E 테스트 주석, TODO.md 인용**: 동일 전환

## 검증

- `pnpm generate` 후 `Runtime/SDK/` 변경이 의도한 주석 갱신뿐임을 확인, `pnpm validate` / `pnpm test`(765 unit) 통과
- `./run-local-tests.sh --validate` 통과
- diff에 추가된 포털 URL 10종 전부 HTTP 200 실측 확인
- 저장소 전수 grep으로 이관 문서 참조 잔존 0건 확인 (이관 문서 본문 상호링크 제외 — 본문은 후속 삭제 대상)