### PR TITLE
테스트: 스크롤 안 InputField 탭 진단 계측 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/PointerTapDiagnosticsTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/PointerTapDiagnosticsTests.cs
@@ -1,0 +1,260 @@
+// -----------------------------------------------------------------------
+// PointerTapDiagnosticsTests.cs - 탭 진단 프로브의 판정식과 인터페이스 제약 검증
+// Level 0: 실기기·브라우저 없이 검증한다.
+//
+// 이 파일에서 가장 중요한 것은 인터페이스 가드다. 프로브는 스크롤 영역 안 InputField가
+// 탭에 반응하지 않는 증상을 관측하려고 붙이는 것인데, IInitializePotentialDragHandler를
+// 구현해버리면 InputField에 없던 핸들러가 생겨 ScrollRect 관성이 멈추는지 여부 자체가
+// 바뀐다. 관측이 대상을 고쳐버리면 진단이 무의미해지므로 컴파일 타임 실수를 여기서 잡는다.
+//
+// 메모: AppsInTossEditModeTests 어셈블리는 overrideReferences=true라 UnityEngine.UI.dll을
+//   참조하지 않는다. 그래서 uGUI 이벤트 인터페이스를 타입으로 쓰지 않고 FullName 문자열로
+//   대조한다.
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+
+[TestFixture]
+public class PointerTapDiagnosticsTests
+{
+    private const string EventSystemsNs = "UnityEngine.EventSystems.";
+
+    private readonly List<GameObject> _spawned = new List<GameObject>();
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var go in _spawned)
+        {
+            if (go != null) Object.DestroyImmediate(go);
+        }
+        _spawned.Clear();
+    }
+
+    private GameObject NewGo(string name)
+    {
+        var go = new GameObject(name);
+        _spawned.Add(go);
+        return go;
+    }
+
+    // =====================================================
+    // 인터페이스 가드
+    // =====================================================
+
+    [Test]
+    public void Probe_ImplementsExactlyTheThreeAllowedEventInterfaces()
+    {
+        var actual = typeof(PointerTapDiagnostics).GetInterfaces()
+            .Select(t => t.FullName)
+            .Where(n => n != null && n.StartsWith(EventSystemsNs))
+            .OrderBy(n => n)
+            .ToArray();
+
+        var expected = new[]
+        {
+            // 세 핸들러가 모두 상속하는 마커 인터페이스라 transitive로 딸려온다. 동작을 담지 않는다.
+            EventSystemsNs + "IEventSystemHandler",
+            EventSystemsNs + "IPointerClickHandler",
+            EventSystemsNs + "IPointerDownHandler",
+            EventSystemsNs + "IPointerUpHandler",
+        };
+
+        // 하나라도 늘거나 줄면 실패한다. InputField(Selectable)가 이미 구현한 셋과 정확히
+        // 같아야 ExecuteHierarchy가 고르는 GameObject가 달라지지 않는다.
+        CollectionAssert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void Probe_MustNotImplementDragInterfaces()
+    {
+        var implemented = typeof(PointerTapDiagnostics).GetInterfaces()
+            .Select(t => t.FullName)
+            .ToArray();
+
+        // IInitializePotentialDragHandler가 특히 위험하다 — InputField에 없던 핸들러가 생겨
+        // ScrollRect의 관성 정지 동작이 바뀐다. 나머지도 드래그 라우팅에 관여하므로 함께 막는다.
+        foreach (var forbidden in new[]
+        {
+            "IInitializePotentialDragHandler",
+            "IBeginDragHandler",
+            "IDragHandler",
+            "IEndDragHandler",
+            "IDropHandler",
+            "IScrollHandler",
+        })
+        {
+            CollectionAssert.DoesNotContain(implemented, EventSystemsNs + forbidden,
+                $"{forbidden}를 구현하면 프로브가 관측 대상의 동작을 바꾼다");
+        }
+    }
+
+    // =====================================================
+    // 판정식 — StandaloneInputModule.cs:436과 같아야 한다
+    // =====================================================
+
+    [Test]
+    public void WillFireClick_SameHandlerAndEligible_IsTrue()
+    {
+        var handler = NewGo("InputField");
+        Assert.IsTrue(PointerTapDiagnostics.WillFireClick(handler, handler, true));
+    }
+
+    [Test]
+    public void WillFireClick_DifferentHandler_IsFalse()
+    {
+        var pressHandler = NewGo("InputField");
+        var releaseHandler = NewGo("OtherInputField");
+
+        // 이름이 아니라 참조로 비교해야 한다. 같은 이름의 GameObject가 둘 있어도 구분되어야 하므로
+        // 이름이 다른 쌍과 같은 쌍을 모두 확인한다.
+        Assert.IsFalse(PointerTapDiagnostics.WillFireClick(pressHandler, releaseHandler, true));
+
+        var sameNameA = NewGo("InputField");
+        var sameNameB = NewGo("InputField");
+        Assert.IsFalse(PointerTapDiagnostics.WillFireClick(sameNameA, sameNameB, true));
+    }
+
+    [Test]
+    public void WillFireClick_NotEligible_IsFalse()
+    {
+        var handler = NewGo("InputField");
+        Assert.IsFalse(PointerTapDiagnostics.WillFireClick(handler, handler, false));
+    }
+
+    [Test]
+    public void WillFireClick_BothNull_MatchesUguiBehaviour()
+    {
+        // uGUI도 null == null을 통과시킨다(:436). 통과해도 Execute(null, ...)이 no-op이라
+        // 무해하다. 프로브는 모듈의 판정을 그대로 비추는 게 목적이므로 여기서 갈라지면 안 된다.
+        Assert.IsTrue(PointerTapDiagnostics.WillFireClick(null, null, true));
+    }
+
+    // =====================================================
+    // 사유 문구
+    // =====================================================
+
+    [Test]
+    public void ExplainNoFire_WhenFiring_IsEmpty()
+    {
+        var s = new PointerTapDiagnostics.TapSnapshot { WillFireClick = true, Eligible = true };
+        Assert.AreEqual("", PointerTapDiagnostics.ExplainNoFire(s));
+    }
+
+    [Test]
+    public void ExplainNoFire_NotEligible_BlamesDragCancellation()
+    {
+        var s = new PointerTapDiagnostics.TapSnapshot { WillFireClick = false, Eligible = false };
+        StringAssert.Contains("eligibleForClick=0", PointerTapDiagnostics.ExplainNoFire(s));
+    }
+
+    [Test]
+    public void ExplainNoFire_HandlerMismatch_NamesBothHandlers()
+    {
+        var s = new PointerTapDiagnostics.TapSnapshot
+        {
+            WillFireClick = false,
+            Eligible = true,
+            PointerClick = "InputField",
+            ReleaseHandler = "(none)",
+        };
+
+        string reason = PointerTapDiagnostics.ExplainNoFire(s);
+
+        // 두 핸들러를 모두 적어야 실기기 로그만 보고 원인을 갈라낼 수 있다.
+        StringAssert.Contains("InputField", reason);
+        StringAssert.Contains("(none)", reason);
+        StringAssert.DoesNotContain("eligibleForClick", reason);
+    }
+
+    // =====================================================
+    // 포맷 — 실기기에서 이 줄만 보고 판단할 수 있어야 한다
+    // =====================================================
+
+    [Test]
+    public void FormatDown_ShowsScrollStateAndThreshold()
+    {
+        var s = new PointerTapDiagnostics.TapSnapshot
+        {
+            Over = "InputField",
+            PointerPress = "InputField",
+            PointerDrag = "InputField",
+            DragThreshold = 20,
+            HasScrollRect = true,
+            ScrollVelocity = new Vector2(0f, -812f),
+        };
+
+        string line = PointerTapDiagnostics.FormatDown(3, "test-key", s);
+
+        StringAssert.Contains("#3 DOWN test-key", line);
+        StringAssert.Contains("scroll=YES", line);
+        // press 순간 관성이 남아 있는지가 남은 가설의 핵심이라 속도를 반드시 찍어야 한다.
+        StringAssert.Contains("-812", line);
+        StringAssert.Contains("thr=20", line);
+    }
+
+    [Test]
+    public void FormatDown_OutsideScrollRect_SaysSo()
+    {
+        var s = new PointerTapDiagnostics.TapSnapshot { Over = "InputField", HasScrollRect = false };
+        string line = PointerTapDiagnostics.FormatDown(1, "Search...", s);
+
+        // 스크롤 밖 검색바가 대조군이므로 한눈에 구분되어야 한다.
+        StringAssert.Contains("scroll=NO", line);
+        StringAssert.DoesNotContain("scroll=YES", line);
+    }
+
+    [Test]
+    public void FormatUp_FiringCase_SaysFireYes()
+    {
+        var s = new PointerTapDiagnostics.TapSnapshot
+        {
+            Over = "InputField",
+            PointerClick = "InputField",
+            ReleaseHandler = "InputField",
+            Eligible = true,
+            WillFireClick = true,
+            MovedPixels = 2.4f,
+        };
+
+        string line = PointerTapDiagnostics.FormatUp(7, "test-key", s);
+
+        StringAssert.Contains("FIRE=YES", line);
+        StringAssert.DoesNotContain("FIRE=NO", line);
+        StringAssert.Contains("moved=2.4px", line);
+    }
+
+    [Test]
+    public void FormatUp_NonFiringCase_CarriesTheReason()
+    {
+        var s = new PointerTapDiagnostics.TapSnapshot
+        {
+            Over = "Text",
+            PointerClick = "InputField",
+            ReleaseHandler = "(none)",
+            Eligible = true,
+            WillFireClick = false,
+            MovedPixels = 11.2f,
+        };
+
+        string line = PointerTapDiagnostics.FormatUp(8, "test-key", s);
+
+        StringAssert.Contains("FIRE=NO", line);
+        StringAssert.Contains("InputField", line);
+        StringAssert.Contains("(none)", line);
+    }
+
+    [Test]
+    public void FormatUpMissing_ExplainsWhyNoUpArrived()
+    {
+        string line = PointerTapDiagnostics.FormatUpMissing(9, "test-key");
+
+        StringAssert.Contains("#9", line);
+        StringAssert.Contains("미수신", line);
+        // UP이 안 오는 경로는 ProcessDrag가 pointerPress를 null로 만든 경우뿐이다.
+        StringAssert.Contains("pointerPress", line);
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/PointerTapDiagnosticsTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/PointerTapDiagnosticsTests.cs
@@ -257,4 +257,57 @@ public class PointerTapDiagnosticsTests
         // UP이 안 오는 경로는 ProcessDrag가 pointerPress를 null로 만든 경우뿐이다.
         StringAssert.Contains("pointerPress", line);
     }
+
+    // ─── 신원 비교 ───
+    //
+    // 아래 두 건은 실기기 실측에서 실제로 걸린 구멍이다. 스크롤 콘텐츠가 손가락 밑으로
+    // 흐르면 press 때와 다른 GameObject 위에서 release되는데, 그 GameObject의 이름이
+    // 같은 경우가 흔하다(같은 목록의 이웃 InputField). 이름만 비교하면 신원이 바뀐 것을
+    // 놓치고, 로그에는 "핸들러(InputField)와 핸들러(InputField)가 다름"이라는 읽을 수 없는
+    // 줄이 남는다. 그래서 Name()이 인스턴스 ID를 붙인다.
+
+    [Test]
+    public void OverChanged_SameNameDifferentInstance_IsTrue()
+    {
+        var r = new PointerTapDiagnostics.TapRecord
+        {
+            UpReceived = true,
+            DownOver = "InputField#-1010",
+            UpOver = "InputField#-2020",
+        };
+
+        Assert.IsTrue(r.OverChanged);
+    }
+
+    [Test]
+    public void OverChanged_SameInstance_IsFalse()
+    {
+        var r = new PointerTapDiagnostics.TapRecord
+        {
+            UpReceived = true,
+            DownOver = "InputField#-1010",
+            UpOver = "InputField#-1010",
+        };
+
+        Assert.IsFalse(r.OverChanged);
+    }
+
+    [Test]
+    public void ExplainNoFire_SameNameDifferentInstance_StaysReadable()
+    {
+        var s = new PointerTapDiagnostics.TapSnapshot
+        {
+            WillFireClick = false,
+            Eligible = true,
+            PointerClick = "InputField#-1010",
+            ReleaseHandler = "InputField#-2020",
+        };
+
+        string reason = PointerTapDiagnostics.ExplainNoFire(s);
+
+        // 두 조각이 서로 다르게 보여야 한다. 이 단언이 깨지면 로그를 읽는 사람이
+        // "같은 것 둘이 다르다"는 문장을 마주하게 된다.
+        StringAssert.Contains("-1010", reason);
+        StringAssert.Contains("-2020", reason);
+    }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/PointerTapDiagnosticsTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/PointerTapDiagnosticsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 426e9afe114449c9b8241b65143f9379
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/TapAutoProbeTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/TapAutoProbeTests.cs
@@ -1,42 +1,102 @@
 // -----------------------------------------------------------------------
-// TapAutoProbeTests.cs - 자동 탭 진단의 판정 로직 검증
+// TapAutoProbeTests.cs - 자동 탭 진단의 판정 로직과 관성 산수 검증
 // Level 0: 실기기·브라우저 없이 검증한다.
 //
 // 자동 진단은 실기기에서 딱 한 번 돌고 그 결과로 #1141의 방향이 갈린다. 집계는 맞는데
-// 판정문이 틀리면 잘못된 결론을 그대로 믿게 되므로, 집계 → 결론 사상을 여기서 고정한다.
-// Conclude/Summarize는 Unity 타입을 쓰지 않아 EditMode에서 그대로 부를 수 있다.
+// 판정문이 틀리면 팀이 잘못된 결론을 그대로 믿는다. Conclude/Summarize와 관성 산수는
+// Unity 타입에 의존하지 않으므로 전 분기를 여기서 고정한다.
 //
-// 특히 중요한 것은 "하네스가 안 돌았다"와 "가설이 반증됐다"를 절대 섞지 않는 것이다.
-// 합성 탭이 빗맞아 기록이 0건인 상황은 FIRE=NO가 아니라 판정 불가여야 한다.
+// 이 파일이 지키는 가장 중요한 성질: "하네스가 안 돌았다"와 "가설이 반증됐다"를 절대 섞지
+// 않는다. 합성 탭이 빗맞아 표본이 없는 상황은 FIRE=NO가 아니라 판정 불가여야 한다.
 // -----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
+using UnityEngine;
 
 [TestFixture]
 public class TapAutoProbeTests
 {
-    private static TapAutoProbe.ConditionResult Control(int landed, int fired)
+    private const float Hold = TapAutoProbe.HoldMs / 1000f;
+    private const float Decel = 0.135f;
+
+    private static TapAutoProbe.HarnessInfo Info(bool inertia = true, float targetHeight = 40f)
+    {
+        return new TapAutoProbe.HarnessInfo
+        {
+            Resolved = true,
+            ControlName = TapAutoProbe.ControlLabel,
+            TargetName = TapAutoProbe.TargetLabel,
+            Inertia = inertia,
+            MovementType = "Elastic",
+            DecelerationRate = Decel,
+            ScaleFactor = 3f,
+            TargetHeight = targetHeight,
+        };
+    }
+
+    private static TapAutoProbe.ConditionResult Control(
+        int attempted, int landed, int fired, int contaminated = 0)
     {
         return new TapAutoProbe.ConditionResult
         {
             Name = "A 대조군",
+            TargetLabel = TapAutoProbe.ControlLabel,
             HasScrollRect = false,
-            Attempted = landed,
+            Attempted = attempted,
             Landed = landed,
             UpReceived = landed,
             Fired = fired,
+            Contaminated = contaminated,
         };
     }
 
-    private static TapAutoProbe.ConditionResult Scroll(string name, float velocity, int landed, int fired)
+    /// <summary>
+    /// 스크롤 조건 하나. up을 안 주면 전부 수신, measured를 안 주면 명령 속도가 그대로
+    /// 유지된 것으로 본다 — 즉 기본값은 "깨끗한 조건"이다.
+    /// </summary>
+    private static TapAutoProbe.ConditionResult Scroll(
+        string name, float displacement, int attempted, int landed, int fired,
+        int up = -1, float measured = -1f, int contaminated = 0,
+        int overChanged = 0, int timedOut = 0, int dragSelf = 0)
     {
+        float velocity = TapAutoProbe.VelocityForDisplacement(displacement, Hold, Decel);
+        if (up < 0) up = landed;
+        if (measured < 0f) measured = Mathf.Abs(velocity);
+
         return new TapAutoProbe.ConditionResult
         {
             Name = name,
-            VelocityY = velocity,
+            TargetLabel = TapAutoProbe.TargetLabel,
             HasScrollRect = true,
-            Attempted = landed,
+            CommandedVelocity = velocity,
+            ExpectedDisplacement = displacement,
+            Attempted = attempted,
+            Landed = landed,
+            UpReceived = up,
+            Fired = fired,
+            Contaminated = contaminated,
+            OverChanged = overChanged,
+            TimedOut = timedOut,
+            DragWasSelf = dragSelf,
+            MeasuredVelocityAbsSum = measured * landed,
+            MeasuredSamples = landed,
+        };
+    }
+
+    private static TapAutoProbe.ConditionResult Stationary(int attempted, int landed, int fired)
+    {
+        return new TapAutoProbe.ConditionResult
+        {
+            Name = "B 정지",
+            TargetLabel = TapAutoProbe.TargetLabel,
+            HasScrollRect = true,
+            CommandedVelocity = 0f,
+            ExpectedDisplacement = 0f,
+            Attempted = attempted,
             Landed = landed,
             UpReceived = landed,
             Fired = fired,
@@ -44,73 +104,168 @@ public class TapAutoProbeTests
     }
 
     // =====================================================
-    // 판정 불가 — 하네스가 안 돈 경우
+    // 관성 산수 — 스윕 설계의 근거
     // =====================================================
+
+    [Test]
+    public void DisplacementPerUnitVelocity_MatchesClosedForm()
+    {
+        // ScrollRect의 v *= pow(rate, dt); pos += v*dt 를 연속 근사하면
+        // ∫₀ᵀ rate^t dt = (rate^T − 1) / ln(rate). 80ms·0.135에서 0.0739.
+        float f = TapAutoProbe.DisplacementPerUnitVelocity(Hold, Decel);
+        Assert.AreEqual(0.073918f, f, 1e-4f);
+    }
+
+    [Test]
+    public void DisplacementPerUnitVelocity_NoDecay_IsLinear()
+    {
+        // 감쇠가 없으면 그냥 v*T다. 계수가 범위를 벗어난 값으로 들어와도 NaN이 나오면 안 된다.
+        Assert.AreEqual(0.08f, TapAutoProbe.DisplacementPerUnitVelocity(0.08f, 1f), 1e-6f);
+        Assert.AreEqual(0.08f, TapAutoProbe.DisplacementPerUnitVelocity(0.08f, 0f), 1e-6f);
+        Assert.AreEqual(0f, TapAutoProbe.DisplacementPerUnitVelocity(0f, Decel), 1e-6f);
+    }
+
+    [Test]
+    public void VelocityForDisplacement_RoundTripsThroughDisplacement()
+    {
+        foreach (float d in new[] { 10f, 20f, 50f, 90f })
+        {
+            float v = TapAutoProbe.VelocityForDisplacement(d, Hold, Decel);
+            float back = v * TapAutoProbe.DisplacementPerUnitVelocity(Hold, Decel);
+            Assert.AreEqual(d, back, 1e-2f, $"변위 {d} 왕복 실패");
+        }
+    }
+
+    [Test]
+    public void SweepDisplacements_StraddleTheWidgetFlipThreshold()
+    {
+        // 합성 탭은 손가락을 안 움직이므로 클릭이 죽는 경로는 "콘텐츠가 흘러 조준점이 위젯을
+        // 벗어나는 것"뿐이다. 문턱은 위젯 높이(40)의 절반인 20. 스윕이 그 아래와 위를 모두
+        // 덮지 않으면 가설을 시험한 적이 없는데도 결론이 나온다.
+        float flip = Info().FlipThreshold;
+        var sweep = TapAutoProbe.SweepDisplacements;
+
+        Assert.Greater(sweep.Length, 2, "스윕이 너무 성기다");
+        Assert.Less(sweep[0], flip, "문턱 아래 음성 대조군이 있어야 한다");
+        Assert.Greater(sweep[sweep.Length - 1], flip * 2f, "문턱을 넉넉히 넘는 조건이 있어야 한다");
+
+        int above = 0;
+        for (int i = 1; i < sweep.Length; i++)
+        {
+            Assert.Greater(sweep[i], sweep[i - 1], "스윕은 오름차순이어야 한다");
+            if (sweep[i] >= flip) above++;
+        }
+        Assert.GreaterOrEqual(above, 3, "문턱 위 조건이 최소 3개는 있어야 임계를 좁힐 수 있다");
+    }
+
+    // =====================================================
+    // 하네스 전제 — 안 서면 아무 말도 하지 않는다
+    // =====================================================
+
+    [Test]
+    public void Conclude_NotResolved_ReportsTheProblemAndNothingElse()
+    {
+        var info = Info();
+        info.Resolved = false;
+        info.Problem = "라벨로 표적을 찾지 못했습니다(표적 \"test-key\"=없음).";
+
+        string verdict = TapAutoProbe.Conclude(info, new List<TapAutoProbe.ConditionResult>());
+
+        StringAssert.Contains("불가", verdict);
+        StringAssert.Contains("test-key", verdict);
+        StringAssert.DoesNotContain("관성 가설", verdict);
+    }
+
+    [Test]
+    public void Conclude_InertiaOff_IsInconclusiveNotRefutation()
+    {
+        // inertia가 꺼져 있으면 velocity가 매 프레임 지워져 스윕이 통째로 무의미하다.
+        // 이때 전 조건 FIRE=YES가 나오는데, 이걸 반증이라고 말하면 최악의 오판이다.
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C +90", 90f, 3, 3, 3),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(inertia: false), results);
+
+        StringAssert.Contains("불가", verdict);
+        StringAssert.Contains("inertia", verdict);
+        StringAssert.DoesNotContain("관성 가설 반증", verdict);
+    }
 
     [Test]
     public void Conclude_NoResults_IsInconclusive()
     {
-        StringAssert.Contains("불가", TapAutoProbe.Conclude(new List<TapAutoProbe.ConditionResult>()));
-        StringAssert.Contains("불가", TapAutoProbe.Conclude(null));
+        StringAssert.Contains("불가", TapAutoProbe.Conclude(Info(), new List<TapAutoProbe.ConditionResult>()));
+        StringAssert.Contains("불가", TapAutoProbe.Conclude(Info(), null));
     }
+
+    // =====================================================
+    // 대조군이 먼저 답을 가른다
+    // =====================================================
 
     [Test]
     public void Conclude_ControlNeverLanded_IsInconclusiveNotRefutation()
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 0, fired: 0),
-            Scroll("B 정지", 0f, landed: 0, fired: 0),
+            Control(3, 0, 0),
+            Stationary(3, 0, 0),
         };
 
-        string verdict = TapAutoProbe.Conclude(results);
+        string verdict = TapAutoProbe.Conclude(Info(), results);
 
-        // 합성 탭이 아예 안 닿은 것이므로 가설에 대해 아무 말도 하면 안 된다.
         StringAssert.Contains("불가", verdict);
         StringAssert.DoesNotContain("폐기", verdict);
-        StringAssert.DoesNotContain("확정", verdict);
+        StringAssert.DoesNotContain("유력", verdict);
     }
 
     [Test]
