### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — webgl-bee-emcc-build-failure

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1910,6 +1910,15 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void BuildLibraryBee_MasterWasmObjFailed_19V_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-19V: master_WebGL_wasm 변형의 또 다른 해시 .o 파일.
+        // 기존 "Building Library/Bee/artifacts/WebGL/" 패턴이 release/master 변형 모두 커버하는지 evidence로 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/master_WebGL_wasm/j9ysjchgfghh.o failed with output:"));
+    }
+
+    [Test]
     public void BuildLibraryBee_WithAitPrefix_StillProtected()
     {
         // SDK 보호 가드: SDK가 동일 prefix로 출력하는 가상의 케이스도 필터링 안 되어야 함.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-19V

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-19V | `UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/master_WebGL_wasm/j9ysjchgfghh.o failed with output:` |

## 분석

Unity Bee/IL2CPP 빌드가 해시 파일명이 매번 다른 `.o` 컴파일 단위 실패를 직접 출력한 케이스로, `AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 이미 등록된 `"Building Library/Bee/artifacts/WebGL/"` 패턴으로 이미 커버됩니다 (release_WebGL_wasm/xv9ku506h1iu.o 등 기존 evidence와 동일 포맷, 이번 건은 master_WebGL_wasm 변형).

## 변경 내용

새 패턴 추가는 필요 없음 — 기존 패턴이 release/master 변형 모두 커버함을 확인.

- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`: `BuildLibraryBee_MasterWasmObjFailed_19V_ReturnsTrue` 테스트 추가 (이번 이슈의 evidence로 기존 패턴 커버리지 검증)

## 검증

- `./run-local-tests.sh --validate` 통과 (구조 검사 + SDK Generator 유닛 테스트 141개 전부 통과)

## 참고

사람 머지 검토 필요.