### PR TITLE
수정: 배포 딥링크 추출 — CLI 박스 줄바꿈 잘림 복원 및 SDK 3.0 host 파라미터 부가

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -540,7 +540,28 @@ jobs:
             exit "$DEPLOY_STATUS"
           fi
 
-          DEPLOY_URL=$(echo "$CLEANED" | grep -oE 'intoss-private://[^[:space:]]+' | head -1 || true)
+          # ait CLI는 URL을 고정폭 박스(│ ... │) 안에 출력해 긴 URL이 여러 줄로 래핑됨 —
+          # 줄 단위 grep은 URL을 중간에서 자르므로, 박스 문자·여백 제거 후 줄 끝까지
+          # 이어지는 URL을 연속 줄과 접합해 복원한다.
+          DEPLOY_URL=$(echo "$CLEANED" | sed 's/│//g; s/^[[:space:]]*//; s/[[:space:]]*$//' | awk '
+            !url && match($0, /intoss-private:\/\/[A-Za-z0-9._~%=&?\/-]+/) {
+              url = substr($0, RSTART, RLENGTH)
+              wrapped = (RSTART + RLENGTH - 1 == length($0))
+              next
+            }
+            wrapped && /^[A-Za-z0-9._~%=&?\/-]+$/ { url = url $0; next }
+            { wrapped = 0 }
+            END { if (url) print url }')
+
+          # SDK 3.0(V3 host) 딥링크는 host 파라미터 필수 — V3로 출시된 적 없는 스킴은
+          # CDN에 deployment.json이 없어 host 없이는 진입 불가. CLI가 이미 붙였으면 유지.
+          if [ -n "$DEPLOY_URL" ] && ! printf '%s' "$DEPLOY_URL" | grep -qE '[?&]host='; then
+            case "$DEPLOY_URL" in
+              *\?*) DEPLOY_URL="${DEPLOY_URL}&host=appsInTossHost" ;;
+              *)    DEPLOY_URL="${DEPLOY_URL}?host=appsInTossHost" ;;
+            esac
+          fi
+
           if [ -z "$DEPLOY_URL" ]; then
             DEPLOY_URL=$(echo "$CLEANED" | grep -oE 'https?://[^[:space:]]+' | head -1 || true)
           fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -336,7 +336,27 @@ jobs:
 
               if [ $DEPLOY_STATUS -eq 0 ]; then
                 CLEANED_OUTPUT=$(echo "$DEPLOY_OUTPUT" | sed 's/\x1b\[[0-9;]*m//g' | tr -d '\r')
-                DEPLOY_URL=$(echo "$CLEANED_OUTPUT" | grep -oE 'intoss-private://[^[:space:]]+' | head -1 || true)
+                # ait CLI는 URL을 고정폭 박스(│ ... │) 안에 출력해 긴 URL이 여러 줄로 래핑됨 —
+                # 줄 단위 grep은 URL을 중간에서 자르므로, 박스 문자·여백 제거 후 줄 끝까지
+                # 이어지는 URL을 연속 줄과 접합해 복원한다.
+                DEPLOY_URL=$(echo "$CLEANED_OUTPUT" | sed 's/│//g; s/^[[:space:]]*//; s/[[:space:]]*$//' | awk '
+                  !url && match($0, /intoss-private:\/\/[A-Za-z0-9._~%=&?\/-]+/) {
+                    url = substr($0, RSTART, RLENGTH)
+                    wrapped = (RSTART + RLENGTH - 1 == length($0))
+                    next
+                  }
+                  wrapped && /^[A-Za-z0-9._~%=&?\/-]+$/ { url = url $0; next }
+                  { wrapped = 0 }
+                  END { if (url) print url }')
+
+                # SDK 3.0(V3 host) 딥링크는 host 파라미터 필수 — V3로 출시된 적 없는 스킴은
+                # CDN에 deployment.json이 없어 host 없이는 진입 불가. CLI가 이미 붙였으면 유지.
+                if [ -n "$DEPLOY_URL" ] && ! printf '%s' "$DEPLOY_URL" | grep -qE '[?&]host='; then
+                  case "$DEPLOY_URL" in
+                    *\?*) DEPLOY_URL="${DEPLOY_URL}&host=appsInTossHost" ;;
+                    *)    DEPLOY_URL="${DEPLOY_URL}?host=appsInTossHost" ;;
+                  esac
+                fi
 
                 if [ -n "$DEPLOY_URL" ]; then
                   echo "✅ Deploy success: ${DEPLOY_URL}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -970,7 +970,28 @@ jobs:
                 elif [ $DEPLOY_STATUS -eq 0 ]; then
                   # 배포 성공 - URL 추출 시도 (ANSI 이스케이프 시퀀스 제거 후 파싱)
                   CLEANED_OUTPUT=$(echo "$DEPLOY_OUTPUT" | sed 's/\x1b\[[0-9;]*m//g' | tr -d '\r')
