### PR TITLE
개선: Local Debug 스트리핑을 High로 통일 — cold 빌드 87→45초

### DIFF
--- a/Editor/AITConfigurationWindow.cs
+++ b/Editor/AITConfigurationWindow.cs
@@ -400,7 +400,7 @@ namespace AppsInToss.Editor
             string[] strippingOptions = { "자동 (High)", "Minimal", "Low", "Medium", "High" };
             int strippingIndex = profile.managedStrippingLevel < 0 ? 0 : profile.managedStrippingLevel;
             strippingIndex = EditorGUILayout.Popup(
-                new GUIContent("Managed Stripping", "코드 스트리핑 레벨 (낮을수록 빌드 속도 향상)"),
+                new GUIContent("Managed Stripping", "코드 스트리핑 레벨. 높을수록 산출물이 작고 실측상 빌드도 빠름(IL2CPP로 넘어가는 관리 코드량이 줄어 변환·컴파일·링크 시간이 감소)"),
                 strippingIndex,
                 strippingOptions
             );

--- a/Editor/AITEditorScriptObject.cs
+++ b/Editor/AITEditorScriptObject.cs
@@ -46,7 +46,13 @@ namespace AppsInToss
                 developmentBuild = true,
                 enableLZ4Compression = true,
                 compressionFormat = 0,  // Disabled - 빌드 속도 우선
-                managedStrippingLevel = 1,  // Minimal - 빌드 속도 우선
+                managedStrippingLevel = -1,  // 자동 (High) - 실측상 Minimal보다 cold 빌드가 더 빠름(87.4s→42.6~47.4s,
+                                              // SampleUnityProject-2022.3/Unity 2022.3.62f2/batchmode).
+                                              // High 스트리핑이 IL2CPP로 넘어가는 관리 코드량을 줄여 UnityLinker가
+                                              // 몇 초 더 쓰는 대신 IL2CPP 변환·컴파일과 직렬 emscripten 링크가 크게 줄어듦.
+                                              // warm 빌드(무변경/1줄 수정)는 Minimal과 동등. 또한 Production·Deploy for
+                                              // Online Test가 이미 High이므로 통일하면 스트리핑 관련 문제가 배포 단계가
+                                              // 아니라 로컬 Dev Server 단계에서 가장 먼저 드러남.
                 debugSymbolsExternal = false
             };
         }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs
@@ -84,12 +84,14 @@ public class AITBuildProfileMappingTests
     }
 
     [Test]
