### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — cloud-save-external-noise

### DIFF
--- a/Editor/ErrorTracker/AITEditorErrorTracker.cs
+++ b/Editor/ErrorTracker/AITEditorErrorTracker.cs
@@ -350,6 +350,8 @@ namespace AppsInToss.Editor.ErrorTracker
         //     SDK 어디에도 "AITPromotion" 문자열이 출력되지 않으며 (grep 확인),
         //     AitKeywords의 "[AIT"/"AIT:"와도 매칭되지 않으므로 ExternalAitPrefixes로 안전하게 분류.
         //     "UnityWarning:" prefix가 덧붙은 변형(SDK-S1 재발)도 IndexOf 부분 매칭으로 동일하게 드롭.
+        //   - SDK-19D: [AIT Cloud Save] 게임 사용자 식별키를 받지 못했습니다. 로컬 저장으로 계속합니다.
+        //     (SDK에 Cloud Save 기능 자체가 없음 — 사용자 게임이 자체 구현한 래퍼의 폴백 로그)
         private static readonly string[] ExternalAitPrefixes =
         {
             "[AIT Login]",
@@ -365,6 +367,13 @@ namespace AppsInToss.Editor.ErrorTracker
             // SDK 코드는 "[AIT_Auth]" prefix를 출력하지 않음(grep 확인). 단, "[AIT"로 시작해 AitKeywords 가드에
             // 걸려 NonSdkMessagePatterns로는 드롭 불가하므로, 가드보다 먼저 매칭되는 ExternalAitPrefixes로 분류.
             "[AIT_Auth]",
+            // SDK-19D: [AIT Cloud Save] 게임 사용자 식별키를 받지 못했습니다. 로컬 저장으로 계속합니다.
+            // SDK에는 Cloud Save 기능/API가 존재하지 않으며(grep 확인 — "Cloud Save", "식별키" 문자열이
+            // Runtime/Editor 어디에도 없음), 사용자 게임이 AIT.Storage/GetAnonymousKey 위에 직접 구현한
+            // 자체 Cloud Save 래퍼가 SDK와 동일한 "[AIT ...]" 로그 컨벤션을 흉내내 출력한 정상 폴백 로그다.
+            // "[AIT"로 시작해 AitKeywords 가드에 걸려 NonSdkMessagePatterns로는 드롭 불가하므로,
+            // 가드보다 먼저 매칭되는 ExternalAitPrefixes로 분류한다.
+            "[AIT Cloud Save]",
         };
 
         #endregion

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -100,6 +100,34 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void ExternalAitCloudSavePrefix_IdentifyKeyMissing_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-19D — 사용자 게임이 AIT.Storage/GetAnonymousKey 위에 직접
+        // 구현한 Cloud Save 래퍼가 SDK와 동일한 "[AIT ...]" 컨벤션으로 출력하는 정상 폴백 로그.
+        // SDK 코드에는 Cloud Save 기능 자체가 없으므로(grep 확인) "[AIT Cloud Save]" 문자열이
+        // 존재하지 않는다. ExternalAitPrefixes로 AitKeywords 가드보다 먼저 매칭되어 노이즈로 드롭된다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT Cloud Save] 게임 사용자 식별키를 받지 못했습니다. 로컬 저장으로 계속합니다."));
+    }
+
+    [Test]
+    public void ExternalAitCloudSavePrefix_WithUnityWarningPrefix_ReturnsTrue()
+    {
+        // 실제 Sentry 이슈 제목은 "UnityWarning: [AIT Cloud Save] ..." 형태로 캡처된다.
+        // Unity 로그 핸들러가 덧붙이는 "UnityWarning:" prefix가 있어도 IndexOf 부분 매칭이므로 동일하게 드롭된다.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityWarning: [AIT Cloud Save] 게임 사용자 식별키를 받지 못했습니다. 로컬 저장으로 계속합니다."));
+    }
+
+    [Test]
+    public void RegularAitPrefix_NotMatchingCloudSave_StillProtected()
+    {
+        // "[AIT Cloud Save]"가 아닌 일반 [AIT] prefix는 SDK 보호 가드로 필터링되지 않아야 함
+        Assert.IsFalse(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "[AIT] Cloud Save initialized"));
+    }
+
+    [Test]
     public void ExternalAitPromotionPrefix_CaptureEntryPointSkipped_ReturnsTrue()
     {
         // Sentry SDK-S1 — 사용자 게임의 프로모션 로직이 <color=Yellow>AITPromotion</color> tag로 출력하는 로그.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-19D

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-19D | UnityWarning: [AIT Cloud Save] 게임 사용자 식별키를 받지 못했습니다. 로컬 저장으로 계속합니다. |

## 원인

SDK에는 Cloud Save 기능 자체가 없다(Runtime/Editor 어디에도 "Cloud Save"/"식별키" 문자열이 없음을 grep으로 확인). 사용자 게임이 `AIT.Storage`/`GetAnonymousKey` 위에 직접 구현한 자체 Cloud Save 래퍼가 SDK와 동일한 `[AIT ...]` 로그 컨벤션을 흉내내면서, `AitKeywords`의 `[AIT` 보호 가드에 걸려 SDK 자체 로그로 오판되어 Sentry에 오탐 캡처됐다.

동일 Sentry ID로 2026-08-26에 `fix/auto-resolve-20260826-cloud-save-identify-key-missing-repro` 브랜치에서 이미 동일한 수정이 이뤄졌으나 PR이 열리지 않은 채 main에 미병합 상태로 남아 있었다. 이번 PR은 해당 브랜치의 커밋(`74d989ea`)을 현재 main 기준으로 재적용한 것이다.

## 추출 패턴

- `ExternalAitPrefixes`에 `[AIT Cloud Save]` 추가 — 가드보다 먼저 매칭되어 노이즈로 드롭

## 추가 위치

- `Editor/ErrorTracker/AITEditorErrorTracker.cs`
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`
  - positive: 원본 메시지, `UnityWarning:` prefix 변형
  - negative: 일반 `[AIT] Cloud Save initialized` (Cloud Save 문자열이 있어도 prefix가 다르면 보호 가드 유지 확인)

## 검증

`./run-local-tests.sh --validate` 통과 (Exit 0, 68초)

## 참고

사람 머지 검토 필요.
