### PR TITLE
수정: 패키징 스킵이 실제로 발동하지 않던 .ait 위치 규약 불일치

### DIFF
--- a/Editor/AITPackageBuilder.cs
+++ b/Editor/AITPackageBuilder.cs
@@ -102,7 +102,7 @@ namespace AppsInToss.Editor
             if (profile == null) profile = AITBuildProfile.CreateProductionProfile();
 
             string buildProjectPath = Path.Combine(projectPath, "ait-build");
-            Package.WebGLBuildCopier.PrepareAitBuildFolder(buildProjectPath, preserveDist: fastBuild);
+            Package.WebGLBuildCopier.PrepareAitBuildFolder(buildProjectPath, preservePackagingOutputs: fastBuild);
 
             // npm 경로 확인
             string npmPath = AITNpmRunner.FindNpmPath();
@@ -178,7 +178,7 @@ namespace AppsInToss.Editor
             if (profile == null) profile = AITBuildProfile.CreateProductionProfile();
 
             string buildProjectPath = Path.Combine(projectPath, "ait-build");
-            Package.WebGLBuildCopier.PrepareAitBuildFolder(buildProjectPath, preserveDist: fastBuild);
+            Package.WebGLBuildCopier.PrepareAitBuildFolder(buildProjectPath, preservePackagingOutputs: fastBuild);
 
             // BuildConfig 복사 (WebGL 출력 불필요 — package.json, lockfile 등만)
             Debug.Log("[AIT] [병렬] BuildConfig 파일 복사 중...");
@@ -348,7 +348,7 @@ namespace AppsInToss.Editor
             // 항상 전량 재빌드한다 (안전 우선).
             if (fastBuild && Package.PackageBuildStateMarker.ShouldSkipPackageBuild(ctx.BuildProjectPath, out string skipReason))
             {
-                Debug.Log($"[AIT] [병렬] 패키징 산출물 무변경 — vite/ait build 스킵 (재실행: ait-build/dist 삭제 또는 {Package.PackageBuildStateMarker.KillSwitchEnvVar}=1) [{skipReason}]");
+                Debug.Log($"[AIT] [병렬] 패키징 산출물 무변경 — vite/ait build 스킵 (재실행: ait-build/*.ait 삭제 또는 {Package.PackageBuildStateMarker.KillSwitchEnvVar}=1) [{skipReason}]");
                 onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.5f, "패키징 산출물 무변경 — vite/ait build 스킵");
                 onProgress?.Invoke(AITConvertCore.BuildPhase.Complete, 1f, "패키징 완료! (스킵)");
                 earlyCtx.CancelAndDisposePnpm();
@@ -360,10 +360,11 @@ namespace AppsInToss.Editor
             }
 
             // granite build 실행 (비동기)
-            // 스킵하지 않기로 했으므로, PrepareAitBuildFolder(preserveDist: true)가 보존해뒀을 수 있는
-            // 이전 dist를 여기서 명시적으로 지운다 — "빌드는 항상 빈 dist에서 시작한다" 불변식 복원.
+            // 스킵하지 않기로 했으므로, PrepareAitBuildFolder(preservePackagingOutputs: true)가 보존해뒀을
+            // 수 있는 이전 산출물(dist/ + 루트 *.ait)을 여기서 명시적으로 지운다 —
+            // "빌드는 항상 빈 산출물 상태에서 시작한다" 불변식 복원.
             var cancellationToken = earlyCtx.PnpmCancellationToken;