-                  DEPLOY_URL=$(echo "$CLEANED_OUTPUT" | grep -oE 'intoss-private://[^[:space:]]+' | head -1 || true)
+                  # ait CLI는 URL을 고정폭 박스(│ ... │) 안에 출력해 긴 URL이 여러 줄로 래핑됨 —
+                  # 줄 단위 grep은 URL을 중간에서 자르므로, 박스 문자·여백 제거 후 줄 끝까지
+                  # 이어지는 URL을 연속 줄과 접합해 복원한다.
+                  DEPLOY_URL=$(echo "$CLEANED_OUTPUT" | sed 's/│//g; s/^[[:space:]]*//; s/[[:space:]]*$//' | awk '
+                    !url && match($0, /intoss-private:\/\/[A-Za-z0-9._~%=&?\/-]+/) {
+                      url = substr($0, RSTART, RLENGTH)
+                      wrapped = (RSTART + RLENGTH - 1 == length($0))
+                      next
+                    }
+                    wrapped && /^[A-Za-z0-9._~%=&?\/-]+$/ { url = url $0; next }
+                    { wrapped = 0 }
+                    END { if (url) print url }')
+
+                  # SDK 3.0(V3 host) 딥링크는 host 파라미터 필수 — V3로 출시된 적 없는 스킴은
+                  # CDN에 deployment.json이 없어 host 없이는 진입 불가. CLI가 이미 붙였으면 유지.
+                  if [ -n "$DEPLOY_URL" ] && ! printf '%s' "$DEPLOY_URL" | grep -qE '[?&]host='; then
+                    case "$DEPLOY_URL" in
+                      *\?*) DEPLOY_URL="${DEPLOY_URL}&host=appsInTossHost" ;;
+                      *)    DEPLOY_URL="${DEPLOY_URL}?host=appsInTossHost" ;;
+                    esac
+                  fi
+
                   if [ -z "$DEPLOY_URL" ]; then
                     DEPLOY_URL=$(echo "$CLEANED_OUTPUT" | grep -oE 'https?://[^[:space:]]+' | head -1 || echo "SUCCESS")
                   fi

