### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — cs0067-unused-event-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -1540,6 +1540,19 @@ namespace AppsInToss.Editor.ErrorTracker
                 && !message.StartsWith("[AIT", StringComparison.Ordinal))
                 return true;
 
+            // 사용자 코드의 미사용 이벤트 선언 경고 (CS0067) — Unity 컴파일러가 직접 출력.
+            // 예: "Assets\ArrowPuzzle\Scripts\AppsInToss\AppsInTossStorageManager.WeeklyLeague.cs(89,31):
+            //       warning CS0067: The event 'AppsInTossStorageManager.WeeklyLeagueResultStateChanged' is never used"
+            // Sentry APPS-IN-TOSS-UNITY-SDK-1A3.
+            // 사용자 클래스명(AppsInTossStorageManager)에 'AppsInToss' 토큰이 포함돼 SDK 키워드 가드가
+            // 발동하므로 CS1998/CS0618과 동일하게 가드보다 먼저 매칭한다(Assets/ 경로 + .cs(L,C) 패턴).
+            // SDK 자체 코드는 Packages/ 또는 Library/PackageCache/ 경로로 출력되어 Assets/ 가드와 충돌 없음.
+            if (message.IndexOf("warning CS0067", StringComparison.Ordinal) >= 0
+                && (message.IndexOf("Assets/", StringComparison.Ordinal) >= 0
+                    || message.IndexOf("Assets\\", StringComparison.Ordinal) >= 0)
+                && message.IndexOf(".cs(", StringComparison.Ordinal) >= 0)
+                return true;
+
             // SDK 자체 로그는 절대 필터링하지 않음 — AitKeywords 전체를 가드로 사용
             if (MessageContainsSdkKeyword(message))
                 return false;

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -2348,6 +2348,34 @@ public class IsKnownNonSdkMessageTests
             "SomeLib.dll: warning CS0618: 'Z' is obsolete"));
     }
 
+    [Test]
+    public void UserCodeCs0067_AssetsBackslashPath_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-1A3 — 사용자 프로젝트(Assets/) 코드의 미사용 이벤트 선언 경고.
+        // 사용자 클래스명 'AppsInTossStorageManager'가 단어 경계 없이 붙어 키워드 가드를 우회하므로
+        // Assets/ + .cs(L,C) 합성으로 좁혀 매칭.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Assets\\ArrowPuzzle\\Scripts\\AppsInToss\\AppsInTossStorageManager.WeeklyLeague.cs(89,31): warning CS0067: The event 'AppsInTossStorageManager.WeeklyLeagueResultStateChanged' is never used"));
+    }
+
+    [Test]
+    public void Cs0067_SdkPackagePath_NeverFiltered()
+    {
+        // SDK 자체 .cs의 CS0067은 Packages/com.toss.apps-in-toss 경로로 출력 → Assets/ 가드 미충족 +
+        // "apps-in-toss" 키워드 가드 보호. SDK 코드 경고는 절대 드롭하지 않는다.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "Packages/com.toss.apps-in-toss/Runtime/Foo.cs(10,5): warning CS0067: The event 'Foo.OnChanged' is never used"));
+    }
+
+    [Test]
+    public void Cs0067_NoAssetsPath_NotFiltered()
+    {
+        // Assets/ 경로도 .cs(L,C)도 없는 일반 CS0067은 합성 가드가 매칭되지 않아 통과.
+        // CS0067을 무차별 드롭하지 않음을 검증.
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "SomeLib.dll: warning CS0067: 'Z' is never used"));
+    }
+
     #endregion
 
     #region Android 키스토어 노이즈 (APPS-IN-TOSS-UNITY-SDK-118)


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-1A3

## 묶음 항목 (N=1)

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-1A3 | `UnityWarning: Assets\ArrowPuzzle\Scripts\AppsInToss\AppsInTossStorageManager.WeeklyLeague.cs(89,31): warning CS0067: The event 'AppsInTossStorageManager.WeeklyLeagueResultStateChanged' is never used` |

## 판단 근거

CS0067(사용되지 않는 이벤트) 컴파일러 경고는 Unity C# 컴파일러가 사용자 코드(`Assets\ArrowPuzzle\...`)에 대해 직접 출력하는 노이즈입니다. 메시지에 `AppsInToss` 토큰이 들어있어 `MessageContainsSdkKeyword` 가드에 걸리지만, 이는 SDK 자체 로그가 아니라 사용자가 자신의 클래스명(`AppsInTossStorageManager`)에 그 문자열을 포함시킨 것뿐입니다.

기존 코드(`AITEditorErrorTracker.cs`)를 확인한 결과 CS0105/CS1998/CS0618/CS1061/CS0103/CS0246/CS1503 등 거의 동일한 패턴(파일/클래스명에 `AppsInToss`가 들어간 CS#### 사용자 코드 경고)이 이미 "가드보다 먼저 매칭되는 bypass" 형태로 여러 건 처리된 강한 선례가 있어, CS0067도 동일한 방식으로 처리했습니다.

## 변경 내용

- `Editor/ErrorTracker/AITEditorErrorTracker.cs`: `MessageContainsSdkKeyword` 체크(구 라인 ~1544, CS1998/CS0618과 동일 패턴) 이전에 `warning CS0067` + `Assets/`(또는 `Assets\`) 경로 + `.cs(` 조건의 bypass guard 추가.
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`: 아래 3개 회귀 테스트 추가.
  - `UserCodeCs0067_AssetsBackslashPath_ReturnsTrue`: Sentry 원본 메시지로 positive 검증
  - `Cs0067_SdkPackagePath_NeverFiltered`: SDK 자체 `Packages/com.toss.apps-in-toss/...` 경로는 절대 필터링되지 않음(negative 가드)
  - `Cs0067_NoAssetsPath_NotFiltered`: `Assets/` 경로가 없는 일반 CS0067은 무차별 드롭되지 않음(negative 가드)

## 검증

`./run-local-tests.sh --validate` 통과 (SDK Generator Unit Tests / Meta GUID Hygiene / E2E 구조 검증 등 4개 항목 모두 성공). 단, 이 스크립트는 Unity EditMode 테스트(`IsKnownNonSdkMessageTests.cs`)를 직접 실행하지 않으므로, 추가한 3개 테스트 케이스는 사람이 Unity Test Runner로 별도 확인 필요.

**사람 머지 검토 필요.**