-            Package.WebGLBuildCopier.DeleteDistFolder(ctx.BuildProjectPath);
+            Package.WebGLBuildCopier.DeletePreviousPackagingOutputs(ctx.BuildProjectPath);
             Package.PackageBuildStateMarker.InvalidateMarker(ctx.BuildProjectPath);
             Package.GraniteBuildRunner.RunGraniteBuildAsync(ctx, cancellationToken, onProgress,
                 (buildResult) =>
@@ -414,13 +415,14 @@ namespace AppsInToss.Editor
             // 활성화된다. Production 배포(fastBuild=false)는 항상 전량 재빌드한다 (안전 우선).
             if (fastBuild && Package.PackageBuildStateMarker.ShouldSkipPackageBuild(ctx.BuildProjectPath, out string skipReason))
             {
-                Debug.Log($"[AIT] 패키징 산출물 무변경 — vite/ait build 스킵 (재실행: ait-build/dist 삭제 또는 {Package.PackageBuildStateMarker.KillSwitchEnvVar}=1) [{skipReason}]");
+                Debug.Log($"[AIT] 패키징 산출물 무변경 — vite/ait build 스킵 (재실행: ait-build/*.ait 삭제 또는 {Package.PackageBuildStateMarker.KillSwitchEnvVar}=1) [{skipReason}]");
                 return AITConvertCore.AITExportError.SUCCEED;
             }
 
-            // 스킵하지 않기로 했으므로, PrepareAitBuildFolder(preserveDist: true)가 보존해뒀을 수 있는
-            // 이전 dist를 여기서 명시적으로 지운다 — "빌드는 항상 빈 dist에서 시작한다" 불변식 복원.
-            Package.WebGLBuildCopier.DeleteDistFolder(ctx.BuildProjectPath);
+            // 스킵하지 않기로 했으므로, PrepareAitBuildFolder(preservePackagingOutputs: true)가 보존해뒀을
+            // 수 있는 이전 산출물(dist/ + 루트 *.ait)을 여기서 명시적으로 지운다 —
+            // "빌드는 항상 빈 산출물 상태에서 시작한다" 불변식 복원.
+            Package.WebGLBuildCopier.DeletePreviousPackagingOutputs(ctx.BuildProjectPath);
             Package.PackageBuildStateMarker.InvalidateMarker(ctx.BuildProjectPath);
             var buildResult = Package.GraniteBuildRunner.RunGraniteBuildSync(ctx);
             if (buildResult != AITConvertCore.AITExportError.SUCCEED) return buildResult;
@@ -620,16 +622,17 @@ namespace AppsInToss.Editor
                     // 패키징 산출물 스킵 판정 — fastBuild에서만 활성화 (Production은 항상 전량 재빌드).
                     if (fastBuild && Package.PackageBuildStateMarker.ShouldSkipPackageBuild(ctx.BuildProjectPath, out string skipReason))
                     {
-                        Debug.Log($"[AIT] 패키징 산출물 무변경 — vite/ait build 스킵 (재실행: ait-build/dist 삭제 또는 {Package.PackageBuildStateMarker.KillSwitchEnvVar}=1) [{skipReason}]");
+                        Debug.Log($"[AIT] 패키징 산출물 무변경 — vite/ait build 스킵 (재실행: ait-build/*.ait 삭제 또는 {Package.PackageBuildStateMarker.KillSwitchEnvVar}=1) [{skipReason}]");
                         onProgress?.Invoke(AITConvertCore.BuildPhase.GraniteBuild, 0.5f, "패키징 산출물 무변경 — vite/ait build 스킵");
                         onProgress?.Invoke(AITConvertCore.BuildPhase.Complete, 1f, "패키징 완료! (스킵)");
                         onComplete?.Invoke(AITConvertCore.AITExportError.SUCCEED);
                         return;
                     }
 
-                    // 스킵하지 않기로 했으므로, PrepareAitBuildFolder(preserveDist: true)가 보존해뒀을 수
-                    // 있는 이전 dist를 여기서 명시적으로 지운다 — "빌드는 항상 빈 dist에서 시작한다" 불변식 복원.
-                    Package.WebGLBuildCopier.DeleteDistFolder(ctx.BuildProjectPath);
+                    // 스킵하지 않기로 했으므로, PrepareAitBuildFolder(preservePackagingOutputs: true)가
+                    // 보존해뒀을 수 있는 이전 산출물(dist/ + 루트 *.ait)을 여기서 명시적으로 지운다 —
+                    // "빌드는 항상 빈 산출물 상태에서 시작한다" 불변식 복원.
+                    Package.WebGLBuildCopier.DeletePreviousPackagingOutputs(ctx.BuildProjectPath);
                     Package.PackageBuildStateMarker.InvalidateMarker(ctx.BuildProjectPath);
                     Package.GraniteBuildRunner.RunGraniteBuildAsync(ctx, cancellationToken, onProgress, (buildResult) =>
                     {

--- a/Editor/Package/PackageBuildStateMarker.cs
+++ b/Editor/Package/PackageBuildStateMarker.cs
@@ -22,7 +22,9 @@ namespace AppsInToss.Editor.Package
     /// 성공한 빌드 직후 (1) ait-build/public 트리 상태(경로·크기·mtime), (2) ait-build 설정
     /// 파일들의 내용 해시, (3) UNITY_METADATA 중 .ait 헤더에 반영되는 필드의 해시를
     /// node_modules/.ait-package-build-state.json 에 기록하고, 다음 빌드에서 전부 일치하며
-    /// 산출물(dist/*.ait)이 여전히 존재하면 vite/ait build 자체를 건너뛴다.
+    /// 산출물(.ait)이 여전히 존재하면 vite/ait build 자체를 건너뛴다. .ait의 위치는
+    /// ait build CLI 버전에 따라 ait-build 루트(2.x·3.x 현행) 또는 dist/이므로
+    /// <see cref="AITBuildValidator.ValidateDistOutput"/>과 동일하게 두 곳을 모두 본다.
     ///
     /// public/ 트리는 내용을 다시 읽지 않고 (경로, 길이, mtimeTicks)만 본다 — WebGLBuildCopier.
     /// CopyFileIfChanged가 내용이 같은 파일은 mtime을 보존한 채 복사를 스킵하므로, mtime이
@@ -124,9 +126,10 @@ namespace AppsInToss.Editor.Package
         /// <summary>
         /// 이번 빌드에서 vite/ait build(패키징)를 건너뛰어도 안전한지 판단한다.
         /// 킬스위치 비활성 + 마커 유효 + 스키마 일치 + web-framework 메이저 버전 일치 +
-        /// public 매니페스트/설정 파일/Unity 메타데이터 해시 일치 + dist/*.ait 산출물 존재를
-        /// 전부 만족할 때만 true. 호출부는 fastBuild(Deploy (Test) 등 빠른 반복 경로)에서만
-        /// 이 메서드를 호출해야 한다 — Production 배포는 항상 전량 재빌드한다(안전 우선).
+        /// public 매니페스트/설정 파일/Unity 메타데이터 해시 일치 + .ait 산출물(ait-build 루트
+        /// 또는 dist/) 존재를 전부 만족할 때만 true. 호출부는 fastBuild(Deploy (Test) 등 빠른
+        /// 반복 경로)에서만 이 메서드를 호출해야 한다 — Production 배포는 항상 전량 재빌드한다
+        /// (안전 우선). 거절 시에는 사유를 Debug.Log로 남긴다 (조용한 fail-closed 금지).
         /// </summary>
         internal static bool ShouldSkipPackageBuild(string aitBuildPath, out string reason)
         {
@@ -134,72 +137,17 @@ namespace AppsInToss.Editor.Package
 
             try
             {
-                if (IsKillSwitchActive(Environment.GetEnvironmentVariable(KillSwitchEnvVar)))
+                string blocker = FindSkipBlocker(aitBuildPath);
+                if (blocker != null)
                 {
+                    // 거절 사유를 항상 남긴다 — fail-closed 분기가 조용히 false를 반환하면
+                    // "스킵이 왜 안 걸리는지" 를 로그만으로 진단할 수 없어(실제로 .ait 위치
+                    // 규약 불일치가 이 방식으로 장기간 은폐됐다) 회귀를 놓치게 된다.
+                    Debug.Log($"[AIT] 패키징 스킵 조건 불충족 — vite/ait build를 실행합니다 ({blocker})");
                     return false;
                 }
 
-                string markerPath = GetMarkerPath(aitBuildPath);
-                if (!File.Exists(markerPath))
-                {
-                    return false;
-                }
-
-                var marker = MiniJson.Deserialize(File.ReadAllText(markerPath)) as Dictionary<string, object>;
-                if (marker == null)
-                {
-                    return false;
-                }
-
-                if (!marker.TryGetValue("schemaVersion", out object schemaObj)
-                    || Convert.ToInt32(schemaObj) != SchemaVersion)
-                {
-                    return false;
-                }
-
-                if (!marker.TryGetValue("webFrameworkMajor", out object majorObj)
-                    || Convert.ToInt32(majorObj) != GraniteBuildRunner.GetWebFrameworkMajor(aitBuildPath))
-                {
-                    return false;
-                }
-
-                if (!marker.TryGetValue("publicManifestHash", out object publicHashObj)
-                    || (publicHashObj as string) != ComputePublicManifestHash(aitBuildPath))
-                {
-                    return false;
-                }
-
-                if (!marker.TryGetValue("configFilesHash", out object configHashObj)
-                    || (configHashObj as string) != ComputeConfigFilesHash(aitBuildPath))
-                {
-                    return false;
-                }
-
-                if (!marker.TryGetValue("metadataHash", out object metadataHashObj)
-                    || (metadataHashObj as string) != ComputeMetadataHash())
-                {
-                    return false;
-                }
-
-                // 해시가 전부 일치해도 산출물이 사라졌으면(수동 삭제, Clean 메뉴 등) 스킵 불가.
-                // AITBuildValidator.ValidateDistOutput은 실패 시 진단용 Debug.LogError를 남겨
-                // (Sentry로도 캡처됨) 성공으로 끝날 스킵 판정에서 유령 에러가 발생하므로 여기서는
-                // 호출하지 않고, 로그를 남기지 않는 조용한 존재 확인만 한다.
-                //
-                // web-framework 2.x가 dist/ 대신 ait-build 루트에 .ait를 emit하는 경우는
-                // 의도적으로 스킵 대상에서 제외한다 (fail-closed) — 아래 dist/ 존재 요구
-                // 자체가 이 케이스를 걸러내므로 2.x 루트 emit 빌드는 항상 재빌드된다.
-                string distPath = Path.Combine(aitBuildPath, "dist");
-                if (!Directory.Exists(distPath))
-                {
-                    return false;
-                }
-                if (Directory.GetFiles(distPath, "*.ait", SearchOption.TopDirectoryOnly).Length == 0)
-                {
-                    return false;
-                }
-
-                reason = "ait-build/public + 설정 파일 + Unity 메타데이터 변경 없음 + dist/*.ait 산출물 존재";
+                reason = "ait-build/public + 설정 파일 + Unity 메타데이터 변경 없음 + .ait 산출물 존재";
                 return true;
             }
             catch (Exception e)
@@ -207,6 +155,110 @@ namespace AppsInToss.Editor.Package
                 Debug.Log($"[AIT] 패키징 빌드 스킵 판정 중 오류 (스킵하지 않고 vite/ait build 진행): {e.Message}");
                 return false;
             }
+        }
+
+        /// <summary>
+        /// 스킵을 막는 첫 번째 사유를 사람이 읽을 수 있는 문자열로 반환한다. 스킵 가능하면 null.
+        /// <see cref="ShouldSkipPackageBuild"/>의 fail-closed 분기를 진단 가능한 형태로 분리한 것.
+        /// </summary>
+        private static string FindSkipBlocker(string aitBuildPath)
+        {
+            if (IsKillSwitchActive(Environment.GetEnvironmentVariable(KillSwitchEnvVar)))
+            {
+                return $"킬스위치 {KillSwitchEnvVar} 활성";
+            }
+
+            string markerPath = GetMarkerPath(aitBuildPath);
+            if (!File.Exists(markerPath))
+            {
+                return "이전 성공 빌드 마커 없음";
+            }
+
+            var marker = MiniJson.Deserialize(File.ReadAllText(markerPath)) as Dictionary<string, object>;
+            if (marker == null)
+            {
+                return "마커 파싱 실패";
+            }
+
+            if (!marker.TryGetValue("schemaVersion", out object schemaObj)
+                || Convert.ToInt32(schemaObj) != SchemaVersion)
+            {
+                return "마커 schemaVersion 불일치";
+            }
+
+            int currentMajor = GraniteBuildRunner.GetWebFrameworkMajor(aitBuildPath);
+            if (!marker.TryGetValue("webFrameworkMajor", out object majorObj)
+                || Convert.ToInt32(majorObj) != currentMajor)
+            {
+                return $"web-framework 메이저 버전 변경 (현재 {currentMajor})";
+            }
+
+            if (!marker.TryGetValue("publicManifestHash", out object publicHashObj)
+                || (publicHashObj as string) != ComputePublicManifestHash(aitBuildPath))
+            {
+                return "ait-build/public 변경";
+            }
+
+            if (!marker.TryGetValue("configFilesHash", out object configHashObj)
+                || (configHashObj as string) != ComputeConfigFilesHash(aitBuildPath))
+            {
+                return "빌드 설정 파일(index.html 포함) 변경";
+            }
+
+            if (!marker.TryGetValue("metadataHash", out object metadataHashObj)
+                || (metadataHashObj as string) != ComputeMetadataHash())
+            {
+                return "Unity 메타데이터(sdkVersion/unityVersion 등) 변경";
+            }
+
+            // 해시가 전부 일치해도 산출물이 사라졌으면(수동 삭제, Clean 메뉴 등) 스킵 불가.
+            // AITBuildValidator.ValidateDistOutput은 실패 시 진단용 Debug.LogError를 남겨
+            // (Sentry로도 캡처됨) 성공으로 끝날 스킵 판정에서 유령 에러가 발생하므로 여기서는
+            // 호출하지 않고, 로그를 남기지 않는 조용한 존재 확인만 한다.
+            if (!HasAitArchive(aitBuildPath))
+            {
+                return ".ait 산출물 없음 (ait-build 루트/dist 모두)";
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// 패키징 산출물(.ait)이 존재하는지 조용히 확인한다. 탐색 위치와 순서는
+        /// <see cref="AITBuildValidator.ValidateDistOutput"/>과 동일해야 한다 — ait build CLI는
+        /// 버전에 따라 ait-build 루트(2.x, 3.x 현행) 또는 dist/에 .ait를 emit하기 때문이다.
+        /// 여기서 dist/만 보면 실제 산출물이 루트에 있는 현행 3.x에서는 스킵이 영원히 발동하지
+        /// 않는다 (#1094가 실측에서 걸리지 않은 원인).
+        /// </summary>
+        private static bool HasAitArchive(string aitBuildPath)
+        {
+            if (ContainsAitArchive(aitBuildPath))
+            {
+                return true;
+            }
+
+            return ContainsAitArchive(Path.Combine(aitBuildPath, "dist"));
+        }
+
+        private static bool ContainsAitArchive(string directory)
+        {
+            if (!Directory.Exists(directory))
+            {
+                return false;
+            }
+
+            // Windows의 8.3 단축명 때문에 "*.ait" glob이 .aitxxx까지 잡을 수 있어
+            // 확장자를 명시적으로 비교한다.
+            foreach (string path in Directory.GetFiles(directory, "*", SearchOption.TopDirectoryOnly))
+            {
+                if (string.Equals(Path.GetExtension(path), WebGLBuildCopier.AitArchiveExtension,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -268,7 +320,7 @@ namespace AppsInToss.Editor.Package
         /// ait-build/public 트리를 재귀 순회해 각 파일의 (상대경로, 길이, mtimeTicks)를
         /// 상대경로 오름차순으로 정렬한 목록의 SHA256. 내용을 읽지 않으므로 대용량
         /// .data/.wasm가 섞여 있어도 저렴하다. public/이 없으면 빈 매니페스트로 취급한다
-        /// (WebGL 출력 복사가 아직 실행되지 않은 비정상 상태 — 아래 dist 존재 검사가
+        /// (WebGL 출력 복사가 아직 실행되지 않은 비정상 상태 — .ait 산출물 존재 검사가
         /// 별도로 막는다).
         /// </summary>
         internal static string ComputePublicManifestHash(string aitBuildPath)

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -30,6 +30,13 @@ namespace AppsInToss.Editor.Package
         };
 
         /// <summary>
+        /// 패키징 산출물(미니앱 아카이브) 확장자. web-framework 2.x/3.x의 `ait build`는 이 파일을
+        /// ait-build 루트에 emit한다(3.x의 dist/에는 vite 산출물인 dist/web만 생성됨).
+        /// AITBuildValidator.ValidateDistOutput이 "루트 → dist/" 순으로 탐색하는 위치 규약과 동일.
+        /// </summary>
+        internal const string AitArchiveExtension = ".ait";
+
+        /// <summary>
         /// Unity WebGL 빌드를 public 폴더로 복사합니다.
         /// <see cref="MirroredPublicDirectories"/>는 이 함수가 미러로 소유합니다 — 변경분만 복사하고,
         /// 소스에 없는 파일·디렉토리와 소스 자체가 사라진 미러 대상은 제거해 전체 삭제+재복사와
@@ -972,17 +979,25 @@ namespace AppsInToss.Editor.Package
         /// 무효화되므로, 미러 대상만 남기고 그 외 public/ 항목은 <see cref="PrunePublicFolder"/>가 정리한다.
         /// internal 승격: facade(AITPackageBuilder) 및 EditMode 테스트(리플렉션)에서 호출하기 위함.
         /// </summary>
-        /// <param name="preserveDist">
-        /// true면 dist/도 정리 대상에서 제외해 보존한다. fastBuild(Deploy (Test)) 경로에서만
-        /// true로 전달해야 한다 — Package.PackageBuildStateMarker.ShouldSkipPackageBuild가
-        /// dist/*.ait 존재를 스킵 조건으로 검사하는데, 이 판정 전에 dist가 지워지면 스킵이
-        /// 절대 발동하지 않는다(모든 빌드 진입점이 이 함수를 가장 먼저 호출하기 때문).
-        /// 스킵 판정이 결국 false로 나오면 호출부가 <see cref="DeleteDistFolder"/>로 실제
-        /// 빌드 시작 직전 dist/를 명시적으로 삭제해 "빌드는 항상 빈 dist에서 시작한다"
-        /// 불변식을 복원한다. 기본값(false)은 Production/Build & Package 경로의 기존 동작과
-        /// 동일 — dist는 항상 이 함수에서 정리된다.
+        /// <param name="preservePackagingOutputs">
+        /// true면 이전 패키징 산출물(dist/ 와 ait-build 루트의 *.ait)을 정리 대상에서 제외해
+        /// 보존한다. fastBuild(Deploy (Test)) 경로에서만 true로 전달해야 한다 —
+        /// Package.PackageBuildStateMarker.ShouldSkipPackageBuild가 .ait 산출물 존재를 스킵
+        /// 조건으로 검사하는데, 이 판정 전에 산출물이 지워지면 스킵이 절대 발동하지 않는다
+        /// (모든 빌드 진입점이 이 함수를 가장 먼저 호출하기 때문).
+        ///
+        /// ⚠️ 루트 *.ait도 함께 보존해야 한다: web-framework 3.x의 `ait build`는 .ait를 dist/가
+        /// 아니라 ait-build 루트에 emit하고(dist/에는 vite 산출물인 dist/web만 생성됨), 2.x도
+        /// 루트에 emit한다. dist/만 보존하면 실제 산출물인 루트 *.ait가 여기서 지워져 스킵이
+        /// 영원히 발동하지 않는다 (AITBuildValidator.ValidateDistOutput의 "루트 → dist/" 탐색
+        /// 순서와 동일한 위치 규약).
+        ///
+        /// 스킵 판정이 결국 false로 나오면 호출부가 <see cref="DeletePreviousPackagingOutputs"/>로
+        /// 실제 빌드 시작 직전 dist/와 루트 *.ait를 명시적으로 삭제해 "빌드는 항상 빈 산출물
+        /// 상태에서 시작한다" 불변식을 복원한다. 기본값(false)은 Production/Build &amp; Package
+        /// 경로의 기존 동작과 동일 — 산출물은 항상 이 함수에서 정리된다.
         /// </param>
-        internal static void PrepareAitBuildFolder(string buildProjectPath, bool preserveDist = false)
+        internal static void PrepareAitBuildFolder(string buildProjectPath, bool preservePackagingOutputs = false)
         {
             if (!Directory.Exists(buildProjectPath))
             {
@@ -1009,7 +1024,7 @@ namespace AppsInToss.Editor.Package
                     "public"
                 };
 
-                if (preserveDist)
+                if (preservePackagingOutputs)
                 {
                     itemsToKeep.Add("dist");
                 }
@@ -1026,6 +1041,14 @@ namespace AppsInToss.Editor.Package
                             shouldKeep = true;
                             break;
                         }
+                    }
+
+                    // 루트 *.ait는 web-framework 2.x/3.x가 실제로 .ait를 emit하는 위치라
+                    // itemsToKeep(고정 이름 매칭)으로는 표현할 수 없다 — 파일명이 appName에
+                    // 따라 달라지므로 확장자로 판별한다.
+                    if (!shouldKeep && preservePackagingOutputs && IsAitArchive(item))
+                    {
+                        shouldKeep = true;
                     }
 
                     if (shouldKeep) continue;
@@ -1046,21 +1069,43 @@ namespace AppsInToss.Editor.Package
         }
 
         /// <summary>
-        /// ait-build/dist를 삭제한다. <see cref="PrepareAitBuildFolder"/>(preserveDist: true)가
-        /// 보존해둔 이전 dist를, Package.PackageBuildStateMarker.ShouldSkipPackageBuild 판정이
-        /// 결국 false로 나와 실제 vite/ait build를 새로 시작하기 직전에 호출해 지운다 —
-        /// "빌드는 항상 빈 dist에서 시작한다" 불변식을 복원해 옛 .ait와 새 .ait가 공존하는
-        /// 것을 막는다(예: appName/version 변경으로 산출물 파일명이 달라지는 경우).
-        /// preserveDist:false 경로에서는 PrepareAitBuildFolder가 이미 dist를 지웠으므로
-        /// 이 호출은 언제나 안전한 no-op이다.
+        /// 이전 패키징 산출물(ait-build/dist 와 ait-build 루트의 *.ait)을 삭제한다.
+        /// <see cref="PrepareAitBuildFolder"/>(preservePackagingOutputs: true)가 보존해둔 이전
+        /// 산출물을, Package.PackageBuildStateMarker.ShouldSkipPackageBuild 판정이 결국 false로
+        /// 나와 실제 vite/ait build를 새로 시작하기 직전에 호출해 지운다 — "빌드는 항상 빈
+        /// 산출물 상태에서 시작한다" 불변식을 복원해 옛 .ait와 새 .ait가 공존하는 것을
+        /// 막는다(예: appName/version 변경으로 산출물 파일명이 달라지는 경우).
+        /// preservePackagingOutputs:false 경로에서는 PrepareAitBuildFolder가 이미 둘 다
+        /// 지웠으므로 이 호출은 언제나 안전한 no-op이다.
         /// </summary>
-        internal static void DeleteDistFolder(string buildProjectPath)
+        internal static void DeletePreviousPackagingOutputs(string buildProjectPath)
         {
             string distPath = Path.Combine(buildProjectPath, "dist");
             if (Directory.Exists(distPath))
             {
                 AITFileUtils.DeleteDirectory(distPath);
             }
+
+            if (!Directory.Exists(buildProjectPath)) return;
+
+            foreach (string item in Directory.GetFiles(buildProjectPath, "*", SearchOption.TopDirectoryOnly))
+            {
+                if (IsAitArchive(item))
+                {
+                    AITFileSystemHelper.SafeDelete(item);
+                }
+            }
+        }
+
+        /// <summary>
+        /// ait-build 루트에 emit된 패키징 산출물(.ait) 여부. 파일명은 appName에 따라 달라지므로
+        /// 확장자로만 판별한다. Windows의 8.3 단축명 때문에 <c>Directory.GetFiles(dir, "*.ait")</c>가
+        /// .aitxxx 같은 더 긴 확장자까지 잡을 수 있어, 열거는 "*"로 하고 여기서 정확히 검사한다.
+        /// </summary>
+        private static bool IsAitArchive(string path)
+        {
+            return File.Exists(path)
+                && string.Equals(Path.GetExtension(path), AitArchiveExtension, System.StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PackageBuildStateMarkerTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/Package/PackageBuildStateMarkerTests.cs
@@ -18,6 +18,13 @@ namespace AppsInToss.Editor.Package.Tests
         private const string WebFrameworkVersion = "3.0.3";
         private const int WebFrameworkMajor = 3;
 
+        /// <summary>
+        /// web-framework 3.x의 `ait build`가 실제로 emit하는 산출물 경로 — ait-build "루트"의
+        /// &lt;appName&gt;.ait 다. dist/ 아래에는 vite 산출물(dist/web)만 생긴다.
+        /// (#1094의 스킵이 실측에서 한 번도 걸리지 않은 원인이 이 위치 규약 불일치였다.)
+        /// </summary>
+        private const string RootAitFileName = "unity-sdk-sample.ait";
+
         private string _tempDir;
 
         [SetUp]
@@ -48,10 +55,46 @@ namespace AppsInToss.Editor.Package.Tests
         }
 
         /// <summary>
-        /// 스킵 가능한 정상 상태 fixture: package.json(웹프레임워크 3.x) + 설정 파일들 +
-        /// public/ 산출물 + dist/*.ait + node_modules/(마커가 여기 저장됨) + 성공 마커.
+        /// 스킵 가능한 정상 상태 fixture — <b>실제 web-framework 3.x 빌드가 남기는 디스크 레이아웃</b>을
+        /// 그대로 재현한다: package.json(3.x) + 설정 파일들 + public/ 산출물 +
+        /// dist/web(=vite build --outDir) + 루트 &lt;appName&gt;.ait(=ait build) +
+        /// node_modules/(마커가 여기 저장됨) + 성공 마커.
+        ///
+        /// 이전 fixture는 존재하지 않는 dist/*.ait 레이아웃을 가정했고, 그래서 판정 로직이
+        /// dist/만 보고 있어도 모든 테스트가 통과했다 — 실측에서 스킵이 한 번도 걸리지 않은
+        /// 결함을 테스트가 잡지 못한 이유다. 실제 레이아웃 고정이 이 fixture의 핵심 계약.
         /// </summary>
         private void CreateValidBuiltState()
+        {
+            CreateSourceState();
+
+            // vite build --outDir dist/web 산출물 (여기에는 .ait가 없다)
+            WriteFile("dist/web/index.html", "<html>vite output</html>");
+            WriteFile("dist/web/assets/index-abc123.js", "console.log('bundle');");
+
+            // ait build 산출물 — ait-build "루트"에 emit된다
+            WriteFile(RootAitFileName, "ait-archive-placeholder");
+
+            FinalizeBuiltState();
+        }
+
+        /// <summary>
+        /// .ait가 dist/ 아래에 생기는 대체 레이아웃(ait build CLI 버전에 따라 가능) fixture.
+        /// AITBuildValidator.ValidateDistOutput이 두 위치를 모두 인정하므로 스킵 판정도 같아야 한다.
+        /// </summary>
+        private void CreateValidBuiltState_AitInsideDist()
+        {
+            CreateSourceState();
+
+            WriteFile("dist/output.ait", "ait-archive-placeholder");
+
+            FinalizeBuiltState();
+        }
+
+        /// <summary>
+        /// 산출물(.ait/dist)을 제외한 입력 측 상태 — 설정 파일 + public/ 트리.
+        /// </summary>
+        private void CreateSourceState()
         {
             WriteFile("package.json", "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"" + WebFrameworkVersion + "\"}}");
             WriteFile("pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
@@ -61,9 +104,10 @@ namespace AppsInToss.Editor.Package.Tests
 
             WriteFile("public/Build/game.wasm", "wasm-bytes-placeholder");
             WriteFile("public/TemplateData/style.css", "body{}");
+        }
 
-            WriteFile("dist/output.ait", "ait-archive-placeholder");
-
+        private void FinalizeBuiltState()
+        {
             // 마커는 node_modules/ 안에 저장된다 (PrepareAitBuildFolder의 itemsToKeep 생존 +
             // NodeModulesValidator.CleanNodeModules와의 fail-closed 정합을 위해) — 폴더가
             // 없으면 RecordSuccessfulBuild가 조용히 기록을 포기한다.
@@ -79,10 +123,10 @@ namespace AppsInToss.Editor.Package.Tests
         [Test]
         public void ShouldSkipPackageBuild_ReturnsFalse_WhenMarkerMissing()
         {
-            // RecordSuccessfulBuild를 호출하지 않은 상태 — public/config/dist는 만들어도 마커가 없음
+            // RecordSuccessfulBuild를 호출하지 않은 상태 — public/config/산출물은 만들어도 마커가 없음
             WriteFile("package.json", "{\"dependencies\":{\"@apps-in-toss/web-framework\":\"" + WebFrameworkVersion + "\"}}");
             WriteFile("public/Build/game.wasm", "wasm-bytes-placeholder");
-            WriteFile("dist/output.ait", "ait-archive-placeholder");
+            WriteFile(RootAitFileName, "ait-archive-placeholder");
 
             Assert.IsFalse(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _));
         }
@@ -310,28 +354,79 @@ namespace AppsInToss.Editor.Package.Tests
         }
 
         // =====================================================
-        // dist/*.ait 부재 → 스킵 불가
+        // .ait 산출물 존재/부재 → 스킵 가부
+        //
+        // 판정이 찾는 위치는 AITBuildValidator.ValidateDistOutput과 정확히 같아야 한다
+        // (루트 → dist/). 3.x는 루트에, 일부 CLI 버전은 dist/에 emit하므로 둘 다 인정.
         // =====================================================
+
+        [Test]
+        public void ShouldSkipPackageBuild_Skips_WhenAitFileIsAtBuildRoot_RealWebFramework3Layout()
+        {
+            // 실제 3.x 레이아웃: dist/에는 vite 산출물(web/)만 있고 .ait는 루트에 있다.
+            CreateValidBuiltState();
+
+            Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "dist", "output.ait")),
+                "Precondition: 3.x는 dist/ 최상위에 .ait를 만들지 않는다");
+            Assert.IsTrue(File.Exists(Path.Combine(_tempDir, RootAitFileName)),
+                "Precondition: 3.x의 .ait는 ait-build 루트에 있다");
+
+            Assert.IsTrue(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _),
+                "루트 .ait를 산출물로 인정하지 않으면 3.x에서는 스킵이 영원히 발동하지 않는다");
+        }
+
+        [Test]
+        public void ShouldSkipPackageBuild_Skips_WhenAitFileIsInsideDist()
+        {
+            CreateValidBuiltState_AitInsideDist();
+
+            Assert.IsTrue(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipPackageBuild_ArtifactGate_AgreesWithValidateDistOutput()
+        {
+            // 산출물 위치 규약이 두 곳에서 갈라지면 다시 같은 결함이 재발한다 — 실제
+            // 검증기(ValidateDistOutput)가 통과시키는 레이아웃은 스킵 판정도 통과시켜야 한다.
+            CreateValidBuiltState();
+
+            Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED,
+                AITBuildValidator.ValidateDistOutput(_tempDir),
+                "Precondition: 실제 검증기는 루트 .ait 레이아웃을 정상으로 본다");
+            Assert.IsTrue(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _),
+                "스킵 판정의 산출물 게이트가 ValidateDistOutput과 같은 위치를 봐야 한다");
+        }
 
         [Test]
         public void ShouldSkipPackageBuild_ReturnsFalse_WhenAitFileMissing()
         {
             CreateValidBuiltState();
 
-            File.Delete(Path.Combine(_tempDir, "dist", "output.ait"));
+            File.Delete(Path.Combine(_tempDir, RootAitFileName));
 
-            // dist/ 디렉토리는 남아있지만 *.ait 파일이 없다 — 판정은 로그를 남기지 않는 조용한
-            // Directory.GetFiles 존재 확인만 하므로(AITBuildValidator.ValidateDistOutput 미호출),
+            // dist/ 디렉토리는 남아있지만 어디에도 *.ait 파일이 없다 — 판정은 로그를 남기지 않는
+            // 조용한 존재 확인만 하므로(AITBuildValidator.ValidateDistOutput 미호출),
             // 여기서 Debug.LogError가 발생하지 않아야 한다 (성공할 스킵 판정에서 유령 에러 방지).
             Assert.IsFalse(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _));
         }
 
         [Test]
-        public void ShouldSkipPackageBuild_ReturnsFalse_WhenDistDirectoryMissing()
+        public void ShouldSkipPackageBuild_ReturnsFalse_WhenAitFileMissingFromDistLayout()
+        {
+            CreateValidBuiltState_AitInsideDist();
+
+            File.Delete(Path.Combine(_tempDir, "dist", "output.ait"));
+
+            Assert.IsFalse(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _));
+        }
+
+        [Test]
+        public void ShouldSkipPackageBuild_ReturnsFalse_WhenAllOutputsMissing()
         {
             CreateValidBuiltState();
 
             Directory.Delete(Path.Combine(_tempDir, "dist"), recursive: true);
+            File.Delete(Path.Combine(_tempDir, RootAitFileName));
 
             Assert.IsFalse(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _));
         }