-    public void Conclude_NoControlCondition_IsInconclusive()
+    public void Conclude_ControlUnderSampled_IsInconclusive()
     {
+        // 3번 시도해 1번 착지, 그 1번이 발화. Fired == Landed라 예전 로직은 "정상"으로 통과시켰다.
+        // 표본 1개짜리 대조군으로는 나머지를 해석할 수 없다.
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Scroll("B 정지", 0f, landed: 3, fired: 3),
+            Control(3, 1, 1),
+            Stationary(3, 3, 3),
+            Scroll("C +90", 90f, 3, 3, 0),
         };
 
-        StringAssert.Contains("불가", TapAutoProbe.Conclude(results));
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.StartsWith("판정: 불가", verdict);
+        StringAssert.Contains("표본", verdict);
+        StringAssert.DoesNotContain("유력", verdict);
     }
 
     [Test]
-    public void Conclude_ScrollTargetNeverLanded_IsInconclusive()
+    public void Conclude_ControlContaminated_IsInconclusive()
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 3, fired: 3),
-            Scroll("B 정지", 0f, landed: 0, fired: 0),
+            Control(3, 3, 3, contaminated: 2),
+            Stationary(3, 3, 3),
         };
 
-        string verdict = TapAutoProbe.Conclude(results);
+        string verdict = TapAutoProbe.Conclude(Info(), results);
 
         StringAssert.Contains("불가", verdict);
-        StringAssert.DoesNotContain("확정", verdict);
+        StringAssert.Contains("만지지", verdict);
     }
-
-    // =====================================================
-    // 대조군이 답을 먼저 가른다
-    // =====================================================
 
     [Test]
     public void Conclude_ControlAlsoFails_DiscardsEveryHypothesis()
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 3, fired: 0),
-            Scroll("B 정지", 0f, landed: 3, fired: 0),
+            Control(3, 3, 0),
+            Stationary(3, 3, 0),
         };
 
-        string verdict = TapAutoProbe.Conclude(results);
+        string verdict = TapAutoProbe.Conclude(Info(), results);
 
         // 스크롤 밖에서도 클릭이 안 나면 ScrollRect 가설은 전부 무의미하다.
         StringAssert.Contains("폐기", verdict);
@@ -122,132 +277,261 @@ public class TapAutoProbeTests
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 3, fired: 2),
-            Scroll("B 정지", 0f, landed: 3, fired: 3),
-            Scroll("C -400", -400f, landed: 3, fired: 0),
+            Control(3, 3, 2),
+            Stationary(3, 3, 3),
+            Scroll("C -50", 50f, 3, 3, 0),
         };
 
-        string verdict = TapAutoProbe.Conclude(results);
+        string verdict = TapAutoProbe.Conclude(Info(), results);
 
-        StringAssert.Contains("확정", verdict);
+        StringAssert.Contains("유력", verdict);
         // 대조군이 흔들렸다는 사실을 숨기면 결론의 신뢰도를 과대평가하게 된다.
-        StringAssert.Contains("불안정", verdict);
+        StringAssert.Contains("흔들", verdict);
     }
 
     // =====================================================
-    // 관성 가설
+    // 명령한 속도가 실제로 유지됐는가
     // =====================================================
+
+    [Test]
+    public void Conclude_CommandedVelocityNotHonored_IsInconclusive()
+    {
+        // 탄성 경계나 관성 억제가 개입해 press 시점 속도가 사라지면, 다른 값이 다 깨끗해도
+        // 관성 가설을 시험한 셈이 아니다.
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C +30", 30f, 3, 3, 3),
+            Scroll("C +90", 90f, 3, 3, 3, measured: 12f),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.StartsWith("판정: 불가", verdict);
+        StringAssert.Contains("C +90", verdict);
+        StringAssert.Contains("실측", verdict);
+        StringAssert.DoesNotContain("관성 가설 반증", verdict);
+    }
+
+    // =====================================================
+    // 표본·미착지를 결론에 반영한다
+    // =====================================================
+
+    [Test]
+    public void Conclude_UnderSampledFailure_IsNotAThresholdCandidate()
+    {
+        // 3번 시도해 1번 착지, 그 1번이 실패. 표본 1개로 "임계 여기부터"를 발표하면 안 된다.
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C +30", 30f, 3, 1, 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.DoesNotContain("변위 30", verdict);
+        StringAssert.Contains("미검증", verdict);
+    }
+
+    [Test]
+    public void Conclude_HighSpeedConditionsNeverLanded_IsNotRefutation()
+    {
+        // 저속만 착지·발화하고 고속이 전부 빗맞은 경우. 예전 로직은 미착지 조건을 소리 없이
+        // 빼고 "쓸어본 모든 속도에서 FIRE=YES"라고 단정했다 — 가설을 시험한 적이 없는데도.
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C -10", 10f, 3, 3, 3),
+            Scroll("C +10", 10f, 3, 3, 3),
+            Scroll("C -50", 50f, 3, 0, 0),
+            Scroll("C +90", 90f, 3, 0, 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.Contains("부분 불가", verdict);
+        StringAssert.DoesNotContain("관성 가설 반증", verdict);
+        StringAssert.DoesNotContain("모든 변위", verdict);
+        // 무엇이 미검증인지 이름으로 열거해야 사람이 다시 돌릴 판단을 할 수 있다.
+        StringAssert.Contains("C -50", verdict);
+        StringAssert.Contains("C +90", verdict);
+    }
+
+    [Test]
+    public void Conclude_UntestedConditionsQualifyTheThreshold()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C +50", 50f, 3, 3, 0),
+            Scroll("C +30", 30f, 3, 0, 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.Contains("유력", verdict);
+        // 미검증 구간이 있으면 임계는 "시험된 범위에서"의 최솟값일 뿐이다.
+        StringAssert.Contains("시험된 범위", verdict);
+        StringAssert.Contains("낮을 수 있습니다", verdict);
+    }
+
+    // =====================================================
+    // UP 미수신은 관성과 다른 경로다
+    // =====================================================
+
+    [Test]
+    public void Conclude_AllMovingConditionsMissUp_GetsItsOwnHeadline()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C +50", 50f, 3, 3, 0, up: 0),
+            Scroll("C +90", 90f, 3, 3, 0, up: 1),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.Contains("UP 미수신", verdict);
+        StringAssert.Contains("pointerPress", verdict);
+        // 관성 임계로 흡수되면 안 된다.
+        StringAssert.DoesNotContain("유력", verdict);
+        StringAssert.DoesNotContain("변위 50", verdict);
+    }
+
+    [Test]
+    public void Conclude_SomeMissUp_ExcludedFromThresholdSearch()
+    {
+        // UP 미수신 조건은 구조상 Fired < Landed라 임계 후보가 되어버린다. 더 낮은 변위에
+        // 있으면 임계를 통째로 왜곡한다. 높이 44라 문턱 22 — 아래 숫자와 겹치지 않게 잡았다.
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C +20", 20f, 3, 3, 0, up: 1),
+            Scroll("C +50", 50f, 3, 3, 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(targetHeight: 44f), results);
+
+        StringAssert.Contains("변위 50", verdict);
+        StringAssert.DoesNotContain("변위 20", verdict);
+        StringAssert.Contains("임계 탐색에서 제외", verdict);
+    }
+
+    // =====================================================
+    // 임계 탐색
+    // =====================================================
+
+    [Test]
+    public void Conclude_ReportsLowestFailingDisplacementRegardlessOfOrder()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C -90", 90f, 3, 3, 0),
+            Scroll("C +50", 50f, 3, 3, 1),
+            Scroll("C -30", 30f, 3, 3, 3),
+            Scroll("C +20", 20f, 3, 3, 3),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.Contains("유력", verdict);
+        // 부호가 아니라 크기로, 목록 순서와 무관하게 가장 낮은 실패 변위를 집어야 한다.
+        StringAssert.Contains("변위 50", verdict);
+        StringAssert.DoesNotContain("변위 90", verdict);
+    }
+
+    [Test]
+    public void Conclude_PartialFailureAtOneDisplacement_CountsAsFailure()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            // 3번 중 2번만 발화해도 실패다. 간헐 증상이라 전부 실패할 이유가 없다.
+            Scroll("C -30", 30f, 3, 3, 2),
+        };
+
+        StringAssert.Contains("변위 30", TapAutoProbe.Conclude(Info(), results));
+    }
+
+    [Test]
+    public void Conclude_FailureBelowFlipThreshold_FlagsAnomaly()
+    {
+        // 변위 10은 위젯 문턱 20을 못 넘어 구조적으로 클릭이 죽을 수 없다. 여기서 죽었다면
+        // 콘텐츠 이동 말고 다른 원인이 함께 있다는 뜻이고, 그 사실을 반드시 알려야 한다.
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C -10", 10f, 3, 3, 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.Contains("이상", verdict);
+        StringAssert.Contains("문턱", verdict);
+    }
+
+    [Test]
+    public void Conclude_EveryTestedDisplacementFires_RefutesInertiaHypothesis()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C -30", 30f, 3, 3, 3),
+            Scroll("C +90", 90f, 3, 3, 3),
+        };
+
+        string verdict = TapAutoProbe.Conclude(Info(), results);
+
+        StringAssert.Contains("관성 가설 반증", verdict);
+        StringAssert.DoesNotContain("유력", verdict);
+    }
 
     [Test]
     public void Conclude_StationaryAlsoFails_BlamesScrollRectNotVelocity()
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 3, fired: 3),
-            Scroll("B 정지", 0f, landed: 3, fired: 0),
-            Scroll("C -400", -400f, landed: 3, fired: 0),
+            Control(3, 3, 3),
+            Stationary(3, 3, 0),
+            Scroll("C -50", 50f, 3, 3, 0),
         };
 
-        string verdict = TapAutoProbe.Conclude(results);
+        string verdict = TapAutoProbe.Conclude(Info(), results);
 
         StringAssert.Contains("관성 무관", verdict);
-        StringAssert.DoesNotContain("확정", verdict);
-    }
-
-    [Test]
-    public void Conclude_EveryVelocityFires_RefutesInertiaHypothesis()
-    {
-        var results = new List<TapAutoProbe.ConditionResult>
-        {
-            Control(landed: 3, fired: 3),
-            Scroll("B 정지", 0f, landed: 3, fired: 3),
-            Scroll("C -400", -400f, landed: 3, fired: 3),
-            Scroll("C +1600", 1600f, landed: 3, fired: 3),
-        };
-
-        string verdict = TapAutoProbe.Conclude(results);
-
-        StringAssert.Contains("반증", verdict);
-        StringAssert.DoesNotContain("확정", verdict);
-    }
-
-    [Test]
-    public void Conclude_ReportsLowestFailingSpeedRegardlessOfSignAndOrder()
-    {
-        var results = new List<TapAutoProbe.ConditionResult>
-        {
-            Control(landed: 3, fired: 3),
-            Scroll("B 정지", 0f, landed: 3, fired: 3),
-            Scroll("C -1600", -1600f, landed: 3, fired: 0),
-            Scroll("C +800", 800f, landed: 3, fired: 1),
-            Scroll("C -400", -400f, landed: 3, fired: 3),
-            Scroll("C +200", 200f, landed: 3, fired: 3),
-        };
-
-        string verdict = TapAutoProbe.Conclude(results);
-
-        StringAssert.Contains("확정", verdict);
-        // 부호가 아니라 크기로, 목록 순서와 무관하게 가장 낮은 실패 속도를 집어야 한다.
-        StringAssert.Contains("800", verdict);
-        StringAssert.DoesNotContain("1600", verdict);
-    }
-
-    [Test]
-    public void Conclude_PartialFailureAtOneSpeed_CountsAsFailure()
-    {
-        var results = new List<TapAutoProbe.ConditionResult>
-        {
-            Control(landed: 3, fired: 3),
-            Scroll("B 정지", 0f, landed: 3, fired: 3),
-            // 3번 중 2번만 발화해도 결정적 실패다. 간헐 증상이라 전부 실패할 이유가 없다.
-            Scroll("C -100", -100f, landed: 3, fired: 2),
-        };
-
-        StringAssert.Contains("확정", TapAutoProbe.Conclude(results));
-        StringAssert.Contains("100", TapAutoProbe.Conclude(results));
+        StringAssert.DoesNotContain("유력", verdict);
     }
 
     // =====================================================
-    // 부가 신호
+    // 부가 신호와 문장 형태
     // =====================================================
 
     [Test]
-    public void Conclude_MissingPointerUp_IsReportedSeparately()
+    public void Conclude_DragWasSelf_IsReportedAsDirectEvidence()
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 3, fired: 3),
-            new TapAutoProbe.ConditionResult
-            {
-                Name = "C -800", VelocityY = -800f, HasScrollRect = true,
-                Attempted = 3, Landed = 3, UpReceived = 1, Fired = 1,
-            },
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C -50", 50f, 3, 3, 0, overChanged: 3, dragSelf: 3),
         };
 
-        string verdict = TapAutoProbe.Conclude(results);
+        string verdict = TapAutoProbe.Conclude(Info(), results);
 
-        // UP 미수신은 반증됐다고 본 드래그 취소 경로가 실재한다는 뜻이라 따로 보여야 한다.
-        StringAssert.Contains("UP 미수신 2건", verdict);
-        StringAssert.Contains("pointerPress", verdict);
-    }
-
-    [Test]
-    public void Conclude_OverChanged_IsReportedSeparately()
-    {
-        var results = new List<TapAutoProbe.ConditionResult>
-        {
-            Control(landed: 3, fired: 3),
-            new TapAutoProbe.ConditionResult
-            {
-                Name = "C -800", VelocityY = -800f, HasScrollRect = true,
-                Attempted = 3, Landed = 3, UpReceived = 3, Fired = 0, OverChanged = 3,
-            },
-        };
-
-        string verdict = TapAutoProbe.Conclude(results);
-
+        // pointerDrag가 InputField 자신이면 ScrollRect가 드래그 대상으로 안 잡혔다는 직접 증거다.
+        StringAssert.Contains("pointerDrag", verdict);
         StringAssert.Contains("over 변화 3건", verdict);
-        StringAssert.Contains("확정", verdict);
     }
 
     [Test]
@@ -255,16 +539,14 @@ public class TapAutoProbeTests
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 3, fired: 3),
-            Scroll("B 정지", 0f, landed: 3, fired: 3),
-            Scroll("C -400", -400f, landed: 3, fired: 3),
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C -30", 30f, 3, 3, 3),
         };
 
-        string verdict = TapAutoProbe.Conclude(results);
+        string verdict = TapAutoProbe.Conclude(Info(), results);
 
-        StringAssert.DoesNotContain("미수신", verdict);
-        StringAssert.DoesNotContain("over 변화", verdict);
-        StringAssert.DoesNotContain("불안정", verdict);
+        Assert.AreEqual(1, verdict.Split('\n').Length, "깨끗한 런에 각주가 붙으면 안 된다:\n" + verdict);
     }
 
     [Test]
@@ -272,51 +554,146 @@ public class TapAutoProbeTests
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 3, fired: 3),
-            new TapAutoProbe.ConditionResult
-            {
-                Name = "C -800", VelocityY = -800f, HasScrollRect = true,
-                Attempted = 3, Landed = 3, UpReceived = 2, Fired = 0, OverChanged = 1,
-            },
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C -50", 50f, 3, 3, 0, overChanged: 2, timedOut: 1),
         };
 
-        string first = TapAutoProbe.Conclude(results).Split('\n')[0];
+        string first = TapAutoProbe.Conclude(Info(), results).Split('\n')[0];
 
         // 화면이 좁아 첫 줄만 보이는 경우가 흔하다. 결론이 거기 있어야 한다.
         StringAssert.StartsWith("판정:", first);
-        StringAssert.Contains("확정", first);
+        StringAssert.Contains("유력", first);
     }
 
-    // =====================================================
-    // 집계표
-    // =====================================================
-
     [Test]
-    public void Summarize_ListsEveryConditionWithLandedRatio()
+    public void Conclude_NeverClaimsUnmeasuredMechanismAsFact()
     {
         var results = new List<TapAutoProbe.ConditionResult>
         {
-            Control(landed: 3, fired: 3),
-            new TapAutoProbe.ConditionResult
-            {
-                Name = "C -1600", VelocityY = -1600f, HasScrollRect = true,
-                Attempted = 3, Landed = 1, UpReceived = 1, Fired = 0,
-            },
+            Control(3, 3, 3),
+            Stationary(3, 3, 3),
+            Scroll("C -50", 50f, 3, 3, 0),
         };
 
-        string table = TapAutoProbe.Summarize(results);
+        string verdict = TapAutoProbe.Conclude(Info(), results);
 
-        StringAssert.Contains("A 대조군", table);
-        StringAssert.Contains("C -1600", table);
-        // 빗맞은 탭이 몇 건인지 보여야 "실패"와 "미착지"를 사람이 구분할 수 있다.
-        StringAssert.Contains("1/3", table);
-        StringAssert.Contains("3/3", table);
+        // 프로브는 IInitializePotentialDragHandler를 일부러 구현하지 않아 그 호출 여부를 못 본다.
+        // 관측하는 것은 클릭 판정식뿐이므로 근인을 단정하면 안 된다.
+        StringAssert.DoesNotContain("근인", verdict);
+        StringAssert.DoesNotContain("확정", verdict);
+    }
+
+    // =====================================================
+    // 집계표 — 자동 판정이 틀렸을 때 대조할 원본
+    // =====================================================
+
+    [Test]
+    public void Summarize_ShowsHarnessPreconditionsAndTargetLabels()
+    {
+        string table = TapAutoProbe.Summarize(Info(), new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+        });
+
+        // 무엇을 때렸는지, 어떤 전제 위에서 돌았는지가 결과지에 남아야 한다.
+        StringAssert.Contains(TapAutoProbe.ControlLabel, table);
+        StringAssert.Contains(TapAutoProbe.TargetLabel, table);
+        StringAssert.Contains("inertia=1", table);
+        StringAssert.Contains("Elastic", table);
+        StringAssert.Contains("문턱=20", table);
     }
 
     [Test]
