### PR TITLE
[auto-resolve] 테스트: *.loader.js 필수 파일 누락 에러 로그 회귀 가드 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs
@@ -185,6 +185,54 @@ public class BuildFileSelectionTests
     }
 
     // =====================================================
+    // Sentry APPS-IN-TOSS-UNITY-SDK-1AN 회귀: *.loader.js 누락 시 에러 로그 방출
+    // WebGLBuildCopier가 loader 패턴을 항상 "isRequired: true"로 검색하므로(압축 포맷과
+    // 무관하게 loader.js는 항상 필수), 빈 문자열을 받으면 FindFileInBuild 내부에서
+    // "[AIT] ✗ 필수 파일을 찾을 수 없습니다: *.loader.js" 에러가 발생한다.
+    // *.framework.js*(SDK-ZM)에는 이미 동일한 회귀 가드가 있었지만 *.loader.js에는
+    // 없었다 — 이 테스트는 그 커버리지 갭을 메운다.
+    // =====================================================
+
+    [Test]
+    public void FindFileInBuild_MissingLoaderJs_EmitsRequiredErrorLog()
+    {
+        // Build/ 폴더에 data, framework.js, wasm만 있고 loader.js는 없음
+        File.WriteAllText(Path.Combine(tempDir, "build.data"), "data");
+        File.WriteAllText(Path.Combine(tempDir, "build.framework.js"), "framework");
+        File.WriteAllText(Path.Combine(tempDir, "build.wasm"), "wasm");
+        // loader.js 의도적으로 생성 안 함
+
+        // AITLog.Error → Debug.LogError 다단 진단 블록(검색 경로·Build 폴더 파일 목록 등
+        // 가변 개수)을 의도적으로 발화시키므로, UTF의 unhandled-log 실패를 스코프 한정으로
+        // 무시한다. 핵심 에러의 실제 방출 여부는 아래 CollectLogs 기반 양성 검증이 보장한다.
+        string result = null;
+        List<LogEntry> logs;
+        LogAssert.ignoreFailingMessages = true;
+        try
+        {
+            logs = CollectLogs(() =>
+                result = AITBuildValidator.FindFileInBuild(tempDir, "*.loader.js", isRequired: true));
+        }
+        finally
+        {
+            LogAssert.ignoreFailingMessages = false;
+        }
+
+        // 빈 문자열 반환 → missingFiles.Add("*.loader.js") 로 이어짐 (WebGLBuildCopier.cs)
+        Assert.AreEqual("", result,
+            "loader.js 파일이 없으면 빈 문자열을 반환해야 함");
+
+        // "[AIT] ✗ 필수 파일을 찾을 수 없습니다: *.loader.js" 에러 로그 방출 확인
+        bool emittedRequiredError = logs.Exists(l =>
+            l.type == LogType.Error &&
+            l.message.Contains("필수 파일을 찾을 수 없습니다") &&
+            l.message.Contains("*.loader.js"));
+        Assert.IsTrue(emittedRequiredError,
+            "isRequired:true 이면서 파일이 없으면 에러 로그가 방출되어야 함. " +
+            "실제 로그: " + string.Join(" | ", logs.ConvertAll(l => $"[{l.type}] {l.message}")));
+    }
+
+    // =====================================================
     // GetFilePatterns — decompressionFallback=true 시 .unityweb 패턴 반환
     // =====================================================
 


### PR DESCRIPTION
**범위**: 원 이슈 `APPS-IN-TOSS-UNITY-SDK-1AN`의 실제 증상(WebGL 빌드 후 *.loader.js 파일이 실제로 누락되는 원인)은 미해결 — 이 PR은 회귀 테스트 커버리지 갭만 메운다. 별도 조사 필요.

## 대상 이슈

| sentry-issue | 메시지 | 판단 |
|---|---|---|
| APPS-IN-TOSS-UNITY-SDK-1AN | `UnityError: [AIT] ✗ 필수 파일을 찾을 수 없습니다: *.loader.js` | repro |

## 재현 시도 및 결론

- `Editor/AITBuildValidator.cs`의 `FindFileInBuild()`는 `isRequired: true`로 호출됐는데 패턴에 매칭되는 파일이 없으면 `AITLog.Error("[AIT] ✗ 필수 파일을 찾을 수 없습니다: {pattern}")`를 방출한다(478번째 줄 부근). 이 메시지 자체는 EditMode 단위 테스트로 트리비얼하게 재현된다 — 실제 사용자 환경에서 WebGL 빌드가 왜 `*.loader.js`를 만들지 못했는지(부분 실패한 빌드 잔여물, 외부 프로세스의 빌드 폴더 간섭 등 환경 요인)까지는 이번 조사 범위에서 재현하지 못했다.
- `WebGLBuildCopier.CopyWebGLToPublic()`이 `loader` 패턴을 압축 포맷과 무관하게 항상 `isRequired: true`로 검색하므로, loader.js 누락은 data/framework.js/wasm과 별개로 항상 이 경로를 탄다.
- 이 코드 경로 자체는 의도된 동작(누락 파일을 감지해 사용자에게 "Clean Build" 안내)이며 버그는 아니다. `REQUIRED_FILE_MISSING` 에러 코드/사용자 안내 문구(`AITExportErrorCatalog.cs`)도 이미 존재한다.

## 발견한 인접 이슈 (테스트 커버리지 갭)

동일 함수의 `*.framework.js*` 누락 경로는 이미 `FindFileInBuild_MissingFrameworkJs_EmitsRequiredErrorLog`(Sentry SDK-ZM 회귀 가드)로 보호되고 있었지만, 이번 이슈의 실제 대상인 `*.loader.js` 누락 경로에는 동등한 회귀 테스트가 없었다. 이 PR은 그 갭을 메운다.

## 변경 사항

- `Tests~/E2E/SharedScripts/Editor/EditModeTests/BuildFileSelectionTests.cs`에 `FindFileInBuild_MissingLoaderJs_EmitsRequiredErrorLog` 테스트 추가 (기존 framework.js 테스트와 동일한 패턴, `*.loader.js`를 대상으로 미러링).

## 검증 결과

- `./run-local-tests.sh --editmode` (Unity 6000.3.0f1): 1538 passed / 0 failed (신규 테스트 포함)
- `./run-local-tests.sh --validate`: 4/4 통과

## 후속 조사 제안

원 증상(실제 빌드 산출물 누락)을 재현하려면 Sentry 이벤트의 breadcrumb/빌드 설정(압축 포맷, decompressionFallback, Unity 버전)과 함께 동일 시점에 data/framework.js/wasm 관련 sibling 이슈가 있었는지 확인이 필요하다 — 하나의 빌드 실패에서 loader/data/framework/wasm 각각이 독립된 fingerprint로 Sentry에 개별 캡처되는 구조라(`AITBuildValidator.cs` 내 개별 캡처 + `WebGLBuildCopier.cs`의 집계 메시지 캡처 중복), 이번 1AN이 더 큰 단일 빌드 실패 이벤트의 여러 파편 중 하나일 가능성이 있다. 다만 이 캡처 중복은 여러 차례(697dd54b, 707b99e9 등) 의도적으로 튜닝된 영역이라 이번 조사에서는 추측성 변경을 하지 않았다.
