### PR TITLE
[auto-resolve] 수정: dist 산출물 검증 .ait 확장자 오검출(Windows 8.3) 방지

### DIFF
--- a/Editor/AITBuildValidator.cs
+++ b/Editor/AITBuildValidator.cs
@@ -503,12 +503,16 @@ namespace AppsInToss.Editor
         /// </summary>
         internal static AITConvertCore.AITExportError ValidateDistOutput(string buildProjectPath)
         {
-            // .ait 파일은 ait build CLI 버전에 따라 빌드 루트 또는 dist/에 생성될 수 있음
-            var aitFiles = Directory.GetFiles(buildProjectPath, "*.ait");
+            // .ait 파일은 ait build CLI 버전에 따라 빌드 루트 또는 dist/에 생성될 수 있음.
+            // GetAitFiles가 Directory.GetFiles(path, "*.ait") 대신 확장자를 명시적으로 비교하는
+            // 이유는 Package.PackageBuildStateMarker.ContainsAitArchive 주석 참조 — Windows의
+            // 8.3 단축명 매칭 때문에 "*.ait" glob이 .aitpart 같은 더 긴 확장자 파일까지 잡을 수
+            // 있어, 그대로 두면 진짜 .ait가 없어도 SUCCEED를 반환하는 성공 오탐이 생긴다.
+            var aitFiles = GetAitFiles(buildProjectPath);
             string distPath = Path.Combine(buildProjectPath, "dist");
             if (aitFiles.Length == 0 && Directory.Exists(distPath))
             {
-                aitFiles = Directory.GetFiles(distPath, "*.ait");
+                aitFiles = GetAitFiles(distPath);
             }
 
             if (aitFiles.Length == 0)
@@ -539,6 +543,31 @@ namespace AppsInToss.Editor
                 Debug.Log($"[AIT] ✓ .ait 파일 발견: {Path.GetFileName(aitFile)}");
             }
             return AITConvertCore.AITExportError.SUCCEED;
+        }
+
+        /// <summary>
+        /// 지정한 디렉터리 최상위에서 확장자가 정확히 .ait인 파일만 반환합니다.
+        /// Directory.GetFiles(dir, "*.ait")는 Windows에서 8.3 단축명 매칭으로 인해 .aitpart처럼
+        /// "ait"로 시작하는 더 긴 확장자의 파일까지 오검출할 수 있으므로 Path.GetExtension으로
+        /// 명시 비교합니다 (Package.PackageBuildStateMarker.ContainsAitArchive와 동일 대응).
+        /// </summary>
+        private static string[] GetAitFiles(string directory)
+        {
+            if (!Directory.Exists(directory))
+            {
+                return Array.Empty<string>();
+            }
+
+            var result = new List<string>();
+            foreach (string path in Directory.GetFiles(directory, "*", SearchOption.TopDirectoryOnly))
+            {
+                if (string.Equals(Path.GetExtension(path), Package.WebGLBuildCopier.AitArchiveExtension,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(path);
+                }
+            }
+            return result.ToArray();
         }
 
         /// <summary>

--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ValidateDistOutputTests.cs
@@ -130,6 +130,45 @@ public class ValidateDistOutputTests
     }
 
     // =====================================================
+    // Windows 8.3 단축명 오검출 방지 (Sentry APPS-IN-TOSS-UNITY-SDK-1AE 참조 —
+    // "[AIT Batch] Export reported success, but no .ait package exists" 증상의
+    // 원인 후보 중 하나. Directory.GetFiles(dir, "*.ait")는 Windows에서 8.3 단축명
+    // 매칭 때문에 .aitpart처럼 "ait"로 시작하는 더 긴 확장자 파일까지 잡을 수 있어,
+    // 그대로 두면 진짜 .ait가 없어도 SUCCEED를 반환하는 성공 오탐이 생길 수 있다.
+    // ValidateDistOutput은 확장자를 명시 비교(Path.GetExtension)해야 하며, 이는
+    // Package.PackageBuildStateMarker.ContainsAitArchive가 이미 적용 중인 방어와
+    // 일치해야 한다.
+    // =====================================================
+
+    [Test]
+    public void ValidateDistOutput_OnlyLongerExtensionStartingWithAit_ReturnsAitFileMissing()
+    {
+        // dist/ 에 진짜 .ait는 없고 "ait"로 시작하는 더 긴 확장자 파일만 있는 경우.
+        string distPath = Path.Combine(tempDir, "dist");
+        Directory.CreateDirectory(distPath);
+        File.WriteAllText(Path.Combine(distPath, "app.aitpart"), "partial-content");
+
+        LogAssert.Expect(LogType.Error, new Regex(@"\.ait 파일이 생성되지 않았습니다"));
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.AIT_FILE_MISSING, result,
+            "확장자가 \"ait\"로 시작할 뿐 정확히 .ait가 아니면 AIT_FILE_MISSING을 반환해야 한다 " +
+            "(Windows 8.3 단축명 오검출 방지)");
+    }
+
+    [Test]
+    public void ValidateDistOutput_RealAitFile_AlongsideLongerAitPrefixedExtension_ReturnsSucceed()
+    {
+        // 진짜 .ait와 "ait"로 시작하는 더 긴 확장자 파일이 함께 있어도 정상 판정되어야 한다.
+        string distPath = Path.Combine(tempDir, "dist");
+        Directory.CreateDirectory(distPath);
+        File.WriteAllText(Path.Combine(distPath, "app.ait"), "ait-content");
+        File.WriteAllText(Path.Combine(distPath, "app.aitpart"), "partial-content");
+
+        var result = AITBuildValidator.ValidateDistOutput(tempDir);
+        Assert.AreEqual(AITConvertCore.AITExportError.SUCCEED, result);
+    }
+
+    // =====================================================
     // 빌드 루트 .ait 파일이 dist/ 탐색보다 우선됨
     // =====================================================
 