@@ -539,87 +634,110 @@ namespace AppsInToss.Editor.Package.Tests
         }
 
         // =====================================================
-        // 실제 빌드 진입 시퀀스: WebGLBuildCopier.PrepareAitBuildFolder(preserveDist) 통합
+        // 실제 빌드 진입 시퀀스: WebGLBuildCopier.PrepareAitBuildFolder(preservePackagingOutputs) 통합
         //
-        // (치명 결함 수정) 모든 빌드 진입점(PreparePackaging/PrepareEarlyPackaging)이 맨 먼저
-        // 호출하는 PrepareAitBuildFolder의 기존 itemsToKeep에는 dist도 마커도 없어서, 정리
-        // 루프가 매 빌드 시작 시 둘 다 지워버리면 ShouldSkipPackageBuild는 항상 false가 된다.
+        // 모든 빌드 진입점(PreparePackaging/PrepareEarlyPackaging)이 맨 먼저 호출하는
+        // PrepareAitBuildFolder의 itemsToKeep에는 마커도 산출물도 없어서, 정리 루프가 매 빌드
+        // 시작 시 이들을 지워버리면 ShouldSkipPackageBuild는 항상 false가 된다.
         // 마커는 node_modules/ 안으로 옮겨 itemsToKeep에 이미 있는 node_modules로 생존시키고,
