### PR TITLE
개선: 비동기 명령 실패 시 stdout 말미도 남겨 원인 추적 가능하게

### DIFF
--- a/Editor/AITAsyncCommandRunner.cs
+++ b/Editor/AITAsyncCommandRunner.cs
@@ -61,6 +61,10 @@ namespace AppsInToss.Editor
         private static int isQueueProcessorRegistered = 0;
         private static int taskIdCounter = 0;
 
+        // stderr 폴백으로 stdout을 Console에 남길 때 Console 폭주를 막기 위한 말미 줄 수 제한.
+        // vite/esbuild 등은 실패 원인을 stdout에 여러 줄 출력할 수 있어 전체를 남기면 로그가 과도해진다.
+        private const int MaxOutputTailLines = 40;
+
         /// <summary>
         /// 비동기 명령 실행 (즉시 반환, 콜백으로 결과 전달)
         /// </summary>
@@ -347,6 +351,16 @@ namespace AppsInToss.Editor
                                     $"[AIT Async] stderr:\n{result.Error.Trim()}",
                                     sentryCapture: false);
                             }
+                            else if (!string.IsNullOrEmpty(result.Output))
+                            {
+                                // vite/esbuild 등은 실패 원인을 stderr가 아닌 stdout에 쓰고 종료 코드만
+                                // non-zero로 남긴다. stderr 폴백이 없으면 원인이 Console에 한 글자도
+                                // 남지 않으므로(실사례: vite build 실패 → 원인 불명 재시도 캐스케이드),
+                                // stdout 말미로 폴백한다.
+                                AppsInToss.Editor.AITLog.Error(
+                                    $"[AIT Async] stdout (stderr 없음):\n{TailLines(result.Output.Trim(), MaxOutputTailLines)}",
+                                    sentryCapture: false);
+                            }
                         }
                         task.OnComplete?.Invoke(result);
                     });
@@ -371,6 +385,36 @@ namespace AppsInToss.Editor
             {
                 if (pid > 0) AITBuildSession.ClearPid(pid);
             }
+        }
+
+        /// <summary>
+        /// 텍스트를 마지막 maxLines 줄로 잘라낸다. Console 폭주 방지용(정상 실패 시 stdout 폴백 로깅).
+        /// 프로세스 실행 없이 순수 문자열 연산만 수행하므로 EditMode 단위 테스트로 검증 가능하다.
+        /// </summary>
+        /// <param name="text">원본 텍스트 (null/빈 문자열은 그대로 반환)</param>
+        /// <param name="maxLines">유지할 마지막 줄 수 (0 이하이면 빈 문자열 반환)</param>
+        /// <returns>줄 수가 maxLines 이하이면 원본 그대로, 초과하면 "…(마지막 N줄만 표시 — 전체 M줄)" 안내 문구 + 마지막 N줄</returns>
+        internal static string TailLines(string text, int maxLines)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            if (maxLines <= 0)
+            {
+                return string.Empty;
+            }
+
+            string[] lines = text.Replace("\r\n", "\n").Split('\n');
+            if (lines.Length <= maxLines)
+            {
+                return text;
+            }
+
+            int start = lines.Length - maxLines;
+            string tail = string.Join("\n", lines, start, maxLines);
+            return $"…(마지막 {maxLines}줄만 표시 — 전체 {lines.Length}줄 중 앞부분 생략)\n{tail}";
         }
 
         /// <summary>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAsyncCommandRunnerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAsyncCommandRunnerTests.cs
@@ -1,0 +1,123 @@
+// -----------------------------------------------------------------------
+// AITAsyncCommandRunnerTests.cs - TailLines 경계 동작 검증
+// 배경: 비동기 명령 실패 시 stderr가 비어 있으면(vite/esbuild 등이 에러를 stdout에 쓰는 경우)
+// Console에 원인이 한 글자도 남지 않는 진단 공백이 있었다(실사례: vite build 실패 →
+// 원인 불명 → node_modules 재설치 캐스케이드 183초). TailLines는 stdout 폴백 로깅 시
+// Console 폭주를 막기 위한 말미 N줄 자르기 순수 함수이며, 프로세스 실행 없이 검증 가능하다.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor;
+
+[TestFixture]
+[Category("Unit")]
+public class AITAsyncCommandRunnerTests
+{
+    #region null / 빈 문자열
+
+    [Test]
+    public void TailLines_Null_ReturnsNull()
+    {
+        Assert.IsNull(AITAsyncCommandRunner.TailLines(null, 40));
+    }
+
+    [Test]
+    public void TailLines_Empty_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, AITAsyncCommandRunner.TailLines(string.Empty, 40));
+    }
+
+    #endregion
+
+    #region maxLines 이하 (잘리지 않음)
+
+    [Test]
+    public void TailLines_SingleLine_ReturnsUnchanged()
+    {
+        string text = "vite build failed: Could not resolve entry module";
+
+        string result = AITAsyncCommandRunner.TailLines(text, 40);
+
+        Assert.AreEqual(text, result);
+    }
+
+    [Test]
+    public void TailLines_LineCountEqualsMaxLines_ReturnsUnchanged()
+    {
+        string text = string.Join("\n", new[] { "line1", "line2", "line3" });
+
+        string result = AITAsyncCommandRunner.TailLines(text, 3);
+
+        Assert.AreEqual(text, result, "줄 수가 정확히 maxLines와 같으면 자르지 않아야 한다");
+    }
+
+    [Test]
+    public void TailLines_LineCountBelowMaxLines_ReturnsUnchanged()
+    {
+        string text = string.Join("\n", new[] { "line1", "line2" });
+
+        string result = AITAsyncCommandRunner.TailLines(text, 40);
+
+        Assert.AreEqual(text, result);
+        StringAssert.DoesNotContain("마지막", result, "잘리지 않았으면 잘림 안내 문구가 붙지 않아야 한다");
+    }
+
+    #endregion
+
+    #region maxLines 초과 (마지막 N줄 + 잘림 표시)
+
+    [Test]
+    public void TailLines_ExceedsMaxLines_KeepsOnlyLastNLinesWithMarker()
+    {
+        string[] lines = { "line1", "line2", "line3", "line4", "line5" };
+        string text = string.Join("\n", lines);
+
+        string result = AITAsyncCommandRunner.TailLines(text, 2);
+
+        StringAssert.Contains("마지막 2줄만 표시", result, "잘림 사실이 드러나는 문구가 있어야 한다");
+        StringAssert.Contains("전체 5줄", result, "원본 줄 수가 안내되어야 한다");
+        StringAssert.DoesNotContain("line1", result, "잘려나간 앞부분은 남지 않아야 한다");
+        StringAssert.DoesNotContain("line3", result, "잘려나간 앞부분은 남지 않아야 한다");
+        StringAssert.Contains("line4", result, "마지막 N줄은 남아야 한다");
+        StringAssert.Contains("line5", result, "마지막 N줄은 남아야 한다");
+    }
+
+    [Test]
+    public void TailLines_CrlfLineEndings_HandledSameAsLf()
+    {
+        string text = "line1\r\nline2\r\nline3\r\nline4";
+
+        string result = AITAsyncCommandRunner.TailLines(text, 2);
+
+        StringAssert.DoesNotContain("line1", result);
+        StringAssert.DoesNotContain("line2", result);
+        StringAssert.Contains("line3", result);
+        StringAssert.Contains("line4", result);
+    }
+
+    #endregion
+
+    #region maxLines 경계값
+
+    [Test]
+    public void TailLines_MaxLinesZero_ReturnsEmpty()
+    {
+        string text = "line1\nline2";
+
+        string result = AITAsyncCommandRunner.TailLines(text, 0);
+
+        Assert.AreEqual(string.Empty, result);
+    }
+
+    [Test]
+    public void TailLines_MaxLinesNegative_ReturnsEmpty()
+    {
+        string text = "line1\nline2";
+
+        string result = AITAsyncCommandRunner.TailLines(text, -1);
+
+        Assert.AreEqual(string.Empty, result);
+    }
+
+    #endregion
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAsyncCommandRunnerTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAsyncCommandRunnerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4858fcac1bd4666b6a86c8f7fdd508b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 배경 (실제 발생 사례)

사용자의 Deploy 실행이 318초 걸렸는데, 그중 183초가 "node_modules 전체 삭제 + 재설치" 재시도 캐스케이드였다. 트리거는 `pnpm exec vite build --outDir dist/web`의 exit code 1 실패였는데, Unity Console에는 다음 한 줄만 남고 원인 텍스트가 전혀 없었다.