-    public void Summarize_NoResults_SaysSo()
+    public void Summarize_ShowsMeasuredVelocityAndLandedRatio()
     {
-        StringAssert.Contains("집계 없음", TapAutoProbe.Summarize(null));
-        StringAssert.Contains("집계 없음", TapAutoProbe.Summarize(new List<TapAutoProbe.ConditionResult>()));
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(3, 3, 3),
+            Scroll("C -90", 90f, 3, 1, 0, measured: 42f),
+        };
+
+        string table = TapAutoProbe.Summarize(Info(), results);
+
+        StringAssert.Contains("C -90", table);
+        // 빗맞은 탭이 몇 건인지 보여야 "실패"와 "미착지"를 사람이 구분할 수 있다.
+        StringAssert.Contains("1/3", table);
+        StringAssert.Contains("3/3", table);
+        // 실측 속도가 없으면 명령값이 유지됐는지 사람이 확인할 방법이 없다.
+        StringAssert.Contains("42", table);
+        StringAssert.Contains("표본부족", table);
+    }
+
+    [Test]
+    public void Summarize_NoResults_StillShowsHarnessInfo()
+    {
+        string table = TapAutoProbe.Summarize(Info(), new List<TapAutoProbe.ConditionResult>());
+
+        StringAssert.Contains("집계 없음", table);
+        StringAssert.Contains("inertia=1", table);
+    }
+
+    // =====================================================
+    // C# ↔ jslib 정합성
+    //
+    // 저장소의 자동 invariant 검사(sdk-runtime-generator~의 vitest)는 Runtime/SDK만 훑는다.
+    // 테스트용 브리지의 신규 함수는 그 그물 밖이라, 한쪽 시그니처만 바뀌면 실기기에서
+    // "함수를 찾을 수 없다"로 죽을 때까지 아무도 모른다. 여기서 양쪽 소스를 직접 대조한다.
+    // =====================================================
+
+    /// <summary>이 테스트 파일의 컴파일 시점 경로. 저장소 안 다른 파일을 찾는 기준점이다.</summary>
+    private static string ThisFile([CallerFilePath] string path = null) => path;
+
+    private static string ReadSibling(string relative)
+    {
+        string dir = Path.GetDirectoryName(ThisFile());
+        if (string.IsNullOrEmpty(dir)) return null;
+        string full = Path.GetFullPath(Path.Combine(dir, relative));
+        return File.Exists(full) ? File.ReadAllText(full) : null;
+    }
+
+    [Test]
+    public void SyntheticTapBridge_SignaturesMatchOnBothSides()
+    {
+        string cs = ReadSibling("../../Runtime/TapAutoProbe.cs");
+        string js = ReadSibling("../../Plugins/E2ETestBridge.jslib");
+        if (cs == null || js == null)
+        {
+            Assert.Ignore("소스 경로를 찾지 못했다(패키지가 복사된 환경). 대조를 건너뛴다.");
+        }
+
+        var csTap = Regex.Match(cs, @"static\s+extern\s+void\s+TAP_Tap\s*\(([^)]*)\)");
+        var jsTap = Regex.Match(js, @"TAP_Tap\s*:\s*function\s*\(([^)]*)\)");
+        Assert.IsTrue(csTap.Success, "C#에 TAP_Tap extern이 없다");
+        Assert.IsTrue(jsTap.Success, "jslib에 TAP_Tap이 없다");
+        Assert.AreEqual(ArgCount(csTap.Groups[1].Value), ArgCount(jsTap.Groups[1].Value),
+            "TAP_Tap의 인자 개수가 C#과 jslib에서 다르다");
+
+        var csBusy = Regex.Match(cs, @"static\s+extern\s+int\s+TAP_DriveBusy\s*\(([^)]*)\)");
+        var jsBusy = Regex.Match(js, @"TAP_DriveBusy\s*:\s*function\s*\(([^)]*)\)");
+        Assert.IsTrue(csBusy.Success, "C#에 TAP_DriveBusy extern이 없다");
+        Assert.IsTrue(jsBusy.Success, "jslib에 TAP_DriveBusy가 없다");
+        Assert.AreEqual(0, ArgCount(csBusy.Groups[1].Value));
+        Assert.AreEqual(0, ArgCount(jsBusy.Groups[1].Value));
+    }
+
+    [Test]
+    public void TapLoggingBridge_ExistsOnBothSides()
+    {
+        string cs = ReadSibling("../../Runtime/PointerTapDiagnostics.cs");
+        string js = ReadSibling("../../Plugins/E2ETestBridge.jslib");
+        if (cs == null || js == null) Assert.Ignore("소스 경로를 찾지 못했다. 대조를 건너뛴다.");
+
+        foreach (string name in new[] { "TAP_Log", "TAP_Clear" })
+        {
+            StringAssert.Contains($"extern void {name}", cs);
+            StringAssert.Contains($"{name}: function", js);
+        }
+    }
+
+    private static int ArgCount(string paramList)
+    {
+        paramList = paramList.Trim();
+        return paramList.Length == 0 ? 0 : paramList.Split(',').Length;
     }
 }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/TapAutoProbeTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/TapAutoProbeTests.cs