-        // dist는 fastBuild 경로에서만 preserveDist:true로 생존시킨 뒤 스킵 판정이 false로
-        // 나오면 WebGLBuildCopier.DeleteDistFolder로 명시적으로 지워 "빌드는 항상 빈 dist에서
-        // 시작한다" 불변식을 복원한다 — 이 시퀀스 전체가 실제로 맞물려 동작하는지 검증한다.
+        // 산출물(dist/ + 루트 *.ait)은 fastBuild 경로에서만 preservePackagingOutputs:true로
+        // 생존시킨 뒤, 스킵 판정이 false로 나오면 WebGLBuildCopier.DeletePreviousPackagingOutputs로
+        // 명시적으로 지워 "빌드는 항상 빈 산출물 상태에서 시작한다" 불변식을 복원한다 —
+        // 이 시퀀스 전체가 실제 3.x 레이아웃에서 맞물려 동작하는지 검증한다.
         // =====================================================
 
         [Test]
-        public void PrepareAitBuildFolder_PreserveDistTrue_KeepsMarkerAndDistAlive_AndStillSkips()
+        public void PreservePackagingOutputs_KeepsMarkerAndRootAitAlive_AndStillSkips()
         {
+            // 실측 결함의 직접 회귀 테스트: fastBuild 2회 연속 실행에서 두 번째 실행의
+            // 준비 단계가 루트 .ait를 지워버리면 스킵은 절대 발동하지 않는다.
             CreateValidBuiltState();
             Assert.IsTrue(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _),
                 "Precondition: valid built state should be skippable before folder prep");
 
