### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 추가 — webgl-bee-il2cpp-build-noise

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1919,6 +1919,15 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void BuildLibraryBee_ReleaseWasmObjFailed_10S_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-10S: 동일 형식의 또 다른 해시 .o 파일(GameAssembly release_WebGL_wasm).
+        // 기존 "Building Library/Bee/artifacts/WebGL/" 패턴이 새 해시 변형도 커버하는지 evidence로 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/33pcnmr1fbpj.o failed with output:"));
+    }
+
+    [Test]
     public void BuildLibraryBee_WithAitPrefix_StillProtected()
     {
         // SDK 보호 가드: SDK가 동일 prefix로 출력하는 가상의 케이스도 필터링 안 되어야 함.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-10S

이 키워드는 squash 머지 후 Sentry가 해당 이슈를 자동 resolve하기 위한 것입니다. (repo의 squash_merge_commit_message=PR_BODY 설정으로 PR body가 머지 커밋에 그대로 들어감)

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-10S | `UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/33pcnmr1fbpj.o failed with output:` |

## 분석

Unity IL2CPP/Bee 빌드 시스템이 직접 출력하는 컴파일 단위별 빌드 실패 메시지로, `.o` 해시 파일명만 매번 달라 별도 이슈로 grouping되는 노이즈입니다.

`AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 이미 `"Building Library/Bee/artifacts/WebGL/"` 패턴(기존 SDK-SA~SV, T7, TV, W0, VZ, 19T, 19V 등 대응)이 존재하며, 이번 이슈의 제목과도 정확히 매칭됩니다. 실 SDK 빌드 실패는 별도로 `"[AIT] WebGL 빌드가 실패했습니다."`로 캡처되므로 이 메시지는 드롭해도 안전합니다.

기존 패턴 배열은 이미 이 케이스를 커버하므로 **코드 변경 없이**, 회귀 방지를 위해 이번 이슈의 실제 evidence(해시 `33pcnmr1fbpj.o`)를 테스트 케이스로만 추가했습니다. 동일 카테고리의 선행 이슈들(W0/VZ/19T/19V)도 같은 방식으로 처리된 전례를 따랐습니다.

## 변경 내용
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`: `BuildLibraryBee_ReleaseWasmObjFailed_10S_ReturnsTrue` positive 테스트 추가 (SDK 보호 가드 negative 테스트는 기존 `BuildLibraryBee_WithAitPrefix_StillProtected`가 동일 패턴에 대해 이미 커버)

## 검증
`./run-local-tests.sh --validate`를 시작 전/재확인(30초 대기 후) 두 차례 모두 다른 worker의 동시 실행과 충돌해 **동시 빌드 회피로 검증 skip — 사람 확인 필요**. 추가한 테스트는 기존에 5개 이상 존재하는 동일 형식 테스트(`BuildLibraryBee_ReleaseWasmObjFailed_*`)와 완전히 동일한 패턴이라 리스크는 낮으나, 머지 전 CI 통과 확인 바랍니다.

---
사람 머지 검토 필요 (auto-resolve worker가 생성한 PR)