```
[AIT Async] ✗ 명령 실패 (Exit: 1): cmd_1
```

원인: `Editor/AITAsyncCommandRunner.cs`의 정상 실패 분기는 **stderr가 비어있지 않을 때만** 로그를 남겼다. stdout 폴백이 없어서, vite/esbuild처럼 에러를 stdout에 쓰고 종료하는 도구는 원인이 한 글자도 Console에 남지 않았다.

동기 경로(`Editor/AITNpmRunner.cs`)는 stdout(`출력:`)과 stderr(`오류:`)를 모두 남기고 `AITBuildDiagnostics.RecordFailure`까지 호출한다 — 비동기 경로만 비대칭적으로 빈약했다. 타임아웃 분기는 이미 stdout/stderr를 result에 실어주는 배려가 있었으니, 그 설계 의도와도 어긋났다.

## 변경 사항

- `Editor/AITAsyncCommandRunner.cs`의 실패 로깅 분기에서, stderr가 비어 있고 stdout이 있으면 stdout 말미(최대 40줄)를 Console에 남긴다. `sentryCapture: false`는 기존대로 유지(상위 `CaptureBuildError`가 단일 캡처를 담당하는 정책 불변).
- 잘라내기 로직을 순수 함수 `internal static string TailLines(string text, int maxLines)`로 분리 — 프로세스 실행 없이 단위 테스트 가능.
- EditMode 테스트 추가(`Tests~/E2E/SharedScripts/Editor/EditModeTests/AITAsyncCommandRunnerTests.cs`): null/빈 문자열, maxLines 이하/동일/초과, CRLF 처리, maxLines 0/음수 경계.

## 하지 않은 것 — `AITBuildDiagnostics.RecordFailure` 추가

이 지점에 `AITBuildDiagnostics.RecordFailure` 호출을 추가하는 것도 검토했지만 넣지 않았다.

- `AITAsyncCommandRunner.RunAsync`는 빌드 전용이 아니라 범용 러너다. `AITPackageInitializer.InstallPnpmGlobal`(내장 Node.js에 pnpm 글로벌 설치, 백그라운드 부트스트랩)도 이 러너를 그대로 쓰며, 그 실패는 명시적으로 "첫 빌드 시 다시 시도됨" 정상 폴백으로 취급되고 빌드 진단으로 간주하지 않는다. 여기서 `RecordFailure`를 호출하면 무관한 백그라운드 작업의 실패가 이후 빌드 실패 Sentry 캡처의 `extra`를 오염시킬 위험이 있다(30분 신선도 창 안에서).
- 빌드 경로(`AITNpmRunner.RunNpmCommandWithCacheAsync`)는 이미 실패 시 `AITBuildDiagnostics.RecordFailure(..., result.Error, result.Output)`를 호출하고 있고, `RecordFailure` 자체가 `stderr가 비어 있으면 stdout으로 폴백`하는 로직을 이미 갖고 있다. 즉 Sentry 진단 쪽은 이미 stdout 폴백이 존재해서 공백이 없었다 — 이번 사례의 공백은 Unity Console 로깅에만 있었다.
- 재시도 캐스케이드에서 `RunAsync`가 여러 번 호출되므로, 여기서 추가로 `RecordFailure`를 호출해도 빌드 경로에서는 곧이어 실행되는 래퍼(`RunNpmCommandWithCacheAsync`)의 `RecordFailure` 호출에 즉시 덮어써져(마지막 1건만 유지) 실질적 이득이 없다.

따라서 이번 PR은 Console 로깅(1번)만 다루고, `RecordFailure` 확장은 하지 않았다.

## 검증

- `./run-local-tests.sh --validate` — 통과 (E2E 구조 검증, Playwright 설정, SDK 유닛 테스트 68개, Meta GUID 위생)
- `./run-local-tests.sh --editmode` (Unity 2022.3.62f2) — 1430개 EditMode 테스트 전부 통과, 신규 `AITAsyncCommandRunnerTests` 9개 전부 통과

## 하지 않은 것 (지시에 따름)

- `NodeModulesValidator.ValidateIntegrity` 검사 범위 확대는 포함하지 않음(오탐 시 매번 전체 재설치를 유발하는 역효과 위험 — 별도 판단 필요).
- 재시도 캐스케이드 자체의 동작은 변경하지 않음. 로깅/진단만 변경.
