### PR TITLE
개선: 테스터 앱의 드래그 판정 임계값을 화면 밀도에 맞춰 보정

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/UIBuilderDragThresholdTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/UIBuilderDragThresholdTests.cs
@@ -1,0 +1,89 @@
+// -----------------------------------------------------------------------
+// UIBuilderDragThresholdTests.cs - 화면 밀도에 따른 드래그 임계값 환산 검증
+// Level 0: UIBuilder.ScaledDragThreshold 를 Unity 런타임 없이 검증한다.
+//
+// 배경: EventSystem.pixelDragThreshold는 탭과 드래그를 가르는 이동 거리다. 기본값 10은
+//   스크린 픽셀 기준이라 화면 밀도가 높을수록 물리 거리가 짧아진다 — WebGL에서 스크린
+//   픽셀은 캔버스 프레임버퍼 픽셀이고 이는 CSS 픽셀의 devicePixelRatio배다. 배율 2인
+//   기기에서는 1.5mm가 안 되어 가만히 눌러도 드래그로 판정된다.
+//
+//   그래서 기본값을 CSS 기준 밀도(96dpi)에서의 물리 거리로 보고 밀도에 비례해
+//   환산한다. WebGL의 Screen.dpi는 devicePixelRatio * 96이므로 결과는 배율과
+//   무관하게 항상 10 CSS 픽셀이 된다.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+
+[TestFixture]
+public class UIBuilderDragThresholdTests
+{
+    private const int UnityDefaultThreshold = 10;
+
+    // =====================================================
+    // 밀도별 환산
+    // =====================================================
+
+    [Test]
+    public void ScaledDragThreshold_CssBaselineDensity_LeavesThresholdUnchanged()
+    {
+        // devicePixelRatio 1 — 데스크톱 브라우저, 그리고 MOBILE_EMULATION이 아닌
+        // Playwright 프로필이 여기 해당한다. 이 경로는 기본값이 유지돼야 한다.
+        Assert.AreEqual(
+            UnityDefaultThreshold,
+            UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, 96f));
+    }
+
+    [Test]
+    public void ScaledDragThreshold_DoubleDensity_YieldsTenCssPixels()
+    {
+        // devicePixelRatio 2 → 20 프레임버퍼 픽셀 = 10 CSS 픽셀.
+        // 실기기(iPhone 15 Pro)와 CI의 MOBILE_EMULATION leg(iPhone 8 프로필) 둘 다
+        // 템플릿의 getOptimalDevicePixelRatio가 배율을 2로 깎아 Screen.dpi가 192가 된다.
+        Assert.AreEqual(20, UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, 192f));
+    }
+
+    [Test]
+    public void ScaledDragThreshold_TripleDensity_YieldsTenCssPixels()
+    {
+        // devicePixelRatio 3 → 30 프레임버퍼 픽셀 = 역시 10 CSS 픽셀.
+        // 배율이 달라져도 물리 거리가 일정하게 유지되는지 확인한다.
+        Assert.AreEqual(30, UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, 288f));
+    }
+
+    // =====================================================
+    // 임계값을 낮추지 않는다
+    // =====================================================
+
+    [Test]
+    public void ScaledDragThreshold_UnknownDensity_FallsBackToBase()
+    {
+        // Screen.dpi가 0을 반환하는 환경. 임의로 키우면 스크롤이 둔해지므로 기본값을 유지한다.
+        Assert.AreEqual(UnityDefaultThreshold, UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, 0f));
+        Assert.AreEqual(UnityDefaultThreshold, UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, -1f));
+    }
+
+    [Test]
+    public void ScaledDragThreshold_BelowBaselineDensity_DoesNotShrinkThreshold()
+    {
+        // 기준보다 낮은 밀도에서 임계값을 줄이면 스크롤 도중 원치 않는 클릭이 발생한다.
+        Assert.AreEqual(UnityDefaultThreshold, UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, 48f));
+    }
+
+    // =====================================================
+    // 경계
+    // =====================================================
+
+    [Test]
+    public void ScaledDragThreshold_FractionalRatio_RoundsToNearest()
+    {
+        // devicePixelRatio 1.5 → 15. 나눗셈이 정수로 떨어지는 경우.
+        Assert.AreEqual(15, UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, 144f));
+
+        // 아래 두 케이스는 소수부가 0.5 양쪽에 하나씩 놓이도록 골랐다.
+        // 반올림을 올림이나 버림으로 바꾸면 둘 중 하나가 반드시 깨진다.
+        // 11.458... → 11 (올림이면 12)
+        Assert.AreEqual(11, UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, 110f));
+        // 13.541... → 14 (버림이면 13)
+        Assert.AreEqual(14, UIBuilder.ScaledDragThreshold(UnityDefaultThreshold, 130f));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/UIBuilderDragThresholdTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/UIBuilderDragThresholdTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28d070ce1da04ddfa15e99156c35e2e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Runtime/UIBuilder.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/UIBuilder.cs
@@ -99,11 +99,62 @@ public static class UIBuilder
         if (EventSystem.current == null)
         {
             var esGo = new GameObject("EventSystem");
-            esGo.AddComponent<EventSystem>();
+            var eventSystem = esGo.AddComponent<EventSystem>();
             esGo.AddComponent<StandaloneInputModule>();
+            ScaleDragThresholdToScreenDensity(eventSystem);
         }
 
         return canvas;
