### PR TITLE
수정: cloudflared를 0.7.1로 고정하는 pnpm override 추가

### DIFF
--- a/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
+++ b/WebGLTemplates/AITTemplate/BuildConfig~/pnpm-workspace.yaml
@@ -21,6 +21,10 @@ overrides:
   '@granite-js/plugin-core': 0.1.30
   find-my-way: '>=8.2.2'
   ip: '>=2.0.1'
+  # 일부 npm 미러/프록시 환경에서 cloudflared 0.7.3 타르볼이 404를 반환해 클라이언트
+  # SDK 빌드의 pnpm install이 실패하는 사례가 있다. 0.7.1은 동일 환경에서 정상 제공되고
+  # @apps-in-toss/devtools@3.0.3이 요구하는 범위(^0.7.1) 안이라 0.7.1로 고정한다.
+  cloudflared: 0.7.1
   # dependabot 취약점 대응(패치 존재분). granite 빌드 툴체인의 전이 의존이며
   # WebGL 산출물에 배포되지 않는다. 예기치 않은 상위 major 점프 차단 위해 캡.
   '@babel/core': '>=7.29.6 <8'


### PR DESCRIPTION
## 배경

일부 npm 미러/프록시 환경에서 `cloudflared-0.7.3.tgz` 타르볼이 404를 반환해 클라이언트 SDK 빌드의 pnpm install이 실패합니다. 설치 실패 시 재시도 사다리(4단계)가 node_modules 삭제 + 전체 재설치까지 진행하므로 빌드가 회당 수 분씩 지연되는 캐스케이드로 이어집니다.

- cloudflared는 `@apps-in-toss/devtools@3.0.3`의 의존성(`^0.7.1`)이며, 0.7.3이 현재 최신입니다.
- 동일 환경에서 0.7.1·0.7.0 타르볼은 정상 제공됨을 확인했습니다.

## 조치

`pnpm-workspace.yaml`(정본)의 overrides에 `cloudflared: 0.7.1` 고정을 추가합니다 — semver 범위(`^0.7.1`) 안이므로 devtools 동작에 영향이 없습니다.

## 후속 (lockfile 정합화)

lockfile은 로컬에서 재생성하지 않는 저장소 규칙에 따라 이 PR에 포함하지 않았습니다. **이 PR 머지 후 Regenerate Lockfiles 워크플로우를 디스패치**하면 override를 반영한 lockfile PR이 자동 생성·머지됩니다.

중간 윈도우(override 머지 ~ lockfile 재생성 사이)에도 클라이언트 빌드는 안전합니다: frozen-lockfile 불일치 시 설치 재시도 2단계(`--no-frozen-lockfile`)가 override 기준으로 해석해 0.7.1을 설치합니다.