### PR TITLE
기능: 쇼핑 광고(IAC) Ads 네임스페이스 SDK 생성 지원

### DIFF
--- a/sdk-runtime-generator~/src/categories.ts
+++ b/sdk-runtime-generator~/src/categories.ts
@@ -71,6 +71,9 @@ export const API_CATEGORIES: Record<string, string[]> = {
     // Full Screen Ads (top-level exports)
     'loadFullScreenAd',
     'showFullScreenAd',
+    // Shopping Ads / IAC 라우팅 (web-framework 3.1.0+, Ads 네임스페이스)
+    'AdsShowTossAdOrShoppingAds',
+    'AdsShowTossShoppingAds',
   ],
   SafeArea: [
     'SafeAreaInsetsGet',
@@ -115,6 +118,7 @@ export const CATEGORY_INFERENCE_RULES: CategoryInferenceRule[] = [
   { pattern: /^IAP[A-Z]/, category: 'IAP' },
   { pattern: /^Storage[A-Z]/, category: 'Storage' },
   { pattern: /^GoogleAdMob/, category: 'Advertising' },
+  { pattern: /^Ads[A-Z]/, category: 'Advertising' },
   { pattern: /^TossAds/, category: 'Advertising' },
   { pattern: /^SafeArea/, category: 'SafeArea' },
   { pattern: /^Partner/, category: 'Partner' },
@@ -316,6 +320,19 @@ export function resolveApiCategory(
 export const FRAMEWORK_APIS: string[] = [
   'loadFullScreenAd',
   'showFullScreenAd',
+];
+
+/**
+ * web-framework 번들 index.d.ts에서 보충 파싱을 허용하는 네임스페이스 목록
+ *
+ * 생성기의 기본 입력은 web-bridge의 파일별 .d.ts지만, 3.x부터 web-framework가
+ * web-bridge에 없는 자체 API(예: Ads — 쇼핑 광고 라우팅)를 번들 index.d.ts에만
+ * 선언한다. 여기 등재된 네임스페이스만 번들에서 추가로 파싱한다
+ * (opt-in — 번들 전체를 파싱하면 의도하지 않은 API 표면 확장이 생기므로).
+ * 설치된 web-framework 버전에 해당 네임스페이스가 없으면 조용히 무시된다.
+ */
+export const BUNDLED_NAMESPACE_ALLOWLIST: string[] = [
+  'Ads', // 쇼핑 광고 라우팅 (web-framework 3.1.0+)
 ];
 
 /**

--- a/sdk-runtime-generator~/src/generators/csharp/type-collector.ts
+++ b/sdk-runtime-generator~/src/generators/csharp/type-collector.ts
@@ -385,8 +385,17 @@ export function collectFunctionParamTypes(
     }
     // Union 멤버들도 재귀 처리
     if (paramType.unionTypes) {
+      // named union이면 union 이름을 컨텍스트로 전달한다. 익명 object 멤버의 중첩
+      // 프로퍼티가 부모 컨텍스트 없이 명명되어 고아 타입(예: data → 'DataType')이
+      // 생기는 것을 막는다 — 병합 클래스(예: ShowTossAdOrShoppingAdsEvent)와 그
+      // 중첩 타입(...EventData)이 이미 수집되어 있어 같은 이름은 스킵된다.
+      // named 멤버는 isAnonymous=false 경로라 컨텍스트의 영향을 받지 않는다.
+      const unionContext =
+        paramType.name && paramType.name.includes('.')
+          ? extractCleanName(paramType.name)
+          : contextName;
       for (const member of paramType.unionTypes) {
-        collectFunctionParamTypes(member, typeMap, exclude, tracker, generateClassType);
+        collectFunctionParamTypes(member, typeMap, exclude, tracker, generateClassType, unionContext);
       }
     }
   }

--- a/sdk-runtime-generator~/src/generators/unity-bridge.ts
+++ b/sdk-runtime-generator~/src/generators/unity-bridge.ts
@@ -6,6 +6,7 @@
  */
 
 import { ParsedAPI, isFromWebAnalytics } from '../types.js';
+import { BUNDLED_NAMESPACE_ALLOWLIST } from '../categories.js';
 
 /**
  * Unity Bridge TypeScript 코드 생성
@@ -31,8 +32,15 @@ export function generateUnityBridge(apis: ParsedAPI[]): string {
   const sortedAnalyticsNs = Array.from(analyticsNamespaces).sort();
   const sortedNamespaces = [...sortedFrameworkNs, ...sortedAnalyticsNs].sort();
 
+  // 번들(dist/index.d.ts) 전용 네임스페이스는 named import 대상에서 제외한다.
+  // 구버전 web-framework나 devtools mock에는 해당 export가 없을 수 있는데,
+  // named import는 export 누락 시 link-time 에러로 unity-bridge 모듈 그래프 전체를 죽인다.
+  const bundledSet = new Set(BUNDLED_NAMESPACE_ALLOWLIST);
+  const staticFrameworkNs = sortedFrameworkNs.filter(ns => !bundledSet.has(ns));
+  const bundledFrameworkNs = sortedFrameworkNs.filter(ns => bundledSet.has(ns));
+
   // 네임스페이스 import 문 생성 (패키지별 분리)
-  const frameworkImports = sortedFrameworkNs
+  const frameworkImports = staticFrameworkNs
     .map(ns => `import { ${ns} } from '@apps-in-toss/web-framework';`)
     .join('\n');
   const analyticsImports = sortedAnalyticsNs
@@ -40,10 +48,33 @@ export function generateUnityBridge(apis: ParsedAPI[]): string {
     .join('\n');
   const allImports = [frameworkImports, analyticsImports].filter(Boolean).join('\n');
 
+  // 번들 전용 네임스페이스 방어적 접근자 (없으면 undefined — 모듈 로드는 계속된다)
+  const bundledAccessors = bundledFrameworkNs
+    .map(
+      ns => `// ${ns}는 번들 전용 네임스페이스 — 구버전 web-framework/devtools mock에 없을 수 있어
+// named import(누락 시 link-time 에러) 대신 방어적으로 접근한다.
+const ${ns} = (WebFramework as Record<string, any>)['${ns}'];`,
+    )
+    .join('\n');
+  const bundledAccessorBlock = bundledAccessors ? `\n\n${bundledAccessors}` : '';
+
   // 네임스페이스 타입 정의 생성
   const namespaceTypeProps = sortedNamespaces
     .map(ns => `      ${ns}: typeof ${ns};`)
     .join('\n');
+
+  // 번들 전용 네임스페이스가 있을 때만 undefined 스킵 가드를 넣는다
+  // (없을 때는 기존 생성물과 byte-identical 유지)
+  const undefinedGuard =
+    bundledFrameworkNs.length > 0
+      ? `    // 번들 전용 네임스페이스가 설치된 web-framework에 없으면 노출을 건너뛴다
+    if (_value === undefined) {
+      console.warn(\`[Unity Bridge] \${_name} is not available in the installed @apps-in-toss/web-framework — skipping\`);
+      continue;
+    }
+
+`
+      : '';
 
   // 네임스페이스 노출 코드 생성 (Unity 6000.3+ Module 읽기 전용 속성 호환)
   const namespaceList_code = sortedNamespaces.join(', ');
@@ -51,7 +82,7 @@ export function generateUnityBridge(apis: ParsedAPI[]): string {
 const _aitNamespaces = { ${namespaceList_code} };
 for (const [_name, _value] of Object.entries(_aitNamespaces)) {
   try {
-    // 이미 존재하고 값이 같으면 건너뛰기
+${undefinedGuard}    // 이미 존재하고 값이 같으면 건너뛰기
     if ((window.AppsInToss as any)[_name] === _value) continue;
 
     // Object.defineProperty로 안전하게 속성 설정
@@ -81,7 +112,7 @@ for (const [_name, _value] of Object.entries(_aitNamespaces)) {
  */
 
 import * as WebFramework from '@apps-in-toss/web-framework';
-${allImports}
+${allImports}${bundledAccessorBlock}
 
 // window.AppsInToss 타입 정의
 declare global {

--- a/sdk-runtime-generator~/src/index.ts
+++ b/sdk-runtime-generator~/src/index.ts
@@ -15,7 +15,7 @@ import { typeCheckBridgeCode, printTypeCheckResult, cleanupCache } from './gener
 import { generateUnityBridge } from './generators/unity-bridge.js';
 import { generateScreenManualCs, generateScreenManualJslib, generateCoreManualJslib } from './generators/webgl-manual.js';
 import { formatCommand } from './commands/format.js';
-import { FRAMEWORK_APIS, EXCLUDED_APIS, DEPRECATED_API_OVERRIDES, CATEGORY_ORDER, DEFAULT_CATEGORY, resolveApiCategory } from './categories.js';
+import { FRAMEWORK_APIS, BUNDLED_NAMESPACE_ALLOWLIST, EXCLUDED_APIS, DEPRECATED_API_OVERRIDES, CATEGORY_ORDER, DEFAULT_CATEGORY, resolveApiCategory } from './categories.js';
 import { getApiImportSource, type ParsedAPI, type GeneratedTypeUnit } from './types.js';
 
 const program = new Command();
@@ -304,6 +304,18 @@ async function generate(options: {
     if (webAnalyticsPath) {
       parser.addSourceDirectory(webAnalyticsPath);
     }
+
+    // web-framework 번들 index.d.ts 보충 등록 (web-bridge에 없는 3.x 전용 네임스페이스 — 예: Ads)
+    const bundledIndexPath = path.join(webFrameworkPath, 'dist', 'index.d.ts');
+    if (BUNDLED_NAMESPACE_ALLOWLIST.length > 0) {
+      try {
+        await fs.access(bundledIndexPath);
+        parser.addBundledNamespaceSource(bundledIndexPath, BUNDLED_NAMESPACE_ALLOWLIST);
+      } catch {
+        // 번들 index.d.ts가 없는 구버전(web-bridge 배포 구조)이면 스킵
+      }
+    }
+
     const allParsedApis = await parser.parseAPIs(FRAMEWORK_APIS);
 
     // DOM-only 타입 위반 검증: 파싱 중 누적된 위반을 한 번에 보고하고 실패시킨다.

--- a/sdk-runtime-generator~/src/parser/TypeScriptParser.ts
+++ b/sdk-runtime-generator~/src/parser/TypeScriptParser.ts
@@ -14,6 +14,8 @@ import { resolvePackagePath } from '../generators/jslib-compiler.js';
 export class TypeScriptParser {
   private project: Project;
   private _frameworkDtsPath?: string;
+  private bundledNamespaceSource?: import('ts-morph').SourceFile;
+  private bundledNamespaceAllowlist: Set<string> = new Set();
 
   constructor(private sourceDir: string, private webFrameworkPath?: string) {
     // tsconfig.json 경로 찾기 (상위 디렉토리도 확인)
@@ -61,6 +63,19 @@ export class TypeScriptParser {
    */
   addSourceDirectory(dir: string): void {
     this.project.addSourceFilesAtPaths(path.join(dir, '**', '*.d.ts'));
+  }
+
+  /**
+   * web-framework 번들 index.d.ts를 보충 네임스페이스 소스로 등록
+   *
+   * 기본 입력(web-bridge의 파일별 .d.ts)에 없는 3.x 전용 네임스페이스(예: Ads)를
+   * 번들에서 추가로 파싱하기 위한 opt-in 경로. allowedNamespaces에 등재된
+   * 네임스페이스의 API만 채택하고, 기본 소스에서 이미 파싱된 API와 이름이
+   * 겹치면 기본 소스 결과를 우선한다 (parseAPIs 참조).
+   */
+  addBundledNamespaceSource(filePath: string, allowedNamespaces: string[]): void {
+    this.bundledNamespaceSource = this.project.addSourceFileAtPath(filePath);
+    this.bundledNamespaceAllowlist = new Set(allowedNamespaces);
   }
 
   /**
@@ -173,6 +188,11 @@ export class TypeScriptParser {
     const sourceFiles = this.project.getSourceFiles();
 
     for (const sourceFile of sourceFiles) {
+      // 번들 보충 소스는 메인 루프에서 제외 (아래에서 허용목록 기반으로만 파싱)
+      if (sourceFile === this.bundledNamespaceSource) {
+        continue;
+      }
+
       const filePath = sourceFile.getFilePath();
       const fileName = path.basename(filePath);
 
@@ -190,6 +210,20 @@ export class TypeScriptParser {
 
       const fileAPIs = parseSourceFile(sourceFile);
       apis.push(...fileAPIs);
+    }
+
+    // web-framework 번들 보충 파싱: 허용목록 네임스페이스만, 기본 소스와 중복되지 않는 것만
+    if (this.bundledNamespaceSource && this.bundledNamespaceAllowlist.size > 0) {
+      const existingNames = new Set(apis.map(api => api.name));
+      const bundledAPIs = parseNamespaceObjects(this.bundledNamespaceSource, {
+        restrictToNamespaces: this.bundledNamespaceAllowlist,
+      }).filter(api => !existingNames.has(api.name));
+      if (bundledAPIs.length > 0) {
+        console.log(
+          `  번들 index.d.ts 보충 파싱: ${bundledAPIs.map(api => api.name).join(', ')}`,
+        );
+      }
+      apis.push(...bundledAPIs);
     }
 
     // @apps-in-toss/framework에서 추가 API 파싱 (web-framework에서 re-export되지 않는 API)

--- a/sdk-runtime-generator~/src/parser/constants.ts
+++ b/sdk-runtime-generator~/src/parser/constants.ts
@@ -56,6 +56,7 @@ export const DOM_TYPES = new Set([
  * 새 네임스페이스가 추가되어도 자동으로 처리됨
  */
 export const NAMESPACE_CATEGORY_OVERRIDES: Record<string, string> = {
+  Ads: 'Advertising',
   GoogleAdMob: 'Advertising',
   SafeAreaInsets: 'SafeArea',
   env: 'Environment',

--- a/sdk-runtime-generator~/src/parser/namespace-parser.ts
+++ b/sdk-runtime-generator~/src/parser/namespace-parser.ts
@@ -227,13 +227,39 @@ export function parseNamespaceObject(
  * @param options detectGlobalFunctions에 그대로 전달됨 (includeDeprecatedGlobals,
  *   includeWrappedCallables). 기본값 둘 다 false — 기존 동작 보존, changelog
  *   self-bundle 경로에서만 opt-in.
+ *
+ *   options.restrictToNamespaces 지정 시 이 집합에 속한 네임스페이스 객체만 파싱한다
+ *   (이벤트 네임스페이스·글로벌 함수 감지는 건너뜀). web-framework 번들 index.d.ts처럼
+ *   대형 파일에서 특정 네임스페이스만 골라 파싱할 때 사용 — 무관한 네임스페이스의
+ *   재귀 타입 순회로 인한 스택 오버플로우와 의도치 않은 API 표면 확장을 방지한다.
  */
 export function parseNamespaceObjects(
   sourceFile: SourceFile,
-  options?: { includeDeprecatedGlobals?: boolean; includeWrappedCallables?: boolean }
+  options?: {
+    includeDeprecatedGlobals?: boolean;
+    includeWrappedCallables?: boolean;
+    restrictToNamespaces?: Set<string>;
+  },
 ): ParsedAPI[] {
   const apis: ParsedAPI[] = [];
   const exportedDeclarations = sourceFile.getExportedDeclarations();
+
+  // 제한 모드: 허용목록의 네임스페이스 객체만 파싱하고 즉시 반환
+  const restrictToNamespaces = options?.restrictToNamespaces;
+  if (restrictToNamespaces) {
+    for (const [name, declarations] of exportedDeclarations) {
+      if (!restrictToNamespaces.has(name)) continue;
+      for (const declaration of declarations) {
+        if (declaration.getKind() === SyntaxKind.VariableDeclaration) {
+          const varDecl = declaration.asKind(SyntaxKind.VariableDeclaration);
+          if (varDecl) {
+            apis.push(...parseNamespaceObject(name, varDecl, sourceFile));
+          }
+        }
+      }
+    }
+    return apis;
+  }
 
   // 1. 이벤트 네임스페이스 감지 (addEventListener 패턴)
   const eventNamespaces = detectEventNamespaces(sourceFile);


### PR DESCRIPTION
## 배경

web-framework 3.1.0부터 쇼핑 광고(IAC) 라우팅 앱브릿지 `Ads.showTossAdOrShoppingAds` / `Ads.showTossShoppingAds`가 추가됐다 (토스앱 5.273.0+). 이 API는 3.x에서 처음 추가된 네임스페이스라 생성기의 기본 입력(web-bridge 파일별 .d.ts)에 존재하지 않아, 버전만 올려서는 SDK에 노출되지 않는다.

## 변경 내용

- **번들 보충 파싱 경로 신설**: web-framework 번들 `dist/index.d.ts`를 opt-in 허용목록(`BUNDLED_NAMESPACE_ALLOWLIST = ['Ads']`) 기반 보조 네임스페이스 소스로 파싱. 기본 소스와 이름이 겹치면 기본 소스 우선.
- `parseNamespaceObjects(sourceFile, restrictToNamespaces?)`: 허용목록 제한 모드 추가 — 대형 번들에서 무관한 네임스페이스의 재귀 타입 순회(스택 오버플로우)와 의도치 않은 API 표면 확장 방지.
- `Ads` → `Advertising` 카테고리 매핑 (`API_CATEGORIES` + `CATEGORY_INFERENCE_RULES` + `NAMESPACE_CATEGORY_OVERRIDES` — jslib은 기존 `AppsInToss-Advertising.jslib`에 통합).
- **type-collector 고아 타입 수정**: named union의 익명 멤버 재귀에 union 컨텍스트를 전달해, 부모 없는 고아 클래스(예: `data` → `DataType`) 생성 방지.

## 검증

- ✅ **3.0.4 기준 재생성 불변**: 이 변경만 적용하고 `pnpm generate` 시 `Runtime/SDK/` diff 0건 — 현행 stable 산출물에 영향 없음
- ✅ web-framework 3.1.0-beta.1로 임시 bump 시 `AdsShowTossAdOrShoppingAds` / `AdsShowTossShoppingAds`가 GoogleAdMob 콜백 선례와 동일 패턴으로 생성 (C# / jslib / unity-bridge.ts / AITCore 디스패치, jslib TS 타입 검사 58파일 통과)
- ✅ `pnpm test` 773/773 통과 (golden·invariants·discovery 포함)
- ✅ `./run-local-tests.sh --validate` / `--editmode` 통과

## 배포 계획

산출물(`Runtime/SDK/`)은 커밋하지 않음 — Beta Release 워크플로우가 `version=3.1.0-beta.1`, `source_ref=feat/ads-shopping-iac`로 재생성해 `beta-iac` 채널로 게시 예정. web-framework 3.1.0 GA 후 이 PR을 머지하면 SDK Update 자동화가 매핑을 그대로 사용한다.