@@ -1,0 +1,322 @@
+// -----------------------------------------------------------------------
+// TapAutoProbeTests.cs - 자동 탭 진단의 판정 로직 검증
+// Level 0: 실기기·브라우저 없이 검증한다.
+//
+// 자동 진단은 실기기에서 딱 한 번 돌고 그 결과로 #1141의 방향이 갈린다. 집계는 맞는데
+// 판정문이 틀리면 잘못된 결론을 그대로 믿게 되므로, 집계 → 결론 사상을 여기서 고정한다.
+// Conclude/Summarize는 Unity 타입을 쓰지 않아 EditMode에서 그대로 부를 수 있다.
+//
+// 특히 중요한 것은 "하네스가 안 돌았다"와 "가설이 반증됐다"를 절대 섞지 않는 것이다.
+// 합성 탭이 빗맞아 기록이 0건인 상황은 FIRE=NO가 아니라 판정 불가여야 한다.
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+[TestFixture]
+public class TapAutoProbeTests
+{
+    private static TapAutoProbe.ConditionResult Control(int landed, int fired)
+    {
+        return new TapAutoProbe.ConditionResult
+        {
+            Name = "A 대조군",
+            HasScrollRect = false,
+            Attempted = landed,
+            Landed = landed,
+            UpReceived = landed,
+            Fired = fired,
+        };
+    }
+
+    private static TapAutoProbe.ConditionResult Scroll(string name, float velocity, int landed, int fired)
+    {
+        return new TapAutoProbe.ConditionResult
+        {
+            Name = name,
+            VelocityY = velocity,
+            HasScrollRect = true,
+            Attempted = landed,
+            Landed = landed,
+            UpReceived = landed,
+            Fired = fired,
+        };
+    }
+
+    // =====================================================
+    // 판정 불가 — 하네스가 안 돈 경우
+    // =====================================================
+
+    [Test]
+    public void Conclude_NoResults_IsInconclusive()
+    {
+        StringAssert.Contains("불가", TapAutoProbe.Conclude(new List<TapAutoProbe.ConditionResult>()));
+        StringAssert.Contains("불가", TapAutoProbe.Conclude(null));
+    }
+
+    [Test]
+    public void Conclude_ControlNeverLanded_IsInconclusiveNotRefutation()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 0, fired: 0),
+            Scroll("B 정지", 0f, landed: 0, fired: 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        // 합성 탭이 아예 안 닿은 것이므로 가설에 대해 아무 말도 하면 안 된다.
+        StringAssert.Contains("불가", verdict);
+        StringAssert.DoesNotContain("폐기", verdict);
+        StringAssert.DoesNotContain("확정", verdict);
+    }
+
+    [Test]
+    public void Conclude_NoControlCondition_IsInconclusive()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Scroll("B 정지", 0f, landed: 3, fired: 3),
+        };
+
+        StringAssert.Contains("불가", TapAutoProbe.Conclude(results));
+    }
+
+    [Test]
+    public void Conclude_ScrollTargetNeverLanded_IsInconclusive()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            Scroll("B 정지", 0f, landed: 0, fired: 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        StringAssert.Contains("불가", verdict);
+        StringAssert.DoesNotContain("확정", verdict);
+    }
+
+    // =====================================================
+    // 대조군이 답을 먼저 가른다
+    // =====================================================
+
+    [Test]
+    public void Conclude_ControlAlsoFails_DiscardsEveryHypothesis()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 0),
+            Scroll("B 정지", 0f, landed: 3, fired: 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        // 스크롤 밖에서도 클릭이 안 나면 ScrollRect 가설은 전부 무의미하다.
+        StringAssert.Contains("폐기", verdict);
+        StringAssert.Contains("무관", verdict);
+    }
+
+    [Test]
+    public void Conclude_FlakyControl_WarnsButStillConcludes()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 2),
+            Scroll("B 정지", 0f, landed: 3, fired: 3),
+            Scroll("C -400", -400f, landed: 3, fired: 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        StringAssert.Contains("확정", verdict);
+        // 대조군이 흔들렸다는 사실을 숨기면 결론의 신뢰도를 과대평가하게 된다.
+        StringAssert.Contains("불안정", verdict);
+    }
+
+    // =====================================================
+    // 관성 가설
+    // =====================================================
+
+    [Test]
+    public void Conclude_StationaryAlsoFails_BlamesScrollRectNotVelocity()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            Scroll("B 정지", 0f, landed: 3, fired: 0),
+            Scroll("C -400", -400f, landed: 3, fired: 0),
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        StringAssert.Contains("관성 무관", verdict);
+        StringAssert.DoesNotContain("확정", verdict);
+    }
+
+    [Test]
+    public void Conclude_EveryVelocityFires_RefutesInertiaHypothesis()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            Scroll("B 정지", 0f, landed: 3, fired: 3),
+            Scroll("C -400", -400f, landed: 3, fired: 3),
+            Scroll("C +1600", 1600f, landed: 3, fired: 3),
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        StringAssert.Contains("반증", verdict);
+        StringAssert.DoesNotContain("확정", verdict);
+    }
+
+    [Test]
+    public void Conclude_ReportsLowestFailingSpeedRegardlessOfSignAndOrder()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            Scroll("B 정지", 0f, landed: 3, fired: 3),
+            Scroll("C -1600", -1600f, landed: 3, fired: 0),
+            Scroll("C +800", 800f, landed: 3, fired: 1),
+            Scroll("C -400", -400f, landed: 3, fired: 3),
+            Scroll("C +200", 200f, landed: 3, fired: 3),
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        StringAssert.Contains("확정", verdict);
+        // 부호가 아니라 크기로, 목록 순서와 무관하게 가장 낮은 실패 속도를 집어야 한다.
+        StringAssert.Contains("800", verdict);
+        StringAssert.DoesNotContain("1600", verdict);
+    }
+
+    [Test]
+    public void Conclude_PartialFailureAtOneSpeed_CountsAsFailure()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            Scroll("B 정지", 0f, landed: 3, fired: 3),
+            // 3번 중 2번만 발화해도 결정적 실패다. 간헐 증상이라 전부 실패할 이유가 없다.
+            Scroll("C -100", -100f, landed: 3, fired: 2),
+        };
+
+        StringAssert.Contains("확정", TapAutoProbe.Conclude(results));
+        StringAssert.Contains("100", TapAutoProbe.Conclude(results));
+    }
+
+    // =====================================================
+    // 부가 신호
+    // =====================================================
+
+    [Test]
+    public void Conclude_MissingPointerUp_IsReportedSeparately()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            new TapAutoProbe.ConditionResult
+            {
+                Name = "C -800", VelocityY = -800f, HasScrollRect = true,
+                Attempted = 3, Landed = 3, UpReceived = 1, Fired = 1,
+            },
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        // UP 미수신은 반증됐다고 본 드래그 취소 경로가 실재한다는 뜻이라 따로 보여야 한다.
+        StringAssert.Contains("UP 미수신 2건", verdict);
+        StringAssert.Contains("pointerPress", verdict);
+    }
+
+    [Test]
+    public void Conclude_OverChanged_IsReportedSeparately()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            new TapAutoProbe.ConditionResult
+            {
+                Name = "C -800", VelocityY = -800f, HasScrollRect = true,
+                Attempted = 3, Landed = 3, UpReceived = 3, Fired = 0, OverChanged = 3,
+            },
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        StringAssert.Contains("over 변화 3건", verdict);
+        StringAssert.Contains("확정", verdict);
+    }
+
+    [Test]
+    public void Conclude_CleanRun_HasNoSpuriousNotes()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            Scroll("B 정지", 0f, landed: 3, fired: 3),
+            Scroll("C -400", -400f, landed: 3, fired: 3),
+        };
+
+        string verdict = TapAutoProbe.Conclude(results);
+
+        StringAssert.DoesNotContain("미수신", verdict);
+        StringAssert.DoesNotContain("over 변화", verdict);
+        StringAssert.DoesNotContain("불안정", verdict);
+    }
+
+    [Test]
+    public void Conclude_HeadlineIsTheFirstLine()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            new TapAutoProbe.ConditionResult
+            {
+                Name = "C -800", VelocityY = -800f, HasScrollRect = true,
+                Attempted = 3, Landed = 3, UpReceived = 2, Fired = 0, OverChanged = 1,
+            },
+        };
+
+        string first = TapAutoProbe.Conclude(results).Split('\n')[0];
+
+        // 화면이 좁아 첫 줄만 보이는 경우가 흔하다. 결론이 거기 있어야 한다.
+        StringAssert.StartsWith("판정:", first);
+        StringAssert.Contains("확정", first);
+    }
+
+    // =====================================================
+    // 집계표
+    // =====================================================
+
+    [Test]
+    public void Summarize_ListsEveryConditionWithLandedRatio()
+    {
+        var results = new List<TapAutoProbe.ConditionResult>
+        {
+            Control(landed: 3, fired: 3),
+            new TapAutoProbe.ConditionResult
+            {
+                Name = "C -1600", VelocityY = -1600f, HasScrollRect = true,
+                Attempted = 3, Landed = 1, UpReceived = 1, Fired = 0,
+            },
+        };
+
+        string table = TapAutoProbe.Summarize(results);
+
+        StringAssert.Contains("A 대조군", table);
+        StringAssert.Contains("C -1600", table);
+        // 빗맞은 탭이 몇 건인지 보여야 "실패"와 "미착지"를 사람이 구분할 수 있다.
+        StringAssert.Contains("1/3", table);
+        StringAssert.Contains("3/3", table);
+    }
+
+    [Test]
+    public void Summarize_NoResults_SaysSo()
+    {
+        StringAssert.Contains("집계 없음", TapAutoProbe.Summarize(null));
+        StringAssert.Contains("집계 없음", TapAutoProbe.Summarize(new List<TapAutoProbe.ConditionResult>()));
+    }
+}

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/TapAutoProbeTests.cs.meta
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/TapAutoProbeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d58f00b429d4f6e9a4e468095280c75
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
+++ b/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
@@ -188,6 +188,33 @@ mergeInto(LibraryManager.library, {
     },
 
     /**
+     * 탭 진단 한 줄을 window.__AIT_TAPLOG에 쌓고 console.log로 흘림
+     *
+     * 화면 패널과 별개로 콘솔에도 남기는 이유: 진단 대상이 "스크롤 영역 안에서 탭이 안 먹는 증상"이라
+     * 화면 UI 조작 자체가 증상의 영향을 받을 수 있다. 원격 인스펙터가 붙는 상황이면 화면을 거치지 않고
+     * 여기서 읽는 편이 확실하다.
+     *
+     * @param {number} linePtr - 진단 한 줄 문자열 포인터
+     */
+    TAP_Log: function(linePtr) {
+        var line = UTF8ToString(linePtr);
+        window.__AIT_TAPLOG = window.__AIT_TAPLOG || [];
+        window.__AIT_TAPLOG.push(line);
+        while (window.__AIT_TAPLOG.length > 200) {
+            window.__AIT_TAPLOG.shift();
+        }
+        console.log('[E2E-TAP] ' + line);
+    },
+
+    /**
+     * window.__AIT_TAPLOG를 비움
+     */
+    TAP_Clear: function() {
+        window.__AIT_TAPLOG = [];
+        console.log('[E2E-TAP] cleared');
+    },
+
+    /**
      * JavaScript에서 JSON 파싱 검증
      * C# → JSON → JavaScript 파싱 → JSON → C# 역직렬화 round-trip 검증용
      * @param {string} jsonPtr - JSON 문자열 포인터

--- a/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
+++ b/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
@@ -247,13 +247,18 @@ mergeInto(LibraryManager.library, {
         window.__AIT_TAP_ID = (window.__AIT_TAP_ID || 0) + 1;
         var id = window.__AIT_TAP_ID;
 
-        var touch = {
-            identifier: id,
-            target: canvas,
-            clientX: cx, clientY: cy,
-            pageX: cx + window.pageXOffset, pageY: cy + window.pageYOffset,
-            screenX: cx, screenY: cy,
-            radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1
+        // emscripten의 터치 콜백은 touch 객체에 isChanged/onTarget을 써 넣는다. 같은 객체를
+        // touchstart와 touchend에 재사용하면 touchstart에서 세워진 값이 touchend까지 새어
+        // 나가므로 이벤트마다 새로 만든다.
+        var makeTouch = function() {
+            return {
+                identifier: id,
+                target: canvas,
+                clientX: cx, clientY: cy,
+                pageX: cx + window.pageXOffset, pageY: cy + window.pageYOffset,
+                screenX: cx, screenY: cy,
+                radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1
+            };
         };
 
         var fire = function(type, touches, changed, target) {
@@ -265,10 +270,12 @@ mergeInto(LibraryManager.library, {
             canvas.dispatchEvent(e);
         };
 
-        fire('touchstart', [touch], [touch], [touch]);
+        var down = makeTouch();
+        fire('touchstart', [down], [down], [down]);
         setTimeout(function() {
             // 손을 뗀 상태라 touches/targetTouches는 비고 changedTouches에만 남는다.
-            fire('touchend', [], [touch], []);
+            var up = makeTouch();
+            fire('touchend', [], [up], []);
             window.__AIT_TAP_BUSY = Math.max(0, (window.__AIT_TAP_BUSY || 1) - 1);
         }, holdMs);
     },

--- a/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
+++ b/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
@@ -270,14 +270,25 @@ mergeInto(LibraryManager.library, {
             canvas.dispatchEvent(e);
         };
 
-        var down = makeTouch();
-        fire('touchstart', [down], [down], [down]);
+        // dispatch를 프레임 밖으로 미룬다. 여기는 C# 코루틴 → jslib 호출 스택 안, 즉 PlayerLoop
+        // 한복판이다. touchstart를 동기로 쏘면 엔진의 터치 핸들러가 그 자리에서 입력 처리를
+        // 재진입하려 들고, Unity가 "PlayerLoop internal function has been called recursively"로
+        // 막는다. 막히기만 하고 이벤트는 다음 프레임에 처리되므로 측정값은 멀쩡했지만, 탭마다
+        // 에러가 하나씩 쌓여 실기기 로그를 덮는다.
+        //
+        // 조준 보정(TapAutoProbe.LeadFrames)은 그대로 둔다. 매크로태스크는 현재 rAF 콜백이
+        // 끝난 뒤 다음 rAF 전에 돌므로, 엔진이 터치를 집어가는 프레임은 동기 dispatch 때와
+        // 같은 다음 프레임이다.
         setTimeout(function() {
-            // 손을 뗀 상태라 touches/targetTouches는 비고 changedTouches에만 남는다.
-            var up = makeTouch();
-            fire('touchend', [], [up], []);
-            window.__AIT_TAP_BUSY = Math.max(0, (window.__AIT_TAP_BUSY || 1) - 1);
-        }, holdMs);
+            var down = makeTouch();
+            fire('touchstart', [down], [down], [down]);
+            setTimeout(function() {
+                // 손을 뗀 상태라 touches/targetTouches는 비고 changedTouches에만 남는다.
+                var up = makeTouch();
+                fire('touchend', [], [up], []);
+                window.__AIT_TAP_BUSY = Math.max(0, (window.__AIT_TAP_BUSY || 1) - 1);
+            }, holdMs);
+        }, 0);
     },
 
     /**

--- a/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
+++ b/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
@@ -215,6 +215,73 @@ mergeInto(LibraryManager.library, {
     },
 
     /**
+     * 캔버스에 합성 터치 탭을 보냄 (touchstart → holdMs 후 touchend)
+     *
+     * Unity WebGL의 입력은 emscripten의 registerTouchEventCallback이 캔버스에 건
+     * 'touchstart'/'touchmove'/'touchend' 리스너로 들어온다(CoreModule이
+     * emscripten_set_touchstart_callback_on_thread 등을 임포트하는 것으로 확인). 그 핸들러는
+     * e.touches / e.changedTouches / e.targetTouches와 각 터치의 identifier·clientX/Y·pageX/Y·
+     * screenX/Y만 읽고, 터치 객체에 isChanged/onTarget을 되쓴다. 그래서 읽기 전용인 진짜 Touch
+     * 인스턴스가 아니라 평범한 객체를 담은 일반 Event가 오히려 알맞다. Safari가 TouchEvent
+     * 생성자를 지원하지 않는 문제도 함께 피한다.
+     *
+     * 좌표는 Unity 스크린 기준 정규화 값(원점 좌하단)으로 받는다. C#이 Screen.width/height로
+     * 나눈 값을 그대로 넘기면 되고, devicePixelRatio는 캔버스 rect가 흡수하므로 신경 쓸 필요가 없다.
+     *
+     * @param {number} nx - 가로 0~1
+     * @param {number} ny - 세로 0~1 (0이 화면 아래)
+     * @param {number} holdMs - 누르고 있는 시간
+     */
+    TAP_Tap: function(nx, ny, holdMs) {
+        var canvas = Module['canvas'] || document.querySelector('canvas');
+        if (!canvas) {
+            console.error('[E2E-TAP] canvas를 찾을 수 없어 합성 탭을 보내지 못했다');
+            return;
+        }
+
+        var rect = canvas.getBoundingClientRect();
+        var cx = rect.left + nx * rect.width;
+        var cy = rect.top + (1 - ny) * rect.height;
+
+        window.__AIT_TAP_BUSY = (window.__AIT_TAP_BUSY || 0) + 1;
+        window.__AIT_TAP_ID = (window.__AIT_TAP_ID || 0) + 1;
+        var id = window.__AIT_TAP_ID;
+
+        var touch = {
+            identifier: id,
+            target: canvas,
+            clientX: cx, clientY: cy,
+            pageX: cx + window.pageXOffset, pageY: cy + window.pageYOffset,
+            screenX: cx, screenY: cy,
+            radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1
+        };
+
+        var fire = function(type, touches, changed, target) {
+            var e = new Event(type, { bubbles: true, cancelable: true });
+            e.touches = touches;
+            e.changedTouches = changed;
+            e.targetTouches = target;
+            e.ctrlKey = false; e.shiftKey = false; e.altKey = false; e.metaKey = false;
+            canvas.dispatchEvent(e);
+        };
+
+        fire('touchstart', [touch], [touch], [touch]);
+        setTimeout(function() {
+            // 손을 뗀 상태라 touches/targetTouches는 비고 changedTouches에만 남는다.
+            fire('touchend', [], [touch], []);
+            window.__AIT_TAP_BUSY = Math.max(0, (window.__AIT_TAP_BUSY || 1) - 1);
+        }, holdMs);
+    },
+
+    /**
+     * 진행 중인 합성 탭이 있으면 1, 없으면 0
+     * @returns {number}
+     */
+    TAP_DriveBusy: function() {
+        return (window.__AIT_TAP_BUSY || 0) > 0 ? 1 : 0;
+    },
+
+    /**
      * JavaScript에서 JSON 파싱 검증
      * C# → JSON → JavaScript 파싱 → JSON → C# 역직렬화 round-trip 검증용
      * @param {string} jsonPtr - JSON 문자열 포인터

--- a/Tests~/E2E/SharedScripts/Runtime/InteractiveAPITester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/InteractiveAPITester.cs
@@ -49,6 +49,7 @@ public class InteractiveAPITester : MonoBehaviour
     private VisibilityBGMTester _visibilityBGMTester;
     private MetricEventTester _metricEventTester;
     private PlayerPrefsTester _playerPrefsTester;
+    private TapDiagnosticsTester _tapDiagnosticsTester;
 
     void Start()
     {
@@ -70,6 +71,7 @@ public class InteractiveAPITester : MonoBehaviour
         _visibilityBGMTester = GetComponent<VisibilityBGMTester>() ?? gameObject.AddComponent<VisibilityBGMTester>();
         _metricEventTester = GetComponent<MetricEventTester>() ?? gameObject.AddComponent<MetricEventTester>();
         _playerPrefsTester = GetComponent<PlayerPrefsTester>() ?? gameObject.AddComponent<PlayerPrefsTester>();
+        _tapDiagnosticsTester = GetComponent<TapDiagnosticsTester>() ?? gameObject.AddComponent<TapDiagnosticsTester>();
 
         // API 목록 로드
         allMethods = APIParameterInspector.GetAllAPIMethods();
@@ -102,6 +104,10 @@ public class InteractiveAPITester : MonoBehaviour
         _contactsViralTester?.SetupUI(subTesterContainer);
         _metricEventTester?.SetupUI(subTesterContainer);
         _playerPrefsTester?.SetupUI(subTesterContainer);
+
+        // 탭 진단 패널은 PlayerPrefs의 Key/Value 입력칸 바로 아래에 둡니다 — 재현 대상을 탭한
+        // 직후 같은 화면에서 결과를 읽을 수 있어야 합니다.
+        _tapDiagnosticsTester?.SetupUI(subTesterContainer);
 
         // Safe Area Insets 적용 (Apps in Toss 플랫폼)
 #if AIT_SDK_1_7_1_OR_LATER

--- a/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs
@@ -86,7 +86,11 @@ public class PointerTapDiagnostics : MonoBehaviour,
         /// </summary>
         public bool DragIsSelf;
 
-        /// <summary>press와 release 사이에 포인터 밑의 GameObject가 바뀌었는가.</summary>
+        /// <summary>
+        /// press와 release 사이에 포인터 밑의 GameObject가 바뀌었는가.
+        /// 두 문자열에는 인스턴스 ID가 붙어 있어서(Name 참조) 이름이 같은 이웃 위젯으로 넘어간
+        /// 경우도 잡힙니다. 스크롤 목록에서는 그쪽이 오히려 흔한 모양입니다.
+        /// </summary>
         public bool OverChanged => UpReceived && DownOver != UpOver;
     }
 
@@ -348,5 +352,11 @@ public class PointerTapDiagnostics : MonoBehaviour,
         return _scrollRect;
     }
 
-    private static string Name(GameObject go) => go != null ? go.name : "(none)";
+    /// <summary>
+    /// 이름 뒤에 인스턴스 ID를 붙입니다. 이름만 찍으면 같은 이름의 다른 GameObject를 구분하지
+    /// 못해서, 실기기 로그에 "핸들러(InputField)와 핸들러(InputField)가 다름" 같은 줄이 나옵니다.
+    /// 스크롤 콘텐츠가 손가락 밑에서 흐르면 실제로 이웃한 동명 위젯으로 넘어가므로 흔한 경우입니다.
+    /// TapRecord.OverChanged도 이 문자열을 비교하니, ID가 없으면 신원이 바뀐 것을 놓칩니다.
+    /// </summary>
+    private static string Name(GameObject go) => go != null ? $"{go.name}#{go.GetInstanceID()}" : "(none)";
 }

--- a/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs
@@ -79,6 +79,13 @@ public class PointerTapDiagnostics : MonoBehaviour,
         public float MovedPixels;
         public bool ClickReceived;
 
+        /// <summary>
+        /// release 시점 pointerDrag가 이 InputField 자신이었는가.
+        /// 가설의 메커니즘(:418이 ScrollRect가 아니라 InputField를 드래그 대상으로 잡는다)에 대한
+        /// 직접 증거라, 클릭 발화 여부와 별개로 기록합니다.
+        /// </summary>
+        public bool DragIsSelf;
+
         /// <summary>press와 release 사이에 포인터 밑의 GameObject가 바뀌었는가.</summary>
         public bool OverChanged => UpReceived && DownOver != UpOver;
     }
@@ -135,6 +142,7 @@ public class PointerTapDiagnostics : MonoBehaviour,
         public string ReleaseHandler;  // release 시점 currentOverGo로 다시 구한 IPointerClickHandler
         public bool Eligible;
         public bool Dragging;
+        public bool DragIsSelf;        // release 시점 pointerDrag == 이 GameObject
         public bool WillFireClick;
         public float MovedPixels;
         public int DragThreshold;
@@ -168,8 +176,11 @@ public class PointerTapDiagnostics : MonoBehaviour,
         string scroll = s.HasScrollRect
             ? $"scroll=YES vel=({s.ScrollVelocity.x:F0},{s.ScrollVelocity.y:F0})"
             : "scroll=NO";
+        // pointerPress/pointerDrag는 여기서 읽으면 안 됩니다. OnPointerDown은 ExecuteHierarchy
+        // 안에서 불리므로(:396) 모듈이 이번 press 값을 대입하기 전이고, 직전 이벤트 값이 남아
+        // 있습니다. 확정값은 UP 줄에 찍습니다.
         return $"#{seq} DOWN {label} | {scroll} thr={s.DragThreshold}\n"
-             + $"    over={s.Over} press={s.PointerPress} drag={s.PointerDrag}";
+             + $"    over={s.Over}";
     }
 
     public static string FormatUp(int seq, string label, TapSnapshot s)
@@ -177,6 +188,7 @@ public class PointerTapDiagnostics : MonoBehaviour,
         string verdict = s.WillFireClick ? "FIRE=YES" : $"FIRE=NO — {ExplainNoFire(s)}";
         return $"#{seq} UP   {label} | moved={s.MovedPixels:F1}px elig={(s.Eligible ? 1 : 0)} dragging={(s.Dragging ? 1 : 0)}\n"
              + $"    over={s.Over} click={s.PointerClick} hnd={s.ReleaseHandler}\n"
+             + $"    drag={s.PointerDrag}{(s.DragIsSelf ? " (자신 — ScrollRect가 아님)" : "")}\n"
              + $"    => {verdict}";
     }
 
@@ -263,6 +275,7 @@ public class PointerTapDiagnostics : MonoBehaviour,
             r.UpOver = s.Over;
             r.WillFireClick = s.WillFireClick;
             r.MovedPixels = s.MovedPixels;
+            r.DragIsSelf = s.DragIsSelf;
             return r;
         });
     }
@@ -312,6 +325,7 @@ public class PointerTapDiagnostics : MonoBehaviour,
             ReleaseHandler = includeRelease ? Name(releaseHandler) : "-",
             Eligible = e.eligibleForClick,
             Dragging = e.dragging,
+            DragIsSelf = includeRelease && e.pointerDrag == gameObject,
             WillFireClick = includeRelease && WillFireClick(e.pointerClick, releaseHandler, e.eligibleForClick),
             MovedPixels = Vector2.Distance(e.position, e.pressPosition),
             DragThreshold = EventSystem.current != null ? EventSystem.current.pixelDragThreshold : -1,

--- a/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs
@@ -1,0 +1,257 @@
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+/// <summary>
+/// InputField 탭 진단 프로브.
+///
+/// 스크롤 영역 안의 InputField가 실기기에서 탭에 반응하지 않는 증상을 가려내기 위한 계측입니다.
+/// UIBuilder.CreateInputField가 만드는 모든 InputField에 붙어 press/release 시점의
+/// PointerEventData 상태를 기록합니다.
+///
+/// StandaloneInputModule.ProcessTouchPress의 release 경로는 클릭을 발화시키기 전에
+/// pointerUpHandler를 먼저 실행합니다(uGUI 6000.3 기준 :428, 판정은 :433-436). 그래서
+/// OnPointerUp 안에서 모듈이 다섯 줄 뒤에 내릴 판정을 그대로 미리 계산할 수 있습니다:
+///
+///     var pointerClickHandler = ExecuteEvents.GetEventHandler&lt;IPointerClickHandler&gt;(currentOverGo);
+///     if (pointerEvent.pointerClick == pointerClickHandler &amp;&amp; pointerEvent.eligibleForClick)
+///
+/// 구현하는 인터페이스는 IPointerDownHandler / IPointerUpHandler / IPointerClickHandler 셋뿐입니다.
+/// Selectable이 이미 셋 다 구현하므로 ExecuteHierarchy(:428 기준 press 시 :396)가 고르는
+/// GameObject가 달라지지 않고, ExecuteEvents.Execute는 대상 GameObject의 핸들러를 전부
+/// 호출하므로 기존 라우팅에 영향이 없습니다.
+///
+/// IDragHandler와 IInitializePotentialDragHandler는 구현하면 안 됩니다. 특히 후자는
+/// InputField에 없던 핸들러를 새로 만들어(:418에서 pointerDrag가 InputField로 잡히고
+/// :421이 그 대상에게만 실행됨) ScrollRect 관성이 멈추는지 여부 자체를 바꿔버립니다.
+/// 관측하려는 대상을 관측 행위가 고쳐버리는 셈이라, 진단이 무의미해집니다.
+/// 이 제약은 PointerTapDiagnosticsTests의 인터페이스 가드가 강제합니다.
+/// </summary>
+public class PointerTapDiagnostics : MonoBehaviour,
+    IPointerDownHandler, IPointerUpHandler, IPointerClickHandler
+{
+#if UNITY_WEBGL && !UNITY_EDITOR
+    /// <summary>진단 한 줄을 window.__AIT_TAPLOG에 쌓고 console.log로 흘립니다.</summary>
+    [DllImport("__Internal")]
+    private static extern void TAP_Log(string line);
+
+    /// <summary>window.__AIT_TAPLOG를 비웁니다.</summary>
+    [DllImport("__Internal")]
+    private static extern void TAP_Clear();
+#endif
+
+    /// <summary>UP이 이 시간(초) 안에 안 오면 미수신으로 판정하고 한 줄 남깁니다.</summary>
+    private const float UpTimeoutSeconds = 1.5f;
+
+    /// <summary>버퍼에 들고 있는 최대 기록 수. 화면에는 이 중 최근 몇 건만 보여줍니다.</summary>
+    public const int MaxLines = 60;
+
+    private static readonly List<string> LinesBuffer = new List<string>();
+    private static readonly List<PendingTap> PendingTaps = new List<PendingTap>();
+    private static int _seqCounter;
+
+    /// <summary>로그가 바뀔 때마다 증가합니다. UI가 매 프레임 문자열을 다시 만들지 않도록 하는 용도.</summary>
+    public static int Revision { get; private set; }
+
+    public static IReadOnlyList<string> Lines => LinesBuffer;
+
+    /// <summary>이 프로브를 구분할 이름. UIBuilder가 placeholder 문구로 채웁니다.</summary>
+    public string Label = "input";
+
+    private ScrollRect _scrollRect;
+    private bool _scrollRectResolved;
+    private int _currentSeq = -1;
+
+    private struct PendingTap
+    {
+        public int Seq;
+        public string Label;
+        public float DownTime;
+    }
+
+    /// <summary>
+    /// press/release 시점에서 뽑아낸 값들. uGUI 타입을 담지 않아 EditMode에서 그대로 만들 수 있습니다.
+    /// </summary>
+    public struct TapSnapshot
+    {
+        public string Over;            // pointerCurrentRaycast.gameObject
+        public string Press;           // pointerPressRaycast.gameObject
+        public string PointerPress;
+        public string PointerDrag;
+        public string PointerClick;
+        public string ReleaseHandler;  // release 시점 currentOverGo로 다시 구한 IPointerClickHandler
+        public bool Eligible;
+        public bool Dragging;
+        public bool WillFireClick;
+        public float MovedPixels;
+        public int DragThreshold;
+        public bool HasScrollRect;
+        public Vector2 ScrollVelocity;
+    }
+
+    // ─── 판정 ───
+
+    /// <summary>
+    /// StandaloneInputModule이 :436에서 내리는 판정을 그대로 옮긴 것입니다.
+    /// 값이 아니라 참조를 비교합니다 — 이름이 같은 GameObject가 둘 있어도 구분되어야 합니다.
+    /// </summary>
+    public static bool WillFireClick(GameObject pointerClick, GameObject releaseHandler, bool eligibleForClick)
+    {
+        return pointerClick == releaseHandler && eligibleForClick;
+    }
+
+    /// <summary>클릭이 발화하지 않는 이유를 한국어 한 조각으로 돌려줍니다. 발화하면 빈 문자열.</summary>
+    public static string ExplainNoFire(TapSnapshot s)
+    {
+        if (s.WillFireClick) return "";
+        if (!s.Eligible) return "eligibleForClick=0 — 드래그로 전환되며 클릭이 취소됨";
+        return $"press 때 잡힌 핸들러({s.PointerClick})와 release 때 핸들러({s.ReleaseHandler})가 다름";
+    }
+
+    // ─── 포맷 ───
+
+    public static string FormatDown(int seq, string label, TapSnapshot s)
+    {
+        string scroll = s.HasScrollRect
+            ? $"scroll=YES vel=({s.ScrollVelocity.x:F0},{s.ScrollVelocity.y:F0})"
+            : "scroll=NO";
+        return $"#{seq} DOWN {label} | {scroll} thr={s.DragThreshold}\n"
+             + $"    over={s.Over} press={s.PointerPress} drag={s.PointerDrag}";
+    }
+
+    public static string FormatUp(int seq, string label, TapSnapshot s)
+    {
+        string verdict = s.WillFireClick ? "FIRE=YES" : $"FIRE=NO — {ExplainNoFire(s)}";
+        return $"#{seq} UP   {label} | moved={s.MovedPixels:F1}px elig={(s.Eligible ? 1 : 0)} dragging={(s.Dragging ? 1 : 0)}\n"
+             + $"    over={s.Over} click={s.PointerClick} hnd={s.ReleaseHandler}\n"
+             + $"    => {verdict}";
+    }
+
+    public static string FormatClick(int seq, string label, bool focused)
+    {
+        return $"#{seq} CLICK {label} | isFocused={(focused ? 1 : 0)}";
+    }
+
+    public static string FormatUpMissing(int seq, string label)
+    {
+        return $"#{seq} UP   {label} | 미수신 — ProcessDrag가 pointerPress를 null로 만든 뒤 release됨";
+    }
+
+    // ─── 로그 ───
+
+    public static void Clear()
+    {
+        LinesBuffer.Clear();
+        PendingTaps.Clear();
+        Revision++;
+#if UNITY_WEBGL && !UNITY_EDITOR
+        try { TAP_Clear(); } catch (System.Exception e) { Debug.LogError($"[TapDiag] TAP_Clear failed: {e.Message}"); }
+#endif
+    }
+
+    private static void Append(string line)
+    {
+        LinesBuffer.Add(line);
+        while (LinesBuffer.Count > MaxLines) LinesBuffer.RemoveAt(0);
+        Revision++;
+
+        Debug.Log($"[TapDiag] {line}");
+#if UNITY_WEBGL && !UNITY_EDITOR
+        try { TAP_Log(line); } catch (System.Exception e) { Debug.LogError($"[TapDiag] TAP_Log failed: {e.Message}"); }
+#endif
+    }
+
+    /// <summary>
+    /// UP이 안 온 press를 걷어냅니다. TapDiagnosticsTester.Update가 매 프레임 호출합니다.
+    /// ProcessDrag가 pointerPress를 null로 만든 경우(:pointerPress != pointerDrag 분기)
+    /// release 때 Execute 대상이 null이라 OnPointerUp이 아예 오지 않습니다 — 그 자체가 신호입니다.
+    /// </summary>
+    public static void PollPendingTaps()
+    {
+        if (PendingTaps.Count == 0) return;
+        float now = Time.realtimeSinceStartup;
+        for (int i = PendingTaps.Count - 1; i >= 0; i--)
+        {
+            if (now - PendingTaps[i].DownTime < UpTimeoutSeconds) continue;
+            Append(FormatUpMissing(PendingTaps[i].Seq, PendingTaps[i].Label));
+            PendingTaps.RemoveAt(i);
+        }
+    }
+
+    // ─── 이벤트 핸들러 ───
+
+    public void OnPointerDown(PointerEventData eventData)
+    {
+        _currentSeq = ++_seqCounter;
+        var s = Sample(eventData, includeRelease: false);
+        Append(FormatDown(_currentSeq, Label, s));
+        PendingTaps.Add(new PendingTap { Seq = _currentSeq, Label = Label, DownTime = Time.realtimeSinceStartup });
+    }
+
+    public void OnPointerUp(PointerEventData eventData)
+    {
+        int seq = _currentSeq;
+        RemovePending(seq);
+        Append(FormatUp(seq, Label, Sample(eventData, includeRelease: true)));
+    }
+
+    public void OnPointerClick(PointerEventData eventData)
+    {
+        var field = GetComponent<InputField>();
+        Append(FormatClick(_currentSeq, Label, field != null && field.isFocused));
+    }
+
+    private static void RemovePending(int seq)
+    {
+        for (int i = PendingTaps.Count - 1; i >= 0; i--)
+        {
+            if (PendingTaps[i].Seq == seq) PendingTaps.RemoveAt(i);
+        }
+    }
+
+    private TapSnapshot Sample(PointerEventData e, bool includeRelease)
+    {
+        var overGo = e.pointerCurrentRaycast.gameObject;
+        GameObject releaseHandler = null;
+        if (includeRelease && overGo != null)
+        {
+            releaseHandler = ExecuteEvents.GetEventHandler<IPointerClickHandler>(overGo);
+        }
+
+        var scroll = ResolveScrollRect();
+        return new TapSnapshot
+        {
+            Over = Name(overGo),
+            Press = Name(e.pointerPressRaycast.gameObject),
+            PointerPress = Name(e.pointerPress),
+            PointerDrag = Name(e.pointerDrag),
+            PointerClick = Name(e.pointerClick),
+            ReleaseHandler = includeRelease ? Name(releaseHandler) : "-",
+            Eligible = e.eligibleForClick,
+            Dragging = e.dragging,
+            WillFireClick = includeRelease && WillFireClick(e.pointerClick, releaseHandler, e.eligibleForClick),
+            MovedPixels = Vector2.Distance(e.position, e.pressPosition),
+            DragThreshold = EventSystem.current != null ? EventSystem.current.pixelDragThreshold : -1,
+            HasScrollRect = scroll != null,
+            ScrollVelocity = scroll != null ? scroll.velocity : Vector2.zero,
+        };
+    }
+
+    /// <summary>
+    /// ScrollRect는 첫 이벤트 때 찾습니다. AddComponent 시점에는 부모 체인이 아직 완성되지
+    /// 않았을 수 있어서 Awake에서 찾으면 놓칩니다.
+    /// </summary>
+    private ScrollRect ResolveScrollRect()
+    {
+        if (!_scrollRectResolved)
+        {
+            _scrollRect = GetComponentInParent<ScrollRect>();
+            _scrollRectResolved = true;
+        }
+        return _scrollRect;
+    }
+
+    private static string Name(GameObject go) => go != null ? go.name : "(none)";
+}

--- a/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs
@@ -50,6 +50,7 @@ public class PointerTapDiagnostics : MonoBehaviour,
 
     private static readonly List<string> LinesBuffer = new List<string>();
     private static readonly List<PendingTap> PendingTaps = new List<PendingTap>();
+    private static readonly List<TapRecord> RecordsBuffer = new List<TapRecord>();
     private static int _seqCounter;
 
     /// <summary>로그가 바뀔 때마다 증가합니다. UI가 매 프레임 문자열을 다시 만들지 않도록 하는 용도.</summary>
@@ -57,12 +58,62 @@ public class PointerTapDiagnostics : MonoBehaviour,
 
     public static IReadOnlyList<string> Lines => LinesBuffer;
 
+    /// <summary>
+    /// 자동 진단이 판정에 쓰는 구조화 기록. 화면용 문자열과 달리 잘리지 않고 전부 남습니다 —
+    /// 문자열을 되파싱하지 않고 이쪽을 읽습니다.
+    /// </summary>
+    public static IReadOnlyList<TapRecord> Records => RecordsBuffer;
+
+    /// <summary>탭 하나에 대한 press/release 결과. 판정 로직이 이것만 보고 결론을 냅니다.</summary>
+    public struct TapRecord
+    {
+        public int Seq;
+        public string Label;
+        public bool HasScrollRect;
+        public float DownVelocityY;
+        public string DownOver;
+        public int DragThreshold;
+        public bool UpReceived;
+        public string UpOver;
+        public bool WillFireClick;
+        public float MovedPixels;
+        public bool ClickReceived;
+
+        /// <summary>press와 release 사이에 포인터 밑의 GameObject가 바뀌었는가.</summary>
+        public bool OverChanged => UpReceived && DownOver != UpOver;
+    }
+
     /// <summary>이 프로브를 구분할 이름. UIBuilder가 placeholder 문구로 채웁니다.</summary>
     public string Label = "input";
 
     private ScrollRect _scrollRect;
     private bool _scrollRectResolved;
     private int _currentSeq = -1;
+
+    private static readonly List<PointerTapDiagnostics> Live = new List<PointerTapDiagnostics>();
+
+    /// <summary>
+    /// 살아 있는 프로브 목록. 자동 진단이 대상 InputField를 찾을 때 씁니다 —
+    /// FindObjectsOfType은 Unity 6에서 이름이 바뀌어 5개 버전을 모두 지원하기 번거롭습니다.
+    /// </summary>
+    public static IReadOnlyList<PointerTapDiagnostics> LiveProbes => Live;
+
+    /// <summary>Label이 일치하는 첫 프로브. 없으면 null.</summary>
+    public static PointerTapDiagnostics FindByLabel(string label)
+    {
+        foreach (var p in Live)
+        {
+            if (p != null && p.Label == label) return p;
+        }
+        return null;
+    }
+
+    private void OnEnable() => Live.Add(this);
+
+    private void OnDisable() => Live.Remove(this);
+
+    /// <summary>이 프로브가 속한 ScrollRect. 없으면 null(스크롤 밖).</summary>
+    public ScrollRect OwningScrollRect => ResolveScrollRect();
 
     private struct PendingTap
     {
@@ -145,6 +196,7 @@ public class PointerTapDiagnostics : MonoBehaviour,
     {
         LinesBuffer.Clear();
         PendingTaps.Clear();
+        RecordsBuffer.Clear();
         Revision++;
 #if UNITY_WEBGL && !UNITY_EDITOR
         try { TAP_Clear(); } catch (System.Exception e) { Debug.LogError($"[TapDiag] TAP_Clear failed: {e.Message}"); }
@@ -188,19 +240,48 @@ public class PointerTapDiagnostics : MonoBehaviour,
         var s = Sample(eventData, includeRelease: false);
         Append(FormatDown(_currentSeq, Label, s));
         PendingTaps.Add(new PendingTap { Seq = _currentSeq, Label = Label, DownTime = Time.realtimeSinceStartup });
+        RecordsBuffer.Add(new TapRecord
+        {
+            Seq = _currentSeq,
+            Label = Label,
+            HasScrollRect = s.HasScrollRect,
+            DownVelocityY = s.ScrollVelocity.y,
+            DownOver = s.Over,
+            DragThreshold = s.DragThreshold,
+        });
     }
 
     public void OnPointerUp(PointerEventData eventData)
     {
         int seq = _currentSeq;
         RemovePending(seq);
-        Append(FormatUp(seq, Label, Sample(eventData, includeRelease: true)));
+        var s = Sample(eventData, includeRelease: true);
+        Append(FormatUp(seq, Label, s));
+        Patch(seq, r =>
+        {
+            r.UpReceived = true;
+            r.UpOver = s.Over;
+            r.WillFireClick = s.WillFireClick;
+            r.MovedPixels = s.MovedPixels;
+            return r;
+        });
     }
 
     public void OnPointerClick(PointerEventData eventData)
     {
         var field = GetComponent<InputField>();
         Append(FormatClick(_currentSeq, Label, field != null && field.isFocused));
+        Patch(_currentSeq, r => { r.ClickReceived = true; return r; });
+    }
+
+    private static void Patch(int seq, System.Func<TapRecord, TapRecord> edit)
+    {
+        for (int i = RecordsBuffer.Count - 1; i >= 0; i--)
+        {
+            if (RecordsBuffer[i].Seq != seq) continue;
+            RecordsBuffer[i] = edit(RecordsBuffer[i]);
+            return;
+        }
     }
 
     private static void RemovePending(int seq)

--- a/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs.meta
+++ b/Tests~/E2E/SharedScripts/Runtime/PointerTapDiagnostics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc84685b27d94043b518fbcb656e04dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Runtime/TapAutoProbe.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/TapAutoProbe.cs
@@ -1,0 +1,440 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// 탭 진단 자동 실행기.
+///
+/// 사람이 손으로 하던 A/B/C/D 절차를 그대로 기계가 돌립니다. 탭은 캔버스에 합성 터치
+/// 이벤트를 쏘아서(<c>TAP_Tap</c>) 실제 입력 경로를 그대로 태우고, 스크롤 관성은
+/// 손가락 플릭을 흉내내는 대신 <see cref="ScrollRect.velocity"/>를 직접 세팅합니다.
+///
+/// 관성을 직접 세팅하는 쪽을 고른 이유:
+/// 검증하려는 가설이 "press 시점에 잔존 속도가 있으면 클릭이 죽는다"이므로 속도가 곧
+/// 독립변수입니다. 플릭을 합성하면 속도가 우연히 정해지지만, 직접 세팅하면 계단식으로
+/// 쓸어서 FIRE가 뒤집히는 임계 속도를 찾을 수 있습니다.
+///
+/// 한계 하나는 미리 밝혀 둡니다. 합성 이벤트는 untrusted라 iOS가 user activation으로
+/// 쳐주지 않습니다. 따라서 "FIRE=YES인데 키보드가 안 뜬다"는 갈래는 이 자동 실행으로
+/// 가려낼 수 없고 사람 손 탭이 한 번 필요합니다. 자동 실행이 답하는 것은 uGUI가 클릭을
+/// 발화시키는가 하나입니다.
+/// </summary>
+public class TapAutoProbe : MonoBehaviour
+{
+#if UNITY_WEBGL && !UNITY_EDITOR
+    /// <summary>캔버스에 합성 터치 탭을 보냅니다. 좌표는 Unity 화면 정규화(좌하단 원점).</summary>
+    [DllImport("__Internal")]
+    private static extern void TAP_Tap(float nx, float ny, int holdMs);
+
+    /// <summary>합성 탭이 아직 손을 떼지 않았으면 1.</summary>
+    [DllImport("__Internal")]
+    private static extern int TAP_DriveBusy();
+#endif
+
+    // 아래 넷은 실행 파라미터입니다. WebGL이 아닌 컴파일에서는 읽는 곳이 없어 private면
+    // 미사용 경고가 나므로 public으로 둡니다 — 어차피 결과를 해석할 때 알아야 하는 값들입니다.
+
+    /// <summary>손가락을 붙이고 있는 시간. 사람 탭의 하한쯤 됩니다.</summary>
+    public const int HoldMs = 80;
+
+    /// <summary>조건 하나당 탭 횟수.</summary>
+    public const int TapsPerCondition = 3;
+
+    /// <summary>쓸어볼 스크롤 속도(px/s). 부호를 뒤집어 위/아래 양쪽을 봅니다.</summary>
+    public static readonly float[] SweepSpeeds = { 100f, 200f, 400f, 800f, 1600f };
+
+    /// <summary>
+    /// 합성 터치가 Unity 입력 큐를 타고 처리되기까지 한 프레임쯤 걸립니다. 그 사이 콘텐츠가
+    /// 흐른 만큼 조준점을 미리 밀어 둡니다. 안 하면 빠른 속도에서 탭이 칸을 벗어나고,
+    /// "클릭이 안 났다"와 "빗맞았다"가 섞여 버립니다.
+    /// </summary>
+    public const int LeadFrames = 1;
+
+    public bool IsRunning { get; private set; }
+
+    /// <summary>진행 상황 한 줄. UI가 매 프레임 읽어 갑니다.</summary>
+    public string Progress { get; private set; } = "";
+
+    /// <summary>마지막 실행의 판정문. 아직 안 돌렸으면 빈 문자열.</summary>
+    public string Verdict { get; private set; } = "";
+
+    private readonly List<ConditionResult> _results = new List<ConditionResult>();
+
+    /// <summary>조건 하나(대조군 / 정지 / 속도 v)에 대한 집계.</summary>
+    public struct ConditionResult
+    {
+        public string Name;
+        public float VelocityY;
+        public bool HasScrollRect;
+
+        /// <summary>보낸 탭 수.</summary>
+        public int Attempted;
+
+        /// <summary>DOWN이 실제로 대상 프로브에 닿은 수. Attempted보다 작으면 빗맞은 것.</summary>
+        public int Landed;
+
+        public int UpReceived;
+
+        /// <summary>uGUI가 클릭을 발화시킬 조건이 성립한 수.</summary>
+        public int Fired;
+
+        /// <summary>press와 release 사이에 포인터 밑 GameObject가 바뀐 수.</summary>
+        public int OverChanged;
+
+        public int ClickReceived;
+    }
+
+    // ─── 판정 ───
+
+    /// <summary>
+    /// 집계만 보고 결론을 냅니다. Unity 타입을 안 쓰므로 EditMode에서 그대로 검증됩니다.
+    /// 첫 줄이 결론, 나머지는 근거입니다.
+    /// </summary>
+    public static string Conclude(IReadOnlyList<ConditionResult> results)
+    {
+        if (results == null || results.Count == 0)
+        {
+            return "판정: 불가 — 한 조건도 실행되지 않았습니다.";
+        }
+
+        var notes = new List<string>();
+
+        ConditionResult control = default;
+        bool hasControl = false;
+        foreach (var r in results)
+        {
+            if (r.HasScrollRect) continue;
+            control = r;
+            hasControl = true;
+            break;
+        }
+
+        if (!hasControl || control.Landed == 0)
+        {
+            return "판정: 불가 — 합성 탭이 대조군 입력칸에 닿지 않았습니다. 하네스가 안 돈 것이므로 "
+                 + "이 결과로 가설을 판단하면 안 됩니다.";
+        }
+
+        if (control.Fired == 0)
+        {
+            return $"판정: 가설 전부 폐기 — 스크롤 밖 대조군도 FIRE=NO ({control.Fired}/{control.Landed}). "
+                 + "ScrollRect와 무관한 원인입니다.";
+        }
+
+        if (control.Fired < control.Landed)
+        {
+            notes.Add($"주의: 대조군이 {control.Fired}/{control.Landed}로 불안정합니다. "
+                    + "아래 결론의 신뢰도가 그만큼 낮습니다.");
+        }
+
+        var moving = new List<ConditionResult>();
+        ConditionResult stationary = default;
+        bool hasStationary = false;
+        int scrollLanded = 0;
+        int upMissing = 0;
+        int overChanged = 0;
+
+        foreach (var r in results)
+        {
+            upMissing += r.Landed - r.UpReceived;
+            overChanged += r.OverChanged;
+            if (!r.HasScrollRect) continue;
+            scrollLanded += r.Landed;
+            if (r.Landed == 0) continue;
+            if (r.VelocityY == 0f)
+            {
+                stationary = r;
+                hasStationary = true;
+            }
+            else
+            {
+                moving.Add(r);
+            }
+        }
+
+        if (upMissing > 0)
+        {
+            notes.Add($"UP 미수신 {upMissing}건 — ProcessDrag가 pointerPress를 null로 만드는 경로가 "
+                    + "실재합니다. 반증했다고 본 드래그 취소를 다시 봐야 합니다.");
+        }
+        if (overChanged > 0)
+        {
+            notes.Add($"press/release 사이 over 변화 {overChanged}건 — 손가락 밑에서 콘텐츠가 움직였습니다.");
+        }
+
+        string headline;
+        if (scrollLanded == 0)
+        {
+            headline = "판정: 불가 — 스크롤 안 입력칸에 합성 탭이 한 번도 닿지 않았습니다.";
+        }
+        else if (hasStationary && stationary.Fired == 0)
+        {
+            headline = $"판정: 관성 무관 — 정지 상태에서도 FIRE=NO ({stationary.Fired}/{stationary.Landed}). "
+                     + "속도가 아니라 ScrollRect 안에 있다는 사실 자체가 원인입니다.";
+        }
+        else
+        {
+            float threshold = 0f;
+            bool found = false;
+            foreach (var r in moving)
+            {
+                if (r.Fired >= r.Landed) continue;
+                float speed = Mathf.Abs(r.VelocityY);
+                if (!found || speed < threshold)
+                {
+                    threshold = speed;
+                    found = true;
+                }
+            }
+
+            if (!found)
+            {
+                headline = moving.Count == 0
+                    ? "판정: 불가 — 관성 조건이 한 번도 착지하지 않았습니다."
+                    : "판정: 관성 가설 반증 — 쓸어본 모든 속도에서 FIRE=YES였습니다. 합성 탭으로는 재현되지 않습니다.";
+            }
+            else
+            {
+                headline = $"판정: 관성 가설 확정 — |속도| {threshold:F0}px/s부터 클릭이 소실됩니다. "
+                         + "ScrollRect에 IInitializePotentialDragHandler가 도달하지 않아 관성이 멈추지 않는 것이 근인입니다.";
+            }
+        }
+
+        var sb = new StringBuilder(headline);
+        foreach (var n in notes)
+        {
+            sb.Append('\n').Append(n);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>조건별 집계를 사람이 읽을 표로 만듭니다.</summary>
+    public static string Summarize(IReadOnlyList<ConditionResult> results)
+    {
+        if (results == null || results.Count == 0) return "(집계 없음)";
+        var sb = new StringBuilder();
+        sb.Append("조건            착지 UP FIRE over\n");
+        foreach (var r in results)
+        {
+            sb.Append(Pad(r.Name, 15))
+              .Append(Pad($"{r.Landed}/{r.Attempted}", 5))
+              .Append(Pad(r.UpReceived.ToString(), 3))
+              .Append(Pad($"{r.Fired}", 5))
+              .Append(r.OverChanged)
+              .Append('\n');
+        }
+        return sb.ToString();
+    }
+
+    private static string Pad(string s, int width)
+    {
+        if (s == null) s = "";
+        return s.Length >= width ? s.Substring(0, width - 1) + " " : s.PadRight(width);
+    }
+
+    // ─── 실행 ───
+
+    /// <summary>버튼이 부르는 진입점. 이미 돌고 있으면 무시합니다.</summary>
+    public void StartRun()
+    {
+        if (IsRunning) return;
+        StartCoroutine(RunAll());
+    }
+
+    private IEnumerator RunAll()
+    {
+        IsRunning = true;
+        Verdict = "";
+        _results.Clear();
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        Progress = "준비 중…";
+        PointerTapDiagnostics.Clear();
+        yield return null;
+
+        var control = FindProbe(wantScroll: false);
+        var target = FindProbe(wantScroll: true);
+
+        if (control == null)
+        {
+            Verdict = "판정: 불가 — 스크롤 밖 입력칸(대조군)을 찾지 못했습니다.";
+            Progress = "";
+            IsRunning = false;
+            yield break;
+        }
+
+        yield return RunCondition("A 대조군", control, null, 0f);
+
+        if (target == null)
+        {
+            _results.Add(new ConditionResult { Name = "B 정지", HasScrollRect = true });
+            Verdict = Conclude(_results);
+            Progress = "";
+            IsRunning = false;
+            yield break;
+        }
+
+        var scroll = target.OwningScrollRect;
+        yield return RunCondition("B 정지", target, scroll, 0f);
+
+        // 위/아래 양쪽을 봅니다. Elastic 리바운드도 결국 부호가 반대인 관성이라,
+        // 경계 밖으로 밀어내는 대신 부호로 대신 덮습니다.
+        foreach (float speed in SweepSpeeds)
+        {
+            yield return RunCondition($"C -{speed:F0}", target, scroll, -speed);
+            yield return RunCondition($"C +{speed:F0}", target, scroll, speed);
+        }
+
+        if (scroll != null) scroll.velocity = Vector2.zero;
+        Verdict = Conclude(_results);
+        Progress = "";
+        IsRunning = false;
+#else
+        Progress = "";
+        Verdict = "판정: 불가 — 자동 진단은 WebGL 빌드에서만 동작합니다(합성 터치가 필요).";
+        IsRunning = false;
+        yield break;
+#endif
+    }
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+    private IEnumerator RunCondition(string name, PointerTapDiagnostics probe, ScrollRect scroll, float velocityY)
+    {
+        var result = new ConditionResult
+        {
+            Name = name,
+            VelocityY = velocityY,
+            HasScrollRect = scroll != null,
+        };
+
+        var rt = probe.transform as RectTransform;
+        for (int i = 0; i < TapsPerCondition; i++)
+        {
+            Progress = $"{name} — {i + 1}/{TapsPerCondition}";
+
+            if (scroll != null)
+            {
+                CenterOn(scroll, rt);
+                yield return null;
+                scroll.velocity = new Vector2(0f, velocityY);
+                // 속도를 세팅한 프레임에는 아직 콘텐츠가 안 움직였습니다. 한 프레임 흘려서
+                // 실제로 흐르는 상태를 만든 뒤 조준합니다.
+                yield return null;
+            }
+
+            float lead = velocityY * Time.unscaledDeltaTime * LeadFrames;
+            Vector2 point;
+            if (!TryGetScreenPoint(rt, scroll, lead, out point))
+            {
+                // 조준점이 뷰포트 밖이면 보내 봐야 빗맞습니다. 시도는 세되 탭은 생략합니다.
+                result.Attempted++;
+                continue;
+            }
+
+            int before = PointerTapDiagnostics.Records.Count;
+            result.Attempted++;
+            TAP_Tap(point.x / Screen.width, point.y / Screen.height, HoldMs);
+
+            float deadline = Time.realtimeSinceStartup + 2f;
+            while (TAP_DriveBusy() != 0 && Time.realtimeSinceStartup < deadline) yield return null;
+            // touchend가 Unity 입력 큐를 타고 OnPointerUp/OnPointerClick까지 도는 시간.
+            yield return new WaitForSecondsRealtime(0.2f);
+
+            Tally(ref result, before, probe.Label);
+        }
+
+        if (scroll != null) scroll.velocity = Vector2.zero;
+        _results.Add(result);
+        yield return new WaitForSecondsRealtime(0.1f);
+    }
+
+    /// <summary>이번 탭으로 새로 생긴 기록만 골라 집계에 더합니다.</summary>
+    private static void Tally(ref ConditionResult result, int startIndex, string label)
+    {
+        var records = PointerTapDiagnostics.Records;
+        for (int i = startIndex; i < records.Count; i++)
+        {
+            var r = records[i];
+            if (r.Label != label) continue;
+            result.Landed++;
+            if (r.UpReceived) result.UpReceived++;
+            if (r.WillFireClick) result.Fired++;
+            if (r.OverChanged) result.OverChanged++;
+            if (r.ClickReceived) result.ClickReceived++;
+        }
+    }
+
+    private static PointerTapDiagnostics FindProbe(bool wantScroll)
+    {
+        // 스크롤 안 후보가 여럿이면 Key 칸(첫 번째)이 잡힙니다 — 등록 순서가 곧 생성 순서입니다.
+        foreach (var p in PointerTapDiagnostics.LiveProbes)
+        {
+            if (p == null || !p.isActiveAndEnabled) continue;
+            if ((p.OwningScrollRect != null) == wantScroll) return p;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// 대상을 뷰포트 한가운데로 스크롤합니다. 콘텐츠가 뷰포트보다 짧으면 할 일이 없습니다.
+    /// </summary>
+    private static void CenterOn(ScrollRect sr, RectTransform target)
+    {
+        if (sr == null || sr.content == null || sr.viewport == null || target == null) return;
+
+        sr.velocity = Vector2.zero;
+        Canvas.ForceUpdateCanvases();
+
+        var content = sr.content;
+        float viewH = sr.viewport.rect.height;
+        float scrollable = content.rect.height - viewH;
+        if (scrollable <= 0f) return;
+
+        Vector3 inContent = content.InverseTransformPoint(target.TransformPoint(target.rect.center));
+        float fromBottom = inContent.y + content.rect.height * content.pivot.y;
+        float desired = Mathf.Clamp(fromBottom - viewH * 0.5f, 0f, scrollable);
+        sr.verticalNormalizedPosition = desired / scrollable;
+        Canvas.ForceUpdateCanvases();
+
+        // 위 계산은 레이아웃 가정이 하나라도 어긋나면 빗나갑니다. 실제로 보이는지 확인하고,
+        // 아니면 성기게 훑어서 보이는 지점을 찾습니다.
+        Vector2 unused;
+        if (TryGetScreenPoint(target, sr, 0f, out unused)) return;
+        for (int i = 0; i <= 50; i++)
+        {
+            sr.verticalNormalizedPosition = i / 50f;
+            Canvas.ForceUpdateCanvases();
+            if (TryGetScreenPoint(target, sr, 0f, out unused)) return;
+        }
+    }
+
+    /// <summary>
+    /// 대상의 화면 좌표. 화면 밖이거나 스크롤 뷰포트에 가려져 있으면 false.
+    /// </summary>
+    private static bool TryGetScreenPoint(RectTransform rt, ScrollRect sr, float leadY, out Vector2 screenPoint)
+    {
+        screenPoint = Vector2.zero;
+        if (rt == null) return false;
+
+        // Screen Space - Overlay 캔버스라 카메라는 null입니다.
+        Vector2 p = RectTransformUtility.WorldToScreenPoint(null, rt.TransformPoint(rt.rect.center));
+        p.y += leadY;
+        screenPoint = p;
+
+        if (p.x <= 0f || p.x >= Screen.width) return false;
+        if (p.y <= 0f || p.y >= Screen.height) return false;
+        if (sr != null && sr.viewport != null &&
+            !RectTransformUtility.RectangleContainsScreenPoint(sr.viewport, p, null))
+        {
+            return false;
+        }
+        return true;
+    }
+#endif
+
+    /// <summary>마지막 실행의 조건별 집계. UI가 표로 그립니다.</summary>
+    public IReadOnlyList<ConditionResult> Results => _results;
+}

--- a/Tests~/E2E/SharedScripts/Runtime/TapAutoProbe.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/TapAutoProbe.cs
@@ -8,19 +8,28 @@ using UnityEngine.UI;
 /// <summary>
 /// 탭 진단 자동 실행기.
 ///
-/// 사람이 손으로 하던 A/B/C/D 절차를 그대로 기계가 돌립니다. 탭은 캔버스에 합성 터치
-/// 이벤트를 쏘아서(<c>TAP_Tap</c>) 실제 입력 경로를 그대로 태우고, 스크롤 관성은
-/// 손가락 플릭을 흉내내는 대신 <see cref="ScrollRect.velocity"/>를 직접 세팅합니다.
+/// 사람이 손으로 밟던 A/B/C 절차를 기계가 그대로 돌립니다. 탭은 캔버스에 합성 터치 이벤트를
+/// 쏘아서(<c>TAP_Tap</c>) 실제 입력 경로를 그대로 태우고, 스크롤 관성은 손가락 플릭을 흉내내는
+/// 대신 <see cref="ScrollRect.velocity"/>를 직접 세팅합니다. 검증하려는 가설의 독립변수가
+/// "press 시점의 잔존 속도"라서 속도를 직접 만드는 편이 정확하고, 계단식으로 쓸면 클릭이
+/// 죽기 시작하는 지점을 집을 수 있습니다.
 ///
-/// 관성을 직접 세팅하는 쪽을 고른 이유:
-/// 검증하려는 가설이 "press 시점에 잔존 속도가 있으면 클릭이 죽는다"이므로 속도가 곧
-/// 독립변수입니다. 플릭을 합성하면 속도가 우연히 정해지지만, 직접 세팅하면 계단식으로
-/// 쓸어서 FIRE가 뒤집히는 임계 속도를 찾을 수 있습니다.
+/// 단위가 이 파일에서 가장 헷갈리는 부분입니다. 세 가지가 섞입니다.
+///   - 캔버스 단위: ScrollRect.velocity, RectTransform.rect, 콘텐츠 변위. 참조 해상도 390x844 기준.
+///   - 화면 픽셀: Screen.width/height, WorldToScreenPoint 결과. 캔버스 단위 x canvas.scaleFactor.
+///   - 정규화 좌표: TAP_Tap에 넘기는 값. 화면 픽셀 / Screen.wh.
+/// 관성 계산은 전부 캔버스 단위로 하고, 조준할 때 한 번만 scaleFactor를 곱합니다.
 ///
-/// 한계 하나는 미리 밝혀 둡니다. 합성 이벤트는 untrusted라 iOS가 user activation으로
-/// 쳐주지 않습니다. 따라서 "FIRE=YES인데 키보드가 안 뜬다"는 갈래는 이 자동 실행으로
-/// 가려낼 수 없고 사람 손 탭이 한 번 필요합니다. 자동 실행이 답하는 것은 uGUI가 클릭을
-/// 발화시키는가 하나입니다.
+/// 스윕을 속도가 아니라 **변위**로 파라미터화한 이유:
+/// 합성 탭은 손가락을 움직이지 않으므로 클릭이 죽는 경로는 "콘텐츠가 흘러 조준점이 위젯 밖으로
+/// 나가는 것" 하나뿐입니다. 그러려면 홀드 시간 동안의 변위가 위젯 높이의 절반을 넘어야 합니다.
+/// 속도로 스윕하면 감쇠율과 홀드 시간에 따라 하위 구간이 통째로 "구조적으로 실패 불가"가 되어,
+/// 가설을 시험한 적도 없이 FIRE=YES만 쌓입니다. 변위로 스윕하면 위젯 높이를 기준으로 임계를
+/// 사이에 두고 양쪽을 확실히 덮을 수 있고, 임계 아래 조건은 음성 대조군 노릇까지 합니다.
+///
+/// 한계 하나는 미리 밝혀 둡니다. 합성 이벤트는 untrusted라 iOS가 user activation으로 쳐주지
+/// 않습니다. 따라서 "클릭은 나는데 키보드가 안 뜬다"는 갈래는 이 자동 실행으로 가려낼 수 없고
+/// 사람 손 탭이 한 번 필요합니다. 자동 실행이 답하는 것은 uGUI가 클릭을 발화시키는가 하나입니다.
 /// </summary>
 public class TapAutoProbe : MonoBehaviour
 {
@@ -34,8 +43,7 @@ public class TapAutoProbe : MonoBehaviour
     private static extern int TAP_DriveBusy();
 #endif
 
-    // 아래 넷은 실행 파라미터입니다. WebGL이 아닌 컴파일에서는 읽는 곳이 없어 private면
-    // 미사용 경고가 나므로 public으로 둡니다 — 어차피 결과를 해석할 때 알아야 하는 값들입니다.
+    // 실행 파라미터. 결과를 해석할 때 알아야 하는 값들이라 공개해 둡니다.
 
     /// <summary>손가락을 붙이고 있는 시간. 사람 탭의 하한쯤 됩니다.</summary>
     public const int HoldMs = 80;
@@ -43,15 +51,41 @@ public class TapAutoProbe : MonoBehaviour
     /// <summary>조건 하나당 탭 횟수.</summary>
     public const int TapsPerCondition = 3;
 
-    /// <summary>쓸어볼 스크롤 속도(px/s). 부호를 뒤집어 위/아래 양쪽을 봅니다.</summary>
-    public static readonly float[] SweepSpeeds = { 100f, 200f, 400f, 800f, 1600f };
-
     /// <summary>
-    /// 합성 터치가 Unity 입력 큐를 타고 처리되기까지 한 프레임쯤 걸립니다. 그 사이 콘텐츠가
-    /// 흐른 만큼 조준점을 미리 밀어 둡니다. 안 하면 빠른 속도에서 탭이 칸을 벗어나고,
-    /// "클릭이 안 났다"와 "빗맞았다"가 섞여 버립니다.
+    /// 합성 터치가 Unity 입력 큐를 타고 처리되기까지 걸리는 프레임 수. 그 사이 콘텐츠가 흐른 만큼
+    /// 조준점을 미리 밀어 둡니다. 안 하면 빠른 조건에서 탭이 칸을 벗어나고, "클릭이 안 났다"와
+    /// "빗맞았다"가 섞여 버립니다.
     /// </summary>
     public const int LeadFrames = 1;
+
+    /// <summary>
+    /// 조건 하나를 판정에 쓰려면 최소 이만큼은 착지해야 합니다. 한 번 착지한 것으로 임계를
+    /// 발표하면 표본 1개로 단정하는 셈입니다.
+    /// </summary>
+    public const int MinLandedForVerdict = 2;
+
+    /// <summary>UP을 기다리는 시간. PointerTapDiagnostics의 미수신 판정과 같은 값이어야 합니다.</summary>
+    public const float UpWaitSeconds = 1.5f;
+
+    /// <summary>
+    /// 명령한 속도가 press 시점에 이 비율 아래로 떨어져 있으면 그 조건은 신뢰하지 않습니다.
+    /// inertia가 꺼져 있거나 탄성 경계에 걸린 경우가 여기 걸립니다.
+    /// </summary>
+    public const float VelocityHonoredRatio = 0.5f;
+
+    /// <summary>대조군 라벨. ScrollRect 밖에 있어야 합니다.</summary>
+    public const string ControlLabel = "Search...";
+
+    /// <summary>표적 라벨. ScrollRect 안에 있어야 합니다.</summary>
+    public const string TargetLabel = "test-key";
+
+    /// <summary>
+    /// 쓸어볼 콘텐츠 변위(캔버스 단위). 홀드 시간 동안 콘텐츠가 이만큼 흐르도록 초기 속도를
+    /// 역산합니다. 위젯 높이 40의 절반인 20을 사이에 두도록 골랐습니다 — 10은 구조적으로
+    /// 클릭이 죽을 수 없는 음성 대조군이고, 여기서 FIRE=NO가 나오면 관성 이동 말고 다른 원인이
+    /// 있다는 뜻입니다.
+    /// </summary>
+    public static readonly float[] SweepDisplacements = { 10f, 20f, 30f, 50f, 90f };
 
     public bool IsRunning { get; private set; }
 
@@ -62,18 +96,65 @@ public class TapAutoProbe : MonoBehaviour
     public string Verdict { get; private set; } = "";
 
     private readonly List<ConditionResult> _results = new List<ConditionResult>();
+    private HarnessInfo _info;
 
-    /// <summary>조건 하나(대조군 / 정지 / 속도 v)에 대한 집계.</summary>
+    /// <summary>마지막 실행의 조건별 집계.</summary>
+    public IReadOnlyList<ConditionResult> Results => _results;
+
+    /// <summary>마지막 실행이 놓인 환경. 판정이 전제를 확인했는지 여기서 드러납니다.</summary>
+    public HarnessInfo Info => _info;
+
+    /// <summary>
+    /// 하네스가 놓인 환경. uGUI 타입을 담지 않아 판정 로직이 순수하게 유지됩니다 —
+    /// EditMode에서 전 분기를 그대로 검증할 수 있어야 합니다.
+    /// </summary>
+    public struct HarnessInfo
+    {
+        /// <summary>표적 두 개를 라벨로 찾았고 배치도 기대와 같은가.</summary>
+        public bool Resolved;
+
+        /// <summary>Resolved가 false인 사유. 판정문에 그대로 실립니다.</summary>
+        public string Problem;
+
+        public string ControlName;
+        public string TargetName;
+
+        /// <summary>ScrollRect.inertia. false면 velocity가 매 프레임 0으로 지워져 스윕이 무의미합니다.</summary>
+        public bool Inertia;
+
+        public string MovementType;
+        public float DecelerationRate;
+
+        /// <summary>캔버스 단위 → 화면 픽셀 배율.</summary>
+        public float ScaleFactor;
+
+        /// <summary>표적 위젯 높이(캔버스 단위).</summary>
+        public float TargetHeight;
+
+        /// <summary>조준점이 위젯을 벗어나는 최소 변위. 위젯 높이의 절반입니다.</summary>
+        public float FlipThreshold => TargetHeight * 0.5f;
+    }
+
+    /// <summary>조건 하나(대조군 / 정지 / 변위 d)에 대한 집계.</summary>
     public struct ConditionResult
     {
         public string Name;
-        public float VelocityY;
+
+        /// <summary>이 조건이 실제로 때린 프로브의 라벨. 결과지만 보고도 표적을 확인할 수 있어야 합니다.</summary>
+        public string TargetLabel;
+
         public bool HasScrollRect;
+
+        /// <summary>세팅한 속도(캔버스 단위/초).</summary>
+        public float CommandedVelocity;
+
+        /// <summary>홀드 시간 동안 흐를 것으로 계산한 변위(캔버스 단위).</summary>
+        public float ExpectedDisplacement;
 
         /// <summary>보낸 탭 수.</summary>
         public int Attempted;
 
-        /// <summary>DOWN이 실제로 대상 프로브에 닿은 수. Attempted보다 작으면 빗맞은 것.</summary>
+        /// <summary>DOWN이 실제로 표적 프로브에 닿은 수.</summary>
         public int Landed;
 
         public int UpReceived;
@@ -85,23 +166,92 @@ public class TapAutoProbe : MonoBehaviour
         public int OverChanged;
 
         public int ClickReceived;
+
+        /// <summary>release 시점 pointerDrag가 표적 자신이던 수. 가설 메커니즘의 직접 증거입니다.</summary>
+        public int DragWasSelf;
+
+        /// <summary>UP을 기다리다 시간이 다 된 수.</summary>
+        public int TimedOut;
+
+        /// <summary>탭 한 번에 기록이 둘 이상 생긴 수. 사람 손이 섞였다는 뜻입니다.</summary>
+        public int Contaminated;
+
+        /// <summary>press 시점 실측 속도의 절댓값 합.</summary>
+        public float MeasuredVelocityAbsSum;
+
+        public int MeasuredSamples;
+
+        public float MeasuredVelocityAbsMean =>
+            MeasuredSamples > 0 ? MeasuredVelocityAbsSum / MeasuredSamples : 0f;
+
+        /// <summary>
+        /// 판정에 쓸 수 있는 표본인가. 오염이 있거나 착지가 부족하면 이 조건은 결론에서 빠지고
+        /// "미검증"으로 보고됩니다 — 조용히 빠지면 안 됩니다.
+        /// </summary>
+        public bool Eligible =>
+            Contaminated == 0 && Landed >= MinLandedForVerdict && Landed * 3 >= Attempted * 2;
+
+        /// <summary>명령한 속도가 press 시점까지 유지됐는가.</summary>
+        public bool VelocityHonored
+        {
+            get
+            {
+                float commanded = Mathf.Abs(CommandedVelocity);
+                if (commanded < 1f) return true;
+                return MeasuredSamples > 0 && MeasuredVelocityAbsMean >= commanded * VelocityHonoredRatio;
+            }
+        }
+    }
+
+    // ─── 관성 산수 ───
+
+    /// <summary>
+    /// 초기 속도 1에 대해 홀드 시간 동안 흐르는 거리.
+    ///
+    /// ScrollRect는 매 프레임 <c>v *= pow(rate, dt)</c> 후 <c>pos += v * dt</c>를 합니다
+    /// (ScrollRect.cs의 관성 분기). 연속 근사는 ∫₀ᵀ rate^t dt = (rate^T − 1) / ln(rate).
+    /// </summary>
+    public static float DisplacementPerUnitVelocity(float holdSeconds, float decelerationRate)
+    {
+        if (holdSeconds <= 0f) return 0f;
+        // 감쇠가 없거나 계수가 범위를 벗어나면 등속으로 근사합니다.
+        if (decelerationRate <= 0f || decelerationRate >= 1f) return holdSeconds;
+        return (Mathf.Pow(decelerationRate, holdSeconds) - 1f) / Mathf.Log(decelerationRate);
+    }
+
+    /// <summary>원하는 변위를 만드는 초기 속도. 변위 스윕을 속도 명령으로 바꿉니다.</summary>
+    public static float VelocityForDisplacement(float displacement, float holdSeconds, float decelerationRate)
+    {
+        float factor = DisplacementPerUnitVelocity(holdSeconds, decelerationRate);
+        return factor <= 1e-4f ? 0f : displacement / factor;
     }
 
     // ─── 판정 ───
 
     /// <summary>
-    /// 집계만 보고 결론을 냅니다. Unity 타입을 안 쓰므로 EditMode에서 그대로 검증됩니다.
-    /// 첫 줄이 결론, 나머지는 근거입니다.
+    /// 집계만 보고 결론을 냅니다. Unity 타입을 안 쓰므로 EditMode에서 전 분기가 그대로 검증됩니다.
+    /// 첫 줄이 결론, 나머지는 근거입니다 — 화면이 좁아 첫 줄만 보이는 경우가 흔합니다.
+    ///
+    /// 판정 불가와 반증을 절대 섞지 않는 것이 이 함수의 존재 이유입니다. 하네스가 안 돌았을 때
+    /// "가설이 틀렸다"고 말하면, 실기기 런이 사실상 1회성이라 그 문장이 그대로 조사 방향이 됩니다.
     /// </summary>
-    public static string Conclude(IReadOnlyList<ConditionResult> results)
+    public static string Conclude(HarnessInfo info, IReadOnlyList<ConditionResult> results)
     {
+        if (!info.Resolved)
+        {
+            return "판정: 불가 — " + (string.IsNullOrEmpty(info.Problem) ? "하네스가 표적을 확정하지 못했습니다." : info.Problem);
+        }
         if (results == null || results.Count == 0)
         {
             return "판정: 불가 — 한 조건도 실행되지 않았습니다.";
         }
+        if (!info.Inertia)
+        {
+            return "판정: 불가 — ScrollRect.inertia가 꺼져 있어 세팅한 속도가 매 프레임 지워집니다. "
+                 + "관성 조건이 성립하지 않으므로 이 런으로는 가설을 시험할 수 없습니다.";
+        }
 
-        var notes = new List<string>();
-
+        // ─ 대조군 ─
         ConditionResult control = default;
         bool hasControl = false;
         foreach (var r in results)
@@ -114,117 +264,246 @@ public class TapAutoProbe : MonoBehaviour
 
         if (!hasControl || control.Landed == 0)
         {
-            return "판정: 불가 — 합성 탭이 대조군 입력칸에 닿지 않았습니다. 하네스가 안 돈 것이므로 "
+            return "판정: 불가 — 합성 탭이 대조군 입력칸에 한 번도 닿지 않았습니다. 하네스가 안 돈 것이므로 "
                  + "이 결과로 가설을 판단하면 안 됩니다.";
         }
-
+        if (control.Contaminated > 0)
+        {
+            return $"판정: 불가 — 대조군에 예상 밖 입력이 {control.Contaminated}건 섞였습니다. "
+                 + "실행 중 화면을 만지지 말고 다시 돌리세요.";
+        }
+        if (!control.Eligible)
+        {
+            return $"판정: 불가 — 대조군 표본이 부족합니다({control.Landed}/{control.Attempted} 착지). "
+                 + "대조군이 흔들린 런은 나머지가 깨끗해도 쓸 수 없습니다.";
+        }
         if (control.Fired == 0)
         {
-            return $"판정: 가설 전부 폐기 — 스크롤 밖 대조군도 FIRE=NO ({control.Fired}/{control.Landed}). "
+            return $"판정: 가설 전부 폐기 — 스크롤 밖 대조군도 클릭이 안 납니다({control.Fired}/{control.Landed}). "
                  + "ScrollRect와 무관한 원인입니다.";
         }
 
+        var notes = new List<string>();
         if (control.Fired < control.Landed)
         {
-            notes.Add($"주의: 대조군이 {control.Fired}/{control.Landed}로 불안정합니다. "
-                    + "아래 결론의 신뢰도가 그만큼 낮습니다.");
+            notes.Add($"주의: 대조군이 {control.Fired}/{control.Landed}로 흔들립니다. 아래 결론의 신뢰도가 그만큼 낮습니다.");
         }
 
-        var moving = new List<ConditionResult>();
+        // ─ 스크롤 조건 분류 ─
+        var eligibleMoving = new List<ConditionResult>();
+        var untested = new List<ConditionResult>();
+        var dishonored = new List<ConditionResult>();
+        var contaminated = new List<ConditionResult>();
         ConditionResult stationary = default;
         bool hasStationary = false;
         int scrollLanded = 0;
-        int upMissing = 0;
-        int overChanged = 0;
 
         foreach (var r in results)
         {
-            upMissing += r.Landed - r.UpReceived;
-            overChanged += r.OverChanged;
             if (!r.HasScrollRect) continue;
             scrollLanded += r.Landed;
-            if (r.Landed == 0) continue;
-            if (r.VelocityY == 0f)
+
+            if (r.Contaminated > 0) { contaminated.Add(r); continue; }
+
+            if (Mathf.Abs(r.CommandedVelocity) < 1f)
             {
-                stationary = r;
-                hasStationary = true;
+                if (r.Eligible) { stationary = r; hasStationary = true; }
+                else untested.Add(r);
+                continue;
             }
-            else
+
+            if (!r.Eligible) { untested.Add(r); continue; }
+            if (!r.VelocityHonored) { dishonored.Add(r); continue; }
+            eligibleMoving.Add(r);
+        }
+
+        if (contaminated.Count > 0)
+        {
+            return $"판정: 불가 — 스크롤 조건 {contaminated.Count}개에 예상 밖 입력이 섞였습니다"
+                 + $"({Names(contaminated)}). 실행 중 화면을 만지지 말고 다시 돌리세요.";
+        }
+        if (scrollLanded == 0)
+        {
+            return "판정: 불가 — 스크롤 안 입력칸에 합성 탭이 한 번도 닿지 않았습니다.";
+        }
+        if (dishonored.Count > 0)
+        {
+            var d = dishonored[0];
+            return $"판정: 불가 — 명령한 속도가 press 시점에 유지되지 않았습니다"
+                 + $"({d.Name}: 명령 {d.CommandedVelocity:F0}, 실측 {d.MeasuredVelocityAbsMean:F0}). "
+                 + $"탄성 경계나 관성 억제가 개입한 것이므로 관성 가설을 시험한 셈이 아닙니다. "
+                 + $"해당 조건 {dishonored.Count}개.";
+        }
+
+        // ─ 정지 조건 ─
+        if (hasStationary && stationary.Fired == 0)
+        {
+            var sb0 = new StringBuilder(
+                $"판정: 관성 무관 — 정지 상태에서도 클릭이 안 납니다({stationary.Fired}/{stationary.Landed}). "
+                + "속도가 아니라 ScrollRect 안에 있다는 사실 자체가 원인입니다.");
+            AppendCommonNotes(sb0, notes, results, untested);
+            return sb0.ToString();
+        }
+
+        if (eligibleMoving.Count == 0)
+        {
+            return "판정: 불가 — 관성 조건이 하나도 판정 가능한 표본을 만들지 못했습니다"
+                 + (untested.Count > 0 ? $" (미검증: {Names(untested)})." : ".");
+        }
+
+        // ─ UP 미수신은 관성과 다른 경로다. 임계 탐색에 섞으면 안 된다. ─
+        var upClean = new List<ConditionResult>();
+        var upDirty = new List<ConditionResult>();
+        foreach (var r in eligibleMoving)
+        {
+            if (r.UpReceived < r.Landed) upDirty.Add(r);
+            else upClean.Add(r);
+        }
+
+        if (upClean.Count == 0)
+        {
+            var sb1 = new StringBuilder(
+                $"판정: UP 미수신 — 관성 조건 {upDirty.Count}개 전부에서 release 이벤트가 오지 않았습니다"
+                + $"({Names(upDirty)}). ProcessDrag가 pointerPress를 null로 만드는 경로이며 관성 이동과는 다른 원인입니다. "
+                + "관성 임계 판정은 유보합니다.");
+            AppendCommonNotes(sb1, notes, results, untested);
+            return sb1.ToString();
+        }
+        if (upDirty.Count > 0)
+        {
+            notes.Add($"UP 미수신 조건 {upDirty.Count}개({Names(upDirty)})는 다른 경로이므로 임계 탐색에서 제외했습니다.");
+        }
+
+        // ─ 임계 탐색 ─
+        bool found = false;
+        ConditionResult worst = default;
+        foreach (var r in upClean)
+        {
+            if (r.Fired >= r.Landed) continue;
+            if (!found || r.ExpectedDisplacement < worst.ExpectedDisplacement)
             {
-                moving.Add(r);
+                worst = r;
+                found = true;
             }
         }
 
-        if (upMissing > 0)
+        var sb = new StringBuilder();
+        if (!found)
         {
-            notes.Add($"UP 미수신 {upMissing}건 — ProcessDrag가 pointerPress를 null로 만드는 경로가 "
-                    + "실재합니다. 반증했다고 본 드래그 취소를 다시 봐야 합니다.");
+            if (untested.Count > 0)
+            {
+                sb.Append($"판정: 부분 불가 — 시험된 조건({Names(upClean)})에서는 클릭이 전부 났지만 "
+                        + $"{untested.Count}개 조건이 착지하지 못해 미검증입니다({Names(untested)}). "
+                        + "반증이라고 말할 수 없습니다.");
+            }
+            else
+            {
+                sb.Append($"판정: 관성 가설 반증 — 쓸어본 모든 변위({Names(upClean)})에서 클릭이 났습니다. "
+                        + "합성 탭으로는 재현되지 않습니다.");
+            }
         }
+        else
+        {
+            bool belowFlip = worst.ExpectedDisplacement < info.FlipThreshold;
+            string qualifier = untested.Count > 0 ? "시험된 범위에서 " : "";
+            sb.Append($"판정: 관성 가설 유력 — {qualifier}콘텐츠 변위 {worst.ExpectedDisplacement:F0}"
+                    + $"(속도 {worst.CommandedVelocity:F0})부터 클릭이 소실됩니다. "
+                    + $"조준점이 위젯을 벗어나는 계산상 문턱은 {info.FlipThreshold:F0}입니다. "
+                    + "press 때 잡힌 핸들러와 release 때 핸들러가 갈리는 정황과 일치합니다.");
+            if (belowFlip)
+            {
+                notes.Add($"이상: {worst.Name}의 변위({worst.ExpectedDisplacement:F0})가 문턱({info.FlipThreshold:F0})보다 "
+                        + "작은데도 클릭이 죽었습니다. 콘텐츠 이동 말고 다른 원인이 함께 있습니다.");
+            }
+            if (untested.Count > 0)
+            {
+                notes.Add($"미검증 {untested.Count}개({Names(untested)}) — 실제 문턱은 이보다 낮을 수 있습니다.");
+            }
+        }
+
+        AppendCommonNotes(sb, notes, results, untested);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// 헤드라인과 무관하게 항상 유효한 부가 신호만 붙입니다. 분기별 문구를 여기 섞으면
+    /// 확정 헤드라인 밑에 반증용 각주가 달리는 모순이 생깁니다.
+    /// </summary>
+    private static void AppendCommonNotes(StringBuilder sb, List<string> notes,
+        IReadOnlyList<ConditionResult> results, List<ConditionResult> untested)
+    {
+        int overChanged = 0, timedOut = 0, dragSelf = 0, landed = 0;
+        foreach (var r in results)
+        {
+            overChanged += r.OverChanged;
+            timedOut += r.TimedOut;
+            dragSelf += r.DragWasSelf;
+            landed += r.Landed;
+        }
+
         if (overChanged > 0)
         {
             notes.Add($"press/release 사이 over 변화 {overChanged}건 — 손가락 밑에서 콘텐츠가 움직였습니다.");
         }
-
-        string headline;
-        if (scrollLanded == 0)
+        if (dragSelf > 0 && landed > 0)
         {
-            headline = "판정: 불가 — 스크롤 안 입력칸에 합성 탭이 한 번도 닿지 않았습니다.";
+            notes.Add($"release 시점 pointerDrag가 InputField 자신이던 경우 {dragSelf}/{landed}건 — "
+                    + "ScrollRect가 아니라 InputField가 드래그 대상으로 잡혔다는 직접 증거입니다.");
         }
-        else if (hasStationary && stationary.Fired == 0)
+        if (timedOut > 0)
         {
-            headline = $"판정: 관성 무관 — 정지 상태에서도 FIRE=NO ({stationary.Fired}/{stationary.Landed}). "
-                     + "속도가 아니라 ScrollRect 안에 있다는 사실 자체가 원인입니다.";
+            notes.Add($"UP 대기 시간 초과 {timedOut}건 — 그만큼 집계가 늦게 도착했을 수 있습니다.");
         }
-        else
+        if (untested != null && untested.Count > 0)
         {
-            float threshold = 0f;
-            bool found = false;
-            foreach (var r in moving)
-            {
-                if (r.Fired >= r.Landed) continue;
-                float speed = Mathf.Abs(r.VelocityY);
-                if (!found || speed < threshold)
-                {
-                    threshold = speed;
-                    found = true;
-                }
-            }
-
-            if (!found)
-            {
-                headline = moving.Count == 0
-                    ? "판정: 불가 — 관성 조건이 한 번도 착지하지 않았습니다."
-                    : "판정: 관성 가설 반증 — 쓸어본 모든 속도에서 FIRE=YES였습니다. 합성 탭으로는 재현되지 않습니다.";
-            }
-            else
-            {
-                headline = $"판정: 관성 가설 확정 — |속도| {threshold:F0}px/s부터 클릭이 소실됩니다. "
-                         + "ScrollRect에 IInitializePotentialDragHandler가 도달하지 않아 관성이 멈추지 않는 것이 근인입니다.";
-            }
+            int missed = 0;
+            foreach (var u in untested) missed += u.Attempted - u.Landed;
+            if (missed > 0) notes.Add($"빗맞은 탭 {missed}건 — 실패가 아니라 미착지입니다.");
         }
 
-        var sb = new StringBuilder(headline);
-        foreach (var n in notes)
+        foreach (var n in notes) sb.Append('\n').Append(n);
+    }
+
+    private static string Names(List<ConditionResult> list)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < list.Count; i++)
         {
-            sb.Append('\n').Append(n);
+            if (i > 0) sb.Append(", ");
+            sb.Append(list[i].Name);
         }
         return sb.ToString();
     }
 
-    /// <summary>조건별 집계를 사람이 읽을 표로 만듭니다.</summary>
-    public static string Summarize(IReadOnlyList<ConditionResult> results)
+    /// <summary>조건별 집계를 사람이 읽을 표로 만듭니다. 자동 판정이 틀렸을 때 대조할 원본입니다.</summary>
+    public static string Summarize(HarnessInfo info, IReadOnlyList<ConditionResult> results)
     {
-        if (results == null || results.Count == 0) return "(집계 없음)";
         var sb = new StringBuilder();
-        sb.Append("조건            착지 UP FIRE over\n");
+        sb.Append($"대조군={info.ControlName ?? "?"} 표적={info.TargetName ?? "?"}\n");
+        sb.Append($"inertia={(info.Inertia ? 1 : 0)} move={info.MovementType} decel={info.DecelerationRate:F3}")
+          .Append($" scale={info.ScaleFactor:F2} h={info.TargetHeight:F0} 문턱={info.FlipThreshold:F0}\n");
+
+        if (results == null || results.Count == 0)
+        {
+            sb.Append("(집계 없음)");
+            return sb.ToString();
+        }
+
+        sb.Append("조건       변위  명령v  실측v 착지 UP FIRE over\n");
         foreach (var r in results)
         {
-            sb.Append(Pad(r.Name, 15))
+            sb.Append(Pad(r.Name, 10))
+              .Append(Pad(r.HasScrollRect ? $"{r.ExpectedDisplacement:F0}" : "-", 6))
+              .Append(Pad(r.HasScrollRect ? $"{r.CommandedVelocity:F0}" : "-", 7))
+              .Append(Pad(r.MeasuredSamples > 0 ? $"{r.MeasuredVelocityAbsMean:F0}" : "-", 6))
               .Append(Pad($"{r.Landed}/{r.Attempted}", 5))
               .Append(Pad(r.UpReceived.ToString(), 3))
-              .Append(Pad($"{r.Fired}", 5))
-              .Append(r.OverChanged)
-              .Append('\n');
+              .Append(Pad(r.Fired.ToString(), 5))
+              .Append(r.OverChanged);
+            if (r.Contaminated > 0) sb.Append($" 오염{r.Contaminated}");
+            if (r.TimedOut > 0) sb.Append($" 지연{r.TimedOut}");
+            if (!r.Eligible) sb.Append(" 표본부족");
+            sb.Append('\n');
         }
         return sb.ToString();
     }
@@ -241,57 +520,74 @@ public class TapAutoProbe : MonoBehaviour
     public void StartRun()
     {
         if (IsRunning) return;
+        IsRunning = true;   // 코루틴 첫 프레임 전에 잠급니다. 같은 프레임 두 번 눌림 방지.
         StartCoroutine(RunAll());
     }
 
     private IEnumerator RunAll()
     {
-        IsRunning = true;
         Verdict = "";
         _results.Clear();
+        _info = new HarnessInfo();
 
 #if UNITY_WEBGL && !UNITY_EDITOR
         Progress = "준비 중…";
         PointerTapDiagnostics.Clear();
         yield return null;
 
-        var control = FindProbe(wantScroll: false);
-        var target = FindProbe(wantScroll: true);
+        var control = PointerTapDiagnostics.FindByLabel(ControlLabel);
+        var target = PointerTapDiagnostics.FindByLabel(TargetLabel);
 
-        if (control == null)
+        // 표적을 라벨로만 찾습니다. "스크롤 안의 첫 프로브" 같은 폴백을 두면 다른 패널의
+        // 입력칸을 때리고도 그럴듯한 판정문이 나옵니다.
+        if (control == null || target == null)
         {
-            Verdict = "판정: 불가 — 스크롤 밖 입력칸(대조군)을 찾지 못했습니다.";
-            Progress = "";
-            IsRunning = false;
-            yield break;
-        }
-
-        yield return RunCondition("A 대조군", control, null, 0f);
-
-        if (target == null)
-        {
-            _results.Add(new ConditionResult { Name = "B 정지", HasScrollRect = true });
-            Verdict = Conclude(_results);
-            Progress = "";
-            IsRunning = false;
+            Finish($"라벨로 표적을 찾지 못했습니다(대조군 \"{ControlLabel}\"={(control != null ? "OK" : "없음")}, "
+                 + $"표적 \"{TargetLabel}\"={(target != null ? "OK" : "없음")}).");
             yield break;
         }
 
         var scroll = target.OwningScrollRect;
-        yield return RunCondition("B 정지", target, scroll, 0f);
-
-        // 위/아래 양쪽을 봅니다. Elastic 리바운드도 결국 부호가 반대인 관성이라,
-        // 경계 밖으로 밀어내는 대신 부호로 대신 덮습니다.
-        foreach (float speed in SweepSpeeds)
+        if (scroll == null || control.OwningScrollRect != null)
         {
-            yield return RunCondition($"C -{speed:F0}", target, scroll, -speed);
-            yield return RunCondition($"C +{speed:F0}", target, scroll, speed);
+            Finish($"표적 배치가 기대와 다릅니다(대조군은 ScrollRect 밖, 표적은 안이어야 합니다). "
+                 + $"대조군 scroll={(control.OwningScrollRect != null ? "YES" : "NO")}, "
+                 + $"표적 scroll={(scroll != null ? "YES" : "NO")}.");
+            yield break;
         }
 
-        if (scroll != null) scroll.velocity = Vector2.zero;
-        Verdict = Conclude(_results);
-        Progress = "";
-        IsRunning = false;
+        var targetRt = target.transform as RectTransform;
+        var canvas = target.GetComponentInParent<Canvas>();
+        _info = new HarnessInfo
+        {
+            Resolved = true,
+            ControlName = control.Label,
+            TargetName = target.Label,
+            Inertia = scroll.inertia,
+            MovementType = scroll.movementType.ToString(),
+            DecelerationRate = scroll.decelerationRate,
+            ScaleFactor = canvas != null ? canvas.rootCanvas.scaleFactor : 1f,
+            TargetHeight = targetRt != null ? targetRt.rect.height : 0f,
+        };
+        Debug.Log($"[TapDiag] harness inertia={_info.Inertia} move={_info.MovementType} "
+                + $"decel={_info.DecelerationRate} scale={_info.ScaleFactor} h={_info.TargetHeight}");
+
+        yield return RunCondition("A 대조군", control, null, 0f, 0f);
+        yield return RunCondition("B 정지", target, scroll, 0f, 0f);
+
+        // 위/아래 양쪽을 봅니다. Elastic 리바운드도 결국 부호가 반대인 관성이라, 경계 밖으로
+        // 밀어내는 대신 부호로 대신 덮습니다 — 경계 밖으로 밀면 표적이 뷰포트를 벗어나
+        // 빗맞은 탭과 실패한 탭이 섞입니다.
+        float hold = HoldMs / 1000f;
+        foreach (float d in SweepDisplacements)
+        {
+            float v = VelocityForDisplacement(d, hold, _info.DecelerationRate);
+            yield return RunCondition($"C -{d:F0}", target, scroll, -v, d);
+            yield return RunCondition($"C +{d:F0}", target, scroll, v, d);
+        }
+
+        scroll.velocity = Vector2.zero;
+        Finish(null);
 #else
         Progress = "";
         Verdict = "판정: 불가 — 자동 진단은 WebGL 빌드에서만 동작합니다(합성 터치가 필요).";
@@ -300,14 +596,29 @@ public class TapAutoProbe : MonoBehaviour
 #endif
     }
 
+    private void Finish(string problem)
+    {
+        if (!string.IsNullOrEmpty(problem))
+        {
+            _info.Resolved = false;
+            _info.Problem = problem;
+        }
+        Verdict = Conclude(_info, _results);
+        Progress = "";
+        IsRunning = false;
+    }
+
 #if UNITY_WEBGL && !UNITY_EDITOR
-    private IEnumerator RunCondition(string name, PointerTapDiagnostics probe, ScrollRect scroll, float velocityY)
+    private IEnumerator RunCondition(string name, PointerTapDiagnostics probe, ScrollRect scroll,
+        float velocityY, float expectedDisplacement)
     {
         var result = new ConditionResult
         {
             Name = name,
-            VelocityY = velocityY,
+            TargetLabel = probe.Label,
             HasScrollRect = scroll != null,
+            CommandedVelocity = velocityY,
+            ExpectedDisplacement = expectedDisplacement,
         };
 
         var rt = probe.transform as RectTransform;
@@ -320,14 +631,20 @@ public class TapAutoProbe : MonoBehaviour
                 CenterOn(scroll, rt);
                 yield return null;
                 scroll.velocity = new Vector2(0f, velocityY);
-                // 속도를 세팅한 프레임에는 아직 콘텐츠가 안 움직였습니다. 한 프레임 흘려서
+                // 속도를 세팅한 프레임에는 아직 콘텐츠가 안 움직입니다. 한 프레임 흘려서
                 // 실제로 흐르는 상태를 만든 뒤 조준합니다.
                 yield return null;
             }
 
-            float lead = velocityY * Time.unscaledDeltaTime * LeadFrames;
+            // 관성 산수는 캔버스 단위, 조준은 화면 픽셀. 여기서 한 번만 변환합니다.
+            // dt를 한 프레임 값 그대로 쓰면 직전 탭의 로그 출력으로 늘어난 프레임이 그대로
+            // 과보정이 됩니다. 30~120fps 범위로 묶어 둡니다.
+            float dt = Mathf.Clamp(Time.unscaledDeltaTime, 1f / 120f, 1f / 30f);
+            float leadCanvas = velocityY * dt * LeadFrames;
+            float leadScreen = leadCanvas * _info.ScaleFactor;
+
             Vector2 point;
-            if (!TryGetScreenPoint(rt, scroll, lead, out point))
+            if (!TryGetScreenPoint(rt, scroll, leadScreen, out point))
             {
                 // 조준점이 뷰포트 밖이면 보내 봐야 빗맞습니다. 시도는 세되 탭은 생략합니다.
                 result.Attempted++;
@@ -338,49 +655,65 @@ public class TapAutoProbe : MonoBehaviour
             result.Attempted++;
             TAP_Tap(point.x / Screen.width, point.y / Screen.height, HoldMs);
 
-            float deadline = Time.realtimeSinceStartup + 2f;
-            while (TAP_DriveBusy() != 0 && Time.realtimeSinceStartup < deadline) yield return null;
-            // touchend가 Unity 입력 큐를 타고 OnPointerUp/OnPointerClick까지 도는 시간.
-            yield return new WaitForSecondsRealtime(0.2f);
+            float busyDeadline = Time.realtimeSinceStartup + 2f;
+            while (TAP_DriveBusy() != 0 && Time.realtimeSinceStartup < busyDeadline) yield return null;
+
+            // 고정 시간을 기다리는 대신 이 탭의 기록에 UP이 설 때까지 폴링합니다. 고정 대기는
+            // 늦게 온 UP을 "미수신"으로 오집계하고, 그 오집계가 관성 임계로 흡수됩니다.
+            bool up = false;
+            float upDeadline = Time.realtimeSinceStartup + UpWaitSeconds;
+            while (Time.realtimeSinceStartup < upDeadline)
+            {
+                if (HasUp(before, probe.Label)) { up = true; break; }
+                yield return null;
+            }
+            // OnPointerClick은 OnPointerUp과 같은 프레임에 이어서 실행됩니다(:428 다음 :436).
+            yield return null;
+            if (!up) result.TimedOut++;
 
             Tally(ref result, before, probe.Label);
         }
 
         if (scroll != null) scroll.velocity = Vector2.zero;
         _results.Add(result);
-        yield return new WaitForSecondsRealtime(0.1f);
+        yield return null;
+    }
+
+    private static bool HasUp(int startIndex, string label)
+    {
+        var records = PointerTapDiagnostics.Records;
+        for (int i = startIndex; i < records.Count; i++)
+        {
+            if (records[i].Label == label && records[i].UpReceived) return true;
+        }
+        return false;
     }
 
     /// <summary>이번 탭으로 새로 생긴 기록만 골라 집계에 더합니다.</summary>
     private static void Tally(ref ConditionResult result, int startIndex, string label)
     {
         var records = PointerTapDiagnostics.Records;
+        int matched = 0;
         for (int i = startIndex; i < records.Count; i++)
         {
             var r = records[i];
             if (r.Label != label) continue;
+            matched++;
             result.Landed++;
             if (r.UpReceived) result.UpReceived++;
             if (r.WillFireClick) result.Fired++;
             if (r.OverChanged) result.OverChanged++;
             if (r.ClickReceived) result.ClickReceived++;
+            if (r.DragIsSelf) result.DragWasSelf++;
+            result.MeasuredVelocityAbsSum += Mathf.Abs(r.DownVelocityY);
+            result.MeasuredSamples++;
         }
+
+        // 합성 탭 하나에 기록이 둘 이상이면 사람 손이 섞인 것입니다. 조건 전체를 판정에서 뺍니다.
+        if (matched > 1) result.Contaminated += matched - 1;
     }
 
-    private static PointerTapDiagnostics FindProbe(bool wantScroll)
-    {
-        // 스크롤 안 후보가 여럿이면 Key 칸(첫 번째)이 잡힙니다 — 등록 순서가 곧 생성 순서입니다.
-        foreach (var p in PointerTapDiagnostics.LiveProbes)
-        {
-            if (p == null || !p.isActiveAndEnabled) continue;
-            if ((p.OwningScrollRect != null) == wantScroll) return p;
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// 대상을 뷰포트 한가운데로 스크롤합니다. 콘텐츠가 뷰포트보다 짧으면 할 일이 없습니다.
-    /// </summary>
+    /// <summary>대상을 뷰포트 한가운데로 스크롤합니다. 콘텐츠가 뷰포트보다 짧으면 할 일이 없습니다.</summary>
     private static void CenterOn(ScrollRect sr, RectTransform target)
     {
         if (sr == null || sr.content == null || sr.viewport == null || target == null) return;
@@ -412,16 +745,18 @@ public class TapAutoProbe : MonoBehaviour
     }
 
     /// <summary>
-    /// 대상의 화면 좌표. 화면 밖이거나 스크롤 뷰포트에 가려져 있으면 false.
+    /// 대상의 화면 좌표(픽셀). 화면 밖이거나 스크롤 뷰포트에 가려져 있으면 false.
+    /// leadScreenPixels는 이미 화면 픽셀로 환산된 선행 보정입니다.
     /// </summary>
-    private static bool TryGetScreenPoint(RectTransform rt, ScrollRect sr, float leadY, out Vector2 screenPoint)
+    private static bool TryGetScreenPoint(RectTransform rt, ScrollRect sr, float leadScreenPixels,
+        out Vector2 screenPoint)
     {
         screenPoint = Vector2.zero;
         if (rt == null) return false;
 
         // Screen Space - Overlay 캔버스라 카메라는 null입니다.
         Vector2 p = RectTransformUtility.WorldToScreenPoint(null, rt.TransformPoint(rt.rect.center));
-        p.y += leadY;
+        p.y += leadScreenPixels;
         screenPoint = p;
 
         if (p.x <= 0f || p.x >= Screen.width) return false;
@@ -434,7 +769,4 @@ public class TapAutoProbe : MonoBehaviour
         return true;
     }
 #endif
-
-    /// <summary>마지막 실행의 조건별 집계. UI가 표로 그립니다.</summary>
-    public IReadOnlyList<ConditionResult> Results => _results;
 }

--- a/Tests~/E2E/SharedScripts/Runtime/TapAutoProbe.cs.meta
+++ b/Tests~/E2E/SharedScripts/Runtime/TapAutoProbe.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8690d03028e46138bf95af66ea79745
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// 탭 진단 로그를 화면에 띄우는 패널.
+///
+/// PointerTapDiagnostics가 모아둔 press/release 기록을 주기적으로 다시 그립니다. 버튼을 눌러야
+/// 갱신되는 구조로 만들지 않은 이유가 있습니다 — 진단 대상이 "스크롤 영역 안에서 탭이 안 먹는
+/// 증상"이고, 이 패널도 같은 스크롤 영역 안에 있습니다. 로그를 보려고 누르는 버튼이 같은 이유로
+/// 안 먹으면 진단 자체를 못 합니다. 그래서 자동 갱신으로 두고, 버튼은 지우기 하나만 둡니다.
+///
+/// 같은 내용이 Debug.Log와 window.__AIT_TAPLOG(console.log)로도 나가므로, 원격 인스펙터가
+/// 붙는 상황이면 화면을 거치지 않고 그쪽에서 읽는 편이 편합니다.
+/// </summary>
+public class TapDiagnosticsTester : MonoBehaviour
+{
+    /// <summary>화면에 보여줄 최근 기록 수. 버퍼 전체(PointerTapDiagnostics.MaxLines)는 콘솔로 나갑니다.</summary>
+    private const int VisibleEntries = 12;
+
+    private const float RefreshIntervalSeconds = 0.3f;
+
+    private Text _logText;
+    private int _lastRenderedRevision = -1;
+    private float _lastRefreshTime = -1f;
+
+    public void SetupUI(Transform parent)
+    {
+        var section = UIBuilder.CreatePanel(parent, UIBuilder.Theme.SectionBg);
+        var vlg = section.gameObject.AddComponent<VerticalLayoutGroup>();
+        vlg.spacing = UIBuilder.Theme.SpacingSmall;
+        vlg.childForceExpandWidth = true;
+        vlg.childForceExpandHeight = false;
+        vlg.childControlWidth = true;
+        vlg.childControlHeight = true;
+        vlg.padding = new RectOffset(12, 12, 12, 12);
+        section.gameObject.AddComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+        UIBuilder.CreateText(section, "탭 진단",
+            UIBuilder.Theme.FontLarge, UIBuilder.Theme.TextAccent, fontStyle: FontStyle.Bold);
+
+        UIBuilder.CreateText(section,
+            "InputField를 탭하면 press/release 시점의 포인터 상태가 아래에 쌓입니다. "
+            + "위쪽 검색바는 스크롤 밖(scroll=NO), 이 아래 PlayerPrefs의 Key/Value 칸은 스크롤 안(scroll=YES)입니다. "
+            + "둘을 번갈아 탭해서 UP 줄의 FIRE 값을 비교하세요.",
+            UIBuilder.Theme.FontTiny, UIBuilder.Theme.TextSecondary);
+
+        UIBuilder.CreateText(section,
+            "FIRE=YES면 클릭이 발화합니다. FIRE=NO거나 UP 줄 자체가 '미수신'이면 그 줄에 적힌 사유가 원인입니다. "
+            + "스크롤을 세게 튕긴 직후(vel이 0이 아닐 때) 탭하면 재현 확률이 올라갑니다.",
+            UIBuilder.Theme.FontTiny, UIBuilder.Theme.TextSecondary);
+
+        UIBuilder.CreateButton(section, "로그 지우기", onClick: OnClearClick);
+
+        _logText = UIBuilder.CreateText(section, "(아직 탭 기록 없음)",
+            UIBuilder.Theme.FontTiny, UIBuilder.Theme.TextPrimary);
+        _logText.horizontalOverflow = HorizontalWrapMode.Wrap;
+    }
+
+    private void OnClearClick()
+    {
+        PointerTapDiagnostics.Clear();
+    }
+
+    private void Update()
+    {
+        PointerTapDiagnostics.PollPendingTaps();
+
+        if (_logText == null) return;
+        if (_lastRefreshTime >= 0f && Time.realtimeSinceStartup - _lastRefreshTime < RefreshIntervalSeconds) return;
+        _lastRefreshTime = Time.realtimeSinceStartup;
+
+        if (_lastRenderedRevision == PointerTapDiagnostics.Revision) return;
+        _lastRenderedRevision = PointerTapDiagnostics.Revision;
+        _logText.text = BuildVisibleLog();
+    }
+
+    private static string BuildVisibleLog()
+    {
+        var lines = PointerTapDiagnostics.Lines;
+        if (lines.Count == 0) return "(아직 탭 기록 없음)";
+
+        int start = Math.Max(0, lines.Count - VisibleEntries);
+        var sb = new StringBuilder();
+        if (start > 0) sb.AppendLine($"... 이전 {start}건은 콘솔에만 남아 있습니다");
+        for (int i = start; i < lines.Count; i++)
+        {
+            sb.AppendLine(lines[i]);
+        }
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs
@@ -95,6 +95,10 @@ public class TapDiagnosticsTester : MonoBehaviour
         RefreshVerdict();
 
         if (_logText == null) return;
+        // 자동 진단이 도는 동안에는 로그 패널을 다시 그리지 않습니다. 이 패널은 측정 대상과 같은
+        // ScrollRect 안에 있어서, 텍스트가 길어지며 일어나는 레이아웃 재구축이 탭이 진행되는
+        // 프레임에 끼어듭니다. 어차피 도는 동안 읽을 사람도 없습니다.
+        if (_autoProbe != null && _autoProbe.IsRunning) return;
         if (_lastRefreshTime >= 0f && Time.realtimeSinceStartup - _lastRefreshTime < RefreshIntervalSeconds) return;
         _lastRefreshTime = Time.realtimeSinceStartup;
 
@@ -122,7 +126,7 @@ public class TapDiagnosticsTester : MonoBehaviour
         }
         else
         {
-            body = _autoProbe.Verdict + "\n\n" + TapAutoProbe.Summarize(_autoProbe.Results);
+            body = _autoProbe.Verdict + "\n\n" + TapAutoProbe.Summarize(_autoProbe.Info, _autoProbe.Results);
         }
 
         if (body != _lastVerdictRender)

--- a/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs
@@ -22,11 +22,18 @@ public class TapDiagnosticsTester : MonoBehaviour
     private const float RefreshIntervalSeconds = 0.3f;
 
     private Text _logText;
+    private Text _verdictText;
+    private Button _runButton;
+    private Text _runButtonLabel;
+    private TapAutoProbe _autoProbe;
     private int _lastRenderedRevision = -1;
     private float _lastRefreshTime = -1f;
+    private string _lastVerdictRender;
 
     public void SetupUI(Transform parent)
     {
+        _autoProbe = GetComponent<TapAutoProbe>() ?? gameObject.AddComponent<TapAutoProbe>();
+
         var section = UIBuilder.CreatePanel(parent, UIBuilder.Theme.SectionBg);
         var vlg = section.gameObject.AddComponent<VerticalLayoutGroup>();
         vlg.spacing = UIBuilder.Theme.SpacingSmall;
@@ -41,14 +48,27 @@ public class TapDiagnosticsTester : MonoBehaviour
             UIBuilder.Theme.FontLarge, UIBuilder.Theme.TextAccent, fontStyle: FontStyle.Bold);
 
         UIBuilder.CreateText(section,
-            "InputField를 탭하면 press/release 시점의 포인터 상태가 아래에 쌓입니다. "
-            + "위쪽 검색바는 스크롤 밖(scroll=NO), 이 아래 PlayerPrefs의 Key/Value 칸은 스크롤 안(scroll=YES)입니다. "
-            + "둘을 번갈아 탭해서 UP 줄의 FIRE 값을 비교하세요.",
+            "아래 버튼 하나면 A/B/C 전부 자동으로 돕니다. 20초쯤 걸리고, 끝나면 판정이 그대로 뜹니다. "
+            + "도는 동안 화면을 만지지 마세요 — 사람 손 입력이 섞이면 집계가 오염됩니다.",
+            UIBuilder.Theme.FontTiny, UIBuilder.Theme.TextSecondary);
+
+        _runButton = UIBuilder.CreateButton(section, "자동 진단 실행", onClick: OnAutoRunClick);
+        _runButtonLabel = _runButton != null ? _runButton.GetComponentInChildren<Text>() : null;
+
+        _verdictText = UIBuilder.CreateText(section, "(아직 실행하지 않음)",
+            UIBuilder.Theme.FontSmall, UIBuilder.Theme.TextAccent);
+        _verdictText.horizontalOverflow = HorizontalWrapMode.Wrap;
+
+        UIBuilder.CreateText(section,
+            "손으로 확인하려면: 위쪽 검색바는 스크롤 밖(scroll=NO), 이 아래 PlayerPrefs의 Key/Value 칸은 "
+            + "스크롤 안(scroll=YES)입니다. 둘을 번갈아 탭해서 UP 줄의 FIRE 값을 비교하세요. "
+            + "FIRE=NO거나 UP 줄이 '미수신'이면 그 줄에 적힌 사유가 원인입니다.",
             UIBuilder.Theme.FontTiny, UIBuilder.Theme.TextSecondary);
 
         UIBuilder.CreateText(section,
-            "FIRE=YES면 클릭이 발화합니다. FIRE=NO거나 UP 줄 자체가 '미수신'이면 그 줄에 적힌 사유가 원인입니다. "
-            + "스크롤을 세게 튕긴 직후(vel이 0이 아닐 때) 탭하면 재현 확률이 올라갑니다.",
+            "자동 진단이 답하지 못하는 것 하나: 합성 터치는 iOS가 사용자 제스처로 쳐주지 않아서 "
+            + "소프트 키보드가 뜨는지는 못 봅니다. FIRE=YES로 나오면 그때 손으로 한 번 탭해서 "
+            + "키보드가 뜨는지 확인해 주세요.",
             UIBuilder.Theme.FontTiny, UIBuilder.Theme.TextSecondary);
 
         UIBuilder.CreateButton(section, "로그 지우기", onClick: OnClearClick);
@@ -63,9 +83,16 @@ public class TapDiagnosticsTester : MonoBehaviour
         PointerTapDiagnostics.Clear();
     }
 
+    private void OnAutoRunClick()
+    {
+        if (_autoProbe == null) return;
+        _autoProbe.StartRun();
+    }
+
     private void Update()
     {
         PointerTapDiagnostics.PollPendingTaps();
+        RefreshVerdict();
 
         if (_logText == null) return;
         if (_lastRefreshTime >= 0f && Time.realtimeSinceStartup - _lastRefreshTime < RefreshIntervalSeconds) return;
@@ -74,6 +101,42 @@ public class TapDiagnosticsTester : MonoBehaviour
         if (_lastRenderedRevision == PointerTapDiagnostics.Revision) return;
         _lastRenderedRevision = PointerTapDiagnostics.Revision;
         _logText.text = BuildVisibleLog();
+    }
+
+    /// <summary>
+    /// 진행 상황과 판정을 다시 그립니다. 실행 중에는 버튼을 잠급니다 — 도는 도중 다시 누르면
+    /// 두 번째 실행이 첫 번째 집계 위에 겹쳐 쌓입니다.
+    /// </summary>
+    private void RefreshVerdict()
+    {
+        if (_verdictText == null || _autoProbe == null) return;
+
+        string body;
+        if (_autoProbe.IsRunning)
+        {
+            body = $"진행 중 — {_autoProbe.Progress}";
+        }
+        else if (string.IsNullOrEmpty(_autoProbe.Verdict))
+        {
+            body = "(아직 실행하지 않음)";
+        }
+        else
+        {
+            body = _autoProbe.Verdict + "\n\n" + TapAutoProbe.Summarize(_autoProbe.Results);
+        }
+
+        if (body != _lastVerdictRender)
+        {
+            _lastVerdictRender = body;
+            _verdictText.text = body;
+        }
+
+        if (_runButton != null) _runButton.interactable = !_autoProbe.IsRunning;
+        if (_runButtonLabel != null)
+        {
+            string label = _autoProbe.IsRunning ? "실행 중…" : "자동 진단 실행";
+            if (_runButtonLabel.text != label) _runButtonLabel.text = label;
+        }
     }
 
     private static string BuildVisibleLog()

--- a/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs.meta
+++ b/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06b5c82ddf3b479384059211643d2c89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests~/E2E/SharedScripts/Runtime/UIBuilder.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/UIBuilder.cs
@@ -478,6 +478,11 @@ public static class UIBuilder
         if (onValueChanged != null) inputField.onValueChanged.AddListener((v) => onValueChanged(v));
         if (onEndEdit != null) inputField.onEndEdit.AddListener((v) => onEndEdit(v));
 
+        // 탭 진단 프로브. InputField가 이미 구현한 인터페이스만 구현하므로 이벤트 라우팅이 바뀌지 않습니다.
+        // 자세한 근거는 PointerTapDiagnostics의 주석 참조.
+        var probe = go.AddComponent<PointerTapDiagnostics>();
+        probe.Label = string.IsNullOrEmpty(placeholder) ? go.name : placeholder;
+
         return inputField;
     }
 


### PR DESCRIPTION
#1141의 원인을 실기기에서 가려내기 위한 계측입니다. **증상을 고치지 않습니다.**

## 무엇을 재는가

`StandaloneInputModule.ProcessTouchPress`의 release 경로는 클릭을 발화시키기 전에 `pointerUpHandler`를 먼저 실행합니다. uGUI 6000.3 기준:

```csharp
var currentOverGo = pointerEvent.pointerCurrentRaycast.gameObject;            // :354
...
ExecuteEvents.Execute(pointerEvent.pointerPress, pointerEvent, ExecuteEvents.pointerUpHandler);   // :428
var pointerClickHandler = ExecuteEvents.GetEventHandler<IPointerClickHandler>(currentOverGo);     // :433
if (pointerEvent.pointerClick == pointerClickHandler && pointerEvent.eligibleForClick)            // :436
```

`OnPointerUp`이 판정 다섯 줄 앞에서 발화하므로, 모듈이 곧 내릴 결론을 그대로 미리 계산할 수 있습니다. `PointerTapDiagnostics`가 그 판정을 `WillFireClick`으로 복제하고, 어긋난 이유까지 한국어로 적습니다.

실기기 화면에 이렇게 찍힙니다:

```
#3 DOWN test-key | scroll=YES vel=(0,-812) thr=20
    over=InputField press=InputField drag=InputField
#3 UP   test-key | moved=2.4px elig=1 dragging=0
    over=Text click=InputField hnd=(none)
    => FIRE=NO — press 때 잡힌 핸들러(InputField)와 release 때 핸들러((none))가 다름
```

## 가설을 어떻게 가르는가

남은 유력 가설은 ScrollRect 관성입니다. ScrollRect는 `IInitializePotentialDragHandler`로 관성을 멈추는데, 이 이벤트는 `ExecuteHierarchy`가 아니라 `Execute`로 `pointerDrag` 하나에만 갑니다(`:418-421`). `pointerDrag`는 InputField 자신이고(텍스트 드래그 선택용으로 `IDragHandler`를 직접 구현), InputField는 `IInitializePotentialDragHandler`를 구현하지 않으므로 관성이 멈추지 않습니다.

로그가 이렇게 갈라줍니다.

| 관측 | 결론 |
|---|---|
| DOWN의 `vel`이 0이 아니고 UP의 `over`가 DOWN과 다름 | 관성 가설 확정 |
| UP 줄이 아예 없음(`미수신`) | `ProcessDrag`가 `pointerPress`를 null로 만든 경로 — 반증됐다고 본 드래그 취소가 실제로 일어난 것 |
| `over`가 그대로인데 `FIRE=YES`인데도 키보드가 안 뜸 | uGUI 밖 문제. iOS user activation 타이밍을 봐야 함 |
| 스크롤 밖 검색바(`scroll=NO`)도 `FIRE=NO` | ScrollRect와 무관한 원인 |

## 관측이 대상을 바꾸지 않게

구현하는 인터페이스는 `IPointerDownHandler` / `IPointerUpHandler` / `IPointerClickHandler` 셋뿐입니다. `Selectable`이 이미 셋 다 구현하므로 `ExecuteHierarchy`가 고르는 GameObject가 달라지지 않고, `ExecuteEvents.Execute`는 대상 GameObject의 핸들러를 전부 호출하므로 라우팅이 그대로입니다.

`IInitializePotentialDragHandler`는 절대 구현하면 안 됩니다 — InputField에 없던 핸들러가 생겨 **관성이 멈추는지 여부 자체가 바뀝니다.** 재려는 것을 재는 행위가 고쳐버리는 셈입니다. EditMode 인터페이스 가드 2건이 이걸 컴파일 타임 실수로부터 막습니다(`IDragHandler` 계열 6종 거부 + 허용 집합 정확히 일치).

## 대조군

새로 만들지 않았습니다. 이슈가 지목한 두 입력칸이 이미 앱에 있습니다.

- 검색바 — `BuildSearchBar`가 `_apiListView`에 직접 붙이므로 ScrollRect **밖** (`scroll=NO`)
- PlayerPrefs Key/Value — `_subTesterContainer`를 통해 API 목록 뷰의 ScrollRect **안** (`scroll=YES`)

`UIBuilder.CreateInputField`가 만드는 모든 InputField에 프로브가 붙으므로 둘 다 자동으로 계측됩니다. 합성 재현이 아니라 실제 신고된 재현 대상을 그대로 잽니다.

## 로그를 꺼내는 두 경로

화면 패널과 `console.log`(`window.__AIT_TAPLOG`) 양쪽으로 나갑니다. 진단 대상이 "스크롤 안에서 탭이 안 먹는 증상"이라 화면 UI 조작 자체가 증상의 영향을 받을 수 있습니다. 그래서 패널은 버튼 없이 0.3초 주기로 자동 갱신하고(버튼은 지우기 하나뿐), 원격 인스펙터가 붙는 상황이면 화면을 거치지 않고 콘솔에서 읽으면 됩니다.

## 범위

`Tests~/E2E/SharedScripts/`만 바뀝니다. SDK 런타임(`Runtime/`, `WebGLTemplates/`, `Editor/`)은 한 줄도 건드리지 않고, `Tests~/`는 UPM 배포에서 제외되므로 SDK 소비자에게 도달하지 않습니다.

문서는 넣지 않았습니다 — 저장소 정책상 `.md` 신규 생성에 명시 허락이 필요해서, 실측 절차는 #1141 코멘트에 적었습니다.

## 테스트

신규 EditMode 14건 — 인터페이스 가드 2, 판정식 4, 사유 문구 3, 포맷 5.

로컬 `--validate` 4/4, `--editmode` 통과. 러너가 출력하는 숫자(1494)는 `grep -o 'result="Passed"'`로 세기 때문에 test-case뿐 아니라 TestFixture 노드까지 포함합니다 — 실제 신규 케이스는 14건이고 러너 표시는 +15입니다.

E2E는 자동 실행되지 않아 이 PR에서 수동 dispatch로 돌립니다. InputField마다 컴포넌트가 하나 늘고 탭마다 `Debug.Log`가 나가므로, 대화형 모드 테스트에 영향이 없는지 확인이 필요합니다.