-            WebGLBuildCopier.PrepareAitBuildFolder(_tempDir, preserveDist: true);
+            WebGLBuildCopier.PrepareAitBuildFolder(_tempDir, preservePackagingOutputs: true);
 
             Assert.IsTrue(File.Exists(PackageBuildStateMarker.GetMarkerPath(_tempDir)),
-                "preserveDist=true: marker (inside node_modules) must survive folder cleanup");
+                "preservePackagingOutputs=true: marker (inside node_modules) must survive folder cleanup");
+            Assert.IsTrue(File.Exists(Path.Combine(_tempDir, RootAitFileName)),
+                "preservePackagingOutputs=true: the real 3.x artifact (root *.ait) must survive folder cleanup");
             Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "dist")),
-                "preserveDist=true: dist/ must survive folder cleanup so the skip check can find it");
+                "preservePackagingOutputs=true: dist/ must survive folder cleanup");
 
-            // index.html은 itemsToKeep에 없어 preserveDist 여부와 무관하게 항상 지워진다 — 실제
+            // index.html은 itemsToKeep에 없어 보존 여부와 무관하게 항상 지워진다 — 실제
             // 파이프라인에서는 이 직후 WebGLBuildCopier.CopyWebGLToPublic이 스킵 여부와 상관없이
             // 매번 동일한 내용으로 무조건 다시 쓰기 때문에(클래스 doc 참조) 실제 스킵 판정
             // 시점에는 이미 복원되어 있다 — 그 필수 재생성 단계를 여기서 재현한다.
             WriteFile("index.html", "<html><body>unity</body></html>");
 
             Assert.IsTrue(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _),
