### PR TITLE
수정: 릴리즈 빌드가 삭제된 Runtime 테스트 타입을 참조해 깨지던 문제

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,9 +241,26 @@ jobs:
           SHARED_RUNTIME="Tests~/E2E/SharedScripts/Runtime"
 
           # SharedScripts/Runtime의 .cs 파일 삭제 (API 호환성 문제가 있는 코드)
+          # .cs.meta도 함께 삭제 — 남기면 Unity가 orphan meta 경고를 20줄 넘게 쏟아내
+          # 실제 컴파일 오류를 가린다. 아래에서 재생성하는 스텁 2종의 .meta는 GUID 유지를 위해 보존.
           if [ -d "$SHARED_RUNTIME" ]; then
             echo "SharedScripts/Runtime .cs 파일 삭제 중..."
             find "$SHARED_RUNTIME" -name "*.cs" -type f -delete
+            find "$SHARED_RUNTIME" -name "*.cs.meta" -type f \
+              ! -name "E2EBootstrapper.cs.meta" \
+              ! -name "E2EBootstrapperHelper.cs.meta" \
+              -delete
+          fi
+
+          # EditMode 테스트 삭제
+          # 릴리즈 빌드는 테스트를 실행하지 않지만 패키지 안에 있으면 컴파일은 된다.
+          # AppsInTossEditModeTests asmdef가 Runtime asmdef를 참조하므로, EditMode 테스트가
+          # 위에서 지운 Runtime 타입을 하나라도 쓰면 빌드 전체가 CS0246으로 깨진다
+          # (SDKAPIReflectionTests → APITestCatalog: v3.0.4 릴리즈 실패 원인).
+          EDITMODE_TESTS="Tests~/E2E/SharedScripts/Editor/EditModeTests"
+          if [ -d "$EDITMODE_TESTS" ]; then
+            echo "SharedScripts/Editor/EditModeTests 삭제 중..."
+            rm -rf "$EDITMODE_TESTS" "${EDITMODE_TESTS}.meta"
           fi
 
           # E2EBuildRunner.cs가 의존하는 최소 스텁 파일 생성

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1667,6 +1667,16 @@ jobs:
             echo "Unity build finished (log-based exit code: $EXIT_CODE)"
 
             if [ $EXIT_CODE -ne 0 ]; then
+              # C# 컴파일 오류 우선 감지 — 결정적 실패이므로 재시도는 순수 낭비다.
+              # Unity 로그에는 정상 기동 시에도 "Access token is unavailable" 같은 라이선스
+              # 문구가 섞여 있어, 이 검사가 없으면 아래 LICENSE_ERROR가 먼저 걸려 컴파일
+              # 오류가 라이선스 오류로 3회 재시도된다 (v3.0.4 릴리즈 실패 시 실제 발생).
+              if grep -qE "error CS[0-9]+" "$LOG_FILE" 2>/dev/null; then
+                echo "::error::C# compile error detected (not a license issue), failing immediately"
+                grep -E "error CS[0-9]+" "$LOG_FILE" 2>/dev/null | sort -u | head -10
+                exit $EXIT_CODE
+              fi
+
               # 빌드 도구 에러 우선 감지 (라이선스 오분류 방지)
               BUILD_TOOL_ERROR=false
               if grep -qE "Unknown Syntax Error|FAIL_NPM_BUILD|FAIL_NPM_INSTALL|Command not found.*ait|npm ERR!" "$LOG_FILE" 2>/dev/null; then