+    }
+
+    /// <summary>
+    /// 드래그 판정 임계값을 화면 밀도에 맞춰 키웁니다.
+    ///
+    /// <see cref="EventSystem.pixelDragThreshold"/>는 탭과 드래그를 가르는 이동 거리이고,
+    /// 기본값 10은 Unity 스크린 픽셀 기준입니다. 이 단위는 화면 밀도에 따라 물리 거리가 달라집니다 —
+    /// WebGL에서는 스크린 픽셀이 캔버스 프레임버퍼 픽셀이라 CSS 픽셀의 devicePixelRatio배이고,
+    /// 배율 2인 기기에서 10 프레임버퍼 픽셀은 5 CSS 픽셀, 1.5mm가 안 됩니다. 손가락으로는
+    /// 가만히 눌러도 넘기는 거리입니다.
+    ///
+    /// 그래서 기본값을 CSS 기준 밀도(96dpi)에서의 물리 거리(약 2.6mm)로 보고, 화면 밀도에 비례해
+    /// 그 물리 거리를 유지합니다. WebGL의 <see cref="Screen.dpi"/>는 devicePixelRatio * 96이므로
+    /// (ScreenManagerWebGL::GetDPI가 배율에 96을 곱해 반환하고, 그 배율은 lib/SystemInfo.js의
+    /// JS_SystemInfo_GetPreferredDevicePixelRatio가 캔버스 스케일과 같은 값으로 넘겨줍니다)
+    /// 결과는 배율과 무관하게 항상 10 CSS 픽셀입니다. Android의 터치 슬롭 8dp(약 1.3mm)와
+    /// Chromium이 스크롤 판정에 쓰는 15 CSS 픽셀(약 4mm) 사이입니다.
+    ///
+    /// 배율 1인 환경(데스크톱 브라우저)에서는 기본값 그대로라 동작이 바뀌지 않습니다.
+    /// CI의 Playwright는 두 갈래인데, 기본 프로필은 배율 1이고 MOBILE_EMULATION=true인 leg는
+    /// iPhone 8 프로필(배율 2)이라 임계값이 20이 됩니다. 그 leg에서 이 경로를 타는 테스트는
+    /// test-interactive-mode 하나뿐이고 제스처를 검증하지 않아 결과에 영향이 없습니다.
+    ///
+    /// 주의: 이 값은 InputField가 탭에 반응하지 않는 증상과는 무관합니다. uGUI의 InputField는
+    /// IDragHandler를 자기가 구현하므로 pointerPress와 pointerDrag가 같은 GameObject가 되고,
+    /// PointerInputModule.ProcessDrag가 eligibleForClick을 끄는 조건(pointerPress != pointerDrag)이
+    /// 성립하지 않습니다. 임계값을 어떻게 잡든 InputField의 클릭은 취소되지 않습니다.
+    /// </summary>
+    private static void ScaleDragThresholdToScreenDensity(EventSystem eventSystem)
+    {
+        eventSystem.pixelDragThreshold =
+            ScaledDragThreshold(eventSystem.pixelDragThreshold, Screen.dpi);
+    }
+
+    /// <summary>CSS가 기준으로 삼는 밀도. Unity WebGL의 Screen.dpi도 이 값에 배율을 곱해 만들어집니다.</summary>
+    private const float CssReferenceDpi = 96f;
+
+    /// <summary>
+    /// <see cref="ScaleDragThresholdToScreenDensity"/>의 계산부. 테스트를 위해 분리했습니다.
+    /// dpi를 알 수 없거나(0 이하) 기준 밀도보다 낮으면 기준값을 그대로 돌려줍니다 —
+    /// 임계값을 낮추면 스크롤 도중 원치 않는 클릭이 발생합니다.
+    /// </summary>
+    /// <param name="baseThreshold">Unity 기본 임계값(스크린 픽셀).</param>
+    /// <param name="dpi"><see cref="Screen.dpi"/>. WebGL에서는 devicePixelRatio * 96입니다.</param>
+    public static int ScaledDragThreshold(int baseThreshold, float dpi)
+    {
+        if (dpi <= 0f) return baseThreshold;
+
+        int scaled = Mathf.RoundToInt(baseThreshold * (dpi / CssReferenceDpi));
+        return Mathf.Max(baseThreshold, scaled);
     }
 
     // ─── Safe Area ───


