### PR TITLE
[auto-resolve] 수정: AIT_FILE_MISSING 안내 문구 dist/만 언급하던 문제

### DIFF
--- a/Editor/AITExportErrorCatalog.cs
+++ b/Editor/AITExportErrorCatalog.cs
@@ -96,9 +96,9 @@ namespace AppsInToss.Editor
                            "3. AIT > Clean 메뉴 실행 후 Clean Build 재시도";
 
                 case AITExportError.AIT_FILE_MISSING:
-                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.\n\n" +
+                    return ".ait 파일이 생성되지 않았습니다.\n\n" +
                            "해결 방법:\n" +
-                           "1. ait-build/dist/ 폴더의 내용을 확인하세요\n" +
+                           "1. ait-build/ 폴더(ait build CLI 버전에 따라 루트 또는 dist/ 하위)의 내용을 확인하세요\n" +
                            "2. granite.config.ts 설정을 확인하세요\n" +
                            "3. AIT > Clean 메뉴 실행 후 Clean Build 재시도";
 
@@ -175,7 +175,7 @@ namespace AppsInToss.Editor
                     return "granite 빌드가 완료되었지만 dist 폴더가 생성되지 않았습니다.\n" +
                            "granite.config.ts 의 플레이스홀더가 올바르게 치환되었는지 확인해주세요.";
                 case AITExportError.AIT_FILE_MISSING:
-                    return "dist/ 폴더에 .ait 파일이 생성되지 않았습니다.\n" +
+                    return "ait-build/ 폴더(ait build CLI 버전에 따라 루트 또는 dist/ 하위)에 .ait 파일이 생성되지 않았습니다.\n" +
                            "granite 빌드 설정을 확인한 뒤 Clean Build 로 재시도해주세요.";
                 default:
                     return $"알 수 없는 오류 (코드: {error}).";

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs
@@ -8,6 +8,14 @@
 //          bundle.ios.js 는 dist/ 에 존재하나 .ait 패키징 단계가 실패한 시나리오.
 //          → ait build CLI 동작이므로 EditMode 재현 불가.
 //            ValidateDistOutput 자체의 판별 로직을 회귀 테스트로 고정.
+//
+// Sentry APPS-IN-TOSS-UNITY-SDK-1AG 관련 후속: "빌드는 성공했는데 .ait 패키지를
+// ait-build/dist/에서 찾지 못함" — 이 역시 ait build CLI 동작이라 EditMode 재현
+// 불가. 다만 조사 중 AIT_FILE_MISSING 사용자 안내 문구(AITExportErrorCatalog)가
+// "dist/ 폴더를 확인하라"고만 안내해 실제 판별 로직(루트 우선, dist/ 폴백)과
+// 어긋나 있음을 발견 — web-framework 3.x(SDK 기본 핀 버전)는 .ait를 dist/가 아닌
+// ait-build 루트에 emit하므로 이 안내를 따라 dist/만 보면 실제 산출물을 놓친다.
+// 문구를 판별 로직과 일치시키고 아래 테스트로 고정한다.
 // -----------------------------------------------------------------------
 
 using NUnit.Framework;
@@ -145,5 +153,33 @@ public class ValidateDistOutputTests
         var result = AITBuildValidator.ValidateDistOutput(tempDir);
         Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result,
             "빌드 루트에 .ait 파일이 있으면 dist/ 탐색 없이 SUCCEED 를 반환해야 한다");
+    }
+
+    // =====================================================
+    // AIT_FILE_MISSING 사용자 안내 문구가 실제 판별 로직(루트 우선, dist/ 폴백)과
+    // 일치하는지 고정 — Sentry APPS-IN-TOSS-UNITY-SDK-1AG 조사 중 발견한
+    // 문구 불일치 회귀 방지 (dist/만 안내하면 web-framework 3.x의 루트 산출물을 놓친다)
+    // =====================================================
+
+    [Test]
+    public void GetErrorMessage_AitFileMissing_MentionsBuildRootNotOnlyDist()
+    {
+        string message = AITConvertCore.GetErrorMessage(AITConvertCore.AITExportError.AIT_FILE_MISSING);
+
+        StringAssert.DoesNotContain("dist/ 폴더에 .ait 파일이 생성되지 않았습니다", message,
+            "dist/ 만 언급하면 루트에 emit되는 3.x 산출물 안내가 누락된다");
+        StringAssert.Contains("루트", message,
+            ".ait 파일은 ait-build 루트에도 생성될 수 있다는 안내가 있어야 한다");
+    }
+
+    [Test]
+    public void GetErrorCause_AitFileMissing_MentionsBuildRootNotOnlyDist()
+    {
+        string cause = AITConvertCore.GetErrorCause(AITConvertCore.AITExportError.AIT_FILE_MISSING);
+
+        StringAssert.DoesNotContain("dist/ 폴더에 .ait 파일이 생성되지 않았습니다", cause,
+            "dist/ 만 언급하면 루트에 emit되는 3.x 산출물 안내가 누락된다");
+        StringAssert.Contains("루트", cause,
+            ".ait 파일은 ait-build 루트에도 생성될 수 있다는 안내가 있어야 한다");
     }
 }


