### PR TITLE
[auto-resolve] 수정: 3.x vite build 실패 로그 Sentry 노이즈 차단

### DIFF
--- a/Editor/Package/GraniteBuildRunner.cs
+++ b/Editor/Package/GraniteBuildRunner.cs
@@ -311,7 +311,15 @@ namespace AppsInToss.Editor.Package
                     if (viteResult != AITConvertCore.AITExportError.SUCCEED)
                     {
                         if (viteResult != AITConvertCore.AITExportError.CANCELLED)
-                            Debug.LogError("[AIT] vite build 실패 (3.x)");
+                        {
+                            // vite build 실패는 lockfile drift/네트워크/AV 스캔/사용자 vite 설정 등
+                            // 사용자 환경 원인 — RunNpmCommandWithCacheAsync가 이미 exit code/stderr를
+                            // Console(AITLog.Error, sentryCapture:false)에 상세 기록했다. 이 요약 로그까지
+                            // raw Debug.LogError로 내보내면 같은 실패가 Sentry에 노이즈로 중복 전송된다
+                            // (Sentry 단일 이벤트는 상위 CaptureBuildError에 위임 — cascade 중복 방지,
+                            // 파일 내 다른 실패 로그와 동일 정책, APPS-IN-TOSS-UNITY-SDK-19M).
+                            AITLog.Error("[AIT] vite build 실패 (3.x)", sentryCapture: false);
+                        }
                         onComplete?.Invoke(viteResult);
                         return;
                     }

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/SentryNoiseSuppressionCallsiteTests.cs
@@ -104,6 +104,25 @@ public class SentryNoiseSuppressionCallsiteTests
             expectWarning: false);  // AITLog.Error (사용자에게 치명적 오류로 표시해야 하므로 Error 레벨)
 
     /// <summary>
+    /// 회귀 가드 — APPS-IN-TOSS-UNITY-SDK-19M:
+    /// Run3xBuildAsync가 vite build(web-framework 3.x, 2단계 빌드의 1단계) 실패를 로그할 때
+    /// raw Debug.LogError 로 되돌아가지 않고 AITLog.Error(sentryCapture:false) 를 유지하는지 검증.
+    ///
+    /// vite build 실패는 lockfile drift/네트워크/AV 스캔/사용자 vite 설정 등 사용자 환경 원인이며,
+    /// RunNpmCommandWithCacheAsync가 이미 exit code/stderr를 Console에 상세 기록한다(동일 정책,
+    /// 파일 내 다른 재시도 실패 로그들과 동일). 진짜 빌드 실패는 상위 CaptureBuildError가 구조화
+    /// 이벤트로 별도 캡처하므로, 이 중간 단계 요약 로그가 raw Debug.LogError로 되돌아가면 동일
+    /// 실패가 "[AIT] vite build 실패 (3.x)"라는 SDK 자체 로그로 Sentry에 노이즈 중복 전송된다.
+    /// </summary>
+    [Test]
+    public void NineteenM_ViteBuildFailure_StaysSentrySuppressed()
+        => AssertCallsiteSuppressed(
+            "GraniteBuildRunner.cs",
+            "vite build 실패 (3.x)",
+            "19M",
+            expectWarning: false);  // AITLog.Error (사용자에게 표시해야 하므로 Error 레벨)
+
+    /// <summary>
     /// fileName 소스에서 messageAnchor를 내보내는 가장 가까운 선행 로그 호출이
     /// AITLog.Warning( 또는 AITLog.Error(이고, 그 호출 인자에 sentryCapture: false가 포함됨을
     /// 정적으로 검증한다.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-19M

## 대상 이슈

| Sentry 이슈 | 메시지 | 분류 |
|---|---|---|
| APPS-IN-TOSS-UNITY-SDK-19M | `UnityError: [AIT] vite build 실패 (3.x)` | repro |

## 재현 절차 및 원인

`[AIT] vite build 실패 (3.x)` 는 `Editor/Package/GraniteBuildRunner.cs`의
`Run3xBuildAsync`에서 web-framework 3.x 빌드(1단계: vite build → 2단계: ait build)
중 vite build 단계가 실패했을 때 남기는 로그입니다.

