### PR TITLE
수정: 앱 이름에 따옴표가 있으면 빌드 산출물이 깨지던 문제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,11 @@ Tests~/E2E/SampleUnityProject*/WebGLBuild/
 Tests~/E2E/SampleUnityProject*/Builds/
 Tests~/E2E/SampleUnityProject*/editmode-results.xml
 Tests~/E2E/SampleUnityProject*/Assets/Plugins/E2ETestBridge.jslib*
+# EditMode 테스트 실행 시 생성되는 자산 — Unity 가 자동 임포트하거나 테스트가 만들어낸다.
+Tests~/E2E/SampleUnityProject*/Assets/TextMesh Pro/
+Tests~/E2E/SampleUnityProject*/Assets/TextMesh Pro.meta
+Tests~/E2E/SampleUnityProject*/Assets/DeployProbeGen/
+Tests~/E2E/SampleUnityProject*/Assets/DeployProbeGen.meta
 # WebGLTemplates: SDK 자동 생성 부분만 무시. AITTemplate(튜토리얼 자산)은 커밋.
 Tests~/E2E/SampleUnityProject*/Assets/WebGLTemplates/AITTemplate/Runtime/
 Tests~/E2E/SampleUnityProject*/Assets/WebGLTemplates/AITTemplate/Runtime.meta