### PR DESCRIPTION
**범위**: 원 이슈 `APPS-IN-TOSS-UNITY-SDK-1AE`의 실제 증상("[AIT Batch] Export reported success, but no .ait package exists")은 재현하지 못했습니다 — 이 PR은 참조만이며 별도 조사가 필요합니다.

## 묶음 항목

| Sentry Issue | 메시지 |
|---|---|
| APPS-IN-TOSS-UNITY-SDK-1AE | `UnityError: [AIT Batch] Export reported success, but no .ait package exists beneath C:\Users\Ha\Documents\ChatGPT\game\ait-build\dist.` |

## 재현 시도 및 결과

- `git log --all -S "AIT Batch"` / `-S "no .ait package exists"` 로 확인한 결과, 이 태그와 메시지 문자열은 이 저장소 히스토리 전체에 존재하지 않습니다. SDK가 실제로 남기는 로그 태그는 `[AIT]`, `[AIT Async]`, `[AIT Mock]`, `[AIT Login]` 뿐이고 `[AIT Batch]`는 없습니다.
- Unity `-batchmode`(`Application.isBatchMode`)에서는 `AITConvertCore.DoExportAsync`가 내부적으로 동기 `DoExport`로 위임되므로, "배치" 실행은 결국 이 경로로 수렴합니다. 기본 옵션(`doPackaging=true`, `skipGraniteBuild=false`)으로 호출되는 표준 경로는 `AITPackageBuilder.PackageWebGLBuild` → `GraniteBuildRunner.RunGraniteBuildSync` → `AITBuildValidator.ValidateDistOutput`으로 이어지고, `.ait` 산출물이 없으면 SUCCEED 대신 `AIT_FILE_MISSING`을 반환하도록 이미 방어돼 있음을 코드 추적으로 확인했습니다.
- 즉 SDK 공개 API의 표준 사용(기본 옵션)으로는 "성공 보고 + 산출물 없음" 상태를 재현할 수 없었습니다. 이벤트가 1건뿐이고 사용자 경로(`ChatGPT\game\...`)로 미루어 커스텀 배치 스크립트나 비표준 옵션 조합(`doPackaging=false`/`skipGraniteBuild=true`)일 가능성이 있으나 이 역시 확정하지 못했습니다.

## 발견한 인접 이슈 (이번에 수정)

코드 추적 중 `AITBuildValidator.ValidateDistOutput`이 `.ait` 존재 여부를 `Directory.GetFiles(path, "*.ait")` glob으로 판단하는데, 같은 산출물을 보는 자매 함수 `Package.PackageBuildStateMarker.ContainsAitArchive`는 이미 다음과 같은 주석과 함께 `Path.GetExtension` 명시 비교로 방어하고 있었습니다.

> Windows의 8.3 단축명 때문에 "*.ait" glob이 .aitxxx까지 잡을 수 있어 확장자를 명시적으로 비교한다.

`ValidateDistOutput`에는 이 방어가 빠져 있어, dist/ 산출물 위치에 진짜 `.ait`는 없고 "ait"로 시작하는 더 긴 확장자 파일(예: 빌드가 중간에 남긴 `.aitpart` 류)만 있는 경우 Windows에서 이 glob이 오탐할 수 있고, 그러면 검증기가 `SUCCEED`를 반환합니다 — 보고된 증상("Export reported success, but no .ait package exists")과 정확히 같은 모양의 실패 클래스입니다. 다만 실제 `ait build` CLI(외부 npm 패키지)가 이런 확장자의 파일을 dist/에 남기는지는 확인하지 못했기 때문에, "원인 확정"이 아니라 "발견한 방어 공백 보강"으로 보고합니다.

## 변경 사항

- `AITBuildValidator.ValidateDistOutput`이 `PackageBuildStateMarker.ContainsAitArchive`와 동일하게 `Path.GetExtension` 명시 비교로 `.ait` 파일만 인식하도록 수정 (`GetAitFiles` 헬퍼 추가)
- `ValidateDistOutputTests.cs`에 회귀 테스트 2건 추가: "ait"로 시작하는 더 긴 확장자 파일만 있을 때 `AIT_FILE_MISSING`, 진짜 `.ait`와 공존해도 `SUCCEED`

## 검증

- `./run-local-tests.sh --validate` 통과 (4/4)
- `./run-local-tests.sh --editmode` 통과 (Unity 6000.3, 1539 tests passed, 신규 테스트 2건 포함)
- 작업 중 동시에 다른 auto-resolve worker가 pnpm store에 접근 중이라 `--validate`/`--editmode` 실행 전 `pgrep -f run-local-tests`로 대기 후 클리어 확인. 최종 실행은 충돌 없이 정상 통과했습니다.

## CI E2E

원 증상을 재현하지 못했고 이 PR은 인접 방어 강화 성격이라 별도 CI E2E dispatch는 생략했습니다.