-                "preserveDist=true: skip should still fire after folder prep since nothing changed");
+                "preservePackagingOutputs=true: skip should still fire after folder prep since nothing changed");
         }
 
         [Test]
-        public void PrepareAitBuildFolder_PreserveDistFalse_DeletesDist_MarkerSurvivesButSkipFails()
+        public void PreservePackagingOutputs_False_DeletesOutputs_MarkerSurvivesButSkipFails()
         {
             CreateValidBuiltState();
 
-            WebGLBuildCopier.PrepareAitBuildFolder(_tempDir, preserveDist: false);
+            WebGLBuildCopier.PrepareAitBuildFolder(_tempDir, preservePackagingOutputs: false);
 
             Assert.IsTrue(File.Exists(PackageBuildStateMarker.GetMarkerPath(_tempDir)),
-                "preserveDist=false: marker still survives because node_modules itself is always preserved");
+                "preservePackagingOutputs=false: marker still survives because node_modules itself is always preserved");
             Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "dist")),
-                "preserveDist=false: dist/ should still be wiped every build (Production/Build & Package invariant)");
+                "preservePackagingOutputs=false: dist/ should still be wiped every build (Production/Build & Package invariant)");
+            Assert.IsFalse(File.Exists(Path.Combine(_tempDir, RootAitFileName)),
+                "preservePackagingOutputs=false: root *.ait should still be wiped every build");
             Assert.IsFalse(PackageBuildStateMarker.ShouldSkipPackageBuild(_tempDir, out _),
-                "dist/ gone means the skip check must fail-closed even though the marker survives");
+                "outputs gone means the skip check must fail-closed even though the marker survives");
         }
 
         [Test]