--- a/Editor/Package/AITJsStringEscaper.cs
+++ b/Editor/Package/AITJsStringEscaper.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+// AITJsStringEscaper.cs - 작은따옴표 JS/TS 문자열 리터럴 이스케이프
+//
+// 빌드 산출물(index.html / granite.config.ts / apps-in-toss.config.ts)의 플레이스홀더
+// 치환은 전부 단순 문자열 Replace 다. 템플릿에서 토큰이 이미 작은따옴표 안에 놓여 있는 자리
+// (예: displayName: '%AIT_DISPLAY_NAME%')에 사용자 입력값을 그대로 끼워 넣으면, 값에 들어 있는
+// 작은따옴표 하나가 리터럴을 조기 종료시켜 그 파일 전체를 문법 오류로 만든다.
+//
+// 실제 노출 경로: AIT Configuration 창의 "표시 이름"·"주 색상"·"아이콘 URL"·"Vite 호스트"·
+// "출력 디렉토리"는 아무 문자 제한 없는 TextField 다(appName 만 IsAppNameValid 로 영숫자+하이픈
+// 검증을 받는다). 그래서 "Dave's Adventure" 같은 흔한 이름이 저장→빌드까지 그대로 흘러가
+// index.html 의 인라인 <script> 블록과 granite.config.ts 를 동시에 깨뜨린다.
+// AITBuildValidator.FindUnsubstitutedPlaceholders 는 미치환 %AIT_*% 잔존만 검사하므로
+// (치환 자체는 성공했고 문법만 깨진) 이 케이스를 통과시켜 빌드 시점에 잡히지 않는다.
+// -----------------------------------------------------------------------
+
+using System.Text;
+
+namespace AppsInToss.Editor.Package
+{
+    internal static class AITJsStringEscaper
+    {
+        /// <summary>
+        /// 값을 <b>작은따옴표 JS/TS 문자열 리터럴 안쪽</b>에 안전하게 넣을 수 있도록 이스케이프한다.
+        /// 감싸는 따옴표는 템플릿에 이미 있으므로 이 메서드는 따옴표를 붙이지 않는다.
+        ///
+        /// ⚠️ 문자열 리터럴 자리에만 쓸 것. %AIT_PERMISSIONS% / %AIT_NAVIGATION_BAR% 처럼 값 자체가
+        /// JSON·불리언 <b>코드</b>로 전개되는 토큰에 적용하면 오히려 산출물이 깨진다.
+        /// </summary>
+        internal static string EscapeSingleQuoted(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return string.Empty;
+
+            var sb = new StringBuilder(value.Length + 8);
+            foreach (char c in value)
+            {
+                switch (c)
+                {
+                    // 백슬래시가 가장 먼저다 — 뒤이어 삽입할 이스케이프 시퀀스가 다시 먹히면 안 된다.
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\'': sb.Append("\\'"); break;
+
+                    // 줄바꿈은 리터럴을 그 자리에서 끝내 버린다(개행이 들어간 값도 실제로 가능하다).
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+
+                    // '<' 를 막으면 값 안의 "</script>" 가 index.html 의 인라인 <script> 블록을 조기
+                    // 종료하는 것과, "<!--" 가 레거시 HTML 주석을 여는 것을 함께 차단한다.
+                    // \x3C 는 표준 JS 이스케이프라 TS 설정 파일에서도 그대로 '<' 로 평가된다.
+                    case '<': sb.Append("\\x3C"); break;
+
+                    // U+2028/U+2029 는 ES2019 이전 파서가 줄바꿈으로 취급해 문법 오류를 낸다.
+                    // (esbuild/vite 가 어떤 target 으로 파싱하든 안전하도록 항상 이스케이프한다.)
+                    case '\u2028': sb.Append("\\u2028"); break;
+                    case '\u2029': sb.Append("\\u2029"); break;
+
+                    default: sb.Append(c); break;
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Editor/Package/AITJsStringEscaper.cs.meta
+++ b/Editor/Package/AITJsStringEscaper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b5dd57fb1574de69d0c284f046c412d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package/BuildConfigMerger.cs
+++ b/Editor/Package/BuildConfigMerger.cs
@@ -407,8 +407,10 @@ namespace AppsInToss.Editor.Package
 
             // 플레이스홀더 치환
             string finalContent = sdkTemplate
-                .Replace("%AIT_VITE_HOST%", config.viteHost)
-                .Replace("%AIT_VITE_PORT%", config.vitePort.ToString());
+                // vite.config.ts 에서도 두 값 모두 작은따옴표 문자열 리터럴 자리에 놓인다
+                // (host: process.env.AIT_VITE_HOST || '%AIT_VITE_HOST%').
+                .Replace("%AIT_VITE_HOST%", AITJsStringEscaper.EscapeSingleQuoted(config.viteHost))
+                .Replace("%AIT_VITE_PORT%", AITJsStringEscaper.EscapeSingleQuoted(config.vitePort.ToString()));
 
             // 프로젝트 파일이 있으면 USER_CONFIG 영역만 보존
             if (File.Exists(projectFile))
@@ -452,20 +454,25 @@ namespace AppsInToss.Editor.Package
 
             // 플레이스홀더 치환
             Debug.Log("[AIT] granite.config.ts placeholder 치환 중...");
+            // 템플릿에서 작은따옴표 문자열 리터럴 자리에 놓이는 토큰은 이스케이프해서 넣는다
+            // (값의 작은따옴표 하나가 granite.config.ts 전체를 깨뜨려 vite/esbuild 파싱 오류가 난다).
+            // %AIT_PERMISSIONS% / %AIT_NAVIGATION_BAR% / 불리언·포트는 값 자체가 코드로 전개되는
+            // 자리라 이스케이프하면 안 된다 — 아래 구분을 유지할 것.
             string finalContent = sdkTemplate
-                .Replace("%AIT_APP_NAME%", config.appName)
-                .Replace("%AIT_DISPLAY_NAME%", config.displayName)
-                .Replace("%AIT_PRIMARY_COLOR%", config.primaryColor)
-                .Replace("%AIT_ICON_URL%", config.iconUrl)
-                .Replace("%AIT_BRIDGE_COLOR_MODE%", config.GetBridgeColorModeString())
-                .Replace("%AIT_WEBVIEW_TYPE%", config.GetWebViewTypeString())
+                .Replace("%AIT_APP_NAME%", AITJsStringEscaper.EscapeSingleQuoted(config.appName))
+                .Replace("%AIT_DISPLAY_NAME%", AITJsStringEscaper.EscapeSingleQuoted(config.displayName))
+                .Replace("%AIT_PRIMARY_COLOR%", AITJsStringEscaper.EscapeSingleQuoted(config.primaryColor))
+                .Replace("%AIT_ICON_URL%", AITJsStringEscaper.EscapeSingleQuoted(config.iconUrl))
+                .Replace("%AIT_BRIDGE_COLOR_MODE%", AITJsStringEscaper.EscapeSingleQuoted(config.GetBridgeColorModeString()))
+                .Replace("%AIT_WEBVIEW_TYPE%", AITJsStringEscaper.EscapeSingleQuoted(config.GetWebViewTypeString()))
                 .Replace("%AIT_NAVIGATION_BAR%", config.GetNavigationBarJson())
                 .Replace("%AIT_ALLOWS_INLINE_MEDIA_PLAYBACK%", config.allowsInlineMediaPlayback.ToString().ToLower())
                 .Replace("%AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%", config.mediaPlaybackRequiresUserAction.ToString().ToLower())
-                .Replace("%AIT_VITE_HOST%", config.viteHost)
-                .Replace("%AIT_VITE_PORT%", config.vitePort.ToString())
+                .Replace("%AIT_VITE_HOST%", AITJsStringEscaper.EscapeSingleQuoted(config.viteHost))
+                // 템플릿에서 parseInt(process.env.AIT_VITE_PORT || '%AIT_VITE_PORT%', 10) 로 따옴표 안에 놓인다.
+                .Replace("%AIT_VITE_PORT%", AITJsStringEscaper.EscapeSingleQuoted(config.vitePort.ToString()))
                 .Replace("%AIT_PERMISSIONS%", config.GetPermissionsJson())
-                .Replace("%AIT_OUTDIR%", config.outdir);
+                .Replace("%AIT_OUTDIR%", AITJsStringEscaper.EscapeSingleQuoted(config.outdir));
 
             // 프로젝트 파일이 있으면 USER_CONFIG 영역만 보존
             if (File.Exists(projectFile))
@@ -516,8 +523,9 @@ namespace AppsInToss.Editor.Package
             // 플레이스홀더 치환 (granite.config.ts와 동일한 값 소스 사용 — 권한 JSON 형식이 3.x와 호환)
             Debug.Log("[AIT] apps-in-toss.config.ts placeholder 치환 중...");
             string finalContent = sdkTemplate
-                .Replace("%AIT_APP_NAME%", config.appName)
-                .Replace("%AIT_PRIMARY_COLOR%", config.primaryColor)
+                // granite.config.ts 와 동일 — 문자열 리터럴 자리만 이스케이프한다.
+                .Replace("%AIT_APP_NAME%", AITJsStringEscaper.EscapeSingleQuoted(config.appName))
+                .Replace("%AIT_PRIMARY_COLOR%", AITJsStringEscaper.EscapeSingleQuoted(config.primaryColor))
                 .Replace("%AIT_ALLOWS_INLINE_MEDIA_PLAYBACK%", config.allowsInlineMediaPlayback.ToString().ToLower())
                 .Replace("%AIT_MEDIA_PLAYBACK_REQUIRES_USER_ACTION%", config.mediaPlaybackRequiresUserAction.ToString().ToLower())
                 .Replace("%AIT_NAVIGATION_BAR%", config.GetNavigationBarJson())

--- a/Editor/Package/WebGLBuildCopier.cs
+++ b/Editor/Package/WebGLBuildCopier.cs
@@ -365,13 +365,21 @@ namespace AppsInToss.Editor.Package
                 .Replace("%UNITY_WEBGL_CODE_FILENAME%", wasmFile)
                 .Replace("%UNITY_WEBGL_SYMBOLS_FILENAME%", symbolsFile)
                 // AIT 커스텀 플레이스홀더
-                .Replace("%AIT_ENABLE_DEBUG_CONSOLE%", enableDebugConsole)
-                .Replace("%AIT_FIRST_INTERACTIVE_LOG%", EffectiveFirstInteractiveLog(config) ? "true" : "false")
-                .Replace("%AIT_PLAYERPREFS_PERSISTENCE%", EffectivePlayerPrefsPersistence(config) ? "true" : "false")
+                // ── 템플릿에서 작은따옴표 문자열 리터럴 자리에 놓이는 토큰 ──
+                // 값에 작은따옴표·개행·"</script>"가 들어가면 그 인라인 <script> 블록 전체가
+                // SyntaxError 로 죽는다(appInfo = { iconUrl: '%AIT_ICON_URL%', ... }).
+                // "따옴표 자리면 예외 없이 이스케이프" 규칙을 유지한다 — 아래 셋처럼 값이 상수라
+                // 실질 no-op 인 경우에도 그대로 통과시켜, 호출부마다 안전 여부를 판단하는 일이
+                // 없도록 한다(판단이 개입하는 순간 다음 토큰에서 빠뜨리게 된다).
+                // AITJsStringEscaperWiringTests 가 템플릿에서 따옴표 자리 토큰을 유도해 대조한다.
+                .Replace("%AIT_ENABLE_DEBUG_CONSOLE%", AITJsStringEscaper.EscapeSingleQuoted(enableDebugConsole))
+                .Replace("%AIT_FIRST_INTERACTIVE_LOG%", AITJsStringEscaper.EscapeSingleQuoted(EffectiveFirstInteractiveLog(config) ? "true" : "false"))
+                .Replace("%AIT_PLAYERPREFS_PERSISTENCE%", AITJsStringEscaper.EscapeSingleQuoted(EffectivePlayerPrefsPersistence(config) ? "true" : "false"))
+                .Replace("%AIT_ICON_URL%", AITJsStringEscaper.EscapeSingleQuoted(config.iconUrl ?? ""))
+                .Replace("%AIT_DISPLAY_NAME%", AITJsStringEscaper.EscapeSingleQuoted(config.displayName ?? ""))
+                .Replace("%AIT_PRIMARY_COLOR%", AITJsStringEscaper.EscapeSingleQuoted(config.primaryColor ?? "#3182f6"))
+                // ── 코드 문맥(값이 그대로 JS 로 전개) — 이스케이프하면 안 된다 ──
                 .Replace("%AIT_DEVICE_PIXEL_RATIO%", config.devicePixelRatio.ToString())
-                .Replace("%AIT_ICON_URL%", config.iconUrl ?? "")
-                .Replace("%AIT_DISPLAY_NAME%", config.displayName ?? "")
-                .Replace("%AIT_PRIMARY_COLOR%", config.primaryColor ?? "#3182f6")
                 // Early Fetch 스크립트 (로딩 성능 개선 + 레거시 warm-reload Cache-Storage 워밍)
                 .Replace("%AIT_EARLY_FETCH_SCRIPT%", GenerateEarlyFetchScript(dataFile, wasmFile, buildSrc, PlayerSettings.bundleVersion));
 
@@ -627,8 +635,13 @@ namespace AppsInToss.Editor.Package
                     continue;
                 }
 
+                // 무조건 덮어쓰기(File.Copy overwrite)가 아니라 IfChanged 경로를 타야 한다:
+                // excludeFolders 에 "public" 이 없어서 사용자가 BuildConfig~/public/ 에 정적 파일을
+                // 두면 그대로 ait-build/public/ 로 복사되는데, PackageBuildStateMarker 는 public/ 트리를
+                // (경로, 길이, mtimeTicks)로 해시하며 "mtime 불변 == 내용 불변"을 전제한다.
+                // 내용이 같은데도 매번 다시 쓰면 mtime 이 전진해 패키징 스킵이 영원히 발동하지 않는다.
                 string destFile = Path.Combine(destDir, fileName);
-                File.Copy(file, destFile, true);
+                CopyFileIfChanged(file, destFile);
 
                 // 의미 있는 파일만 로그 출력
                 if (fileName.EndsWith(".ts") || fileName.EndsWith(".tsx") ||

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITJsStringEscaperTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITJsStringEscaperTests.cs
@@ -1,0 +1,156 @@
+// -----------------------------------------------------------------------
+// AITJsStringEscaperTests.cs
+// AITJsStringEscaper.EscapeSingleQuoted 단위 테스트.
+//
+// 배선(어느 치환부가 이 함수를 거쳐야 하는가)은 AITJsStringEscaperWiringTests 가 검증하고,
+// 여기서는 이스케이프 자체가 옳은지 — 특히 산출물을 깨뜨릴 수 있는 문자들이 실제로
+// 무력화되는지 — 를 본다.
+// -----------------------------------------------------------------------
+
+using System.Text;
+using NUnit.Framework;
+using AppsInToss.Editor.Package;
+
+[TestFixture]
+[Category("Unit")]
+public class AITJsStringEscaperTests
+{
+    [Test]
+    public void SafeValue_PassesThroughUnchanged()
+    {
+        // 흔한 값들은 이스케이프로 오염되지 않아야 한다(산출물 diff 노이즈 방지).
+        Assert.AreEqual("#3182F6", AITJsStringEscaper.EscapeSingleQuoted("#3182F6"));
+        Assert.AreEqual("localhost", AITJsStringEscaper.EscapeSingleQuoted("localhost"));
+        Assert.AreEqual("dist", AITJsStringEscaper.EscapeSingleQuoted("dist"));
+        Assert.AreEqual("true", AITJsStringEscaper.EscapeSingleQuoted("true"));
+        Assert.AreEqual("https://example.com/icon.png",
+            AITJsStringEscaper.EscapeSingleQuoted("https://example.com/icon.png"));
+    }
+
+    [Test]
+    public void NullOrEmpty_BecomesEmptyString()
+    {
+        Assert.AreEqual(string.Empty, AITJsStringEscaper.EscapeSingleQuoted(null));
+        Assert.AreEqual(string.Empty, AITJsStringEscaper.EscapeSingleQuoted(string.Empty));
+    }
+
+    [Test]
+    public void SingleQuote_IsEscaped_SoLiteralDoesNotTerminateEarly()
+    {
+        // 이 저장소를 실제로 깨뜨렸을 케이스: 표시 이름의 아포스트로피.
+        Assert.AreEqual("Dave\\'s Adventure", AITJsStringEscaper.EscapeSingleQuoted("Dave's Adventure"));
+    }
+
+    [Test]
+    public void Backslash_IsEscapedBeforeOtherSequences()
+    {
+        // 백슬래시를 먼저 처리하지 않으면 뒤이어 넣은 이스케이프가 다시 해석되어 무력화된다.
+        Assert.AreEqual("a\\\\b", AITJsStringEscaper.EscapeSingleQuoted("a\\b"));
+
+        // 값이 이미 \' 를 담고 있어도 결과가 리터럴을 탈출하지 않아야 한다.
+        Assert.AreEqual("a\\\\\\'b", AITJsStringEscaper.EscapeSingleQuoted("a\\'b"));
+    }
+
+    [Test]
+    public void Newlines_AreEscaped()
+    {
+        Assert.AreEqual("a\\nb", AITJsStringEscaper.EscapeSingleQuoted("a\nb"));
+        Assert.AreEqual("a\\rb", AITJsStringEscaper.EscapeSingleQuoted("a\rb"));
+        Assert.AreEqual("a\\tb", AITJsStringEscaper.EscapeSingleQuoted("a\tb"));
+    }
+
+    [Test]
+    public void ScriptCloseTag_CannotTerminateInlineScriptBlock()
+    {
+        string escaped = AITJsStringEscaper.EscapeSingleQuoted("</script><script>alert(1)</script>");
+
+        // '<' 가 남아 있으면 HTML 파서가 인라인 <script> 블록을 그 자리에서 끝내 버린다.
+        StringAssert.DoesNotContain("<", escaped);
+        StringAssert.Contains("\\x3C", escaped);
+    }
+
+    [Test]
+    public void HtmlCommentOpener_IsNeutralized()
+    {
+        StringAssert.DoesNotContain("<", AITJsStringEscaper.EscapeSingleQuoted("<!--"));
+    }
+
+    [Test]
+    public void LineSeparators_AreEscaped()
+    {
+        // U+2028/U+2029 는 ES2019 이전 파서가 줄바꿈으로 취급해 문법 오류를 낸다.
+        Assert.AreEqual("a\\u2028b", AITJsStringEscaper.EscapeSingleQuoted("a\u2028b"));
+        Assert.AreEqual("a\\u2029b", AITJsStringEscaper.EscapeSingleQuoted("a\u2029b"));
+    }
+
+    /// <summary>
+    /// 이스케이프 결과를 작은따옴표 리터럴로 감쌌을 때, JS 파서가 읽어들이는 값이 원본과
+    /// 같아야 한다(= 이스케이프가 과하지도 부족하지도 않다). 테스트 안에 최소 언이스케이퍼를
+    /// 두어 왕복을 확인한다 — EditMode 에서 실제 JS 엔진을 띄울 수 없기 때문이다.
+    /// </summary>
+    [Test]
+    public void EscapedValue_RoundTripsBackToOriginal()
+    {
+        string[] hostileValues =
+        {
+            "Dave's Adventure",
+            "back\\slash",
+            "quote'and\\backslash",
+            "line\nbreak",
+            "tab\there",
+            "</script>",
+            "<!-- comment",
+            "sep\u2028arator",
+            "#3182F6",
+            "",
+        };
+
+        foreach (string original in hostileValues)
+        {
+            string escaped = AITJsStringEscaper.EscapeSingleQuoted(original);
+
+            Assert.AreEqual(original, UnescapeJsSingleQuoted(escaped),
+                $"이스케이프 왕복이 값을 바꿨다. 원본=[{original}] 이스케이프=[{escaped}]");
+        }
+    }
+
+    // 작은따옴표 리터럴 안쪽 문자열을 JS 파서처럼 되돌린다(이 escaper 가 내는 시퀀스만 지원).
+    private static string UnescapeJsSingleQuoted(string escaped)
+    {
+        var sb = new StringBuilder(escaped.Length);
+
+        for (int i = 0; i < escaped.Length; i++)
+        {
+            if (escaped[i] != '\\')
+            {
+                sb.Append(escaped[i]);
+                continue;
+            }
+
+            Assert.Less(i + 1, escaped.Length, "이스케이프 문자로 문자열이 끝났다(리터럴이 깨진다).");
+            char next = escaped[++i];
+
+            switch (next)
+            {
+                case '\\': sb.Append('\\'); break;
+                case '\'': sb.Append('\''); break;
+                case 'n': sb.Append('\n'); break;
+                case 'r': sb.Append('\r'); break;
+                case 't': sb.Append('\t'); break;
+                case 'x':
+                    sb.Append((char)System.Convert.ToInt32(escaped.Substring(i + 1, 2), 16));
+                    i += 2;
+                    break;
+                case 'u':
+                    sb.Append((char)System.Convert.ToInt32(escaped.Substring(i + 1, 4), 16));
+                    i += 4;
+                    break;
+                default:
+                    Assert.Fail($"예상하지 못한 이스케이프 시퀀스: \\{next}");
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITJsStringEscaperTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITJsStringEscaperTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae35dc7efebf481ca3da72eb179718b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITJsStringEscaperWiringTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITJsStringEscaperWiringTests.cs
@@ -1,0 +1,173 @@
+// -----------------------------------------------------------------------
+// AITJsStringEscaperWiringTests.cs
+// "템플릿에서 작은따옴표 문자열 리터럴 자리에 있는 %AIT_*% 토큰은 예외 없이
+//  AITJsStringEscaper.EscapeSingleQuoted 를 거쳐 치환된다"는 계약의 소스 텍스트 가드.
+//
+// 이 계약이 깨지면 사용자가 표시 이름에 아포스트로피 하나만 넣어도
+// (예: "Dave's Adventure") index.html 의 인라인 <script> 블록이나 granite.config.ts 가
+// 문법 오류로 죽는다. UI 는 이 필드들에 아무 문자 제한을 두지 않고,
+// AITBuildValidator.FindUnsubstitutedPlaceholders 는 미치환 토큰 잔존만 검사하므로
+// (치환은 성공하고 문법만 깨지는) 이 케이스를 아무도 잡아주지 않는다.
+//
+// 대상 토큰 목록을 손으로 적지 않는 것이 핵심이다 — 템플릿을 파싱해 따옴표 자리인지
+// 코드 자리인지 ★유도★하고, 그 결과로 C# 치환부를 대조한다. 그래서 템플릿에 새 토큰이
+// 추가되거나 기존 토큰이 따옴표 안팎으로 옮겨가면 이 테스트가 자동으로 따라간다.
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using AppsInToss;
+using AppsInToss.Editor;
+
+[TestFixture]
+[Category("Unit")]
+public class AITJsStringEscaperWiringTests
+{
+    private const string EscaperCall = "AITJsStringEscaper.EscapeSingleQuoted";
+
+    private static readonly Regex AnyToken = new Regex(@"%AIT_[A-Z0-9_]+%");
+    private static readonly Regex QuotedToken = new Regex(@"'(%AIT_[A-Z0-9_]+%)'");
+
+    // 치환을 담당하는 C# 소스와, 그 소스가 처리하는 템플릿들.
+    private sealed class SubstitutionGroup
+    {
+        public string SourcePath;
+        public string[] TemplatePaths;
+    }
+
+    private static readonly SubstitutionGroup[] Groups =
+    {
+        new SubstitutionGroup
+        {
+            SourcePath = "Editor/Package/WebGLBuildCopier.cs",
+            TemplatePaths = new[] { "WebGLTemplates/AITTemplate/index.html" },
+        },
+        new SubstitutionGroup
+        {
+            SourcePath = "Editor/Package/BuildConfigMerger.cs",
+            TemplatePaths = new[]
+            {
+                "WebGLTemplates/AITTemplate/BuildConfig~/vite.config.ts",
+                "WebGLTemplates/AITTemplate/BuildConfig~/granite.config.ts",
+                "WebGLTemplates/AITTemplate/BuildConfig~/apps-in-toss.config.ts",
+            },
+        },
+    };
+
+    [Test]
+    public void QuotedPlaceholders_AreEscapedAtEverySubstitutionSite()
+    {
+        foreach (SubstitutionGroup group in Groups)
+        {
+            string source = ReadRepoFile(group.SourcePath);
+            CollectTokens(group, out HashSet<string> quoted, out HashSet<string> codeContext);
+
+            Assert.IsNotEmpty(quoted,
+                $"{group.SourcePath} 가 담당하는 템플릿에서 따옴표 자리 토큰을 하나도 찾지 못했다 — " +
+                "템플릿 경로나 토큰 표기가 바뀌었는지 확인하라(가드가 조용히 무의미해지는 것 방지).");
+
+            foreach (string token in quoted.OrderBy(t => t))
+            {
+                List<string> sites = FindSubstitutionSites(source, token);
+
+                Assert.IsNotEmpty(sites,
+                    $"템플릿에는 {token} 이 있는데 {group.SourcePath} 에서 치환부를 찾지 못했다. " +
+                    "치환이 다른 파일로 옮겨갔거나 .Replace 호출이 여러 줄로 쪼개졌을 수 있다 — " +
+                    "이 가드가 대조할 수 있도록 Groups 매핑이나 코드 서식을 맞춰라.");
+
+                foreach (string site in sites)
+                {
+                    StringAssert.Contains(EscaperCall, site,
+                        $"{token} 은 템플릿에서 작은따옴표 문자열 리터럴 자리에 놓이므로 " +
+                        $"{EscaperCall} 을 거쳐 치환해야 한다.\n  치환부: {site.Trim()}\n" +
+                        "값에 작은따옴표·개행·\"</script>\"가 들어가면 산출물이 통째로 문법 오류가 된다. " +
+                        "값이 상수라 실질 no-op 인 경우에도 규칙을 예외 없이 유지한다 — " +
+                        "호출부마다 안전 여부를 판단하기 시작하면 다음 토큰에서 빠뜨리게 된다.");
+                }
+            }
+
+            // 같은 토큰이 한 템플릿에선 따옴표 자리, 다른 템플릿에선 코드 자리인 경우
+            // 치환부 단위로는 옳게 대조할 수 없다. 현재 그런 토큰은 없으며, 생기면 여기서 알린다.
+            var ambiguous = quoted.Intersect(codeContext).OrderBy(t => t).ToArray();
+            CollectionAssert.IsEmpty(ambiguous,
+                $"{group.SourcePath} 가 담당하는 템플릿들에서 다음 토큰이 따옴표 자리와 코드 자리에 " +
+                $"동시에 쓰인다: {string.Join(", ", ambiguous)}. " +
+                "이 경우 치환부 한 줄로는 어느 쪽에 맞춰야 할지 결정할 수 없으므로, " +
+                "토큰을 분리하거나 템플릿 표기를 통일하라.");
+        }
+    }
+
+    [Test]
+    public void CodeContextPlaceholders_AreNotEscaped()
+    {
+        foreach (SubstitutionGroup group in Groups)
+        {
+            string source = ReadRepoFile(group.SourcePath);
+            CollectTokens(group, out HashSet<string> quoted, out HashSet<string> codeContext);
+
+            foreach (string token in codeContext.Except(quoted).OrderBy(t => t))
+            {
+                foreach (string site in FindSubstitutionSites(source, token))
+                {
+                    StringAssert.DoesNotContain(EscaperCall, site,
+                        $"{token} 은 값이 그대로 JS/TS 코드로 전개되는 자리다(JSON·불리언·숫자). " +
+                        $"{EscaperCall} 을 적용하면 따옴표·백슬래시가 이스케이프되어 산출물이 깨진다.\n" +
+                        $"  치환부: {site.Trim()}");
+                }
+            }
+        }
+    }
+
+    private static void CollectTokens(
+        SubstitutionGroup group,
+        out HashSet<string> quoted,
+        out HashSet<string> codeContext)
+    {
+        quoted = new HashSet<string>();
+        codeContext = new HashSet<string>();
+
+        foreach (string templatePath in group.TemplatePaths)
+        {
+            string template = ReadRepoFile(templatePath);
+
+            var quotedHere = new HashSet<string>();
+            foreach (Match m in QuotedToken.Matches(template))
+            {
+                quotedHere.Add(m.Groups[1].Value);
+            }
+
+            foreach (Match m in AnyToken.Matches(template))
+            {
+                if (!quotedHere.Contains(m.Value))
+                {
+                    codeContext.Add(m.Value);
+                }
+            }
+
+            quoted.UnionWith(quotedHere);
+        }
+    }
+
+    // .Replace("<token>", ...) 가 등장하는 소스 줄 전체를 돌려준다.
+    // 이 저장소의 치환 체인은 한 줄에 하나씩 쓰여 있다(서식이 바뀌면 위의 IsNotEmpty 가 알린다).
+    private static List<string> FindSubstitutionSites(string source, string token)
+    {
+        string needle = "Replace(\"" + token + "\"";
+        return source
+            .Split('\n')
+            .Where(line => line.Contains(needle))
+            .ToList();
+    }
+
+    private static string ReadRepoFile(string relativePath)
+    {
+        Assert.IsTrue(
+            AITPackagePathResolver.TryResolveFile(relativePath, out string path, typeof(AITConvertCore)),
+            $"{relativePath} 경로를 찾지 못했습니다.");
+        Assert.IsTrue(File.Exists(path), $"파일이 존재하지 않습니다: {path}");
+        return File.ReadAllText(path);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITJsStringEscaperWiringTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/AITJsStringEscaperWiringTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b22b639988c49a797eb98cc8e835bfc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 문제

AIT Configuration 창의 **표시 이름 / 주 색상 / 아이콘 URL / Vite 호스트 / 출력 디렉토리**는 아무 문자 제한이 없는 입력란입니다 (`appName`만 `IsAppNameValid()`로 영숫자+하이픈 검증을 받습니다).

이 값들은 템플릿의 **작은따옴표 문자열 리터럴 자리**에 단순 `.Replace()`로 끼워 넣어집니다:

```ts
displayName: '%AIT_DISPLAY_NAME%',
```

그래서 표시 이름에 아포스트로피 하나만 들어가도 (예: `Dave's Adventure`) 리터럴이 조기 종료되어:

- `index.html`의 인라인 `<script>` 블록이 통째로 `SyntaxError`로 죽고
- `granite.config.ts` / `apps-in-toss.config.ts` / `vite.config.ts`가 파싱 오류로 빌드를 실패시킵니다

`AITBuildValidator.FindUnsubstitutedPlaceholders`는 **미치환 `%AIT_*%` 잔존만** 검사하므로, 치환은 성공하고 문법만 깨지는 이 경우를 잡지 못합니다. 사용자는 원인을 알기 어려운 vite/esbuild 오류만 보게 됩니다.

## 수정

`AITJsStringEscaper.EscapeSingleQuoted`를 추가하고 문자열 리터럴 자리의 토큰을 전부 통과시킵니다. 작은따옴표·백슬래시·개행·U+2028/2029를 이스케이프하고, `<`를 `\x3C`로 바꿔 값 안의 `</script>`가 인라인 스크립트 블록을 조기 종료하는 것도 막습니다.

**"따옴표 자리면 예외 없이 이스케이프"** 규칙을 유지했습니다 — 값이 상수라 실질 no-op인 자리도 통과시켜, 호출부마다 안전 여부를 판단하는 일이 없게 했습니다. 판단이 개입하면 다음 토큰에서 빠뜨립니다. (실제로 작업 중 `vite.config.ts` 쪽 두 자리를 놓쳤고, 아래 배선 가드가 잡아냈습니다.)

## 재발 방지 — 목록을 손으로 적지 않습니다

`AITJsStringEscaperWiringTests`가 템플릿을 파싱해 각 `%AIT_*%` 토큰이 **따옴표 자리인지 코드 자리인지 유도**하고, C# 치환부가 그에 맞게 이스케이프하는지 (코드 자리는 반대로 이스케이프하지 **않는지**) 대조합니다. `%AIT_PERMISSIONS%` / `%AIT_NAVIGATION_BAR%`처럼 값이 JSON·불리언 코드로 전개되는 자리는 이스케이프하면 오히려 깨지기 때문에 양방향 검사가 필요합니다.

템플릿에 토큰이 추가되거나 따옴표 안팎으로 옮겨가면 가드가 자동으로 따라갑니다.

## 함께 수정 — `CopyUserFilesRecursive`의 무조건 덮어쓰기

`excludeFolders`에 `public`이 없어, 사용자가 `BuildConfig~/public/`에 정적 파일을 두면 `ait-build/public/`로 **매 빌드 재작성**됐습니다. `PackageBuildStateMarker`는 `public/` 트리를 `(경로, 길이, mtimeTicks)`로 해시하며 *"mtime 불변 == 내용 불변"*을 전제하므로, 내용이 같아도 mtime이 전진해 **패키징 스킵이 영원히 발동하지 않았습니다.**

`CopyFileIfChanged`(바이트 단위 비교 — 바이너리 자산에도 안전)로 교체했습니다.

## 검증

- EditMode **1305건 통과** (신규 단위 테스트 9 + 배선 가드 2 포함)
- 배선 가드는 **뮤테이션으로 실효성 확인**: 따옴표 자리의 이스케이프를 제거 → `QuotedPlaceholders_AreEscapedAtEverySubstitutionSite` RED, 코드 자리에 이스케이프를 추가 → `CodeContextPlaceholders_AreNotEscaped` RED

## 기타

EditMode 테스트 실행 시 샘플 프로젝트에 생성되는 `TextMesh Pro/`, `DeployProbeGen/`을 `.gitignore`에 추가했습니다 (기존 E2E 산출물 무시 관례와 동일).
