### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — cs0414-appsintoss-path-guard-gap

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1340,6 +1340,22 @@ namespace AppsInToss.Editor.ErrorTracker
                 && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
                 return true;
 
+            // 사용자 코드의 사용되지 않은 필드 경고 (CS0414) — Unity 컴파일러가 직접 출력.
+            // 예: "UnityWarning: Assets\01_Script\AppsInToss\AppsInTossPromotionManager.cs(28,35): warning CS0414:
+            //       The field 'AppsInTossPromotionManager.persistEditorMockGrantState' is assigned but its value is never used"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-140.
+            // 위 NonSdkMessagePatterns에 "warning CS0414" substring이 이미 있으나, 사용자 폴더명이
+            // 'AppsInToss'(예: Assets\01_Script\AppsInToss\...)이면 단어 경계로 SDK 키워드 가드가 먼저
+            // 발동해 NonSdkMessagePatterns 루프(가드 이후)까지 도달하지 못하는 갭이 있었다.
+            // CS0103/CS0117/CS1061/CS1998/CS0618과 동일한 컨벤션으로 Assets/ 경로 + .cs(L,C) 마커를
+            // 합성 AND로 요구해 가드보다 먼저 매칭한다. SDK 자체 코드는 Packages/ 또는 Library/PackageCache/
+            // 경로로 출력되어 안전.
+            if (message.IndexOf("warning CS0414", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
             // 사용자 코드의 'AppsInToss' 미발견 컴파일 에러 — SDK 미설치 또는 asmdef 참조 누락.
             // 예: "Assets/.../Foo.cs(L,C): error CS0246: The type or namespace name 'AppsInToss' could not be found ..."
             // 메시지에 'AppsInToss' 토큰이 들어가 SDK 키워드 가드가 발동하므로 가드보다 먼저 매칭한다.

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1126,6 +1126,54 @@ public class IsKnownNonSdkMessageTests
 
     #endregion
 
+    #region 사용자 코드 CS0414 미사용 필드 경고 — AppsInToss 폴더명 경로 가드 갭 (APPS-IN-TOSS-UNITY-SDK-140)
+
+    [Test]
+    public void UserCodeCS0414_AppsInTossFolderPath_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-140 — 사용자 폴더명이 'AppsInToss'라 기존 NonSdkMessagePatterns의
+        // "warning CS0414" substring이 SDK 키워드 가드(MessageContainsSdkKeyword)에 먼저 막혀 도달하지
+        // 못했던 갭. CS0103/CS0117/CS1061/CS1998/CS0618과 동일한 composite AND 가드로 매칭돼야 한다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: Assets\\01_Script\\AppsInToss\\AppsInTossPromotionManager.cs(28,35): warning CS0414: The field 'AppsInTossPromotionManager.persistEditorMockGrantState' is assigned but its value is never used"));
+    }
+
+    [Test]
+    public void UserCodeCS0414_ForwardSlashPath_ReturnsTrue()
+    {
+        // POSIX 경로 변형 — AppsInToss 폴더명이 없어도 Assets/ + .cs(L,C) 합성 가드로 동일하게 매칭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets/Scripts/PlayerController.cs(12,17): warning CS0414: The field 'PlayerController.unusedFlag' is assigned but its value is never used"));
+    }
+
+    [Test]
+    public void Cs0414_SdkPackagePath_NeverFiltered()
+    {
+        // SDK 자체 .cs의 CS0414는 Packages/com.toss.apps-in-toss 경로로 출력 → Assets/ 가드 미충족 +
+        // "apps-in-toss" 키워드 가드로 보호되어 절대 드롭되지 않아야 한다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/com.toss.apps-in-toss/Editor/Foo.cs(10,5): warning CS0414: The field 'Foo.bar' is assigned but its value is never used"));
+    }
+
+    [Test]
+    public void Cs0414_NoAssetsPath_StillFilteredByLegacyPattern()
+    {
+        // Assets/ 경로도 .cs(L,C)도 없어 새 composite 가드는 매칭되지 않지만, 기존 NonSdkMessagePatterns의
+        // "warning CS0414" substring(가드 회귀 방지)이 여전히 드롭한다 — 기존 동작 불변 확인.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SomeLib.dll: warning CS0414: 'Z' is assigned but its value is never used"));
+    }
+
+    [Test]
+    public void Cs0414WithoutAssetsPrefix_AitProtected_ReturnsFalse()
+    {
+        // SDK 자체 진단 라인(Assets/ 경로 미포함)은 [AIT] prefix로 보호됨 — CS0103/CS1061과 동일 컨벤션.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] diag: warning CS0414 reported in SDK fallback path"));
+    }
+
+    #endregion
+
     #region pnpm stdout/stderr 패스스루 (SDK-HA, SDK-R6, SDK-VF, SDK-VA)
 
     [Test]


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-140

## 묶음 항목
| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-140 | UnityWarning: Assets\01_Script\AppsInToss\AppsInTossPromotionManager.cs(28,35): warning CS0414: The field 'AppsInTossPromotionManager.persistEditorMockGrantState' is assigned but its value is never used |

## 배경
`NonSdkMessagePatterns`에 이미 `"warning CS0414"` substring이 등록돼 있으나, 사용자 폴더명이 `AppsInToss`(예: `Assets\01_Script\AppsInToss\...`)인 변형은 `MessageContainsSdkKeyword`(AitKeywords 단어경계 가드)가 `IsKnownNonSdkMessage`의 `NonSdkMessagePatterns` 루프보다 먼저 매칭돼 드롭되지 않는 갭이 있었습니다. `CS0103`/`CS0117`/`CS1061`/`CS1998`/`CS0618`과 동일한 컨벤션으로, 가드보다 먼저 매칭되는 composite AND 조건(`"warning CS0414"` && `Assets/`|`Assets\` 경로 && `.cs(`)을 추가해 이 갭을 닫았습니다.

## 변경
- `Editor/ErrorTracker/AITEditorErrorTracker.cs`: `IsKnownNonSdkMessage`에 CS0414 composite AND 가드 추가 (CS0246 블록 바로 앞)
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`: 신규 region `사용자 코드 CS0414 미사용 필드 경고 — AppsInToss 폴더명 경로 가드 갭 (APPS-IN-TOSS-UNITY-SDK-140)`에 positive 2건(백슬래시/포워드슬래시 경로), SDK 패키지 경로 보호 negative 1건, 기존 legacy substring 동작 불변 확인 1건, `[AIT]` prefix 보호 negative 1건 = 총 5개 테스트 추가

## 검증
- `./run-local-tests.sh --validate` 미실행: 동시에 다른 auto-resolve worker가 동일 SDK repo에서 `run-local-tests.sh --validate`를 실행 중이어서(pgrep 2회 확인 모두 충돌) 동시 빌드 회피 정책에 따라 **검증 skip** — 사람 확인 필요
- 변경은 두 대상 파일에 한정된 순수 추가(additive)이며, 수정 파일 brace 균형은 기계적으로 확인함
- 커밋 시 pre-commit hook(Unity .meta 파일 검사)은 통과함

사람 머지 검토 필요.