### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — unity-bee-wasm-build-failure

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1853,6 +1853,15 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void BuildLibraryBee_ReleaseWasmObjFailed_19T_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-19T: 동일 형식의 또 다른 해시 .o 파일(GameAssembly release_WebGL_wasm).
+        // 기존 "Building Library/Bee/artifacts/WebGL/" 패턴이 새 해시 변형도 커버하는지 evidence로 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/k3yyjft82n8a.o failed with output:"));
+    }
+
+    [Test]
     public void BuildLibraryBee_WithAitPrefix_StillProtected()
     {
         // SDK 보호 가드: SDK가 동일 prefix로 출력하는 가상의 케이스도 필터링 안 되어야 함.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-19T

## 묶음 항목 (1개)

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-19T | "UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/k3yyjft82n8a.o failed with output:" |

## 분석

Unity Bee/Emscripten(wasm) 빌드 툴체인의 emcc 컴파일 실패 로그로 SDK 외부 출처입니다. `AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 이미 `"Building Library/Bee/artifacts/WebGL/"` 패턴이 존재하며, 이 패턴은 오늘 보고된 메시지(`UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/k3yyjft82n8a.o failed with output:`)를 부분 문자열로 이미 커버합니다. 동일 형식의 다른 해시 변형(SDK-W0, SDK-VZ)도 과거 동일한 방식(패턴 추가 없이 evidence 테스트만 추가)으로 auto 분류된 전례가 있습니다.

## 변경 내용

- 패턴 배열(`NonSdkMessagePatterns`) 변경 없음 — 기존 패턴이 이미 커버.
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`에 이번 이슈의 evidence(새 해시 `.o` 파일명)로 positive 테스트 1건 추가해 커버리지를 검증.

## 검증

- `./run-local-tests.sh --validate` 통과 (SDK Generator Unit Tests 68 passed, Meta GUID Hygiene 통과 등 4/4 항목 통과)
- 참고: `--validate`는 Unity Editor 없이 도는 빠른 검증으로, C# EditModeTests 자체(Unity Test Runner)는 CI에서 실행됨.

사람 머지 검토 필요.