### PR TITLE
수정: changelog가 web-framework 3.x 자기완결 번들을 파싱하도록 발견 경로 교정

### DIFF
--- a/sdk-runtime-generator~/src/categories.ts
+++ b/sdk-runtime-generator~/src/categories.ts
@@ -177,6 +177,62 @@ export const CATEGORY_ORDER: string[] = [
 ];
 
 /**
+ * changelog 리포트 전용 카테고리 매핑 (web-framework 3.x self-bundle 등에서 새로
+ * 발견된 API 이름 → 카테고리).
+ *
+ * ⚠️ 이 맵은 getCategory()에 명시적으로 전달됐을 때만(changelog-model.ts) 참조된다.
+ * C# 생성 경로(resolveApiCategory → index.ts/CSharpGenerator.ts/CSharpTypeGenerator.ts,
+ * framework-parser.ts)는 이 맵을 절대 전달하지 않는다 — 2.10.8 fallback dist에도
+ * 동일한 이름(getGroupId, requestReview, grantPromotionReward, openPDFViewer,
+ * requestTossPayPaysBilling, getAnonymousKey, getConsentedUserData, getDeclaredAgeRange
+ * 등)이 실제로 존재해서(실측), API_CATEGORIES에 직접 추가하면 그 이름들의 카테고리가
+ * 바뀌어 `pnpm generate`의 Runtime/SDK/ 출력이 달라지는 회귀가 발생하기 때문이다
+ * (생성 경로 무변경 불변식 보호 — B2/B3의 includeDeprecatedGlobals/includeWrappedCallables
+ * opt-in 패턴과 동일한 이유).
+ *
+ * 새 카테고리 3종(Promotion/Notification/Review)은 changelog 표시 전용이라
+ * CATEGORY_ORDER에 넣지 않는다 — changelog-model.ts의 카테고리 정렬은 getCategory가
+ * 반환한 문자열을 그대로 쓰고, CATEGORY_ORDER에 없는 이름은 알파벳 순으로 뒤에 붙는다.
+ */
+export const CHANGELOG_ONLY_CATEGORIES: Record<string, string[]> = {
+  Clipboard: ['ClipboardGetText', 'ClipboardSetText'],
+  Media: ['DeviceOpenCamera', 'FileOpenPDFViewer', 'FileSaveBase64', 'openPDFViewer'],
+  Navigation: ['DeviceOpenURL', 'ScreenClose'],
+  Environment: ['envGetDeploymentId'],
+  SystemInfo: [
+    'EnvironmentGetNetworkStatus',
+    'EnvironmentGetServerTime',
+    'getGroupId',
+    'getAnonymousKey',
+    'getConsentedUserData',
+    'getDeclaredAgeRange',
+    'UserGetAnonymousKey',
+    'UserGetConsentedData',
+    'UserGetDeclaredAgeRange',
+  ],
+  GameCenter: [
+    'GameGetUserProfile',
+    // 구버전(2.x 이전) @apps-in-toss/web-bridge에 존재하던, getUserKeyForGame과는
+    // 별개의 독립 심볼. 실제 존재가 실측 확인됨(생성 경로의 2.10.8 fallback dist에는
+    // 없음 — 있었다면 이 맵이 아니라 API_CATEGORIES에 직접 추가했을 것).
+    'getUserKey',
+  ],
+  SafeArea: ['getSafeAreaInsets'],
+  Promotion: ['grantPromotionReward', 'PromotionGrantReward'],
+  Notification: ['NotificationRequestAgreement', 'requestNotificationAgreement'],
+  Partner: ['partnerAddAccessoryButton', 'partnerRemoveAccessoryButton'],
+  Review: ['requestReview', 'ReviewRequest'],
+  Payment: [
+    'requestTossPayPaysBilling',
+    'TossPayAuthorize',
+    'TossPayAuthorizeSubscription',
+    'TossPayRequestTossPayPaysBilling',
+  ],
+  Device: ['ScreenSetAwakeMode', 'ScreenSetIosSwipeBack', 'ScreenSetSecure'],
+  Authentication: ['TossAuthIsIntegrated', 'TossAuthLogin', 'TossAuthSign'],
+};
+
+/**
  * API 이름으로 카테고리 찾기
  *
  * 카테고리 결정 우선순위:
@@ -187,13 +243,30 @@ export const CATEGORY_ORDER: string[] = [
  * @param apiName API 이름 (camelCase, 예: appLogin) 또는 PascalCase (예: IAPGetProductItemList)
  * @param warn 매핑 누락 시 경고 출력 여부 (기본 true). 타입 분류처럼 동일 API에 대해
  *   getCategory가 두 번 호출되는 경로에서는 false로 넘겨 중복 경고를 막는다.
+ * @param extraCategories 명시적 매핑에 추가로 참조할 카테고리 맵 (기본 없음). changelog
+ *   리포트 전용 CHANGELOG_ONLY_CATEGORIES를 넘길 때만 사용 — C# 생성 경로
+ *   (resolveApiCategory)는 이 인자를 절대 넘기지 않는다. CHANGELOG_ONLY_CATEGORIES의
+ *   주석 참고.
  * @returns 카테고리 이름
  */