@@ -1806,6 +1816,19 @@ jobs:
             }
 
             if ($exitCode -ne 0) {
+              # C# 컴파일 오류 우선 감지 — 결정적 실패이므로 재시도는 순수 낭비다.
+              # Unity 로그에는 정상 기동 시에도 라이선스 문구가 섞여 있어, 이 검사가 없으면
+              # 아래 licenseError가 먼저 걸려 컴파일 오류가 라이선스 오류로 재시도된다.
+              if (Test-Path $logFile) {
+                $logContent = Get-Content $logFile -Raw -ErrorAction SilentlyContinue
+                if ($logContent -match "error CS[0-9]+") {
+                  Write-Host "::error::C# compile error detected (not a license issue), failing immediately"
+                  Select-String -Path $logFile -Pattern "error CS[0-9]+" |
+                    ForEach-Object { $_.Line } | Select-Object -Unique -First 10
+                  exit $exitCode
+                }
+              }
+
               # 빌드 도구 에러 우선 감지 (라이선스 오분류 방지)
               $buildToolError = $false
               if (Test-Path $logFile) {


### PR DESCRIPTION
## 문제

v3.0.4 릴리즈가 macOS 2021.3 빌드에서 재현성 있게 실패한다. 두 커밋(`b75471fd`, `19a3cda5`)에서 동일 시그니처로 실패했고, 2026-08-11 릴리즈(`068c722f`)까지는 같은 job이 통과했다.

```
Tests~/E2E/SharedScripts/Editor/EditModeTests/SDKAPIReflectionTests.cs(29,28):
  error CS0246: The type or namespace name 'APITestCatalog' could not be found
```

## 원인

`release.yml`의 `릴리즈용 테스트 코드 제외` 단계는 `SharedScripts/Runtime/*.cs`를 전부 삭제하고 `E2EBootstrapper`/`E2EBootstrapperHelper` 스텁 2종만 되살린다. 이 삭제가 반영된 orphan commit(`_build/release-vX.Y.Z`)을 Unity가 체크아웃해 빌드한다.

그런데 `Editor/`는 손대지 않는다. `AppsInTossEditModeTests.asmdef`는 Runtime asmdef(`AppsInTossTestScripts`)를 참조하므로, EditMode 테스트가 삭제 대상 Runtime 타입을 쓰기 시작하면 릴리즈 빌드가 컴파일 단계에서 통째로 깨진다.

`APITestCatalog`(Runtime)를 `SDKAPIReflectionTests`(Editor)가 `[TestCaseSource(typeof(APITestCatalog), ...)]`로 참조하게 되면서 정확히 이 조건이 성립했다. 삭제 로직은 2026-01에 들어왔고 이 결합은 2026-08에 생겨, 7개월 뒤 터진 회귀다.

부수적으로 `.cs`만 지우고 `.cs.meta`는 남겨 orphan meta 경고 21줄이 실제 오류를 가렸고, 재시도 판정이 이를 라이선스 오류로 오분류해 동일 컴파일 오류를 3회 재시도했다 — Unity 로그에는 정상 기동 시에도 `Access token is unavailable`가 남기 때문이다.

## 변경

**`release.yml`**
- `Editor/EditModeTests` 디렉토리를 제외 대상에 추가. 릴리즈 빌드는 테스트를 실행하지 않으므로 컴파일할 이유가 없고, Editor 테스트 → Runtime 타입 결합이라는 결함 클래스 자체가 사라진다.
- 삭제한 `.cs`의 `.cs.meta`도 함께 제거. 재생성하는 스텁 2종의 meta는 GUID 유지를 위해 보존한다.

**`unity-build.yml`** (macOS/Windows 양쪽)
- `error CS<번호>`를 라이선스 판정보다 먼저 검사해 즉시 실패. 결정적 실패에 재시도는 낭비고, 진짜 원인이 라이선스 경고에 묻힌다.

## 검증

스크래치 복사본에 삭제 로직을 그대로 실행해 확인:

- Runtime 잔존: asmdef + 스텁 2종 + `Resources/` — 기대대로
- Editor 잔존 `.cs` 4개: `E2EBuildRunner`, `BuildOutputValidator`, `HeavyBuildRunner`, `Tests/PackageManagerTests`
- 짝 없는 `.cs.meta`: 0건 (기존 21건)
- 잔존 코드에서 삭제된 Runtime 타입 21종 참조: 0건 (주석 제외)
- 두 워크플로 YAML 파싱 통과

`AppsInTossEditModeTests` asmdef를 참조하는 다른 asmdef는 없어(이름·GUID 전수 검색) 삭제해도 참조 깨짐이 없다.
