### PR TITLE
[auto-resolve] 수정: Sentry 노이즈 패턴 회귀 테스트 추가 — webgl-bee-il2cpp-build-noise

### DIFF
--- a/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
+++ b/Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs
@@ -1956,6 +1956,15 @@ public class IsKnownNonSdkMessageTests
     }
 
     [Test]
+    public void BuildLibraryBee_ReleaseWasmObjFailed_19S_ReturnsTrue()
+    {
+        // Sentry APPS-IN-TOSS-UNITY-SDK-19S: 동일 형식의 또 다른 해시 .o 파일(GameAssembly release_WebGL_wasm).
+        // 기존 "Building Library/Bee/artifacts/WebGL/" 패턴이 새 해시 변형도 커버하는지 evidence로 검증.
+        Assert.IsTrue(AITEditorErrorTracker.IsKnownNonSdkMessage(
+            "UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/t07s1i7wa2fq.o failed with output:"));
+    }
+
+    [Test]
     public void BuildLibraryBee_WithAitPrefix_StillProtected()
     {
         // SDK 보호 가드: SDK가 동일 prefix로 출력하는 가상의 케이스도 필터링 안 되어야 함.


### PR DESCRIPTION
Fixes APPS-IN-TOSS-UNITY-SDK-19S

이 키워드는 squash 머지 후 Sentry가 해당 이슈를 자동 resolve하기 위한 것입니다. (repo의 squash_merge_commit_message=PR_BODY 설정으로 PR body가 머지 커밋에 그대로 들어갑니다)

## 묶음 항목

| source | id | title |
|---|---|---|
| sentry-issue | APPS-IN-TOSS-UNITY-SDK-19S | `UnityError: Building Library/Bee/artifacts/WebGL/GameAssembly/release_WebGL_wasm/t07s1i7wa2fq.o failed with output:` |

## 분석

Unity IL2CPP/Bee 빌드 시스템이 컴파일 단위(.o)별 실패 시 직접 출력하는 메시지로, 파일명이 매 빌드마다 랜덤 해시라 Sentry에서 매번 새 이슈로 grouping되는 노이즈입니다.

`Editor/ErrorTracker/AITEditorErrorTracker.cs`의 `NonSdkMessagePatterns`에 이미 `"Building Library/Bee/artifacts/WebGL/"` 패턴이 존재하며(선행 이슈 SA~SV, T7, TV, W0, VZ, 19T, 19V, 10S 대응), 이번 이슈의 메시지 전문과도 부분 문자열로 정확히 매칭됩니다. `MessageContainsSdkKeyword` 가드(AIT/AppsInToss 키워드)도 이 메시지에는 걸리지 않아 정상적으로 필터 루프까지 도달합니다.

즉 이 저장소의 현재 코드는 이미 이 케이스를 올바르게 "SDK와 무관한 노이즈"로 분류합니다. Sentry에 새 이슈로 계속 올라오는 원인은 이 필터가 배포되기 이전 버전의 SDK를 여전히 쓰는 사용자 환경에서 발생한 빌드 실패가 남아 있기 때문으로 판단되며, 이 저장소에서 추가로 조치할 코드 결함은 없습니다. 동일 카테고리의 선행 이슈(10S 등)도 같은 방식(코드 변경 없이 evidence 테스트만 추가)으로 처리된 전례를 따랐습니다.

### 재현 절차
1. `Editor/ErrorTracker/AITEditorErrorTracker.cs`의 `IsKnownNonSdkMessage` / `NonSdkMessagePatterns` / `MessageContainsSdkKeyword` 로직을 코드로 추적해 이번 이슈의 메시지 전문이 기존 패턴에 매칭됨을 확인
2. 참고로 동일 Unity 2022.3.62f3 + WebGL(release, GameAssembly/il2cpp) 빌드를 로컬에서 실행해(`./run-local-tests.sh --unity-build --unity-version 2022.3`), 이 SDK 저장소의 샘플 프로젝트 자체는 GameAssembly `.o` 컴파일 단계에서 정상 진행됨을 확인(정상 종료까지는 대기하지 않고 중단 — 클린 샘플 프로젝트에서 재현되지 않을 가능성이 높아 보고된 실패는 리포터 프로젝트 환경 고유 문제로 판단)
3. `EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`에 이번 해시(`t07s1i7wa2fq.o`)를 evidence로 한 positive 테스트 추가 → 통과 확인

## 변경 내용
- `Tests~/E2E/SharedScripts/Editor/EditModeTests/ErrorTracker/IsKnownNonSdkMessageTests.cs`: `BuildLibraryBee_ReleaseWasmObjFailed_19S_ReturnsTrue` positive 테스트 추가 (SDK 보호 가드 negative 테스트는 기존 `BuildLibraryBee_WithAitPrefix_StillProtected`가 동일 패턴에 대해 이미 커버)

## 검증
- `./run-local-tests.sh --editmode --unity-version 2022.3`: 1542 tests passed (신규 테스트 포함)
- `./run-local-tests.sh --validate`: 4/4 통과 (E2E 파일 구조, Playwright 설정, SDK Generator 유닛 테스트 205/205, Meta GUID 위생)

---
사람 머지 검토 필요 (auto-resolve worker가 생성한 PR)