### PR DESCRIPTION
버그 수정이 아니라 밀도 보정 개선이다. 처음에는 실기기 키보드 증상의 수정으로 작성했지만 그 진단이 반증됐다 (아래 "원래 진단은 틀렸다"). 코드는 독립적으로 타당해서 남기고, 인과 주장만 걷어냈다.

## 무엇을 바꾸나

`Tests~/E2E`의 테스터 앱이 EventSystem을 만들 때 `pixelDragThreshold`를 화면 밀도에 맞춰 환산한다.

`pixelDragThreshold`는 탭과 드래그를 가르는 이동 거리다. 기본값 10은 Unity 스크린 픽셀 기준인데, WebGL에서 스크린 픽셀은 캔버스 프레임버퍼 픽셀이라 CSS 픽셀의 devicePixelRatio배다. 배율 2인 기기에서 10 프레임버퍼 픽셀은 5 CSS 픽셀, 1.5mm가 안 된다. 손가락으로는 가만히 눌러도 넘기는 거리다.

기본값을 CSS 기준 밀도(96dpi)에서의 물리 거리로 보고 밀도에 비례해 환산하면, 배율과 무관하게 항상 10 CSS 픽셀(약 2.6mm)이 된다. Android 터치 슬롭 8dp(약 1.3mm)와 Chromium이 스크롤 판정에 쓰는 15 CSS 픽셀(약 4mm) 사이다.

## `Screen.dpi = round(devicePixelRatio × 96)` 근거

6000.2.13f1의 `WebGLSupport_UnityPlayer.CoreModule_Dynamic.a`에서 `PlatformDependent_WebGL_Source_2_qfa7a.o`를 뽑아 `ScreenManagerWebGL::GetDPI`를 디스어셈블했다:

```
f64.load  160          ; this->[160]
f64.const 0x1.8p6      ; 96.0
f64.mul
f64.const 0x1p-1       ; 0.5
f64.add
i32.trunc_f64_s
f32.convert_i32_s
```

오프셋 160에 쓰는 곳은 생성자와 `Update` 둘뿐이고, 릴로케이션이 둘 다 같은 함수를 지목한다:

```
R_WASM_FUNCTION_INDEX_LEB JS_SystemInfo_GetPreferredDevicePixelRatio+0
```

그 JS 구현(`BuildTools/lib/SystemInfo.js:70`)이 반환하는 `Module.devicePixelRatio`는 캔버스 프레임버퍼 스케일링이 읽는 값과 같다. 따라서 `Screen.dpi / 96`이 CSS → 프레임버퍼 배율과 정확히 일치한다. 생성자가 값을 채우므로 첫 프레임 이전에도 0이 아니다.

## 원래 진단은 틀렸다

이 변경은 처음에 "고밀도 화면에서 스크롤 영역 안 InputField가 탭에 반응하지 않는" 증상의 수정으로 작성했다. 적대적 리뷰에서 그 인과가 반증됐고, uGUI 원본으로 직접 확인했다.