### PR DESCRIPTION
**범위**: 원 이슈 `APPS-IN-TOSS-UNITY-SDK-1AG`의 실제 증상(빌드 후 .ait 미생성)은 미해결 — 참조만. 별도 조사 필요

## 대상 항목

| 유형 | ID | 메시지 |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-1AG | UnityError: [AIT-CI] 빌드는 성공했는데 .ait 패키지를 찾지 못했습니다. ait-build/dist/ 를 확인하세요. |

## 재현 시도 및 결과

1. 코드베이스에서 `[AIT-CI]` 태그, `AIT-CI` 문자열을 전체 검색(git log -S 포함)했으나 SDK 어디에도 존재하지 않음 — 이 태그가 붙은 로그는 SDK 자체 소스가 아니라 사용자 측 CI 스크립트 등 외부에서 온 것으로 보임.
2. ".ait 패키지 미생성" 자체는 `AITBuildValidator.ValidateDistOutput`이 처리하는 영역이며, 동일 카테고리의 이전 이슈(Sentry `APPS-IN-TOSS-UNITY-SDK-10X`, PR #766/#801)에서 이미 "ait build CLI(외부 npm 패키지) 동작이라 EditMode/로컬에서 직접 재현 불가"로 결론 나 있고, 판별 로직 자체는 `ValidateDistOutputTests.cs`로 이미 회귀 테스트가 잡혀 있음. 오늘 사례도 동일한 외부 CLI 동작에 해당해 **보고된 증상 자체는 이번에도 재현하지 못함**.
3. 조사 과정에서 `Editor/AITExportErrorCatalog.cs`의 `AIT_FILE_MISSING` 사용자 안내 문구가 "dist/ 폴더를 확인하라"고만 안내하고 있음을 발견. 그러나 실제 판별 로직(`ValidateDistOutput`)과 다른 곳의 주석(`WebGLBuildCopier.PrepareAitBuildFolder` 등)은 "web-framework 3.x(SDK 기본 핀 버전, `sdk-runtime-generator~/package.json`)는 .ait를 dist/가 아니라 ait-build **루트**에 emit한다"고 명시함 — 즉 안내 문구가 실제 동작과 어긋나 있었음. 오늘 이슈의 메시지에 등장하는 "ait-build/dist/ 를 확인하세요" 문구와 표현이 거의 동일해, 사용자(혹은 외부 CI 스크립트)가 이 오래된 안내를 따라 dist/만 보고 실제 산출물(루트의 .ait)을 놓쳤을 가능성이 있음.

## 원인 (인접 이슈, 원 증상과 별개)

`AITExportErrorCatalog.GetErrorMessage`/`GetErrorCause`의 `AIT_FILE_MISSING` 케이스가 "dist/ 폴더"만 언급 — 실제로는 ait build CLI 버전에 따라 **루트 또는 dist/** 양쪽에 생성될 수 있음(`ValidateDistOutput`과 동일한 탐색 규약).

## Fix

- 두 안내 문구를 "ait-build/ 폴더(루트 또는 dist/ 하위)"로 정정해 실제 판별 로직과 일치시킴.
- `ValidateDistOutputTests.cs`에 두 문구가 다시 dist/ 전용으로 퇴화하지 않도록 회귀 테스트 2건 추가.

## 검증

- 변경은 순수 문자열 리터럴 수정 + 신규 유닛 테스트(문자열 assertion)로 로직 변경 없음.
- 로컬 `./run-local-tests.sh` 실행 시도 중 다른 auto-resolve worker가 동시에 `--validate`/`--editmode`를 실행 중이어서(30초 간격 재확인 2회 모두 충돌) 런북의 동시 빌드 회피 가드에 따라 로컬 검증을 스킵함. CI에서 EditMode 테스트 결과 확인 필요.

## 절대 금지 준수

- `Fixes` 키워드 미사용 — 원 증상(빌드 성공 후 .ait 미생성) 자체는 재현/수정하지 못했으므로 Sentry 이슈를 auto-close 대상으로 삼지 않음.