-        public void PrepareAitBuildFolder_DefaultOverload_BehavesLikePreserveDistFalse()
+        public void PrepareAitBuildFolder_DefaultOverload_BehavesLikePreserveFalse()
         {
-            // preserveDist 파라미터를 생략한 기존 호출부(BuildCleanupTests 등)가 계속 이전과
-            // 동일하게 dist를 지우는지 확인 — 기본값 자체의 회귀 방지.
+            // 파라미터를 생략한 기존 호출부(BuildCleanupTests 등)가 계속 이전과 동일하게
+            // 산출물을 지우는지 확인 — 기본값 자체의 회귀 방지.
             CreateValidBuiltState();
 
             WebGLBuildCopier.PrepareAitBuildFolder(_tempDir);
 
             Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "dist")));
+            Assert.IsFalse(File.Exists(Path.Combine(_tempDir, RootAitFileName)));
         }
 
         [Test]
-        public void DeleteDistFolder_RemovesDist_PreservedByPrepareAitBuildFolder()
+        public void DeletePreviousPackagingOutputs_RemovesDistAndRootAit()
         {
-            // 실제 시퀀스 재현: fastBuild 경로에서 PrepareAitBuildFolder(preserveDist:true)로
-            // dist를 보존했다가, 스킵 판정이 false가 되어 실제 빌드로 진행할 때
-            // WebGLBuildCopier.DeleteDistFolder가 불변식을 복원하는지 검증.
+            // 실제 시퀀스 재현: fastBuild 경로에서 PrepareAitBuildFolder(preservePackagingOutputs:true)로
+            // 산출물을 보존했다가, 스킵 판정이 false가 되어 실제 빌드로 진행할 때
+            // DeletePreviousPackagingOutputs가 불변식을 복원하는지 검증 (스테일 .ait 공존 방지).
             CreateValidBuiltState();
-            WebGLBuildCopier.PrepareAitBuildFolder(_tempDir, preserveDist: true);
+            WebGLBuildCopier.PrepareAitBuildFolder(_tempDir, preservePackagingOutputs: true);
             Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "dist")), "Precondition: dist preserved");
+            Assert.IsTrue(File.Exists(Path.Combine(_tempDir, RootAitFileName)), "Precondition: root .ait preserved");
 
-            WebGLBuildCopier.DeleteDistFolder(_tempDir);
+            WebGLBuildCopier.DeletePreviousPackagingOutputs(_tempDir);
 
             Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "dist")));
+            Assert.IsFalse(File.Exists(Path.Combine(_tempDir, RootAitFileName)));
         }
 
         [Test]
-        public void DeleteDistFolder_DoesNotThrow_WhenDistAbsent()
+        public void DeletePreviousPackagingOutputs_KeepsNonAitRootFiles()
         {
-            Assert.DoesNotThrow(() => WebGLBuildCopier.DeleteDistFolder(_tempDir));
+            // 루트 정리는 확장자 기준이므로 설정 파일 등 다른 루트 파일을 건드리면 안 된다.
+            CreateValidBuiltState();
+
+            WebGLBuildCopier.DeletePreviousPackagingOutputs(_tempDir);
+
+            Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "package.json")));
+            Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "vite.config.ts")));
+            Assert.IsTrue(File.Exists(PackageBuildStateMarker.GetMarkerPath(_tempDir)));
+        }
+
+        [Test]
+        public void DeletePreviousPackagingOutputs_DoesNotThrow_WhenOutputsAbsent()
+        {
+            Assert.DoesNotThrow(() => WebGLBuildCopier.DeletePreviousPackagingOutputs(_tempDir));
         }
     }
 }


### PR DESCRIPTION
## 문제

머지된 #1094("패키징 산출물 무변경 시 vite/ait build 스킵")가 **실측에서 한 번도 발동하지 않았다**.

무변경 상태로 `DoExport(buildWebGL:true, doPackaging:true, fastBuild:true)`를 연속 2회 실행했을 때:

- 2회차에서 스킵 로그가 없고 `vite build` → `ait build`를 전량 재실행
- 그런데 2회차 종료 후 마커의 세 해시(`publicManifestHash` / `configFilesHash` / `metadataHash`)가 1회차와 **완전히 동일** → "입력이 매번 바뀐다"는 가설은 기각. 입력은 동일한데도 판정이 false였다
- 킬스위치(`AIT_DISABLE_PACKAGE_BUILD_SKIP`) 미설정

