### PR TITLE
개선: Deploy for Online Test에 디버그 콘솔 활성화 — 실기기 디버깅 지원

### DIFF
--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -71,8 +71,9 @@ namespace AppsInToss
         /// <summary>
         /// Deploy for Online Test 전용 오버라이드 프로필 생성.
         /// baseProfile(보통 productionProfile)의 나머지 필드는 그대로 복사한 "새 인스턴스"에
-        /// 압축 포맷/외부 디버그 심볼만 빌드 가속용 값으로 덮어쓴다. Managed Stripping Level은
-        /// 실측상 base(Production=High) 유지가 오히려 더 빠르므로 오버라이드하지 않는다(아래 참고).
+        /// 압축 포맷/외부 디버그 심볼은 빌드 가속용 값으로, 디버그 콘솔은 실기기 디버깅용으로
+        /// 덮어쓴다. Managed Stripping Level은 실측상 base(Production=High) 유지가 오히려
+        /// 더 빠르므로 오버라이드하지 않는다(아래 참고).
         /// </summary>
         /// <remarks>
         /// baseProfile 인스턴스는 절대 변형하지 않는다 — config.productionProfile은 ScriptableObject로
@@ -95,7 +96,7 @@ namespace AppsInToss
 
             return new AITBuildProfile
             {
-                enableDebugConsole = baseProfile.enableDebugConsole,
+                enableDebugConsole = true,  // Deploy for Online Test는 실기기 디버깅 용도라 콘솔 활성화(Production은 base=false 유지). 템플릿 주입만 결정하므로 빌드 시간·캐시 영향 없음
                 developmentBuild = baseProfile.developmentBuild,
                 enableLZ4Compression = baseProfile.enableLZ4Compression,
                 compressionFormat = 1,  // Gzip — Deploy for Online Test 가속: 압축 시간 단축(Production은 Brotli 유지)

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs
@@ -182,13 +182,13 @@ public class AITBuildProfileMappingTests
     // =====================================================
 
     // =====================================================
-    // AITBuildProfile.CreateTestDeployProfile — Deploy for Online Test 전용 압축/외부 심볼 오버라이드
+    // AITBuildProfile.CreateTestDeployProfile — Deploy for Online Test 전용 압축/외부 심볼/디버그 콘솔 오버라이드
     // (스트리핑은 실측상 base 유지가 더 빠르므로 오버라이드하지 않음 — 아래 테스트 참고)
     // baseProfile(보통 productionProfile)을 절대 변형하지 않고 새 인스턴스를 만들어야 한다.
     // =====================================================
 
     [Test]
-    public void CreateTestDeployProfile_OverridesCompressionAndSymbols_PreservesBaseStripping()
+    public void CreateTestDeployProfile_OverridesCompressionSymbolsAndDebugConsole_PreservesBaseStripping()
     {
         var baseProfile = AITBuildProfile.CreateProductionProfile();
 
@@ -198,6 +198,8 @@ public class AITBuildProfileMappingTests
         Assert.AreEqual(baseProfile.managedStrippingLevel, testProfile.managedStrippingLevel,
             "Deploy for Online Test는 Stripping을 오버라이드하지 않고 base(Production) 값을 그대로 물려받아야 함 — 실측상 High가 Minimal보다 cold 빌드가 빠름.");
         Assert.IsFalse(testProfile.debugSymbolsExternal, "Deploy for Online Test는 외부 디버그 심볼을 끄고 Embedded여야 함 (링크 시간 단축).");
+        Assert.IsTrue(testProfile.enableDebugConsole,
+            "Deploy for Online Test는 실기기 디버깅 용도라 base(Production=false)와 무관하게 디버그 콘솔이 켜져야 함.");
         Assert.AreEqual(WebGLCompressionFormat.Gzip, AITBuildInitializer.ConvertToCompressionFormat(testProfile.compressionFormat));
         Assert.AreEqual(ManagedStrippingLevel.High, AITBuildInitializer.ConvertToManagedStrippingLevel(testProfile.managedStrippingLevel));
     }
@@ -207,7 +209,7 @@ public class AITBuildProfileMappingTests
     {
         var baseProfile = new AITBuildProfile
         {
-            enableDebugConsole = true,
+            enableDebugConsole = false,      // 오버라이드로 true가 됨을 증명하기 위한 값
             developmentBuild = true,
             enableLZ4Compression = false,
             compressionFormat = 2,          // Brotli — 오버라이드 대상이 아님을 증명하기 위한 값
@@ -217,15 +219,16 @@ public class AITBuildProfileMappingTests
 
         var testProfile = AITBuildProfile.CreateTestDeployProfile(baseProfile);
 
-        Assert.AreEqual(baseProfile.enableDebugConsole, testProfile.enableDebugConsole);
         Assert.AreEqual(baseProfile.developmentBuild, testProfile.developmentBuild);
         Assert.AreEqual(baseProfile.enableLZ4Compression, testProfile.enableLZ4Compression);
 
-        // 압축/외부 심볼만 오버라이드되고, 스트리핑을 포함한 나머지는 baseProfile 값을 그대로 물려받아야 함
+        // 압축/외부 심볼/디버그 콘솔이 오버라이드되고, 스트리핑을 포함한 나머지는 baseProfile 값을 그대로 물려받아야 함
         Assert.AreEqual(1, testProfile.compressionFormat);
         Assert.AreEqual(baseProfile.managedStrippingLevel, testProfile.managedStrippingLevel,
             "managedStrippingLevel은 오버라이드 대상이 아니므로 base 값(이 테스트에서는 4/High)을 그대로 물려받아야 함.");
         Assert.IsFalse(testProfile.debugSymbolsExternal);
+        Assert.IsTrue(testProfile.enableDebugConsole,
+            "enableDebugConsole은 base=false여도 Deploy for Online Test에서는 항상 true로 오버라이드되어야 함.");
     }
 
     [Test]


### PR DESCRIPTION
## 목적

Deploy for Online Test는 실기기에서 직접 확인하는 온라인 테스트 배포다. 그런데 `CreateTestDeployProfile`이 base(Production) 값을 그대로 상속받아 디버그 콘솔(vconsole)이 꺼진 채로 배포되고 있었다 — 실기기 디버깅이 필요한 배포 목적과 맞지 않았다. `enableDebugConsole = true`를 명시 오버라이드해 Deploy for Online Test 배포에서는 항상 디버그 콘솔이 켜지도록 한다.

## 동작

- `enableDebugConsole`은 WebGL 템플릿에 vconsole 스크립트를 주입할지만 결정하는 플래그다 — 압축/스트리핑/심볼 생성처럼 빌드 파이프라인 단계를 바꾸는 값이 아니라 템플릿 치환 결과물만 달라진다.
- 따라서 이번 변경은 빌드 시간이나 빌드 캐시(패키징 스킵 판정 등)에 영향을 주지 않는다.
- Production은 여전히 base 값(false)을 그대로 사용 — Deploy for Online Test 경로에서만 강제로 true.
- 기존 오버라이드(`compressionFormat=1` Gzip, `debugSymbolsExternal=false` Embedded)와 base 상속(`managedStrippingLevel`)은 그대로 유지.

## 검증

- `AITBuildProfileMappingTests`: `enableDebugConsole`을 "base 값을 그대로 물려받는 필드" 목록에서 빼고 "오버라이드되는 필드" 목록으로 옮겨, base에 `false`를 넣어도 `CreateTestDeployProfile` 결과는 항상 `true`가 됨을 증명하도록 갱신.
- EditMode 전체 1420개 테스트 통과 (0 failed, 0 skipped).