-    public void DevServerProfile_Default_Stripping_Applies_Minimal()
+    public void DevServerProfile_Default_Stripping_Applies_High()
     {
-        // Dev Server 프로필 기본값(저장값 1)은 주석("Minimal - 빌드 속도 우선")대로 Minimal이어야 함
-        // 원래 버그: 직접 캐스팅으로 Low가 적용됨
+        // Dev Server 프로필 기본값(저장값 -1 = 자동)은 High로 매핑되어야 함.
+        // 실측(SampleUnityProject-2022.3, Unity 2022.3.62f2, batchmode): cold 빌드가
+        // Minimal 87.4s → High 42.6~47.4s로 오히려 더 빠름(warm 빌드는 동등) — Production·
+        // Deploy for Online Test와 스트리핑 레벨을 통일해 세 프로필 모두 High를 사용한다.
         var profile = AITBuildProfile.CreateDevServerProfile();
-        Assert.AreEqual(ManagedStrippingLevel.Minimal,
+        Assert.AreEqual(ManagedStrippingLevel.High,
             AITBuildInitializer.ConvertToManagedStrippingLevel(profile.managedStrippingLevel));
     }
 


### PR DESCRIPTION
## 요약

Dev Server(Local Debug) 빌드 프로필의 `managedStrippingLevel`을 Minimal(1)에서 자동/High(-1)로 바꿔, Production·Deploy for Online Test와 세 프로필의 Managed Stripping Level을 통일한다.

## 근거 (실측)

SampleUnityProject-2022.3, Unity 2022.3.62f2, batchmode, 동일 머신에서 직접 측정:

- Local Debug **cold**(Deploy 빌드 상태에서 전환): Minimal 87.4s → High **42.6s / 47.4s** (2회 재현)
- Local Debug **warm** 무변경: 1.75s → 1.93s (동등)
- Local Debug **warm** 1줄 수정: 13.3s → 13.5s (동등)
- 부수 효과: 양쪽 프로필이 모두 High인 상태에서 Deploy for Online Test cold가 108.4s → **76.8s**

기존 통념("Minimal이 빌드가 빠르다")과 반대다. 이유: High 스트리핑이 IL2CPP로 넘어가는 관리 코드량 자체를 줄여, UnityLinker가 몇 초 더 쓰는 대신 IL2CPP 변환·컴파일과 직렬 emscripten 링크가 크게 줄어든다. Deploy 경로에서는 이미 동일 현상을 확인해 반영했다(#1095).

## 변경 내용

1. `Editor/AITEditorScriptObject.cs`의 `CreateDevServerProfile()` — `managedStrippingLevel`을 `1`(Minimal)에서 `-1`(자동/High)로 변경하고 주석을 실측 근거로 교체.
2. `Tests~/E2E/SharedScripts/Editor/EditModeTests/AITBuildProfileMappingTests.cs` — `DevServerProfile_Default_Stripping_Applies_Minimal` → `DevServerProfile_Default_Stripping_Applies_High`로 이름/단언 변경, 주석을 실측 근거로 갱신.
3. `Editor/AITConfigurationWindow.cs:403` — Managed Stripping 툴팁이 `"코드 스트리핑 레벨 (낮을수록 빌드 속도 향상)"`으로 되어 있었는데, 이번 실측으로 사실이 아님이 확인됐다. 이 문구가 애초에 Dev Server 프로필이 Minimal로 굳어진 원인으로 보인다. 실측 결과에 맞게 "높을수록 산출물이 작고 실측상 빌드도 빠름(IL2CPP로 넘어가는 관리 코드량이 줄어 변환·컴파일·링크 시간이 감소)"으로 정정.
4. `Editor/AITConfigurationWindow.cs:307-308,329`(프로필 리셋 경로)는 팩토리 메서드(`CreateDevServerProfile()`)를 그대로 호출하므로 별도 수정 불필요 — 확인만 하고 손대지 않았다.

세 프로필(Dev Server / Production / Deploy for Online Test)이 모두 High를 쓰게 되면, 스트리핑 관련 문제(예: 링커가 실수로 필요한 코드를 제거)가 배포 단계가 아니라 가장 이른 로컬 Dev Server 단계에서부터 드러난다.

## 적용 범위 (마이그레이션 없음)

이 PR은 **마이그레이션을 포함하지 않는다.** `CreateDevServerProfile()`은 팩토리 메서드라서 이 변경은 다음 두 경우에만 적용된다.

- 신규 프로젝트에서 처음 `AITConfig.asset`을 생성하는 경우
- Configuration 창에서 "모든 프로필 기본값으로 초기화" 버튼을 누르는 경우

**기존 프로젝트의 `AITConfig.asset`에는 저장값 `1`(Minimal)이 그대로 남아있어 자동으로 바뀌지 않는다.** 다만 기본값이 `-1`로 바뀌면서 `IsProfileDefault()` 비교가 어긋나, Configuration 창의 Dev Server 프로필 섹션에 "Dev Server 프로필 기본값으로 복원" 버튼이 자동으로 노출된다. 기존 사용자는 이 버튼을 누르거나, Managed Stripping 드롭다운을 직접 "자동 (High)"로 바꾸면 동일한 효과를 얻는다.

## 검증

- `./run-local-tests.sh --validate`: Passed 4 / Failed 0 (E2E 파일 구조, Playwright 설정, SDK 유닛 테스트 68/68, Meta GUID 위생)
- EditMode 테스트(SampleUnityProject-2022.3, Unity 2022.3.62f2, batchmode): **Passed 1420 / Failed 0** — 이름 변경한 `DevServerProfile_Default_Stripping_Applies_High` 포함 전부 통과.