--- a/Documentation~/internal/github-actions.md
+++ b/Documentation~/internal/github-actions.md
@@ -114,6 +114,8 @@ gh api repos/toss/apps-in-toss-unity-sdk/actions/workflows/216269700/dispatches 
 EOF
 ```
 
+빌드가 끝나면 deploy 단계가 `intoss-private://` URL을 추출해 QR 이미지를 생성하고 Job Summary에 게시합니다. `target_ref`가 PR로 해석된 경우에만 PR 코멘트에도 게시됩니다(브랜치로 dispatch한 경우는 Job Summary에만 게시). QR을 토스 앱으로 스캔하면 해당 빌드가 실기기에서 열립니다.
+
 ### Release
 
 ```bash

--- a/Editor/Menu/AITDeployManager.cs
+++ b/Editor/Menu/AITDeployManager.cs
@@ -666,24 +666,56 @@ namespace AppsInToss.Editor.Menu
         }
 
         /// <summary>
-        /// 배포 출력에서 intoss-private:// URL 추출
+        /// 배포 출력에서 intoss-private:// URL 추출.
+        /// ait CLI는 URL을 고정폭 박스(│ ... │) 안에 출력하므로 긴 URL(예: UUID deploymentId)은
+        /// 여러 줄로 래핑된다 — 줄 단위 매칭은 URL을 중간에서 자르므로, 박스 문자·여백 제거 후
+        /// 줄 끝까지 이어지는 URL을 연속 줄과 접합해 복원한다.
         /// </summary>
-        private static string ExtractDeployUrl(string output)
+        internal static string ExtractDeployUrl(string output)
         {
             if (string.IsNullOrEmpty(output))
             {
                 return null;
             }
 
-            // intoss-private://... URL 패턴 찾기
             // (ANSI 코드는 AITPlatformHelper.ExecuteCommand에서 이미 제거됨)
-            var match = Regex.Match(output, @"intoss-private://[^\s\│\│]+");
-            if (match.Success)
+            const string urlChars = "A-Za-z0-9._~%=&?/-";
+            string url = null;
+            bool wrapped = false;
+            foreach (var raw in output.Split('\n'))
             {
-                return match.Value.TrimEnd('│', ' ', '\r', '\n');
+                string line = raw.Replace("│", "").Trim();
+                if (url == null)
+                {
+                    var match = Regex.Match(line, "intoss-private://[" + urlChars + "]+");
+                    if (match.Success)
+                    {
+                        url = match.Value;
+                        // URL이 줄 끝까지 이어졌으면 박스 폭 래핑으로 잘렸을 수 있음
+                        wrapped = match.Index + match.Length == line.Length;
+                    }
+                    continue;
+                }
+                if (wrapped && Regex.IsMatch(line, "^[" + urlChars + "]+$"))
+                {
+                    url += line;
+                    continue;
+                }
+                break;
             }
 
-            return null;
+            if (url == null)
+            {
+                return null;
+            }
+
+            // SDK 3.0(V3 host) 딥링크는 host 파라미터가 필수 — V3로 출시된 적 없는 스킴은
+            // CDN에 deployment.json이 없어 host 없이는 V3 진입이 안 된다. CLI가 이미 붙였으면 유지.
+            if (!Regex.IsMatch(url, @"[?&]host="))
+            {
+                url += (url.Contains("?") ? "&" : "?") + "host=appsInTossHost";
+            }
+            return url;
         }
 
         /// <summary>

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 > 2026-04-14 전체 리뷰 기준 작성 · 2026-06-16 코드 대조로 완료 항목 정리.
 > 우선순위 P1(높음) ~ P3(낮음).
-> 2026-07-08 P2 잔여 항목 완료로 정리 · 2026-07-26 베타 기능 항목 추가 · 2026-07-27 문서 통합 정리에서 발견한 항목 추가 · 2026-08-01 의존성 항목 추가 · 2026-08-10 Deploy 항목 추가.
+> 2026-07-08 P2 잔여 항목 완료로 정리 · 2026-07-26 베타 기능 항목 추가 · 2026-07-27 문서 통합 정리에서 발견한 항목 추가 · 2026-08-01 의존성 항목 추가 · 2026-08-10 Deploy 항목 추가 · 2026-08-25 머지 전 감사에서 나온 배포 URL 추출 항목 추가.
 
 ## 베타 기능
 
@@ -13,6 +13,10 @@
 - **P3 — devtools tunnel(실기기 프리뷰) 재검토**: `AIT_DEVTOOLS_TUNNEL`은 `aitc.dev` 호스트 + `cloudflared` 다운로드에 의존해 사람이 수동으로만 켜도록 막아뒀다(Editor/CI는 절대 설정하지 않음). `aitc.dev` 호스트 운영 상황이 안정화되면 Editor 통합(자동 설정, 메뉴 노출) 여부를 재검토.
 
 ## Deploy
+
+- **P3 — 배포 URL 추출 로직이 네 벌로 복제돼 있고 자동 검증은 C# 한 벌에만 걸린다**: 박스 래핑된 `ait deploy` 출력에서 URL을 복원하는 같은 로직이 `Editor/Menu/AITDeployManager.cs`의 `ExtractDeployUrl`(C#)과 `.github/workflows/{preview,beta-release,release}.yml`의 awk 블록 세 벌에 있다. 머지 전 감사에서 네 벌을 필드별로 대조해 **현재는 동작 등가**임을 확인했다(문자 클래스, 래핑 판정, `host=` 멱등 검사, `?`/`&` 분기가 1:1. C#은 비매치 줄에서 `break`, awk는 스캔을 계속하지만 `!url` 가드 때문에 두 번째 URL을 잡지 않아 결과가 같다). 문제는 검증 비대칭이다 — `Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployUrlTests.cs`(6건)는 C#만 고정하고, awk 세 벌은 shellcheck/actionlint도 없어 드리프트하면 해당 채널의 배포 링크만 조용히 깨진다. 고친다면 awk를 `scripts/`의 셸 스크립트 한 벌로 추출해 세 워크플로가 호출하게 하고, `DeployUrlTests.cs`와 같은 입력을 먹이는 셸 테스트를 `run-local-tests.sh --validate`에 등록하는 형태.
+
+  같은 감사에서 나온 **알려진 한계**도 함께 기록한다: 래핑 판정은 "매치가 줄 끝에 닿았는가"로만 하므로, URL의 마지막 조각이 박스 폭을 **정확히** 채우면 래핑이 끝났는데도 다음 줄을 이어붙인다. 다음 줄이 공백 없는 순수 ASCII 토큰(`SUCCESS` 등)이면 그대로 URL에 붙어 잘못된 링크가 된다. 하단 테두리·빈 줄·공백 포함 문장은 문자 클래스에 걸리지 않아 안전하고, URL이 줄 끝에 닿지 않는 경우는 `ExtractDeployUrl_UnwrappedUrlFollowedByText_DoesNotSwallowNextLine`이 고정하고 있다. 렌더된 박스 출력만 보고는 "폭을 정확히 채운 마지막 줄"과 "래핑 중인 줄"을 원리적으로 구분할 수 없어 지금은 방어를 넣지 않았다. 선결 조건은 **`ait deploy`의 실제 stdout 전체 포맷을 한 번 캡처하는 것** — 저장소·CI 로그 어디에도 전체 출력이 없어 현재 로직은 관측된 두 스니펫과 추론으로만 고정돼 있다. 캡처하면 박스 내부 폭과 URL 뒤에 오는 줄의 실제 형태가 확정되고, 그때 방어가 필요한지도 함께 결정된다. 피해 범위는 PR 코멘트·릴리스 노트의 링크이며 배포 산출물 자체는 무관하다.
 
 - **P3 — Deploy Release Candidate 성공 창의 콘솔 딥링크**: `Editor/Menu/DeploySuccessWindow.cs`의 "콘솔 열기" 버튼은 현재 콘솔 베이스 URL(`https://apps-in-toss.toss.im/console`)만 여는데, deploymentId로 배포 상세 화면에 바로 이동하는 딥링크 라우트가 있는지 콘솔 라우트가 미확인이라 적용하지 못했다. 플랫폼 팀 확인 후 딥링크로 교체.
 

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployUrlTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployUrlTests.cs
@@ -1,0 +1,102 @@
+// -----------------------------------------------------------------------
+// DeployUrlTests.cs - 배포 출력에서 intoss-private:// 딥링크 추출 검증
+// Level 0: AITDeployManager.ExtractDeployUrl 을 Unity/pnpm 실행 없이 검증한다.
+//
+// 배경: ait CLI는 배포 URL을 고정폭 유니코드 박스(│ ... │) 안에 출력하므로 긴 URL
+//   (UUID deploymentId, host 파라미터)은 여러 줄로 래핑된다. 줄 단위 정규식은 URL을
+//   중간에서 자르므로 연속 줄 접합이 필요하다. 또한 SDK 3.0(V3 host) 딥링크는
+//   host=appsInTossHost 파라미터가 없으면 V3로 출시된 적 없는 스킴에서 진입이 불가하다
+//   (CDN deployment.json 부재) — CLI가 붙이지 않은 경우 추출 시점에 부가한다.
+//
+// 메모: 이 파일은 AppsInTossEditModeTests 어셈블리에 속한다(DeployMemoTests.cs와 동일 위치).
+//   해당 어셈블리는 InternalsVisibleTo로 internal AITDeployManager에 접근 가능하다.
+// -----------------------------------------------------------------------
+
+using NUnit.Framework;
+using AppsInToss.Editor.Menu;  // AITDeployManager (internal, .Menu 하위 네임스페이스)
+
+[TestFixture]
+public class DeployUrlTests
+{
+    // =====================================================
+    // 박스 래핑 접합
+    // =====================================================
+
+    [Test]
+    public void ExtractDeployUrl_BoxWrappedUrl_JoinsContinuationLines()
+    {
+        // 실제 CI 배포 로그에서 관측된 형태: UUID가 박스 폭에서 잘려 다음 줄로 이어짐
+        string output =
+            "╭──────────────────────────────────────────────────────────────────────────────╮\n" +
+            "│  intoss-private://unity-sdk-sample?_deploymentId=01a01868-f10b-7279-b96f-ab  │\n" +
+            "│  bcd6865b68  │\n" +
+            "╰──────────────────────────────────────────────────────────────────────────────╯\n";
+
+        string url = AITDeployManager.ExtractDeployUrl(output);
+        Assert.AreEqual(
+            "intoss-private://unity-sdk-sample?_deploymentId=01a01868-f10b-7279-b96f-abbcd6865b68&host=appsInTossHost",
+            url);
+    }
+
+    [Test]
+    public void ExtractDeployUrl_HostParamWrappedToSecondLine_JoinsAndKeepsHost()
+    {
+        // 최신 ait CLI 출력 형태: CLI가 host 파라미터까지 붙이고 그 부분이 래핑됨
+        string output =
+            "│  intoss-private://ait?_deploymentId=01a018fc-a0e5-7558-9a3a-166fcf  │\n" +
+            "│  e4e4e1&host=appsInTossHost  │\n";
+
+        string url = AITDeployManager.ExtractDeployUrl(output);
+        Assert.AreEqual(
+            "intoss-private://ait?_deploymentId=01a018fc-a0e5-7558-9a3a-166fcfe4e4e1&host=appsInTossHost",
+            url);
+    }
+
+    [Test]
+    public void ExtractDeployUrl_UnwrappedUrlFollowedByText_DoesNotSwallowNextLine()
+    {
+        // URL이 줄 끝까지 닿지 않으면(래핑 아님) 다음 줄의 토큰을 이어붙이면 안 됨
+        string output =
+            "│  intoss-private://app?_deploymentId=0198c10b-68c3-7d2b-a0ab-2c9626b475ec 완료  │\n" +
+            "│  SUCCESS  │\n";
+
+        string url = AITDeployManager.ExtractDeployUrl(output);
+        Assert.AreEqual(
+            "intoss-private://app?_deploymentId=0198c10b-68c3-7d2b-a0ab-2c9626b475ec&host=appsInTossHost",
+            url);
+    }
+
+    // =====================================================
+    // SDK 3.0 host 파라미터 부가 (멱등)
+    // =====================================================
+
+    [Test]
+    public void ExtractDeployUrl_HostAlreadyPresent_DoesNotDuplicate()
+    {
+        string output = "intoss-private://app?_deploymentId=0198c10b-68c3-7d2b-a0ab-2c9626b475ec&host=appsInTossHost\n";
+
+        string url = AITDeployManager.ExtractDeployUrl(output);
+        Assert.AreEqual(
+            "intoss-private://app?_deploymentId=0198c10b-68c3-7d2b-a0ab-2c9626b475ec&host=appsInTossHost",
+            url);
+    }
+
+    [Test]
+    public void ExtractDeployUrl_NoQueryString_AppendsHostWithQuestionMark()
+    {
+        string url = AITDeployManager.ExtractDeployUrl("intoss-private://app\n");
+        Assert.AreEqual("intoss-private://app?host=appsInTossHost", url);
+    }
+
+    // =====================================================
+    // 경계 케이스
+    // =====================================================
+
+    [Test]
+    public void ExtractDeployUrl_NoUrlInOutput_ReturnsNull()
+    {
+        Assert.IsNull(AITDeployManager.ExtractDeployUrl("배포 완료. URL 없음.\n"));
+        Assert.IsNull(AITDeployManager.ExtractDeployUrl(""));
+        Assert.IsNull(AITDeployManager.ExtractDeployUrl(null));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployUrlTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/DeployUrlTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b47a51951a5347169b1e1485102749e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
> **#1088 재분할 스택 (4/4)** — 위에서부터 순서대로 머지
> 1. #1145 되돌리기: #1088 번들
> 2. **#1146** ← 이 PR 수정: 배포 딥링크 추출
> 3. #1147 기능: PlayerPrefs 레거시 origin seam
> 4. #1148 테스트: PlayerPrefs 실기기 실측 킷

---

#1088에서 떼어낸 조각 1/3. 내용은 머지됐던 것과 동일하고, 관심사만 갈랐다. 앞선 되돌리기 PR 뒤에 쌓인다.

## 문제

`ait deploy`는 결과 URL을 박스 안에 렌더한다. URL이 박스 폭보다 길면 박스가 줄을 바꾸는데, 기존 추출 로직은 첫 줄만 집었다. 잘린 URL이 그대로 QR 코드와 PR 코멘트에 실렸다.

## 고친 것

- 매치가 줄 끝에 닿았으면 다음 줄을 이어붙여 복원한다. 줄 끝에 닿지 않은(래핑이 아닌) 매치는 뒤 텍스트를 삼키지 않는다.
- SDK 3.0부터 딥링크에 `host` 파라미터가 필요하다. 없으면 멱등하게 덧붙인다.

## 중복에 대해

같은 로직이 네 벌 있다 — C# `AITDeployManager.ExtractDeployUrl` 하나와 워크플로 awk 세 벌(release / preview / beta-release). 이번에 네 벌을 필드별로 대조해 동작이 같은 것을 확인하고 그대로 뒀다. 통합은 릴리스 경로를 건드리는 별건이라 이 PR 범위 밖이다. 중복 자체와 awk 쪽 자동 검증 부재는 TODO.md에 P3로 남겼다.

## 테스트

`DeployUrlTests.cs` 신규 6건이 C# 쪽을 고정한다 — 래핑 복원, 비래핑 매치가 뒤 텍스트를 삼키지 않는지, `host` 파라미터 멱등성.

로컬: `--validate` 4/4, EditMode 1479건 통과(되돌리기 시점 1472건).

awk 세 벌은 여전히 자동 검증이 없다. 워크플로 안에서만 도는 코드라 유닛 테스트를 붙일 자리가 마땅치 않다 — 실제 릴리스에서 확인하는 수밖에 없고, 그래서 이 PR을 스택 첫 번째에 뒀다.