실제 `vite build` 자체를 SDK 생성 템플릿(`WebGLTemplates/AITTemplate/BuildConfig~`,
`@apps-in-toss/web-framework@3.1.1` 고정)으로 로컬에서 pnpm install + `vite build`
재현했을 때는 정상 빌드되어, vite 자체의 결함은 아니었습니다(lockfile drift/네트워크/AV
스캔/사용자 vite 설정 등 사용자 환경에 따라 실패할 수 있는 정상 실패 경로).

문제는 이 실패를 로그로 남기는 방식입니다. 같은 파일의 다른 모든 실패 로그
(`granite build 재시도도 실패`, `pnpm install 재시도도 실패` 등, 5곳)는
`AITLog.Error(msg, sentryCapture: false)`로 Sentry 전송을 억제합니다 — 상세 진단
(exit code/stdout/stderr)은 이미 `RunNpmCommandWithCacheAsync`가 Console에 남기고,
진짜 빌드 실패는 상위 `CaptureBuildError`가 구조화 이벤트로 단일 캡처하기 때문입니다
(cascade 중복 방지 정책, 파일 내 주석에 명시).

그런데 `vite build` 실패 시점의 로그만 유일하게 `Debug.LogError(...)`를 직접 호출해
이 억제 정책을 건너뛰고 있었습니다. 그 결과 3.x 사용자 환경에서 vite build가 실패할
때마다(사용자 환경 원인이라도) `[AIT] vite build 실패 (3.x)`라는 SDK 자체 로그가
그대로 Sentry `UnityError`로 전송되어 노이즈 이슈가 반복 생성됩니다.

## Fix

`Run3xBuildAsync`의 해당 로그를 `AITLog.Error("[AIT] vite build 실패 (3.x)", sentryCapture: false)`로
변경해 같은 파일의 다른 실패 로그들과 정책을 통일했습니다. Console 가시성(Error 레벨)은
그대로 유지되고, Sentry 전송만 억제됩니다.

## 회귀 테스트

기존 `SentryNoiseSuppressionCallsiteTests`(정적 소스 스캔으로 "메시지가 `AITLog.Warning/Error(...,
sentryCapture: false)`로 나가는지" 검증하는 패턴, PR #733/#715/#746 계열)에 이번 콜사이트용
테스트(`NineteenM_ViteBuildFailure_StaysSentrySuppressed`)를 추가했습니다. 이 가드가 없으면
향후 리팩토링 중 이 로그가 다시 raw `Debug.LogError`로 되돌아가도 감지되지 않습니다.

## 검증

- 수정 대상 로직을 SDK 생성 템플릿 그대로 로컬 스크래치 디렉터리에서 pnpm install +
  `vite build --outDir dist/web`로 직접 재현 시도 → 정상 빌드 확인(사용자 환경 실패 경로이지
  SDK 결함은 아님을 배제).
- 코드 변경은 기존 5개 콜사이트와 동일한 `AITLog.Error(sentryCapture:false)` 패턴을 그대로
  따랐고, 신규 회귀 테스트는 기존 `AssertCallsiteSuppressed` 정적 스캔 로직을 재사용.
- **`./run-local-tests.sh --validate` 로컬 실행은 스킵했습니다** — 동시에 실행 중인 다른
  auto-resolve worker의 `run-local-tests.sh --editmode/--e2e`와 두 차례 연속 충돌(pgrep 가드
  기준)해 런북의 "두 번 충돌 시 검증 skip" 규칙을 적용했습니다. 변경 범위가 1개 콜사이트의
  로그 함수 치환 + 기존 테스트 파일에 대한 패턴 반복 추가뿐이라 위험도는 낮다고 판단했습니다.
  CI E2E는 아래에서 별도로 트리거합니다.

## 범위

`Runtime/SDK/` 미변경. `Editor/Package/GraniteBuildRunner.cs` 1개 콜사이트와
`Tests~/.../SentryNoiseSuppressionCallsiteTests.cs` 회귀 테스트 추가만 포함.