-export function getCategory(apiName: string, warn: boolean = true): string {
+export function getCategory(
+  apiName: string,
+  warn: boolean = true,
+  extraCategories?: Record<string, string[]>
+): string {
   // 1. 명시적 매핑 확인 (가장 우선)
   for (const [category, apis] of Object.entries(API_CATEGORIES)) {
     if (apis.includes(apiName)) {
       return category;
+    }
+  }
+
+  // 1.5. 호출부가 명시적으로 넘긴 추가 매핑 확인 (changelog 전용, opt-in)
+  if (extraCategories) {
+    for (const [category, apis] of Object.entries(extraCategories)) {
+      if (apis.includes(apiName)) {
+        return category;
+      }
     }
   }
 
@@ -257,6 +330,15 @@ export const EXCLUDED_APIS: string[] = [
   'GoogleAdMobShowAdMobRewardedAd',
   // v1.8.0에서 제거된 API (AppsInTossEvent = {})
   'AppsInTossEventSubscribeEntryMessageExited',
+  // web-framework 3.x self-bundle dist/index.d.ts(discovery.ts detectSelfContainedDts
+  // 참고)에 동거하는 내부/설정 심볼 — 실제 제품 API가 아니라 스퓨리어스 오검출이므로
+  // 제외한다. createAsyncBridge는 파서 크래시(RangeError)를 유발해 이미 파서 레벨
+  // (detection.ts PARSER_SKIP_GLOBAL_FUNCTIONS)에서 별도로 제외되므로 여기 없음.
+  'createConstantBridge',
+  'createEventBridge',
+  // dist/config.d.ts가 dist/index.d.ts와 동거하며 함께 파싱되어 검출되는 빌드 설정
+  // 헬퍼(defineConfig) — SDK 브릿지 API가 아님.
+  'defineConfig',
 ];
 
 /**

--- a/sdk-runtime-generator~/src/discovery.ts
+++ b/sdk-runtime-generator~/src/discovery.ts
@@ -20,10 +20,13 @@ import { TypeScriptParser } from './parser/index.js';
 /**
  * .d.ts 디렉토리를 찾은 전략.
  * - sibling: web-framework의 pnpm 의존성 그래프 sibling에서 발견 (가장 정확)
- * - pnpm-store: node_modules/.pnpm 전체를 스캔해 발견 (sibling 실패 시 폴백)
+ * - self-bundle: web-framework 자체 dist/index.d.ts가 전체 API 표면을 번들링하고
+ *   있어(더 이상 별도 web-bridge sibling 패키지가 없음) 그 파일 자체를 사용 (3.x+)
+ * - pnpm-store: node_modules/.pnpm 전체를 스캔해 발견 (sibling·self-bundle 모두
+ *   실패했을 때의 폴백 — stale 버전의 web-bridge를 근사로 사용하므로 부정확할 수 있음)
  * - package-dir: node_modules 직하 또는 web-framework 패키지 내부 경로에서 발견
  */
-export type DtsSource = 'sibling' | 'pnpm-store' | 'package-dir';
+export type DtsSource = 'sibling' | 'self-bundle' | 'pnpm-store' | 'package-dir';
 
 /**
  * 특정 web-framework 버전에 대해 해석된 경로 정보.
@@ -121,6 +124,44 @@ async function hasValidDtsFiles(dir: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * self-bundle(자기완결) dist/index.d.ts 판정에 쓰는 최소 //#region 마커 개수.
+ * 낮은 임계값은 우연히 region 주석 몇 개 있는 일반 barrel 파일을 오탐할 수 있고,
+ * 너무 높으면 작은 self-bundle 버전을 놓칠 수 있다. 실측(3.0.1 dist/index.d.ts,
+ * 2502줄)에서 102개가 관찰되어 여유 있게 10으로 잡는다.
+ */
+const SELF_BUNDLE_REGION_MARKER_THRESHOLD = 10;
+
+/**
+ * web-framework 패키지 자체의 dist/index.d.ts가 "자기완결(self-contained) 번들"인지
+ * 판정한다 — 즉 별도 web-bridge sibling 패키지 없이 전체 API 표면이 이 파일 하나에
+ * 번들되어 있는지.
+ *
+ * 실측 근거(2026-08-22 조사, `@apps-in-toss/web-framework` 3.0.1~3.0.4):
+ * - dist/index.d.ts가 2502줄이며 원본 소스 파일 경계마다 rollup-plugin-dts류 번들러가
+ *   삽입하는 `//#region src/apis/.../*.d.ts` 마커가 102개 존재 (일반 재수출 barrel
+ *   파일에는 이런 마커가 없다).
+ * - dist/ 디렉토리에 index.d.ts 외에 config.d.ts가 동거하지만, index.d.ts 자체에
+ *   전체 API(Device, TossPay, Share, checkoutPayment, getDeviceId, ... 등)가 이미
+ *   다 들어있어 index.d.ts만으로 충분히 자기완결적이다.
+ * - 3.0.1~3.0.3의 index.d.ts는 바이트 동일(md5 e4c54acb)이고 3.0.4는 다르다(md5
+ *   d37b0236) — 버전이 달라도 이 판정 로직 자체는 파일 내용에 의존하지 않고 구조적
+ *   특징(region 마커 개수)만 보므로 안정적으로 동작한다.
+ */
+export async function detectSelfContainedDts(webFrameworkPath: string): Promise<string | null> {
+  const indexDtsPath = path.join(webFrameworkPath, 'dist', 'index.d.ts');
+  try {
+    const content = await fs.readFile(indexDtsPath, 'utf-8');
+    const regionMarkerCount = (content.match(/\/\/#region /g) ?? []).length;
+    if (regionMarkerCount >= SELF_BUNDLE_REGION_MARKER_THRESHOLD) {
+      return path.join(webFrameworkPath, 'dist');
+    }
+  } catch {
+    // dist/index.d.ts가 없으면 self-bundle이 아님
+  }
+  return null;
 }
 
 /**
@@ -308,22 +349,59 @@ export function hasFrameworkApis(version: string): boolean {
 /**
  * 특정 web-framework alias 버전의 경로 전체를 해석한다.
  *
- * sibling에서 dtsDir을 찾지 못하면(예: 3.0.0+의 web-bridge → webview-bridge 리네임)
- * pnpm store 폴백을 시도하고, 그래도 해석에 실패하면 조용히 스킵하는 대신 이 버전이
- * 왜 빠지는지 알 수 있도록 명확한 한국어 메시지로 throw한다 — changelog 최신 버전
- * 누락(예: 3.0.1) 버그의 재발을 방지하기 위함.
+ * ⚠️ 스코프 경계: 이 함수는 changelog 전용 호출부(tests/unit/scripts/generate-changelog.ts,
+ * tests/unit/multi-version.test.ts)에서만 쓰인다. index.ts의 generate() 파이프라인은
+ * findTypeDefinitions()/findTypeDefinitionsWithSource()를 직접 호출하며 이 함수를 거치지
+ * 않는다. 그래서 여기서 self-bundle 단축 경로를 앞에 추가해도 findTypeDefinitionsWithSource의
+ * 공유 후보 배열 순서(및 그걸 그대로 쓰는 generate() 경로의 동작)는 전혀 바뀌지 않는다
+ * (검증: `pnpm generate` 후 `git status`에서 Runtime/SDK/ 무변경 — 이 파일 상단 주석 참고).
+ *
+ * web-framework 3.x+는 별도 web-bridge sibling 패키지 없이 자체 dist/index.d.ts에 전체
+ * API 표면을 번들링한다(detectSelfContainedDts 참고) — sibling 탐색보다 먼저 이 단축
+ * 경로를 확인해 stale pnpm-store 폴백(2.10.8 고정)으로 새지 않게 한다.
+ *
+ * self-bundle도 sibling에서 dtsDir을 찾지도 못하면(예: 3.0.0+의 web-bridge →
+ * webview-bridge 리네임) pnpm store 폴백을 시도하고, 그래도 해석에 실패하면 조용히
+ * 스킵하는 대신 이 버전이 왜 빠지는지 알 수 있도록 명확한 한국어 메시지로 throw한다 —
+ * changelog 최신 버전 누락(예: 3.0.1) 버그의 재발을 방지하기 위함.
+ *
+ * fail-loud 게이트: web-framework major가 3 이상인데도 최종 source가 'pnpm-store'
+ * 폴백이면(= self-bundle 판정도 실패하고 sibling도 없어 stale 근사로 빠진 것) 조용히
+ * 근사 리포트를 내는 대신 즉시 throw한다. 향후 4.x 등에서 또 구조가 바뀌면(예: dist
+ * 번들링 방식 변경) self-bundle 판정이 깨질 수 있는데, 이때 stale 2.10.8로 조용히
+ * 폴백하며 "변경 없음"을 오보하는 사고(이번 3.0.1 버그와 동일한 유형)가 재발하지
+ * 않도록 하기 위함.
  */
 export async function resolveVersionPaths(version: string): Promise<VersionPaths> {
   const aliasPath = path.join(process.cwd(), 'node_modules', `web-framework-${version}`);
   const realPath = await fs.realpath(aliasPath);
 
-  const result = await findTypeDefinitionsWithSource(realPath);
+  const selfBundleDtsDir = await detectSelfContainedDts(realPath);
+  const result = selfBundleDtsDir
+    ? { path: selfBundleDtsDir, source: 'self-bundle' as const }
+    : await findTypeDefinitionsWithSource(realPath);
+
   if (!result) {
     throw new Error(
       `web-framework v${version}의 TypeScript 정의 파일을 찾을 수 없습니다.\n` +
-      `  확인한 경로: sibling(web-bridge), pnpm store 폴백, ${realPath} 하위 dist/built/lib 등.\n` +
+      `  확인한 경로: self-bundle(dist/index.d.ts), sibling(web-bridge), pnpm store 폴백, ` +
+      `${realPath} 하위 dist/built/lib 등.\n` +
       `  web-framework 재구성(예: web-bridge → webview-bridge 리네임)으로 발견 전략이 깨졌을 수 있습니다.\n` +
       `  discovery.ts의 findTypeDefinitionsWithSource를 확인하세요.`
+    );
+  }
+
+  const majorVersion = Number(version.split('.')[0]);
+  if (majorVersion >= 3 && result.source === 'pnpm-store') {
+    throw new Error(
+      `web-framework v${version}(major ${majorVersion})의 API 표면을 pnpm-store 폴백으로만 ` +
+      `찾았습니다 — self-bundle 판정과 sibling 탐색 모두 실패했다는 뜻입니다.\n` +
+      `  이 폴백은 stale 버전의 web-bridge(예: v2.10.8)를 근사로 사용하므로, 3.x+에서는 ` +
+      `changelog가 "변경 없음"을 오보하는 사고(2026-08 web-framework 3.0.1 누락 버그와 ` +
+      `동일 유형)로 이어질 수 있어 조용히 넘어가지 않고 즉시 실패시킵니다.\n` +
+      `  discovery.ts의 detectSelfContainedDts(//#region 마커 판정)가 v${version}의 새 dist ` +
+      `구조를 더 이상 인식하지 못할 수 있습니다 — 실제 dist/index.d.ts 구조를 확인하고 ` +
+      `판정 로직을 갱신하세요.`
     );
   }
 
@@ -340,10 +418,16 @@ export async function resolveVersionPaths(version: string): Promise<VersionPaths
 
 /**
  * 버전 경로에서 파서를 생성하고 web-analytics 소스가 있으면 추가
+ *
+ * self-bundle(paths.dtsSource === 'self-bundle')인 경우 dist/index.d.ts 자체가 이미
+ * Analytics 네임스페이스를 포함한 전체 API 표면을 번들링하고 있으므로(detectSelfContainedDts
+ * 참고) web-analytics sibling dist를 추가로 addSourceDirectory하면 같은 API가 두 번
+ * 파싱되어 changelog 카탈로그에 중복 항목이 생긴다 (실측: AnalyticsClick/Impression/Screen
+ * 각 2건). self-bundle은 "이 파일 하나로 완결"이라는 설계와 정합하도록 여기서 스킵한다.
  */
 export function createParserForVersion(paths: VersionPaths): TypeScriptParser {
   const parser = new TypeScriptParser(paths.dtsDir, paths.webFrameworkPath);
-  if (paths.webAnalyticsDtsDir) {
+  if (paths.webAnalyticsDtsDir && paths.dtsSource !== 'self-bundle') {
     parser.addSourceDirectory(paths.webAnalyticsDtsDir);
   }
   return parser;

--- a/sdk-runtime-generator~/src/parser/TypeScriptParser.ts
+++ b/sdk-runtime-generator~/src/parser/TypeScriptParser.ts
@@ -160,8 +160,15 @@ export class TypeScriptParser {
   /**
    * 모든 API 파싱
    * @param frameworkApiNames @apps-in-toss/framework에서 직접 파싱할 API 이름 목록 (선택)
+   * @param options parseNamespaceObjects/detectGlobalFunctions에 그대로 전달됨
+   *   (includeDeprecatedGlobals, includeWrappedCallables). 기본값 둘 다 false로, C#
+   *   생성 경로(index.ts)를 포함한 기존 모든 호출부의 동작을 그대로 보존한다 —
+   *   changelog self-bundle(3.x) 경로에서만 opt-in.
    */
-  async parseAPIs(frameworkApiNames?: string[]): Promise<ParsedAPI[]> {
+  async parseAPIs(
+    frameworkApiNames?: string[],
+    options?: { includeDeprecatedGlobals?: boolean; includeWrappedCallables?: boolean }
+  ): Promise<ParsedAPI[]> {
     const apis: ParsedAPI[] = [];
     const sourceFiles = this.project.getSourceFiles();
 
@@ -171,7 +178,7 @@ export class TypeScriptParser {
 
       // index.d.ts는 네임스페이스 객체만 파싱 (IAP, Storage 등)
       if (fileName === 'index.d.ts') {
-        const namespaceAPIs = parseNamespaceObjects(sourceFile);
+        const namespaceAPIs = parseNamespaceObjects(sourceFile, options);
         apis.push(...namespaceAPIs);
         continue;
       }
@@ -188,6 +195,19 @@ export class TypeScriptParser {
     // @apps-in-toss/framework에서 추가 API 파싱 (web-framework에서 re-export되지 않는 API)
     if (frameworkApiNames && frameworkApiNames.length > 0) {
       const frameworkAPIs = this.parseFrameworkAPIs(frameworkApiNames, this.frameworkDtsPath);
+      if (frameworkAPIs.length > 0) {
+        // includeWrappedCallables(self-bundle 전용 opt-in) 사용 시 web-framework
+        // 자체 dist/index.d.ts에 loadFullScreenAd/showFullScreenAd 같은 FRAMEWORK_APIS
+        // 이름이 intersection 타입(`(...) & { isSupported }`)으로 재선언되어 있어,
+        // 위 메인 스캔에서도 같은 이름이 이미 잡혔을 수 있다(실측: v3.0.1에서 카탈로그에
+        // AIT.LoadFullScreenAd/AIT.ShowFullScreenAd가 2줄씩 중복 출력됨). FRAMEWORK_APIS
+        // 전용 파서가 isTopLevelExport/category(Advertising) 등 C# 생성에 필요한 필드를
+        // 정확히 채우므로 그쪽을 우선하고, 메인 스캔 쪽 중복 항목은 제거한다.
+        const frameworkNames = new Set(frameworkAPIs.map(a => a.name));
+        for (let i = apis.length - 1; i >= 0; i--) {
+          if (frameworkNames.has(apis[i].name)) apis.splice(i, 1);
+        }
+      }
       apis.push(...frameworkAPIs);
     }
 

--- a/sdk-runtime-generator~/src/parser/api-parser.ts
+++ b/sdk-runtime-generator~/src/parser/api-parser.ts
@@ -213,40 +213,50 @@ export function parseSourceFile(sourceFile: SourceFile): ParsedAPI[] {
 
   for (const [name, declarations] of exportedDeclarations) {
     for (const declaration of declarations) {
-      // 함수 선언
-      if (declaration.getKind() === SyntaxKind.FunctionDeclaration) {
-        const func = declaration as FunctionDeclaration;
-        const api = parseFunctionDeclaration(func, sourceFile);
-        if (api) {
-          apis.push(api);
-        }
-      }
-
-      // 변수 선언 (const openCamera = ..., const getClipboardText: PermissionFunctionWithDialog<...>)
-      if (declaration.getKind() === SyntaxKind.VariableDeclaration) {
-        const varDecl = declaration.asKind(SyntaxKind.VariableDeclaration);
-        if (varDecl) {
-          const initializer = varDecl.getInitializer();
-          // Arrow function (const fn = () => {})
-          if (initializer && initializer.getKind() === SyntaxKind.ArrowFunction) {
-            const api = parseVariableFunction(name, varDecl, sourceFile);
-            if (api) {
-              apis.push(api);
-            }
+      try {
+        // 함수 선언
+        if (declaration.getKind() === SyntaxKind.FunctionDeclaration) {
+          const func = declaration as FunctionDeclaration;
+          const api = parseFunctionDeclaration(func, sourceFile);
+          if (api) {
+            apis.push(api);
           }
-          // Const with function type (const fn: FnType = ...)
-          // Arrow function이 없어도 타입이 함수면 파싱
-          else {
-            const type = varDecl.getType();
-            const callSignatures = type.getCallSignatures();
-            if (callSignatures.length > 0) {
+        }
+
+        // 변수 선언 (const openCamera = ..., const getClipboardText: PermissionFunctionWithDialog<...>)
+        if (declaration.getKind() === SyntaxKind.VariableDeclaration) {
+          const varDecl = declaration.asKind(SyntaxKind.VariableDeclaration);
+          if (varDecl) {
+            const initializer = varDecl.getInitializer();
+            // Arrow function (const fn = () => {})
+            if (initializer && initializer.getKind() === SyntaxKind.ArrowFunction) {
               const api = parseVariableFunction(name, varDecl, sourceFile);
               if (api) {
                 apis.push(api);
               }
             }
+            // Const with function type (const fn: FnType = ...)
+            // Arrow function이 없어도 타입이 함수면 파싱
+            else {
+              const type = varDecl.getType();
+              const callSignatures = type.getCallSignatures();
+              if (callSignatures.length > 0) {
+                const api = parseVariableFunction(name, varDecl, sourceFile);
+                if (api) {
+                  apis.push(api);
+                }
+              }
+            }
           }
         }
+      } catch (err) {
+        // 일부 심볼(예: 자기참조 제네릭 타입)은 .getType()/.getCallSignatures() 호출 시
+        // ts-morph/TypeScript 컴파일러 내부에서 RangeError(스택 오버플로우) 등을 유발할 수
+        // 있다. 파이프라인 전체를 죽이지 않고 해당 심볼만 건너뛴다 — 침묵 스킵 금지,
+        // 원인 진단이 가능하도록 심볼명과 에러를 남긴다.
+        console.warn(
+          `⚠️  API '${name}' 파싱 중 오류가 발생해 건너뜁니다: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     }
   }

--- a/sdk-runtime-generator~/src/parser/detection.ts
+++ b/sdk-runtime-generator~/src/parser/detection.ts
@@ -32,11 +32,36 @@ export function isDefinedInFile(decl: any, sourceFile: SourceFile): boolean {
 }
 
 /**
+ * 선언의 JSDoc 목록을 가져온다.
+ *
+ * ts-morph에서 `declare const NAME: Type;` 형태는 VariableDeclaration 노드에
+ * getJsDocs()가 없다(JSDocableNode를 구현하지 않음) — 실제 JSDoc(예: `@deprecated`)은
+ * 그 부모인 VariableStatement에 붙는다. `decl.getJsDocs?.()`만 쓰면 옵셔널 체이닝이
+ * 조용히 undefined를 반환해 항상 "JSDoc 없음"으로 오판하므로(실측: getServerTime 등
+ * wrapped-callable 전역 함수의 @deprecated가 매번 누락됨), VariableDeclaration이면
+ * getVariableStatement()로 올라가 그쪽 JSDoc을 사용한다.
+ */
+function getJsDocsForDeclaration(decl: any): any[] {
+  try {
+    if (typeof decl.getJsDocs === 'function') {
+      return decl.getJsDocs() || [];
+    }
+    const stmt = decl.getVariableStatement?.();
+    if (stmt && typeof stmt.getJsDocs === 'function') {
+      return stmt.getJsDocs() || [];
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * 선언이 deprecated인지 확인 (JSDoc @deprecated 태그)
  */
 export function isDeprecatedDeclaration(decl: any): boolean {
   try {
-    const jsDocs = decl.getJsDocs?.() || [];
+    const jsDocs = getJsDocsForDeclaration(decl);
     for (const jsDoc of jsDocs) {
       const tags = jsDoc.getTags?.() || [];
       if (tags.some((tag: any) => tag.getTagName?.() === 'deprecated')) {
@@ -46,6 +71,28 @@ export function isDeprecatedDeclaration(decl: any): boolean {
     return false;
   } catch {
     return false;
+  }
+}
+
+/**
+ * 선언의 JSDoc @deprecated 태그 코멘트(대체 API 안내 등)를 추출.
+ * 태그가 없거나 코멘트가 비어 있으면 undefined.
+ */
+export function getDeprecatedMessage(decl: any): string | undefined {
+  try {
+    const jsDocs = getJsDocsForDeclaration(decl);
+    for (const jsDoc of jsDocs) {
+      const tags = jsDoc.getTags?.() || [];
+      for (const tag of tags) {
+        if (tag.getTagName?.() === 'deprecated') {
+          const text = tag.getCommentText?.();
+          if (text && text.trim()) return text.trim();
+        }
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -76,21 +123,139 @@ export function detectEventNamespaces(sourceFile: SourceFile): Set<string> {
 }
 
 /**
- * 글로벌 함수 감지 (이 파일에 정의된 FunctionDeclaration 또는 단순 화살표 함수)
- * 패턴: declare function NAME(...) 또는 declare const NAME: () => ...
- * deprecated 함수는 제외
+ * 파서 레벨에서 항상 스킵하는 글로벌 함수 이름.
+ *
+ * `createAsyncBridge`: web-framework 3.x dist/index.d.ts(자기완결 번들, discovery.ts의
+ * self-bundle 판정 참고)에 등장하는 내부 브릿지 팩토리. 시그니처가
+ * `<Args extends unknown[] = unknown[], Result = unknown>(method: string): (...args: Args) => Promise<Result>`
+ * 형태의 제네릭 함수 타입인데, 이 반환 타입을 parseType()에 넘기면 ts-morph 타입
+ * 해석이 순환에 빠져 `RangeError: Maximum call stack size exceeded`가 발생한다(실측,
+ * --stack-size=30000에서도 재현 — 얕은 스택 한계 문제가 아니라 실제 순환).
+ * EXCLUDED_APIS(categories.ts) 같은 파싱 이후 필터로는 막을 수 없다 — 크래시가
+ * parseType() 호출 시점(=파싱 도중)에 발생하기 때문에, 파서가 이 이름을 애초에
+ * 글로벌 함수로 감지하지 않도록 여기서 제외해야 한다.
  */
-export function detectGlobalFunctions(sourceFile: SourceFile): Set<string> {
+const PARSER_SKIP_GLOBAL_FUNCTIONS = new Set(['createAsyncBridge']);
+
+/**
+ * 타입 텍스트가 "callable" 화살표 함수 타입인지 판정.
+ * `() => X` 같은 파라미터 없는 형태뿐 아니라 `(args: { ... }) => Y` 처럼 파라미터가
+ * 객체 리터럴(중괄호 포함)인 형태도 인식한다 — 선행 `(...)`의 괄호 깊이를 직접 카운트해
+ * 그 매칭되는 닫는 괄호 바로 뒤에 `=>`가 오는지만 확인하므로, 파라미터 내부에 `{`가
+ * 있어도(중첩 객체/제네릭) 오탐하지 않는다.
+ *
+ * 객체 리터럴 타입(`{ method: ... }` 형태의 네임스페이스 객체)은 애초에 `(`로 시작하지
+ * 않으므로 이 판정에서 자연히 걸러진다. `(() => X) & { isSupported: ... }` 같은
+ * intersection 타입은 선행 `(...)` 뒤에 `=>`가 아니라 `&`가 오므로 여기서 제외된다
+ * (이런 형태는 detectGlobalFunctions/detectNamespaceObjects 어느 쪽에도 걸리지 않는
+ * 기존 동작을 그대로 유지 — FRAMEWORK_APIS 등 별도 경로로 처리됨).
+ */
+function isCallableArrowType(typeText: string): boolean {
+  const trimmed = typeText.trim();
+  if (!trimmed.startsWith('(')) return false;
+
+  let depth = 0;
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch === '(') {
+      depth++;
+    } else if (ch === ')') {
+      depth--;
+      if (depth === 0) {
+        const rest = trimmed.slice(i + 1).trimStart();
+        return rest.startsWith('=>');
+      }
+      if (depth < 0) return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * "래핑된" callable 타입 판정 — isCallableArrowType으로는 못 잡는 두 형태를 추가로 인식:
+ *
+ * 1. intersection: `(<화살표 타입>) & { isSupported: ...; ... }` — 선행 `(...)`의
+ *    매칭 닫는 괄호 바로 뒤에 `&`가 오면, 그 괄호를 벗기고 안쪽이 화살표 타입인지 재귀
+ *    확인한다. (예: 3.x self-bundle의 `getServerTime: (() => Promise<number|undefined>)
+ *    & { isSupported: () => boolean }`, `startUpdateLocation: ((eventParams) =>
+ *    (() => void)) & { ... }`)
+ * 2. 제네릭 wrapper: `Identifier<<화살표 타입>>` 형태 — 마지막 `>`까지를 제네릭
+ *    인자로 보고 안쪽이 화살표 타입인지 재귀 확인한다. (예:
+ *    `PermissionFunctionWithDialog<(options?: X) => Promise<Y>>`)
+ *
+ * ⚠️ 스코프: 이 두 형태는 2.x sibling(web-bridge)의 index.d.ts에도 동일 이름·동일
+ * 형태로 존재하는 API가 있고(getServerTime, fetchAlbumPhotos 등), 2.x에서는 그 API가
+ * *같은 이름의 개별 .d.ts 파일*(file-per-API, parseSourceFile 경로)로도 파싱되므로,
+ * 여기서 무조건 켜면 같은 이름이 두 경로에서 중복 파싱된다(C# 생성 경로 포함 —
+ * Runtime/SDK 변경으로 이어짐). 그래서 이 판정은 호출부가 명시적으로 opt-in할 때만
+ * 쓰여야 한다 — detectGlobalFunctions의 includeWrappedCallables 참고.
+ */
+function isWrappedCallableType(typeText: string): boolean {
+  const trimmed = typeText.trim();
+
+  // intersection: 선행 (...) 뒤에 '&'
+  if (trimmed.startsWith('(')) {
+    let depth = 0;
+    for (let i = 0; i < trimmed.length; i++) {
+      const ch = trimmed[i];
+      if (ch === '(') {
+        depth++;
+      } else if (ch === ')') {
+        depth--;
+        if (depth === 0) {
+          const rest = trimmed.slice(i + 1).trimStart();
+          if (rest.startsWith('&')) {
+            return isCallableArrowType(trimmed.slice(1, i).trim());
+          }
+          break;
+        }
+        if (depth < 0) break;
+      }
+    }
+  }
+
+  // 제네릭 wrapper: Identifier<...>
+  const genericMatch = trimmed.match(/^[A-Za-z_$][\w$.]*\s*<([\s\S]+)>$/);
+  if (genericMatch) {
+    return isCallableArrowType(genericMatch[1].trim());
+  }
+
+  return false;
+}
+
+/**
+ * 글로벌 함수 감지 (이 파일에 정의된 FunctionDeclaration 또는 화살표 함수 타입 declare const)
+ * 패턴: declare function NAME(...) 또는 declare const NAME: (...) => ...
+ *
+ * @param options.includeDeprecatedGlobals true면 deprecated 선언도 포함(호출부가
+ *   isDeprecated 플래그를 직접 확인/보존할 책임을 진다). 기본값 false — 이 기본값은
+ *   C# 생성 경로(index.ts)를 포함한 기존 모든 호출부의 동작을 그대로 보존한다.
+ *   changelog 파이프라인의 self-bundle(3.x) 경로에서만 true로 호출해 deprecated
+ *   최상위 함수가 "제거"가 아니라 "변경(deprecated 전환)"으로 잡히게 한다.
+ * @param options.includeWrappedCallables true면 isWrappedCallableType(intersection/
+ *   제네릭 wrapper 화살표 타입)도 감지 대상에 포함한다. 기본값 false — 2.x sibling에서
+ *   이 형태는 같은 이름이 file-per-API 경로에서 이미 파싱되므로 여기서까지 켜면
+ *   중복이 생긴다(isWrappedCallableType 문서 참고). self-bundle(3.x)에서만 opt-in.
+ */
+export function detectGlobalFunctions(
+  sourceFile: SourceFile,
+  options?: { includeDeprecatedGlobals?: boolean; includeWrappedCallables?: boolean }
+): Set<string> {
   const globalFunctions = new Set<string>();
   const exportedDeclarations = sourceFile.getExportedDeclarations();
+  const includeDeprecated = options?.includeDeprecatedGlobals ?? false;
+  const includeWrapped = options?.includeWrappedCallables ?? false;
 
   for (const [name, declarations] of exportedDeclarations) {
+    // 파서 크래시를 유발하는 이름은 애초에 감지하지 않음 (PARSER_SKIP_GLOBAL_FUNCTIONS 주석 참고)
+    if (PARSER_SKIP_GLOBAL_FUNCTIONS.has(name)) continue;
+
     for (const decl of declarations) {
       // 이 파일에 정의된 선언만 처리 (re-export 제외)
       if (!isDefinedInFile(decl, sourceFile)) continue;
 
-      // deprecated 선언은 제외
-      if (isDeprecatedDeclaration(decl)) continue;
+      // deprecated 선언은 기본적으로 제외 (includeDeprecatedGlobals일 때만 포함)
+      if (!includeDeprecated && isDeprecatedDeclaration(decl)) continue;
 
       // Case 1: function declaration (declare function isMinVersionSupported(...))
       if (decl.getKind() === SyntaxKind.FunctionDeclaration) {
@@ -98,11 +263,19 @@ export function detectGlobalFunctions(sourceFile: SourceFile): Set<string> {
         continue;
       }
 
-      // Case 2: const with simple arrow function type (const getAppsInTossGlobals: () => ...)
+      // Case 2: const with callable arrow function type
+      // (const getAppsInTossGlobals: () => ... 또는
+      //  const onVisibilityChangedByTransparentServiceWeb: (eventParams: { ... }) => (() => void))
       if (decl.getKind() === SyntaxKind.VariableDeclaration) {
         const typeText = getTypeAnnotationText(decl);
-        // 단순 화살표 함수 타입: () => ... 형태이면서 객체 리터럴이 아닌 경우
-        if (/^\s*\(\s*\)\s*=>\s*\w/.test(typeText) && !typeText.includes('{')) {
+        if (isCallableArrowType(typeText)) {
+          globalFunctions.add(name);
+          continue;
+        }
+        // Case 3 (opt-in): intersection/제네릭 wrapper 화살표 타입
+        // (const getServerTime: (() => Promise<number|undefined>) & { isSupported } 또는
+        //  const getClipboardText: PermissionFunctionWithDialog<() => Promise<string>>)
+        if (includeWrapped && isWrappedCallableType(typeText)) {
           globalFunctions.add(name);
         }
       }

--- a/sdk-runtime-generator~/src/parser/namespace-parser.ts
+++ b/sdk-runtime-generator~/src/parser/namespace-parser.ts
@@ -8,6 +8,8 @@ import {
   detectEventNamespaces,
   detectGlobalFunctions,
   detectNamespaceObjects,
+  isDeprecatedDeclaration,
+  getDeprecatedMessage,
 } from './detection.js';
 import { parseEventNamespace } from './event-parser.js';
 
@@ -221,8 +223,15 @@ export function parseNamespaceObject(
 /**
  * index.d.ts에서 네임스페이스 객체, 이벤트 네임스페이스, 글로벌 함수 파싱
  * 모든 항목을 동적으로 감지하여 파싱
+ *
+ * @param options detectGlobalFunctions에 그대로 전달됨 (includeDeprecatedGlobals,
+ *   includeWrappedCallables). 기본값 둘 다 false — 기존 동작 보존, changelog
+ *   self-bundle 경로에서만 opt-in.
  */
-export function parseNamespaceObjects(sourceFile: SourceFile): ParsedAPI[] {
+export function parseNamespaceObjects(
+  sourceFile: SourceFile,
+  options?: { includeDeprecatedGlobals?: boolean; includeWrappedCallables?: boolean }
+): ParsedAPI[] {
   const apis: ParsedAPI[] = [];
   const exportedDeclarations = sourceFile.getExportedDeclarations();
 
@@ -230,59 +239,68 @@ export function parseNamespaceObjects(sourceFile: SourceFile): ParsedAPI[] {
   const eventNamespaces = detectEventNamespaces(sourceFile);
 
   // 2. 글로벌 함수 감지 (FunctionDeclaration)
-  const globalFunctions = detectGlobalFunctions(sourceFile);
+  const globalFunctions = detectGlobalFunctions(sourceFile, options);
 
   // 3. 네임스페이스 객체 감지 (나머지 중 메서드만 있는 객체)
   const namespaceObjects = detectNamespaceObjects(sourceFile, eventNamespaces, globalFunctions);
 
   for (const [name, declarations] of exportedDeclarations) {
-    // 네임스페이스 객체 파싱 (동적 감지됨)
-    if (namespaceObjects.has(name)) {
-      for (const declaration of declarations) {
-        if (declaration.getKind() === SyntaxKind.VariableDeclaration) {
-          const varDecl = declaration.asKind(SyntaxKind.VariableDeclaration);
-          if (varDecl) {
-            const namespaceAPIs = parseNamespaceObject(name, varDecl, sourceFile);
-            apis.push(...namespaceAPIs);
+    try {
+      // 네임스페이스 객체 파싱 (동적 감지됨)
+      if (namespaceObjects.has(name)) {
+        for (const declaration of declarations) {
+          if (declaration.getKind() === SyntaxKind.VariableDeclaration) {
+            const varDecl = declaration.asKind(SyntaxKind.VariableDeclaration);
+            if (varDecl) {
+              const namespaceAPIs = parseNamespaceObject(name, varDecl, sourceFile);
+              apis.push(...namespaceAPIs);
+            }
           }
         }
       }
-    }
 
-    // 이벤트 네임스페이스 파싱 (동적 감지됨)
-    if (eventNamespaces.has(name)) {
-      const eventAPIs = parseEventNamespace(name, sourceFile);
-      apis.push(...eventAPIs);
-    }
+      // 이벤트 네임스페이스 파싱 (동적 감지됨)
+      if (eventNamespaces.has(name)) {
+        const eventAPIs = parseEventNamespace(name, sourceFile);
+        apis.push(...eventAPIs);
+      }
 
-    // 글로벌 함수 파싱 (동적 감지됨)
-    if (globalFunctions.has(name)) {
-      for (const declaration of declarations) {
-        if (declaration.getKind() === SyntaxKind.FunctionDeclaration) {
-          const func = declaration as FunctionDeclaration;
-          const api = parseFunctionDeclarationForNamespace(func, sourceFile);
-          if (api) {
-            // 글로벌 함수는 Environment 카테고리로 설정
-            api.category = 'Environment';
-            apis.push(api);
+      // 글로벌 함수 파싱 (동적 감지됨)
+      if (globalFunctions.has(name)) {
+        for (const declaration of declarations) {
+          if (declaration.getKind() === SyntaxKind.FunctionDeclaration) {
+            const func = declaration as FunctionDeclaration;
+            const api = parseFunctionDeclarationForNamespace(func, sourceFile);
+            if (api) {
+              // 글로벌 함수는 Environment 카테고리로 설정
+              api.category = 'Environment';
+              apis.push(api);
+            }
           }
-        }
-        // 변수 선언 형태의 함수도 처리
-        if (declaration.getKind() === SyntaxKind.VariableDeclaration) {
-          const varDecl = declaration.asKind(SyntaxKind.VariableDeclaration);
-          if (varDecl) {
-            const type = varDecl.getType();
-            const callSignatures = type.getCallSignatures();
-            if (callSignatures.length > 0) {
-              const api = parseVariableFunctionForNamespace(name, varDecl, sourceFile);
-              if (api) {
-                api.category = 'Environment';
-                apis.push(api);
+          // 변수 선언 형태의 함수도 처리
+          if (declaration.getKind() === SyntaxKind.VariableDeclaration) {
+            const varDecl = declaration.asKind(SyntaxKind.VariableDeclaration);
+            if (varDecl) {
+              const type = varDecl.getType();
+              const callSignatures = type.getCallSignatures();
+              if (callSignatures.length > 0) {
+                const api = parseVariableFunctionForNamespace(name, varDecl, sourceFile);
+                if (api) {
+                  api.category = 'Environment';
+                  apis.push(api);
+                }
               }
             }
           }
         }
       }
+    } catch (err) {
+      // 자기참조 제네릭 타입 등에서 .getType()/.getCallSignatures() 호출이 컴파일러
+      // 내부 RangeError(스택 오버플로우) 등을 유발할 수 있다. 해당 심볼만 건너뛰고
+      // 파이프라인은 계속 진행한다 — 침묵 스킵 금지, 심볼명과 원인을 남긴다.
+      console.warn(
+        `⚠️  네임스페이스 API '${name}' 파싱 중 오류가 발생해 건너뜁니다: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
   }
 
@@ -351,6 +369,8 @@ function parseFunctionDeclarationForNamespace(
     isAsync: isCallbackBased ? false : isAsync,
     hasPermission,
     isCallbackBased,
+    isDeprecated: isDeprecatedDeclaration(func),
+    deprecatedMessage: getDeprecatedMessage(func),
   };
 }
 
@@ -423,6 +443,8 @@ function parseVariableFunctionForNamespace(
     isAsync: isCallbackBased ? false : isAsync,
     hasPermission: false,
     isCallbackBased,
+    isDeprecated: isDeprecatedDeclaration(varDecl),
+    deprecatedMessage: getDeprecatedMessage(varDecl),
   };
 }
 

--- a/sdk-runtime-generator~/tests/unit/discovery-invariants.test.ts
+++ b/sdk-runtime-generator~/tests/unit/discovery-invariants.test.ts
@@ -8,10 +8,47 @@
  */
 
 import { describe, test, expect } from 'vitest';
-import { assertWebFrameworkAliasInvariant } from '../../src/discovery.js';
+import {
+  assertWebFrameworkAliasInvariant,
+  discoverInstalledVersions,
+  resolveVersionPaths,
+} from '../../src/discovery.js';
 
 describe('web-framework alias invariant', () => {
   test('devDependencies의 web-framework-X.Y.Z 최고 버전이 dependencies 버전과 일치해야 함', () => {
     expect(() => assertWebFrameworkAliasInvariant()).not.toThrow();
   });
+});
+
+describe('web-framework 3.x self-bundle invariant', () => {
+  // web-framework 3.x+는 별도 web-bridge sibling 패키지 없이 자체 dist/index.d.ts에
+  // 전체 API 표면을 번들링한다(discovery.ts detectSelfContainedDts). 이 invariant는
+  // 설치된 3.x+ alias 전부가 실제로 'self-bundle'로 판정되는지 검증한다 — 판정이
+  // 깨지면(예: 4.x에서 번들 방식이 또 바뀜) resolveVersionPaths의 fail-loud 게이트가
+  // pnpm-store 폴백에 대해 throw하겠지만, 이 테스트는 그 회귀를 changelog 생성을
+  // 직접 돌리지 않고도 PR CI에서 더 빠르고 명시적으로 잡아낸다.
+  const major3PlusVersions = discoverInstalledVersions().filter(v => Number(v.split('.')[0]) >= 3);
+
+  test.each(major3PlusVersions.map(v => ({ version: v })))(
+    'v$version은 self-bundle로 판정되어야 함',
+    async ({ version }) => {
+      const paths = await resolveVersionPaths(version);
+      expect(paths.dtsSource).toBe('self-bundle');
+    },
+  );
+
+  // 음성(negative) invariant: 2.x 이하는 self-bundle로 판정되면 안 된다.
+  // 현재는 2.x web-bridge 패키지에 dist/index.d.ts 자체 번들 형태가 없어 우연히
+  // 안전하지만(detectSelfContainedDts가 애초에 감지하지 못함), 그 우연에 기대지 않고
+  // 명시적으로 고정한다 — 향후 2.x 배포 방식이 바뀌어도 self-bundle 오판정이면 여기서
+  // 즉시 잡힌다.
+  const majorBelow3Versions = discoverInstalledVersions().filter(v => Number(v.split('.')[0]) < 3);
+
+  test.each(majorBelow3Versions.map(v => ({ version: v })))(
+    'v$version은 self-bundle로 판정되면 안 됨',
+    async ({ version }) => {
+      const paths = await resolveVersionPaths(version);
+      expect(paths.dtsSource).not.toBe('self-bundle');
+    },
+  );
 });

--- a/sdk-runtime-generator~/tests/unit/multi-version.test.ts
+++ b/sdk-runtime-generator~/tests/unit/multi-version.test.ts
@@ -40,7 +40,15 @@ describe('다중 버전 호환성 테스트', () => {
     beforeAll(async () => {
       paths = await resolveVersionPaths(version);
       const frameworkApiNames = hasFrameworkApis(version) ? FRAMEWORK_APIS : [];
-      apis = await createParserForVersion(paths).parseAPIs(frameworkApiNames);
+      // changelog 파이프라인(generate-changelog.ts)과 동일한 옵션 — self-bundle(3.x+)
+      // index.d.ts의 deprecated 최상위 함수(checkoutPayment 등)를 isDeprecated=true로
+      // 보존하고, intersection/제네릭 wrapper 화살표 타입(getServerTime 등)도 감지해서
+      // 파싱한다 (detection.ts detectGlobalFunctions 참고).
+      const isSelfBundle = paths.dtsSource === 'self-bundle';
+      apis = await createParserForVersion(paths).parseAPIs(frameworkApiNames, {
+        includeDeprecatedGlobals: isSelfBundle,
+        includeWrappedCallables: isSelfBundle,
+      });
     });
 
     test('TypeScript 정의 파일 디렉토리를 찾을 수 있어야 함', () => {
@@ -60,10 +68,37 @@ describe('다중 버전 호환성 테스트', () => {
 
     test('핵심 API가 포함되어야 함', () => {
       const apiNames = new Set(apis.map(a => a.name));
-      // 모든 버전에 존재하는 기본 API
+      const major = Number(version.split('.')[0]);
+
+      // appLogin은 3.x에서도 플랫 함수로 그대로 남아있음 (실측)
       expect(apiNames.has('appLogin')).toBe(true);
-      expect(apiNames.has('getDeviceId')).toBe(true);
-      expect(apiNames.has('checkoutPayment')).toBe(true);
+
+      if (major < 3) {
+        // 2.x 이하: getDeviceId/checkoutPayment가 플랫 함수로 존재
+        expect(apiNames.has('getDeviceId')).toBe(true);
+        expect(apiNames.has('checkoutPayment')).toBe(true);
+      } else {
+        // 3.x+: web-framework 자체 dist/index.d.ts(discovery.ts detectSelfContainedDts가
+        // 'self-bundle'로 판정)는 getDeviceId/checkoutPayment를 여전히 최상위 export로
+        // 유지하되 @deprecated JSDoc만 붙인다(실측: 3.0.1 index.d.ts). self-bundle 경로에서
+        // 파서는 이런 deprecated 플랫 함수를 제거하지 않고 isDeprecated=true로 보존한다
+        // (detectGlobalFunctions의 includeDeprecatedGlobals 옵션) — 그래서 getDeviceId/
+        // checkoutPayment 둘 다 여전히 파싱 결과에 존재한다.
+        expect(apiNames.has('getDeviceId')).toBe(true);
+        expect(apiNames.has('checkoutPayment')).toBe(true);
+        const flatCheckoutPayment = apis.find(a => a.name === 'checkoutPayment');
+        expect(flatCheckoutPayment?.isDeprecated).toBe(true);
+
+        // TossPay 네임스페이스 객체는 checkoutPayment를 `typeof checkoutPayment`로
+        // 그대로 재노출하며, 이 재노출 지점(TossPay.checkoutPayment)에도 별도로
+        // `@deprecated TossPay.authorize를 사용해주세요` JSDoc이 붙어 있다(실측).
+        // 즉 TossPayCheckoutPayment는 대체 API가 아니라 checkoutPayment와 동일하게
+        // deprecated된 별칭이며, 실제 대체 API는 TossPayAuthorize다.
+        expect(apiNames.has('TossPayCheckoutPayment')).toBe(true);
+        const namespacedCheckoutPayment = apis.find(a => a.name === 'TossPayCheckoutPayment');
+        expect(namespacedCheckoutPayment?.isDeprecated).toBe(true);
+        expect(apiNames.has('TossPayAuthorize')).toBe(true);
+      }
     });
 
     test('FRAMEWORK_APIS 호환성', () => {

--- a/sdk-runtime-generator~/tests/unit/report/changelog-model.ts
+++ b/sdk-runtime-generator~/tests/unit/report/changelog-model.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ParsedAPI } from '../../../src/types.js';
-import { getCategory, EXCLUDED_APIS } from '../../../src/categories.js';
+import { getCategory, EXCLUDED_APIS, CHANGELOG_ONLY_CATEGORIES } from '../../../src/categories.js';
 import { mapToCSharpType } from '../../../src/validators/types.js';
 
 export interface SerializedParam {
@@ -38,13 +38,17 @@ export interface SerializedAPI {
 }
 
 function serializeAPI(api: ParsedAPI, versions: string[]): SerializedAPI {
-  const category = getCategory(api.name);
+  const category = getCategory(api.name, true, CHANGELOG_ONLY_CATEGORIES);
+  // file은 리포트 표시용 category가 아니라 C# 생성기와 동일한 분류(getCategory 기본 맵)를
+  // 따라야 한다 — HTML 렌더러가 이 값으로 Runtime/SDK/<file> 딥링크를 만들기 때문에,
+  // CHANGELOG_ONLY_CATEGORIES로 재분류된 이름을 쓰면 실존하지 않는 .cs 파일(404)을 가리킨다.
+  const generatorCategory = getCategory(api.name, false);
   return {
     name: api.name,
     pascalName: api.pascalName,
     displayName: 'AIT.' + api.pascalName,
     category,
-    file: 'AIT.' + category + '.cs',
+    file: 'AIT.' + generatorCategory + '.cs',
     description: api.description,
     returnDescription: api.returnDescription,
     examples: api.examples,
@@ -225,7 +229,7 @@ export function buildChangelogModel(
   for (const [version, apis] of filteredVersionApis) {
     const catMap = new Map<string, string[]>();
     for (const api of apis) {
-      const cat = getCategory(api.name);
+      const cat = getCategory(api.name, true, CHANGELOG_ONLY_CATEGORIES);
       if (!catMap.has(cat)) catMap.set(cat, []);
       catMap.get(cat)!.push(api.name);
     }

--- a/sdk-runtime-generator~/tests/unit/scripts/generate-changelog.ts
+++ b/sdk-runtime-generator~/tests/unit/scripts/generate-changelog.ts
@@ -57,11 +57,27 @@ async function main() {
     // resolveVersionPaths는 dtsDir을 못 찾으면 명확한 한국어 메시지로 throw한다 —
     // 과거처럼 "if (!paths.dtsDir) continue"로 조용히 스킵하지 않는다.
     const paths = await resolveVersionPaths(version);
-    if (paths.dtsSource !== 'sibling') {
+    // 'sibling'과 'self-bundle' 모두 그 버전 자신의 실제 .d.ts를 정확히 반영한다
+    // (self-bundle: web-framework 3.x+가 별도 web-bridge sibling 없이 자체
+    // dist/index.d.ts에 전체 API 표면을 번들링 — discovery.ts detectSelfContainedDts
+    // 참고). "근사(폴백)"로 표시해야 하는 건 stale 버전을 근사로 사용하는
+    // pnpm-store/package-dir뿐이다.
+    if (paths.dtsSource !== 'sibling' && paths.dtsSource !== 'self-bundle') {
       approximatedVersions.push(version);
     }
     const frameworkApiNames = hasFrameworkApis(version) ? FRAMEWORK_APIS : [];
-    const apis = await createParserForVersion(paths).parseAPIs(frameworkApiNames);
+    // self-bundle(3.x+) index.d.ts는 deprecated 최상위 함수(checkoutPayment 등)를 여전히
+    // export하고, getServerTime/fetchAlbumPhotos 류는 intersection/제네릭 wrapper
+    // 화살표 타입(예: `(() => X) & { isSupported }`, `PermissionFunctionWithDialog<...>`)
+    // 으로 선언되어 있다 — includeDeprecatedGlobals/includeWrappedCallables로 둘 다
+    // 감지해 diff가 "제거"가 아니라 "변경(deprecated 전환)"으로 잡히게 한다.
+    // sibling(2.x)은 opt-in하지 않는다 — 같은 이름이 file-per-API 경로에서 이미
+    // 파싱되므로 여기서 켜면 중복이 생긴다(detection.ts isWrappedCallableType 참고).
+    const isSelfBundle = paths.dtsSource === 'self-bundle';
+    const apis = await createParserForVersion(paths).parseAPIs(frameworkApiNames, {
+      includeDeprecatedGlobals: isSelfBundle,
+      includeWrappedCallables: isSelfBundle,
+    });
     versionApis.set(version, apis);
   }
   if (approximatedVersions.length > 0) {


### PR DESCRIPTION
## 문제

changelog 리포트가 web-framework 3.0.x 전이를 전부 "변경 없음"으로 오보하고 있었다 (`v2.10.8 → v3.0.1: 변경 없음`, 이후 3.0.2~3.0.4도 동일). 실제 3.0은 네임스페이스 재편(Device/TossPay/Share 등)과 플랫 함수 대량 deprecated 전환이 있었던 대규모 표면 변경이다.

## 원인

- 3.x는 `@apps-in-toss/web-bridge` sibling 없이 **자체 `dist/index.d.ts`에 전체 API 표면을 번들링**한다 (`@webview-bridge/web` 의존으로 전환).
- 발견 후보 순서상 pnpm-store 폴백(최신 `web-bridge` = **stale 2.10.8**)이 먼저 걸려, 3.0.1~3.0.4 전 버전이 동일한 구 표면을 파싱 → diff 입력이 서로 같아져 "변경 없음"이 됨.

## 수정 (changelog 경로에만 opt-in — C# 생성 경로 불변)

1. **discovery** (`src/discovery.ts`)
   - `detectSelfContainedDts()`: `dist/index.d.ts`의 `//#region ` 마커 수(≥10)로 자기완결 번들 판정, changelog 전용 `resolveVersionPaths()`에서만 최우선 적용 (`dtsSource: 'self-bundle'`).
   - **fail-loud 게이트**: major≥3인데 pnpm-store 폴백이 걸리면 조용한 근사 대신 즉시 throw — 4.x에서 같은 버그 재발 방지.
2. **파서** (`detection.ts`/`TypeScriptParser.ts`/`namespace-parser.ts`/`api-parser.ts`)
   - self-bundle 파싱 시에만 켜지는 opt-in 옵션 `includeDeprecatedGlobals`/`includeWrappedCallables`: 3.x가 살려둔 `@deprecated` 플랫 함수 47종을 "제거"가 아닌 "**변경(deprecated 전환)**"으로 보존하고, intersection/제네릭 wrapper 형태의 화살표 콜러블을 감지.
   - JSDoc이 `VariableStatement`에 붙는 ts-morph 특성 대응(`getJsDocsForDeclaration`), `createAsyncBridge`는 ts-morph 순환으로 `RangeError`를 유발해 파서 레벨 제외 + 선언 단위 try/catch 가드.
3. **카테고리** (`categories.ts`)
   - changelog 표시 전용 `CHANGELOG_ONLY_CATEGORIES` 격리 맵 신설. `API_CATEGORIES`에 직접 추가하면 C# 생성 분류가 바뀌는 회귀를 **실측으로 확인한 뒤** 격리했다 (2.10.8 폴백 표면이 같은 플랫 이름을 공유).
   - 소스 딥링크 `file:` 필드는 생성기와 동일 분류 유지 — 실존하지 않는 `.cs` 파일 링크(404) 방지.
4. **기타**: self-bundle 시 web-analytics 중복 파싱 스킵(카탈로그 Analytics 중복 제거), FRAMEWORK_APIS 우선 dedup, discovery 불변식 테스트(양·음성) 추가.

## 결과 (실측)

| 항목 | before | after |
|------|--------|-------|
| v2.10.8 → v3.0.1 | 변경 없음 | **추가 42 · 변경 64 · 제거 0** (변경 중 47건 = deprecated 전환) |
| v3.0.1 → 3.0.4 | 근사 폴백 | 정직한 "변경 없음" (3.0.1~3.0.3 d.ts 바이트 동일, 3.0.4는 side-effect import 1줄 차이) |
| 근사(폴백) 표기 | 4건 | **0건** |
| 카테고리 경고 / Analytics 중복 | — | 0건 / 0건 |

## 검증

- `pnpm generate` → `Runtime/SDK/` **무변경** (git status clean) — 생성 경로 불변 게이트
- 설치된 major<3 전 버전(66개) 파싱 결과 HEAD 대비 **바이트 동일** 검증
- `pnpm test` 843/843 green, `./run-local-tests.sh --validate` 통과
- 리포트 결정성: 2회 생성 md5 동일

## 후속 (이 PR 범위 아님)

- **rename 매핑**: 추가 42/변경 64로 잡힌 churn을 "rename"으로 읽히게 하는 매핑 테이블 (별도 PR 예정)
- `config.d.ts` 스키마 diff (`withTitle` 등)
- C# 생성 경로가 3.x `@deprecated` 플랫 alias에 의존하는 구조적 문제 — 4.x에서 alias 제거 시 깨짐. 제품 결정 필요라 명시적으로 범위 제외.
