### PR TITLE
테스트: 소프트 키보드가 뜰 때 뷰포트 변화를 기록하는 프로브 추가

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/TapAutoProbeTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/TapAutoProbeTests.cs
@@ -691,6 +691,25 @@ public class TapAutoProbeTests
         }
     }
 
+    [Test]
+    public void ViewportProbeBridge_ExistsOnBothSides()
+    {
+        string cs = ReadSibling("../../Runtime/TapDiagnosticsTester.cs");
+        string js = ReadSibling("../../Plugins/E2ETestBridge.jslib");
+        if (cs == null || js == null) Assert.Ignore("소스 경로를 찾지 못했다. 대조를 건너뛴다.");
+
+        var csInstall = Regex.Match(cs, @"static\s+extern\s+void\s+VP_Install\s*\(([^)]*)\)");
+        var jsInstall = Regex.Match(js, @"VP_Install\s*:\s*function\s*\(([^)]*)\)");
+        Assert.IsTrue(csInstall.Success, "C#에 VP_Install extern이 없다");
+        Assert.IsTrue(jsInstall.Success, "jslib에 VP_Install이 없다");
+        Assert.AreEqual(0, ArgCount(csInstall.Groups[1].Value));
+        Assert.AreEqual(0, ArgCount(jsInstall.Groups[1].Value));
+
+        // 두 쪽이 같은 태그로 찍어야 Dev Console 내보내기에서 한 흐름으로 읽힌다.
+        StringAssert.Contains("[E2E-VP]", cs);
+        StringAssert.Contains("[E2E-VP]", js);
+    }
+
     private static int ArgCount(string paramList)
     {
         paramList = paramList.Trim();

--- a/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
+++ b/Tests~/E2E/SharedScripts/Plugins/E2ETestBridge.jslib
@@ -300,6 +300,73 @@ mergeInto(LibraryManager.library, {
     },
 
     /**
+     * 소프트 키보드가 뜰 때 뷰포트가 어떻게 움직이는지 기록한다.
+     *
+     * 갈라야 하는 것은 둘이다. (a) 캔버스가 실제로 줄어드는가 — innerHeight·캔버스 rect 높이·
+     * 프레임버퍼(canvas.width/height)가 변한다. (b) 캔버스가 통째로 밀려 올라가는가 — 크기는
+     * 그대로인데 visualViewport.offsetTop이 커지고 캔버스 rect top이 음수가 된다.
+     *
+     * MobileKeyboard.js는 body 직하위에 position:fixed; bottom:0 컨테이너를 만들고 그 안의
+     * input에 focus()를 건다. 그 순간(focusin)과 뷰포트 이벤트마다 한 줄씩 찍고, 키보드
+     * 애니메이션이 끝난 뒤의 정착 상태를 보려고 focusin 뒤 600ms/1500ms에 한 번씩 더 찍는다.
+     * 같은 값이 연달아 오는 vv-scroll은 한 줄만 남긴다.
+     */
+    VP_Install: function() {
+        if (window.__AIT_VP_INSTALLED) return;
+        window.__AIT_VP_INSTALLED = true;
+
+        var canvas = Module['canvas'] || document.querySelector('canvas');
+        var vv = window.visualViewport;
+        var last = '';
+
+        var barRect = function() {
+            // 포커스된 input의 부모(= MobileKeyboard.js 컨테이너) 위치. 키보드 위에 보이는지,
+            // 레이아웃 뷰포트 바닥(= 키보드 뒤)에 있는지를 vvTop+vv와 대조하면 알 수 있다.
+            var ae = document.activeElement;
+            if (!ae || (ae.tagName !== 'INPUT' && ae.tagName !== 'TEXTAREA')) return '-';
+            var el = ae.parentElement || ae;
+            var r = el.getBoundingClientRect();
+            return Math.round(r.top) + '..' + Math.round(r.bottom);
+        };
+
+        var snap = function(tag) {
+            var r = canvas ? canvas.getBoundingClientRect() : { top: 0, height: 0 };
+            var ae = document.activeElement;
+            var focus = ae && ae !== document.body ? ae.tagName.toLowerCase() : '-';
+            var body = ' inner=' + window.innerHeight
+                + ' vv=' + (vv ? Math.round(vv.height) : '-')
+                + ' vvTop=' + (vv ? Math.round(vv.offsetTop) : '-')
+                + ' scrollY=' + Math.round(window.scrollY)
+                + ' cTop=' + Math.round(r.top) + ' cH=' + Math.round(r.height)
+                + ' fb=' + (canvas ? canvas.width + 'x' + canvas.height : '-')
+                + ' focus=' + focus + ' bar=' + barRect();
+            if (tag.indexOf('vv-') === 0 && body === last) return;
+            last = body;
+            console.log('[E2E-VP] ' + tag + body);
+        };
+
+        snap('base');
+        document.addEventListener('focusin', function(e) {
+            var t = e.target && e.target.tagName ? e.target.tagName.toLowerCase() : '?';
+            snap('focusin:' + t);
+            setTimeout(function() { snap('focusin+600ms'); }, 600);
+            setTimeout(function() { snap('focusin+1500ms'); }, 1500);
+        }, true);
+        document.addEventListener('focusout', function() {
+            snap('focusout');
+            setTimeout(function() { snap('focusout+600ms'); }, 600);
+        }, true);
+        if (vv) {
+            vv.addEventListener('resize', function() { snap('vv-resize'); });
+            vv.addEventListener('scroll', function() { snap('vv-scroll'); });
+        }
+        window.addEventListener('resize', function() { snap('win-resize'); });
+        window.addEventListener('scroll', function() { snap('win-scroll'); });
+        window.__AIT_VP = snap;
+        console.log('[E2E-VP] installed visualViewport=' + (vv ? 'yes' : 'no'));
+    },
+
+    /**
      * JavaScript에서 JSON 파싱 검증
      * C# → JSON → JavaScript 파싱 → JSON → C# 역직렬화 round-trip 검증용
      * @param {string} jsonPtr - JSON 문자열 포인터

--- a/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs
+++ b/Tests~/E2E/SharedScripts/Runtime/TapDiagnosticsTester.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Text;
 using UnityEngine;
 using UnityEngine.UI;
@@ -21,6 +22,12 @@ public class TapDiagnosticsTester : MonoBehaviour
 
     private const float RefreshIntervalSeconds = 0.3f;
 
+#if UNITY_WEBGL && !UNITY_EDITOR
+    /// <summary>소프트 키보드가 뜰 때 뷰포트 변화를 콘솔에 남기는 프로브. E2ETestBridge.jslib.</summary>
+    [DllImport("__Internal")]
+    private static extern void VP_Install();
+#endif
+
     private Text _logText;
     private Text _verdictText;
     private Button _runButton;
@@ -30,9 +37,21 @@ public class TapDiagnosticsTester : MonoBehaviour
     private float _lastRefreshTime = -1f;
     private string _lastVerdictRender;
 
+    // Unity가 보는 화면 크기. JS 쪽 프로브(VP_Install)가 찍는 canvas.width/height와 대조해
+    // 키보드가 뜰 때 엔진이 리사이즈를 인지하는지 본다.
+    private int _lastScreenW = -1;
+    private int _lastScreenH = -1;
+    private Rect _lastSafeArea;
+    private bool _lastKeyboardVisible;
+
     public void SetupUI(Transform parent)
     {
         _autoProbe = GetComponent<TapAutoProbe>() ?? gameObject.AddComponent<TapAutoProbe>();
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        try { VP_Install(); }
+        catch (Exception e) { Debug.LogWarning($"[E2E-VP] VP_Install failed: {e.Message}"); }
+#endif
 
         var section = UIBuilder.CreatePanel(parent, UIBuilder.Theme.SectionBg);
         var vlg = section.gameObject.AddComponent<VerticalLayoutGroup>();
@@ -71,6 +90,11 @@ public class TapDiagnosticsTester : MonoBehaviour
             + "키보드가 뜨는지 확인해 주세요.",
             UIBuilder.Theme.FontTiny, UIBuilder.Theme.TextSecondary);
 
+        UIBuilder.CreateText(section,
+            "키보드가 뜰 때 화면이 밀리거나 줄어드는 증상은 콘솔의 [E2E-VP] 줄에 남습니다. "
+            + "입력칸을 탭해 키보드를 띄운 뒤 Dev Console에서 로그를 내보내면 됩니다.",
+            UIBuilder.Theme.FontTiny, UIBuilder.Theme.TextSecondary);
+
         UIBuilder.CreateButton(section, "로그 지우기", onClick: OnClearClick);
 
         _logText = UIBuilder.CreateText(section, "(아직 탭 기록 없음)",
@@ -92,6 +116,7 @@ public class TapDiagnosticsTester : MonoBehaviour
     private void Update()
     {
         PointerTapDiagnostics.PollPendingTaps();
+        WatchScreen();
         RefreshVerdict();
 
         if (_logText == null) return;
@@ -105,6 +130,23 @@ public class TapDiagnosticsTester : MonoBehaviour
         if (_lastRenderedRevision == PointerTapDiagnostics.Revision) return;
         _lastRenderedRevision = PointerTapDiagnostics.Revision;
         _logText.text = BuildVisibleLog();
+    }
+
+    /// <summary>
+    /// Screen 크기·safeArea·TouchScreenKeyboard.visible이 바뀔 때만 한 줄 남깁니다.
+    /// JS 프로브가 찍는 값과 태그([E2E-VP])를 맞춰서 Dev Console 내보내기에서 한 흐름으로 읽힙니다.
+    /// 값이 한 번도 안 바뀌면 "Unity는 키보드를 전혀 인지하지 못한다"는 뜻이고, 그것도 결과입니다.
+    /// </summary>
+    private void WatchScreen()
+    {
+        int w = Screen.width, h = Screen.height;
+        Rect sa = Screen.safeArea;
+        bool kb = TouchScreenKeyboard.visible;
+        if (w == _lastScreenW && h == _lastScreenH && sa == _lastSafeArea && kb == _lastKeyboardVisible) return;
+
+        string tag = _lastScreenW < 0 ? "unity-base" : "unity-change";
+        _lastScreenW = w; _lastScreenH = h; _lastSafeArea = sa; _lastKeyboardVisible = kb;
+        Debug.Log($"[E2E-VP] {tag} Screen={w}x{h} safeArea=({sa.x:F0},{sa.y:F0},{sa.width:F0},{sa.height:F0}) kbVisible={(kb ? 1 : 0)}");
     }
 
     /// <summary>


### PR DESCRIPTION
## 왜

실기기에서 스크롤 밖 검색바를 탭하면 키보드는 뜨는데 검색바가 화면 밖으로 사라진다. #1141 손 확인 중에 나온 별개 증상이다.

두 가지 중 하나다.

- 캔버스가 실제로 줄어든다 — `innerHeight`·캔버스 rect 높이·프레임버퍼(`canvas.width/height`)가 변한다
- 캔버스가 통째로 밀려 올라간다 — 크기는 그대로인데 `visualViewport.offsetTop`이 커지고 캔버스 rect top이 음수가 된다

어느 쪽인지에 따라 고치는 곳이 완전히 다르다. 전자면 Unity 쪽 relayout까지 필요하고, 후자면 `#unity-container`를 비주얼 뷰포트에 고정하는 것으로 끝난다.

## 추정

`MobileKeyboard.js:65`는 body 직하위에 `position:fixed; bottom:0` 컨테이너를 만들고 그 안의 input에 `focus()`를 건다. 레이아웃 뷰포트는 키보드에 줄어들지 않으므로 그 바는 키보드 뒤에 깔리고, iOS가 포커스된 엘리먼트를 보이게 하려고 비주얼 뷰포트를 아래로 밀어 올린다. `#unity-container`도 `position: fixed`라 같이 밀린다. 캔버스 맨 위에 있는 검색바가 제일 먼저 사라지는 것과 맞다.

추정이다. 이 PR은 그걸 확인하는 프로브다.

## 무엇을

`Tests~/E2E/SharedScripts/`만 바뀐다. UPM 배포에서 제외되므로 SDK 소비자에게 도달하지 않는다.

**JS (`VP_Install`)** — `focusin`/`focusout`, `visualViewport` `resize`/`scroll`, `window` `resize`/`scroll`마다 `[E2E-VP]` 한 줄을 찍는다. 값: `inner`, `vv`(비주얼 뷰포트 높이), `vvTop`(offsetTop), `scrollY`, `cTop`/`cH`(캔버스 rect), `fb`(프레임버퍼), `focus`(활성 엘리먼트), `bar`(입력 바 rect top..bottom). 키보드 애니메이션이 끝난 정착 상태를 보려고 `focusin` 뒤 600ms/1500ms에 한 번씩 더 찍는다. 값이 같은 `vv-scroll`은 한 줄만 남긴다.

**C# (`WatchScreen`)** — `Screen` 크기·`safeArea`·`TouchScreenKeyboard.visible`이 바뀔 때만 같은 태그로 한 줄 남긴다. 한 번도 안 바뀌면 엔진이 키보드를 전혀 인지하지 못한다는 뜻이고, 그것도 결과다.

둘이 같은 `[E2E-VP]` 태그를 써서 Dev Console 내보내기에서 한 흐름으로 읽힌다.

## 읽는 법

| 신호 | 뜻 |
|---|---|
| `inner`·`cH`·`fb` 그대로 + `vvTop` > 0 + `cTop` < 0 | 밀린 것. 캔버스를 비주얼 뷰포트에 고정 |
| `inner`·`cH`·`fb` 줄어듦 + `unity-change` 줄 존재 | 진짜 리사이즈. Unity relayout 포함 |
| `bar`가 `vvTop + vv` 아래 | 입력 바가 키보드 뒤에 있음 — iOS가 밀어 올린 이유 |

## 테스트

EditMode 1552건 통과(failed 0). 브릿지 시그니처 가드 1건 추가(`ViewportProbeBridge_ExistsOnBothSides`) — C# extern과 jslib 정의의 인자 수, 양쪽 태그 일치. `--validate` 4/4.