레거시 `UnityEngine.UI.InputField`는 `IBeginDragHandler`/`IDragHandler`/`IPointerClickHandler`를 자기가 구현한다 (`InputField.cs:17-27`, 텍스트 드래그 선택용). `ExecuteEvents.GetEventHandler<IDragHandler>`는 raycast 지점에서 부모로 올라가며 첫 매치에서 멈추므로 ScrollRect까지 도달하지 못하고 InputField 자신에서 끝난다. `pointerPress`도 같은 GameObject다.

`PointerInputModule.ProcessDrag`가 클릭을 취소하는 조건은 하나뿐이다:

```csharp
if (pointerEvent.dragging)
{
    if (pointerEvent.pointerPress != pointerEvent.pointerDrag)
    {
        ExecuteEvents.Execute(pointerEvent.pointerPress, pointerEvent, ExecuteEvents.pointerUpHandler);
        pointerEvent.eligibleForClick = false;
        ...
```

`pointerPress == pointerDrag`이므로 이 분기는 실행되지 않는다. 임계값을 어떻게 잡든 InputField의 클릭은 살아남는다. ScrollRect가 탭을 가로챈다는 메커니즘은 `IDragHandler`를 구현하지 않는 위젯(Button 등)에서만 성립한다.

**키보드 증상은 이 PR로 고쳐지지 않는다.** 그 원인은 #1141에서 실기기 실측으로 확정됐다. `ScrollRect.OnInitializePotentialDrag`가 `pointerDrag`(= InputField)에게만 실행돼 ScrollRect에 도달하지 못하고, 그래서 관성이 멈추지 않는다. 관성이 남은 상태에서 탭하면 콘텐츠가 손가락 밑에서 흐르고 release 시점 `currentOverGo`가 달라져 `pointerClick == pointerClickHandler` 비교가 깨진다. 변위 20 부근이 경계였고, 36탭 전부 `moved=0.0px` / `eligibleForClick=1` / `dragging=0`이었다. 임계값은 그 경로에 아예 개입하지 않는다.

그래서 이 PR은 버그 수정이 아니라 밀도 보정 개선으로 다시 프레이밍했다. 그 자체로는 타당하다 — Unity 기본값 10은 96dpi 데스크톱 기준이고, 고밀도 기기에서 물리 거리를 보존하도록 스케일하는 건 표준적인 조치다.

## 범위

`Tests~/E2E/SharedScripts/`의 테스터 앱만 바뀐다. SDK 런타임(`Runtime/`, `WebGLTemplates/`, `Editor/`)은 한 줄도 건드리지 않고, `Tests~/`는 UPM 배포에서 제외되므로 SDK 소비자에게 도달하지 않는다.

`CreateCanvas` 호출부는 `InteractiveAPITesterUI` 하나뿐이고, 이 경로는 `?e2e=true`가 아닌 대화형 모드에서만 실행된다. CI에서 이 경로를 타는 것은 `test-interactive-mode` 하나인데, `MOBILE_EMULATION=true`인 leg는 iPhone 8 프로필(배율 2)이라 임계값이 20이 된다. 그 테스트는 로그 확인과 스크린샷만 하고 제스처를 검증하지 않는다. Playwright 스위트 전체에 스크롤·드래그를 구동하는 테스트가 없다.

## 테스트

계산부를 `UIBuilder.ScaledDragThreshold(baseThreshold, dpi)`로 분리해 Unity 런타임 없이 검증한다. 신규 EditMode 6건:

| 케이스 | dpi | 기대 |
|---|---|---|
| CSS 기준 밀도 | 96 | 10 (변화 없음) |
| 배율 2 (실기기, CI 모바일 leg) | 192 | 20 |
| 배율 3 | 288 | 30 |
| dpi 미상 | 0, -1 | 10 |
| 기준 미만 | 48 | 10 (줄이지 않음) |
| 소수 배율 | 144 / 110 / 130 | 15 / 11 / 14 |

마지막 줄의 110·130은 소수부가 0.5 양쪽에 하나씩 놓이도록 골랐다. 반올림을 올림이나 버림으로 바꾸면 둘 중 하나가 반드시 깨진다. (초안에서는 dpi 120에 범위 단언만 걸어서 두 변형 모두 통과했다.)

로컬: EditMode 1486건 통과(신규 6건 `editmode-results.xml`에서 실행 확인), `--validate` 4/4 통과.