## 근본 원인 — `.ait` 산출물의 위치 규약 불일치

`ShouldSkipPackageBuild`의 마지막 게이트가 `dist/` 최상위의 `*.ait`만 인정했다.

```csharp
// 수정 전 (Editor/Package/PackageBuildStateMarker.cs)
string distPath = Path.Combine(aitBuildPath, "dist");
if (!Directory.Exists(distPath)) return false;
if (Directory.GetFiles(distPath, "*.ait", SearchOption.TopDirectoryOnly).Length == 0) return false;
```

그러나 실제 web-framework 3.x 빌드가 남기는 레이아웃은 다르다:

```
ait-build/
├── dist/
│   └── web/            ← vite build --outDir dist/web (GraniteBuildRunner.ViteOutDir)
├── <appName>.ait       ← ait build 산출물은 "루트"에 emit
└── node_modules/.ait-package-build-state.json
```

`dist/` 최상위에는 `.ait`가 **절대** 존재하지 않으므로, 해시가 전부 일치해도 이 게이트에서 항상 fail-closed로 거절된다. `AITBuildValidator.ValidateDistOutput`은 이미 "루트 → `dist/`" 순으로 두 위치를 모두 탐색하고 있어, 두 곳의 규약이 갈라져 있었다.

**두 번째 결함(같은 원인의 다른 쪽)**: `PrepareAitBuildFolder`의 `itemsToKeep`에 루트 `*.ait`가 없다. 파일명이 `appName`에 따라 달라져 고정 이름 매칭으로 표현할 수 없기 때문인데, 결과적으로 `preserveDist: true`(fastBuild)에서도 **매 빌드 시작 시 실제 산출물이 삭제**됐다. 모든 빌드 진입점이 이 함수를 가장 먼저 호출하므로, 판정 시점에는 스킵의 근거가 되는 산출물 자체가 이미 사라진 상태였다. 즉 게이트 위치만 고쳐도 부족하고 보존까지 함께 고쳐야 한다.

## 왜 #1094의 EditMode 테스트가 못 잡았나

테스트 fixture가 **실제로 존재하지 않는 레이아웃**을 만들었다.

```csharp
// 수정 전 CreateValidBuiltState()
WriteFile("dist/output.ait", "ait-archive-placeholder");   // 현실에 없는 경로
```

이 fixture에서는 `.ait`가 `dist/` 안에 있으니 판정이 `dist/`만 봐도 통과하고, `dist`는 `itemsToKeep`에 있으니 `PrepareAitBuildFolder`에서도 살아남는다. 실제 파이프라인이 만드는 상태와 어긋난 픽스처를 시뮬레이션한 탓에 두 결함 모두 테스트를 그대로 통과했다.

## 수정

1. **`PackageBuildStateMarker`** — 산출물 게이트를 `ValidateDistOutput`과 동일한 위치 규약(ait-build 루트 → `dist/`)으로 통일.
2. **`WebGLBuildCopier`** — `PrepareAitBuildFolder(preservePackagingOutputs:)`가 `dist/`와 함께 루트 `*.ait`도 보존. 스킵 판정이 false면 `DeletePreviousPackagingOutputs`가 둘 다 삭제해 "빌드는 항상 빈 산출물 상태에서 시작한다" 불변식을 유지(스테일 `.ait` 공존 방지). 의미가 `dist`에 한정되지 않으므로 `preserveDist` → `preservePackagingOutputs`, `DeleteDistFolder` → `DeletePreviousPackagingOutputs`로 개명.
3. **조용한 fail-closed 제거** — 거절 사유를 항상 `Debug.Log`로 남긴다. 6개 거절 분기가 전부 무언(無言)이라 "왜 스킵이 안 걸리는지"를 로그만으로 진단할 수 없었던 것이 이 결함이 오래 은폐된 직접적 이유다.

```
[AIT] 패키징 스킵 조건 불충족 — vite/ait build를 실행합니다 (.ait 산출물 없음 (ait-build 루트/dist 모두))
```

## 회귀 테스트 — 이번엔 실제 경로를 탄다

- fixture를 **실제 3.x 레이아웃**(`dist/web/*` + 루트 `<appName>.ait`)으로 교체. 기존 테스트 전부가 자동으로 현실 레이아웃 위에서 돌게 된다.
- `ShouldSkipPackageBuild_Skips_WhenAitFileIsAtBuildRoot_RealWebFramework3Layout` — 실측 결함의 직접 회귀 테스트.
- `PreservePackagingOutputs_KeepsMarkerAndRootAitAlive_AndStillSkips` — 준비 단계가 루트 `.ait`를 지우지 않는지(2회 연속 fastBuild 시퀀스 재현).
- `ShouldSkipPackageBuild_ArtifactGate_AgreesWithValidateDistOutput` — 실제 검증기가 통과시키는 레이아웃은 스킵 판정도 통과시켜야 한다는 구조적 커플링. 두 곳의 규약이 다시 갈라지면 실패한다.
- `.ait`가 `dist/`에 생기는 대체 레이아웃도 별도 fixture로 계속 커버.

## 검증

- **수정 전 코드로 재현**: 산출물 게이트만 `dist/` 전용으로 되돌리면 새 fixture 위에서 7개 실패 — `..._RealWebFramework3Layout`, `..._AgreesWithValidateDistOutput`, `PreservePackagingOutputs_KeepsMarkerAndRootAitAlive_AndStillSkips`, `RecordSuccessfulBuild_ThenShouldSkipPackageBuild_RoundTrips`, `StillSkips_WhenKillSwitchExplicitlyOff(0/false)` 등. 새 테스트가 결함을 실제로 잡는다는 증거.
- **수정 후**: Unity 2022.3.62f2 batchmode EditMode **1435개 전부 통과**(실패 0).
- `PackageBuildStateMarkerTests` 53개 전부 통과.

## 영향 범위

- `fastBuild`(Deploy (Test) 등 빠른 반복) 경로에만 영향. Production 배포(`fastBuild:false`)는 스킵 분기에 진입하지 않으며, `preservePackagingOutputs` 기본값 `false`라 기존 동작(매 빌드 산출물 정리)이 그대로다.
- 안전성 설계는 유지: 해시 6종 게이트 + 산출물 존재 + 킬스위치 + 판단 불가 시 fail-closed.

## 비고

로컬 `./run-local-tests.sh --validate`의 SDK 유닛 테스트 스텝은 이 브랜치와 무관하게 `origin/main`에서도 실패한다 — 사내 레지스트리 프록시가 `baseline-browser-mapping-2.11.15.tgz`에 404를 반환해 `pnpm install`이 중단된다(이 PR은 JS 파일을 전혀 건드리지 않는다). 파일 구조 검증 / Playwright 설정 / Meta GUID Hygiene 스텝은 통과.
